### PR TITLE
add responsibleai text and vision images to azureml-assets

### DIFF
--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/asset.yaml
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/asset.yaml
@@ -1,0 +1,10 @@
+name: responsibleai-text-ubuntu20.04-py38-cpu
+version: auto
+type: environment
+spec: spec.yaml
+extra_config: environment.yaml
+test:
+  pytest:
+    enabled: true 
+    pip_requirements: tests/requirements.txt
+    tests_dir: tests

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
+
+ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-vision
+
+# Prepend path to AzureML conda environment
+ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
+
+# Create conda environment
+COPY conda_dependencies.yaml .
+RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
+    rm conda_dependencies.yaml && \
+    conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
+    conda clean -a -y
+
+RUN pip install --pre 'azure-ai-ml'
+
+# Workaround for dependency conflict around tqdm with nlp-feature-extractors
+RUN pip install 'datasets==1.18.4'
+
+# This is needed for mpi to locate libpython
+ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -1,0 +1,35 @@
+name: responsibleai-text
+channels:
+  - conda-forge
+  - huggingface
+  - anaconda
+  - pytorch
+dependencies:
+  - python=3.8
+  - pip=22.1.2
+  - pytorch
+  - torchvision
+  - cpuonly
+  - pip:
+    - numpy
+    - pandas
+    - pyarrow
+    - scikit-learn
+    - mlflow
+    - azureml-mlflow
+    - responsibleai~=0.22.0
+    - raiwidgets~=0.22.0
+    # Limit markupsafe version is a workaround to resolve the issue from markupsafe's breaking change: https://github.com/aws/aws-sam-cli/issues/3661
+    - markupsafe<2.1.0
+    # Workaround to fix import failure related to itsdangerous's latest release: https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous
+    - itsdangerous==2.0.1
+    - azureml-dataset-runtime
+    - azureml-core
+    - --extra-index-url https://azuremlsdktestpypi.azureedge.net/sdk-cli-v2
+    - nlp-feature-extractors==0.0.3
+    - https://publictestdatasets.blob.core.windows.net/packages/pypi/responsibleai-text/responsibleai_text-0.0.7-py3-none-any.whl
+    - https://publictestdatasets.blob.core.windows.net/packages/pypi/azureml-model-serializer/azureml_model_serializer-0.0.2-py3-none-any.whl
+    - click<8.0.0
+    - mltable==0.1.0b3
+    - transformers>=4.17.0
+    - ml-wrappers==0.2.2

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/environment.yaml
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/environment.yaml
@@ -1,0 +1,29 @@
+image:
+  name: azureml/curated/responsibleai-text-ubuntu20.04-py38-cpu
+  os: linux
+  context:
+    dir: context
+    dockerfile: Dockerfile
+    template_files:
+    - Dockerfile
+    - conda_dependencies.yaml
+  publish:
+    location: mcr
+    visibility: public
+environment:
+  metadata:
+    MachineLearningFramework:
+      name: ResponsibleAI
+      version: "0.22"
+    Mpi:
+      name: OpenMpi
+      version: "4.1.0"
+    Purpose:
+      HasTrainingSupport: true
+      HasInferencingSupport: false
+    Runtime:
+      name: Python
+      version: "3.8"
+    Os:
+      name: Ubuntu
+      version: "20.04"

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/spec.yaml
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/spec.yaml
@@ -1,0 +1,18 @@
+$schema: https://azuremlschemas.azureedge.net/latest/environment.schema.json
+
+description: >-
+  AzureML Responsible AI Text environment.
+
+name: "{{asset.name}}"
+version: "{{asset.version}}"
+
+build:
+  path: "{{asset.repo.url}}#{{asset.repo.commit_hash}}:{{asset.repo.build_context.path}}"
+  dockerfile_path: "{{image.dockerfile.path}}"
+
+os_type: linux
+
+tags:
+  OS: Ubuntu20.04
+  Training: ""
+  Preview: ""

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/requirements.txt
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/requirements.txt
@@ -1,0 +1,3 @@
+azure-ai-ml==0.1.0b4
+azure.identity==1.10.0
+azureml-core==1.43.0

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/responsibleai_text_sample_test.py
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/responsibleai_text_sample_test.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests running a sample job in the responsibleai text environment."""
+import os
+import time
+from pathlib import Path
+from azure.ai.ml import MLClient
+from azure.ai.ml import command
+from azure.ai.ml.entities import Environment, BuildContext
+from azure.identity import AzureCliCredential
+
+BUILD_CONTEXT = Path("../context")
+JOB_SOURCE_CODE = "src"
+TIMEOUT_MINUTES = os.environ.get("timeout_minutes", 30)
+
+
+def test_responsibleai_text():
+    """Tests a sample job using responsibleai text image as the environment."""
+    this_dir = Path(__file__).parent
+
+    subscription_id = os.environ.get("subscription_id")
+    resource_group = os.environ.get("resource_group")
+    workspace_name = os.environ.get("workspace")
+
+    ml_client = MLClient(
+        AzureCliCredential(), subscription_id, resource_group, workspace_name
+    )
+
+    env_name = "responsibleai-text"
+
+    env_docker_context = Environment(
+        build=BuildContext(path=this_dir / BUILD_CONTEXT),
+        name=env_name,
+        description="ResponsibleAI Text environment created from a Docker context.",
+    )
+    ml_client.environments.create_or_update(env_docker_context)
+
+    # create the command
+    job = command(
+        code=this_dir / JOB_SOURCE_CODE,  # local path where the code is stored
+        command="python main.py",
+        environment=f"{env_name}@latest",
+        compute=os.environ.get("cpu_cluster"),
+        display_name="responsibleai-text-example",
+        description="A test run of the responsibleai text curated environment",
+        experiment_name="responsibleaiTextExperiment"
+    )
+
+    returned_job = ml_client.create_or_update(job)
+    assert returned_job is not None
+
+    # Poll until final status is reached, or timed out
+    timeout = time.time() + (TIMEOUT_MINUTES * 60)
+    while time.time() <= timeout:
+        current_status = ml_client.jobs.get(returned_job.name).status
+        if current_status in ["Completed", "Failed"]:
+            break
+        time.sleep(30)  # sleep 30 seconds
+
+    assert current_status == "Completed"

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/src/main.py
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/src/main.py
@@ -1,0 +1,107 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Validate running RAITextInsights using responsibleai text docker image."""
+
+import pandas as pd
+
+import datasets
+import zipfile
+from transformers import (AutoModelForSequenceClassification, AutoTokenizer,
+                          pipeline)
+from raiutils.common.retries import retry_function
+from responsibleai_text import RAITextInsights, ModelTask
+
+from spacy.cli import download
+
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
+LABELS = 'labels'
+DBPEDIA_MODEL_NAME = "dbpedia_model"
+NUM_LABELS = 9
+
+
+def load_dataset(split):
+    dataset = datasets.load_dataset("DeveloperOats/DBPedia_Classes", split=split)
+    return pd.DataFrame({"text": dataset["text"], "label": dataset["l1"]})
+
+
+class FetchModel(object):
+    def __init__(self):
+        pass
+
+    def fetch(self):
+        zipfilename = DBPEDIA_MODEL_NAME + '.zip'
+        url = ('https://publictestdatasets.blob.core.windows.net/models/' +
+               DBPEDIA_MODEL_NAME + '.zip')
+        urlretrieve(url, zipfilename)
+        with zipfile.ZipFile(zipfilename, 'r') as unzip:
+            unzip.extractall(DBPEDIA_MODEL_NAME)
+
+
+def retrieve_dbpedia_model():
+    fetcher = FetchModel()
+    action_name = "Model download"
+    err_msg = "Failed to download model"
+    max_retries = 4
+    retry_delay = 60
+    retry_function(fetcher.fetch, action_name, err_msg,
+                   max_retries=max_retries,
+                   retry_delay=retry_delay)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        DBPEDIA_MODEL_NAME, num_labels=NUM_LABELS)
+    return model
+
+
+def main():
+    """Retrieve model and then run RAITextInsights."""
+    NUM_TEST_SAMPLES = 100
+
+    print(download("en_core_web_sm"))
+
+    pd_data = load_dataset("train")
+    pd_valid_data = load_dataset("test")
+
+    train_data = pd_data[NUM_TEST_SAMPLES:]
+    test_data = pd_valid_data[:NUM_TEST_SAMPLES]
+
+    model = retrieve_dbpedia_model()
+
+    # load the model and tokenizer
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+
+    device = -1
+    if device >= 0:
+        model = model.cuda()
+
+    # build a pipeline object to do predictions
+    pred = pipeline(
+        "text-classification",
+        model=model,
+        tokenizer=tokenizer,
+        device=device,
+        return_all_scores=True
+    )
+
+    encoded_classes = ['Agent', 'Device', 'Event', 'Place', 'Species',
+                       'SportsSeason', 'TopicalConcept', 'UnitOfWork',
+                       'Work']
+
+    rai_insights = RAITextInsights(pred, train_data, test_data,
+                                   "label",
+                                   classes=encoded_classes,
+                                   task_type=ModelTask.TEXT_CLASSIFICATION)
+
+    rai_insights.error_analysis.add()
+    rai_insights.compute()
+
+    print(rai_insights.error_analysis.get())
+
+
+# run script
+if __name__ == "__main__":
+    # run main function
+    main()

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/asset.yaml
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/asset.yaml
@@ -1,0 +1,10 @@
+name: responsibleai-vision-ubuntu20.04-py38-cpu
+version: auto
+type: environment
+spec: spec.yaml
+extra_config: environment.yaml
+test:
+  pytest:
+    enabled: true 
+    pip_requirements: tests/requirements.txt
+    tests_dir: tests

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
+
+# Install OpenCV native dependencies
+RUN apt-get update
+RUN apt-get install -y ffmpeg libsm6 libxext6 && \
+    apt-get install -y python3-opencv
+
+ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-vision
+
+# Prepend path to AzureML conda environment
+ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
+
+# Create conda environment
+COPY conda_dependencies.yaml .
+RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
+    rm conda_dependencies.yaml && \
+    conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
+    conda clean -a -y
+
+RUN pip install --pre 'azure-ai-ml'
+
+# This is needed for mpi to locate libpython
+ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -1,0 +1,34 @@
+name: responsibleai-vision
+channels:
+  - conda-forge
+  - anaconda
+  - pytorch
+dependencies:
+  - python=3.8
+  - pip=22.1.2
+  - pytorch
+  - torchvision
+  - cpuonly
+  - pip:
+    - numpy
+    - pandas
+    - pyarrow
+    - scikit-learn
+    - azure-core==1.25.1
+    - mlflow
+    - responsibleai~=0.22.0
+    - raiwidgets~=0.22.0
+    # Limit markupsafe version is a workaround to resolve the issue from markupsafe's breaking change: https://github.com/aws/aws-sam-cli/issues/3661
+    - markupsafe<2.1.0
+    # Workaround to fix import failure related to itsdangerous's latest release: https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous
+    - itsdangerous==2.0.1
+    - azureml-dataset-runtime
+    - azureml-core
+    - azureml-mlflow
+    - https://publictestdatasets.blob.core.windows.net/packages/pypi/responsibleai-vision/responsibleai_vision-0.0.8-py3-none-any.whl
+    - https://publictestdatasets.blob.core.windows.net/packages/pypi/azureml-model-serializer/azureml_model_serializer-0.0.2-py3-none-any.whl
+    - click<8.0.0
+    - mltable==0.1.0b3
+    - ml-wrappers==0.2.2
+    - fastai
+    - opencv-python

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/environment.yaml
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/environment.yaml
@@ -1,0 +1,29 @@
+image:
+  name: azureml/curated/responsibleai-vision-ubuntu20.04-py38-cpu
+  os: linux
+  context:
+    dir: context
+    dockerfile: Dockerfile
+    template_files:
+    - Dockerfile
+    - conda_dependencies.yaml
+  publish:
+    location: mcr
+    visibility: public
+environment:
+  metadata:
+    MachineLearningFramework:
+      name: ResponsibleAI
+      version: "0.22"
+    Mpi:
+      name: OpenMpi
+      version: "4.1.0"
+    Purpose:
+      HasTrainingSupport: true
+      HasInferencingSupport: false
+    Runtime:
+      name: Python
+      version: "3.8"
+    Os:
+      name: Ubuntu
+      version: "20.04"

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/spec.yaml
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/spec.yaml
@@ -1,0 +1,18 @@
+$schema: https://azuremlschemas.azureedge.net/latest/environment.schema.json
+
+description: >-
+  AzureML Responsible AI Vision environment.
+
+name: "{{asset.name}}"
+version: "{{asset.version}}"
+
+build:
+  path: "{{asset.repo.url}}#{{asset.repo.commit_hash}}:{{asset.repo.build_context.path}}"
+  dockerfile_path: "{{image.dockerfile.path}}"
+
+os_type: linux
+
+tags:
+  OS: Ubuntu20.04
+  Training: ""
+  Preview: ""

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/tests/requirements.txt
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/tests/requirements.txt
@@ -1,0 +1,3 @@
+azure-ai-ml==0.1.0b4
+azure.identity==1.10.0
+azureml-core==1.43.0

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/tests/responsibleai_vision_sample_test.py
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/tests/responsibleai_vision_sample_test.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests running a sample job in the responsibleai vision environment."""
+import os
+import time
+from pathlib import Path
+from azure.ai.ml import MLClient
+from azure.ai.ml import command
+from azure.ai.ml.entities import Environment, BuildContext
+from azure.identity import AzureCliCredential
+
+BUILD_CONTEXT = Path("../context")
+JOB_SOURCE_CODE = "src"
+TIMEOUT_MINUTES = os.environ.get("timeout_minutes", 30)
+
+
+def test_responsibleai_vision():
+    """Tests a sample job using responsibleai vision image as the environment."""
+    this_dir = Path(__file__).parent
+
+    subscription_id = os.environ.get("subscription_id")
+    resource_group = os.environ.get("resource_group")
+    workspace_name = os.environ.get("workspace")
+
+    ml_client = MLClient(
+        AzureCliCredential(), subscription_id, resource_group, workspace_name
+    )
+
+    env_name = "responsibleai-vision"
+
+    env_docker_context = Environment(
+        build=BuildContext(path=this_dir / BUILD_CONTEXT),
+        name=env_name,
+        description="ResponsibleAI Vision environment created from a Docker context.",
+    )
+    ml_client.environments.create_or_update(env_docker_context)
+
+    # create the command
+    job = command(
+        code=this_dir / JOB_SOURCE_CODE,  # local path where the code is stored
+        command="python main.py",
+        environment=f"{env_name}@latest",
+        compute=os.environ.get("cpu_cluster"),
+        display_name="responsibleai-vision-example",
+        description="A test run of the responsibleai vision curated environment",
+        experiment_name="responsibleaiVisionExperiment"
+    )
+
+    returned_job = ml_client.create_or_update(job)
+    assert returned_job is not None
+
+    # Poll until final status is reached, or timed out
+    timeout = time.time() + (TIMEOUT_MINUTES * 60)
+    while time.time() <= timeout:
+        current_status = ml_client.jobs.get(returned_job.name).status
+        if current_status in ["Completed", "Failed"]:
+            break
+        time.sleep(30)  # sleep 30 seconds
+
+    assert current_status == "Completed"

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/tests/src/main.py
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/tests/src/main.py
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Validate running RAIVisionInsights using responsibleai vision docker image."""
+
+import os
+import sys
+from zipfile import ZipFile
+import pandas as pd
+from responsibleai_vision import ModelTask, RAIVisionInsights
+from responsibleai_vision.common.constants import ImageColumns
+from fastai.learner import load_learner
+from raiutils.common.retries import retry_function
+
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
+
+EPOCHS = 10
+LEARNING_RATE = 1e-4
+IM_SIZE = 300
+BATCH_SIZE = 16
+FRIDGE_MODEL_NAME = 'fridge_model'
+FRIDGE_MODEL_WINDOWS_NAME = 'fridge_model_windows'
+WIN = 'win'
+
+
+def load_fridge_dataset():
+    # create data folder if it doesnt exist.
+    os.makedirs("data", exist_ok=True)
+
+    # download data
+    download_url = ("https://cvbp-secondary.z19.web.core.windows.net/" +
+                    "datasets/image_classification/fridgeObjects.zip")
+    data_file = "./data/fridgeObjects.zip"
+    urlretrieve(download_url, filename=data_file)
+
+    # extract files
+    with ZipFile(data_file, "r") as zip:
+        print("extracting files...")
+        zip.extractall(path="./data")
+        print("done")
+    # delete zip file
+    os.remove(data_file)
+    # get all file names into a pandas dataframe with the labels
+    data = pd.DataFrame(columns=[ImageColumns.IMAGE.value,
+                                 ImageColumns.LABEL.value])
+    for folder in os.listdir("./data/fridgeObjects"):
+        for file in os.listdir("./data/fridgeObjects/" + folder):
+            image_path = "./data/fridgeObjects/" + folder + "/" + file
+            data = data.append({ImageColumns.IMAGE.value: image_path,
+                                ImageColumns.LABEL.value: folder},
+                               ignore_index=True)
+    return data
+
+
+class FetchModel(object):
+    def __init__(self):
+        pass
+
+    def fetch(self):
+        if sys.platform.startswith(WIN):
+            model_name = FRIDGE_MODEL_WINDOWS_NAME
+        else:
+            model_name = FRIDGE_MODEL_NAME
+        url = ('https://publictestdatasets.blob.core.windows.net/models/' +
+               model_name)
+        urlretrieve(url, FRIDGE_MODEL_NAME)
+
+
+def retrieve_fridge_model():
+    fetcher = FetchModel()
+    action_name = "Model download"
+    err_msg = "Failed to download model"
+    max_retries = 4
+    retry_delay = 60
+    retry_function(fetcher.fetch, action_name, err_msg,
+                   max_retries=max_retries,
+                   retry_delay=retry_delay)
+    model = load_learner(FRIDGE_MODEL_NAME)
+    return model
+
+
+def main():
+    """Retrieve model and then run RAIVisionInsights."""
+    data = load_fridge_dataset()
+    model = retrieve_fridge_model()
+
+    train_data = data
+    test_data = data
+    class_names = data[ImageColumns.LABEL.value].unique()
+
+    rai_insights = RAIVisionInsights(model, train_data, test_data,
+                                     "label",
+                                     task_type=ModelTask.IMAGE_CLASSIFICATION,
+                                     classes=class_names)
+    rai_insights.compute()
+
+
+# run script
+if __name__ == "__main__":
+    # run main function
+    main()


### PR DESCRIPTION
Add image files for ResponsibleAI Text and Vision scenarios for large language models (ie GPT3) and computer vision models.
Also adds tests which use RAITextInsights and RAIVisionInsights in the environment definitions.