### PR TITLE
Vision: add environment variables for benchmarking

### DIFF
--- a/vision/src/pipelines/benchmark/train.yml
+++ b/vision/src/pipelines/benchmark/train.yml
@@ -25,6 +25,7 @@ jobs:
     resources:
       instance_count: 1 # number of nodes
     distribution:
+      type: pytorch
       process_count_per_instance: 1 # number of gpus
 
     # NOTE: set env var if needed


### PR DESCRIPTION
In order to benchmark different containers and communication protocols, we're adding some specific environment variables in our training pipeline.