### PR TITLE
Vision: fix prefetch_factor when num_workers = 0

### DIFF
--- a/vision/src/components/torchvision_finetune/train.py
+++ b/vision/src/components/torchvision_finetune/train.py
@@ -208,22 +208,22 @@ class PyTorchDistributedModelTrainingSequence:
         )
 
         # setting up DataLoader with the right arguments
-        data_loading_kwargs = {
-            "batch_size" : self.dataloading_config.batch_size,
-            "num_workers" : self.dataloading_config.num_workers,
-            "pin_memory" : self.dataloading_config.pin_memory,
-        }
+        optional_data_loading_kwargs = {}
+        
         if self.dataloading_config.num_workers > 0:
             # NOTE: this option _ONLY_ applies if num_workers > 0
             # or else DataLoader will except
-            data_loading_kwargs["prefetch_factor"] = self.dataloading_config.prefetch_factor
+            optional_data_loading_kwargs["prefetch_factor"] = self.dataloading_config.prefetch_factor
 
         self.training_data_loader = DataLoader(
             training_dataset,
+            batch_size=self.dataloading_config.batch_size,
+            num_workers=self.dataloading_config.num_workers,  # self.cpu_count,
+            pin_memory=self.dataloading_config.pin_memory,
             # DISTRIBUTED: the sampler needs to be provided to the DataLoader
             sampler=self.training_data_sampler,
             # all other args
-            **data_loading_kwargs
+            **optional_data_loading_kwargs
         )
 
         # DISTRIBUTED: we don't need a sampler for validation set

--- a/vision/tests/components/test_torchvision_finetune.py
+++ b/vision/tests/components/test_torchvision_finetune.py
@@ -51,7 +51,7 @@ def test_components_torchvision_finetune(mlflow_pytorch_log_model_mock, temporar
         "--valid_images", random_image_in_folder_classes, # using same data for train/valid
         "--batch_size", "16",
         "--num_workers", "0", # single thread pre-fetching
-        "--prefetch_factor", "2",
+        "--prefetch_factor", "2", # will be discarded if num_workers=0
         "--pin_memory", "True",
         "--non_blocking", "False",
         "--model_arch", "resnet18",


### PR DESCRIPTION
Modify logic of arguments to DataLoader to NOT provide prefetch_factor at all when num_workers=0. Even if prefetch_factor is None, pytorch will except if it is provided.