### PR TITLE
use same datastore everywhere in benchmark jobs

### DIFF
--- a/benchmark/src/jobs/create_places2_dataset.yml
+++ b/benchmark/src/jobs/create_places2_dataset.yml
@@ -13,11 +13,11 @@ outputs:
   train_images:
     type: uri_folder
     mode: upload
-    path: azureml://datastores/workspaceblobstore/paths/azureml-vision-datasets/places2/train/
+    path: azureml://datastores/dlbenchmarkdatablobstandard/paths/azureml-vision-datasets/places2/train/
   valid_images:
     type: uri_folder
     mode: upload
-    path: azureml://datastores/workspaceblobstore/paths/azureml-vision-datasets/places2/valid/
+    path: azureml://datastores/dlbenchmarkdatablobstandard/paths/azureml-vision-datasets/places2/valid/
 
 environment: azureml:AzureML-sklearn-1.0-ubuntu20.04-py38-cpu@latest
 

--- a/benchmark/src/jobs/create_stanford_dogs_dataset.yml
+++ b/benchmark/src/jobs/create_stanford_dogs_dataset.yml
@@ -12,7 +12,7 @@ outputs:
   images:
     type: uri_folder
     mode: upload
-    path: azureml://datastores/workspaceblobstore/paths/azureml-vision-datasets/dogs/
+    path: azureml://datastores/dlbenchmarkdatablobstandard/paths/azureml-vision-datasets/dogs/
 
 environment: azureml:AzureML-sklearn-1.0-ubuntu20.04-py38-cpu@latest
 

--- a/benchmark/src/pipelines/benchmark/pt_image_classification.yml
+++ b/benchmark/src/pipelines/benchmark/pt_image_classification.yml
@@ -6,13 +6,13 @@ inputs:
   training_images:
     type: uri_folder
     mode: download # pick ro_mount, rw_mount or download
-    path: azureml://datastores/workspaceblobstore/paths/azureml-vision-datasets/dogs/**
-    # path: azureml://datastores/workspaceblobstore/paths/azureml-vision-datasets/places2/train//**
+    path: azureml://datastores/dlbenchmarkdatablobstandard/paths/azureml-vision-datasets/dogs/**
+    # path: azureml://datastores/dlbenchmarkdatablobstandard/paths/azureml-vision-datasets/places2/train//**
   validation_images:
     type: uri_folder
     mode: download # pick ro_mount, rw_mount or download
-    path: azureml://datastores/workspaceblobstore/paths/azureml-vision-datasets/dogs/**
-    # path: azureml://datastores/workspaceblobstore/paths/azureml-vision-datasets/places2/valid/**
+    path: azureml://datastores/dlbenchmarkdatablobstandard/paths/azureml-vision-datasets/dogs/**
+    # path: azureml://datastores/dlbenchmarkdatablobstandard/paths/azureml-vision-datasets/places2/valid/**
 # </inputs_and_outputs>
 
 # <jobs>


### PR DESCRIPTION
We created a specific datastore for the benchmark, not using default. This PR uses that same dstore everywhere.