### PR TITLE
add text and vision dpv2 components, jobs and tests to azureml-assets

### DIFF
--- a/responsibleai/tests.yml
+++ b/responsibleai/tests.yml
@@ -5,4 +5,17 @@ tabular_rai_insight:
     raiinsight_pipeline:
       pre: "./tabular/jobs/prepare.py"
       job: "./tabular/jobs/pipeline_boston_analyze.yml"
-      
+text_rai_insight:
+  includes:
+    - "./text/jobs/"
+  jobs:
+    raitextinsight_pipeline:
+      pre: "./text/jobs/prepare.py"
+      job: "./text/jobs/pipeline_dbpedia_analyze.yml"
+vision_rai_insight:
+  includes:
+    - "./vision/jobs/"
+  jobs:
+    raivisioninsight_pipeline:
+      pre: "./vision/jobs/prepare.py"
+      job: "./vision/jobs/pipeline_fridge_analyze.yml"

--- a/responsibleai/text/components/rai_text_insights/asset.yaml
+++ b/responsibleai/text/components/rai_text_insights/asset.yaml
@@ -1,0 +1,2 @@
+type: component
+spec: spec.yaml

--- a/responsibleai/text/components/rai_text_insights/spec.yaml
+++ b/responsibleai/text/components/rai_text_insights/spec.yaml
@@ -1,0 +1,54 @@
+$schema: http://azureml/sdk-2-0/CommandComponent.json
+name: rai_text_insights
+display_name: RAI Text Insights
+version: 0.0.1.preview
+type: command
+inputs:
+  task_type:
+    type: string # [text_classification]
+    enum: ['text_classification']
+  model_input: # mlflow model name:version
+    type: mlflow_model
+    optional: false
+  model_info:
+    type: string # model name:version
+    optional: false
+  train_dataset:
+    type: mltable
+  test_dataset:
+    type: mltable
+  target_column_name:
+    type: string
+  maximum_rows_for_test_dataset:
+    type: integer
+    default: 5000
+  classes:
+    type: string # Optional[List[str]]
+    default: '[]'
+  enable_explanation:
+    type: boolean
+    default: True
+  enable_error_analysis:
+    type: boolean
+    default: True
+outputs:
+  dashboard:
+    type: path
+  ux_json:
+    type: path
+code: ../src/
+environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/1
+command: >-
+  python ./rai_text_insights.py
+  --task_type ${{inputs.task_type}}
+  --model_input '${{inputs.model_input}}'
+  --model_info '${{inputs.model_info}}'
+  --train_dataset ${{inputs.train_dataset}}
+  --test_dataset ${{inputs.test_dataset}}
+  --target_column_name ${{inputs.target_column_name}}
+  --maximum_rows_for_test_dataset ${{inputs.maximum_rows_for_test_dataset}}
+  --classes ${{inputs.classes}}
+  --enable_explanation ${{inputs.enable_explanation}}
+  --enable_error_analysis ${{inputs.enable_error_analysis}}
+  --dashboard ${{outputs.dashboard}}
+  --ux_json ${{outputs.ux_json}}

--- a/responsibleai/text/components/src/rai_text_insights.py
+++ b/responsibleai/text/components/src/rai_text_insights.py
@@ -1,0 +1,329 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import logging
+import json
+import os
+
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import mltable
+
+from azureml.core import Run
+
+import pandas as pd
+
+from spacy.cli import download
+
+from responsibleai import __version__ as responsibleai_version
+
+from responsibleai_text import (
+    RAITextInsights,
+    __version__ as responsibleai_text_version,
+)
+from raiutils.data_processing import serialize_json_safe
+
+from azureml_model_serializer import ModelSerializer
+
+print(download("en_core_web_sm"))
+
+_logger = logging.getLogger(__file__)
+logging.basicConfig(level=logging.INFO)
+
+
+TEXT_DATA_TYPE = "text"
+
+
+class DashboardInfo:
+    MODEL_ID_KEY = "id"  # To match Model schema
+    MODEL_INFO_FILENAME = "model_info.json"
+    TRAIN_FILES_DIR = "train"
+    TEST_FILES_DIR = "test"
+
+    RAI_INSIGHTS_MODEL_ID_KEY = "model_id"
+    RAI_INSIGHTS_RUN_ID_KEY = "rai_insights_parent_run_id"
+    RAI_INSIGHTS_CONSTRUCTOR_ARGS_KEY = "constructor_args"
+    RAI_INSIGHTS_PARENT_FILENAME = "rai_insights.json"
+
+
+class PropertyKeyValues:
+    # The property to indicate the type of Run
+    RAI_INSIGHTS_TYPE_KEY = "_azureml.responsibleai.rai_insights.type"
+    RAI_INSIGHTS_TYPE_CONSTRUCT = "construction"
+    RAI_INSIGHTS_TYPE_CAUSAL = "causal"
+    RAI_INSIGHTS_TYPE_COUNTERFACTUAL = "counterfactual"
+    RAI_INSIGHTS_TYPE_EXPLANATION = "explanation"
+    RAI_INSIGHTS_TYPE_ERROR_ANALYSIS = "error_analysis"
+    RAI_INSIGHTS_TYPE_GATHER = "gather"
+
+    # Property to point at the model under examination
+    RAI_INSIGHTS_MODEL_ID_KEY = "_azureml.responsibleai.rai_insights.model_id"
+
+    # Property for tool runs to point at their constructor run
+    RAI_INSIGHTS_CONSTRUCTOR_RUN_ID_KEY = (
+        "_azureml.responsibleai.rai_insights.constructor_run"
+    )
+
+    # Property to record responsibleai version
+    RAI_INSIGHTS_RESPONSIBLEAI_VERSION_KEY = (
+        "_azureml.responsibleai.rai_insights.responsibleai_version"
+    )
+
+    # Property format to indicate presence of a tool
+    RAI_INSIGHTS_TOOL_KEY_FORMAT = \
+        "_azureml.responsibleai.rai_insights.has_{0}"
+
+    RAI_INSIGHTS_TEXT_VERSION_KEY = "responsibleai_text_version"
+
+    RAI_INSIGHTS_DATA_TYPE_KEY = (
+        "_azureml.responsibleai.rai_insights.data_type"
+    )
+
+
+class RAIToolType:
+    CAUSAL = "causal"
+    COUNTERFACTUAL = "counterfactual"
+    ERROR_ANALYSIS = "error_analysis"
+    EXPLANATION = "explanation"
+
+
+def boolean_parser(target: str) -> bool:
+    true_values = ["True", "true"]
+    false_values = ["False", "false"]
+    if target in true_values:
+        return True
+    if target in false_values:
+        return False
+    raise ValueError("Failed to parse to boolean: {target}")
+
+
+def parse_args():
+    # setup arg parser
+    parser = argparse.ArgumentParser()
+
+    # add arguments
+    parser.add_argument(
+        "--task_type", type=str, required=True, choices=["text_classification"]
+    )
+
+    parser.add_argument(
+        "--model_input", type=str, help="model local path on remote",
+        required=True
+    )
+
+    parser.add_argument(
+        "--model_info", type=str, help="name:version", required=True
+    )
+
+    parser.add_argument("--train_dataset", type=str, required=True)
+    parser.add_argument("--test_dataset", type=str, required=True)
+
+    parser.add_argument("--target_column_name", type=str, required=True)
+
+    parser.add_argument("--maximum_rows_for_test_dataset", type=int,
+                        default=5000)
+    parser.add_argument(
+        "--categorical_column_names", type=str, help="Optional[List[str]]"
+    )
+
+    parser.add_argument("--classes", type=str, help="Optional[List[str]]")
+
+    # Explanations
+    parser.add_argument("--enable_explanation", type=boolean_parser)
+
+    # Error analysis
+    parser.add_argument("--enable_error_analysis", type=boolean_parser)
+
+    # Outputs
+    parser.add_argument("--dashboard", type=str, required=True)
+    parser.add_argument("--ux_json", type=str, required=True)
+
+    # parse args
+    args = parser.parse_args()
+
+    # return args
+    return args
+
+
+def get_from_args(args, arg_name: str, custom_parser, allow_none: bool) -> Any:
+    _logger.info("Looking for command line argument '{0}'".format(arg_name))
+    result = None
+
+    extracted = getattr(args, arg_name)
+    if extracted is None and not allow_none:
+        raise ValueError("Required argument {0} missing".format(arg_name))
+
+    if custom_parser:
+        if extracted is not None:
+            result = custom_parser(extracted)
+    else:
+        result = extracted
+
+    _logger.info("{0}: {1}".format(arg_name, result))
+
+    return result
+
+
+def json_empty_is_none_parser(target: str) -> Union[Dict, List]:
+    parsed = json.loads(target)
+    if len(parsed) == 0:
+        return None
+    else:
+        return parsed
+
+
+def load_mltable(mltable_path: str) -> pd.DataFrame:
+    _logger.info("Loading MLTable: {0}".format(mltable_path))
+    df: pd.DataFrame = None
+    try:
+        tbl = mltable.load(mltable_path)
+        df: pd.DataFrame = tbl.to_pandas_dataframe()
+    except Exception as e:
+        _logger.info("Failed to load MLTable")
+        _logger.info(e)
+    return df
+
+
+def load_parquet(parquet_path: str) -> pd.DataFrame:
+    _logger.info("Loading parquet file: {0}".format(parquet_path))
+    df = pd.read_parquet(parquet_path)
+    return df
+
+
+def load_dataset(dataset_path: str) -> pd.DataFrame:
+    _logger.info(f"Attempting to load: {dataset_path}")
+    df = load_mltable(dataset_path)
+    if df is None:
+        df = load_parquet(dataset_path)
+    print(df.dtypes)
+    print(df.head(10))
+    return df
+
+
+def fetch_model_id(model_info_path: str):
+    model_info_path = os.path.join(model_info_path,
+                                   DashboardInfo.MODEL_INFO_FILENAME)
+    with open(model_info_path, "r") as json_file:
+        model_info = json.load(json_file)
+    return model_info[DashboardInfo.MODEL_ID_KEY]
+
+
+def add_properties_to_gather_run(
+    dashboard_info: Dict[str, str], tool_present_dict: Dict[str, str]
+):
+    _logger.info("Adding properties to the gather run")
+    gather_run = Run.get_context()
+
+    run_properties = {
+        PropertyKeyValues.RAI_INSIGHTS_TYPE_KEY:
+            PropertyKeyValues.RAI_INSIGHTS_TYPE_GATHER,
+        PropertyKeyValues.RAI_INSIGHTS_RESPONSIBLEAI_VERSION_KEY:
+            responsibleai_version,
+        PropertyKeyValues.RAI_INSIGHTS_TEXT_VERSION_KEY:
+            responsibleai_text_version,
+        PropertyKeyValues.RAI_INSIGHTS_MODEL_ID_KEY: dashboard_info[
+            DashboardInfo.RAI_INSIGHTS_MODEL_ID_KEY
+        ],
+        PropertyKeyValues.RAI_INSIGHTS_DATA_TYPE_KEY:
+            TEXT_DATA_TYPE
+    }
+
+    _logger.info("Appending tool present information")
+    for k, v in tool_present_dict.items():
+        key = PropertyKeyValues.RAI_INSIGHTS_TOOL_KEY_FORMAT.format(k)
+        run_properties[key] = str(v)
+
+    _logger.info("Making service call")
+    gather_run.add_properties(run_properties)
+    _logger.info("Properties added to gather run")
+
+
+def main(args):
+    _logger.info("Dealing with initialization dataset")
+    train_df = load_dataset(args.train_dataset)
+
+    _logger.info("Dealing with evaluation dataset")
+    test_df = load_dataset(args.test_dataset)
+
+    if args.model_input is None or args.model_info is None:
+        raise ValueError(
+            "Both model info and model input need to be supplied.")
+
+    model_id = args.model_info
+    _logger.info("Loading model: {0}".format(model_id))
+    my_run = Run.get_context()
+    workspace = my_run.experiment.workspace
+    model_serializer = ModelSerializer(model_id, workspace=workspace)
+    text_model = model_serializer.load("Ignored path")
+
+    _logger.info("Creating RAI Text Insights")
+    rai_ti = RAITextInsights(
+        model=text_model,
+        train=train_df,
+        test=test_df,
+        target_column=args.target_column_name,
+        task_type=args.task_type,
+        classes=get_from_args(
+            args, "classes", custom_parser=json_empty_is_none_parser,
+            allow_none=True
+        ),
+        maximum_rows_for_test=args.maximum_rows_for_test_dataset,
+        serializer=model_serializer,
+    )
+
+    included_tools: Dict[str, bool] = {
+        RAIToolType.CAUSAL: False,
+        RAIToolType.COUNTERFACTUAL: False,
+        RAIToolType.ERROR_ANALYSIS: False,
+        RAIToolType.EXPLANATION: False,
+    }
+
+    if args.enable_explanation:
+        _logger.info("Adding explanation")
+        rai_ti.explainer.add()
+        included_tools[RAIToolType.EXPLANATION] = True
+
+    if args.enable_error_analysis:
+        _logger.info("Adding error analysis")
+        rai_ti.error_analysis.add()
+        included_tools[RAIToolType.ERROR_ANALYSIS] = True
+
+    _logger.info("Starting computation")
+    rai_ti.compute()
+    _logger.info("Computation complete")
+
+    rai_ti.save(args.dashboard)
+    _logger.info("Saved dashboard to output")
+
+    rai_data = rai_ti.get_data()
+    rai_dict = serialize_json_safe(rai_data)
+    json_filename = "dashboard.json"
+    output_path = Path(args.ux_json) / json_filename
+    with open(output_path, "w") as json_file:
+        json.dump(rai_dict, json_file)
+    _logger.info("Dashboard JSON written")
+
+    dashboard_info = dict()
+    dashboard_info[DashboardInfo.RAI_INSIGHTS_MODEL_ID_KEY] = model_id
+
+    add_properties_to_gather_run(dashboard_info, included_tools)
+    _logger.info("Processing completed")
+
+
+# run script
+if __name__ == "__main__":
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")
+
+    # parse args
+    args = parse_args()
+
+    # run main function
+    main(args)
+
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")

--- a/responsibleai/text/jobs/fetch_dbpedia_model.yml
+++ b/responsibleai/text/jobs/fetch_dbpedia_model.yml
@@ -1,0 +1,25 @@
+$schema: http://azureml/sdk-2-0/CommandComponent.json
+name: fetch_dbpedia_for_rai
+display_name: Fetch model trained on DBPedia Dataset and register model for RAI
+version: 0.0.1.preview
+type: command
+inputs:
+  model_base_name:
+    type: string
+  model_name_suffix: # Set negative to use epoch_secs
+    type: integer
+    default: -1
+  device: # set to >= 0 to use GPU
+    type: integer
+    default: 0
+outputs:
+  model_output_path:
+    type: path
+code: ./src_dbpedia/
+environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/1
+command: >-
+  python fetch_text_model.py
+  --model_base_name ${{inputs.model_base_name}}
+  --model_name_suffix ${{inputs.model_name_suffix}}
+  --device ${{inputs.device}}
+  --model_output_path ${{outputs.model_output_path}}

--- a/responsibleai/text/jobs/pipeline_dbpedia_analyze.yml
+++ b/responsibleai/text/jobs/pipeline_dbpedia_analyze.yml
@@ -1,0 +1,36 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+experiment_name: dbpedia_analyze
+type: pipeline
+
+inputs:
+  dbpedia_model_info: dbpedia_model_1:1
+  my_training_data:
+    type: mltable
+    path: ./resources/dbpedia_train
+  my_test_data:
+    type: mltable
+    path: ./resources/dbpedia_test
+  target_column_name: label
+
+compute: azureml:cpu-cluster
+
+jobs:
+  analyse_model:
+    type: command
+    component: file:../components/rai_text_insights/spec.yaml
+    limits:
+      timeout: 120
+    inputs:
+      title: DBPedia Text Classification Analysis
+      task_type: text_classification
+      model_input:
+        type: mlflow_model
+        path: azureml:dbpedia_model_1:1
+      model_info: ${{parent.inputs.dbpedia_model_info}}
+      train_dataset: ${{parent.inputs.my_training_data}}
+      test_dataset: ${{parent.inputs.my_test_data}}
+      target_column_name: ${{parent.inputs.target_column_name}}
+      maximum_rows_for_test_dataset: 5000
+      classes: '[]'
+      enable_explanation: True
+      enable_error_analysis: True

--- a/responsibleai/text/jobs/prepare.py
+++ b/responsibleai/text/jobs/prepare.py
@@ -1,0 +1,141 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import datasets
+
+import os
+import pandas as pd
+from sklearn import preprocessing
+from azure.ai.ml.entities import AmlCompute, PipelineJob
+from azure.ai.ml import dsl, load_component, MLClient
+from azure.identity import DefaultAzureCredential
+import time
+
+try:
+    from azureml.core import Workspace
+    azureml_core_installed = True
+except ImportError:
+    print("azureml.core not found")
+    azureml_core_installed = False
+
+
+NUM_TEST_SAMPLES = 100
+
+
+def load_dataset(split):
+    dataset = datasets.load_dataset("DeveloperOats/DBPedia_Classes", split=split)
+    return pd.DataFrame({"text": dataset["text"], "l1": dataset["l1"]})
+
+
+def transform_dataset(le, dataset):
+    dataset["label"] = le.transform(dataset["l1"])
+    dataset = dataset.drop(columns="l1")
+    return dataset
+
+
+def fetch_and_write_dbpedia_dataset():
+    train_path = "./resources/dbpedia_train/"
+    test_path = "./resources/dbpedia_test/"
+
+    pd_data = load_dataset("train")
+    pd_test_data = load_dataset("test")
+    # encode the labels
+    encoded_classes = ['Agent', 'Device', 'Event', 'Place', 'Species',
+                       'SportsSeason', 'TopicalConcept', 'UnitOfWork',
+                       'Work']
+    le = preprocessing.LabelEncoder()
+    le.fit(encoded_classes)
+
+    pd_data = transform_dataset(le, pd_data)
+    pd_test_data = transform_dataset(le, pd_test_data)
+
+    train_data = pd_data[NUM_TEST_SAMPLES:]
+    test_data = pd_test_data[:NUM_TEST_SAMPLES]
+
+    # Add some known error instances to make the data more interesting
+    error_indices = [101, 319, 391, 414, 894, 1078, 1209]
+    error_data = pd_test_data.iloc[error_indices]
+    test_data = test_data.append(error_data)
+    test_data = test_data.reset_index(drop=True)
+
+    print("Saving to files")
+    train_data.to_parquet(os.path.join(train_path, "dbpedia_train.parquet"), index=False)
+    test_data.to_parquet(os.path.join(test_path, "dbpedia_test.parquet"), index=False)
+
+
+def submit_and_wait(ml_client, pipeline_job) -> PipelineJob:
+    created_job = ml_client.jobs.create_or_update(pipeline_job)
+    assert created_job is not None
+
+    while created_job.status not in ['Completed', 'Failed', 'Canceled', 'NotResponding']:
+        time.sleep(30)
+        created_job = ml_client.jobs.get(created_job.name)
+        print("Latest status : {0}".format(created_job.status))
+    assert created_job.status == 'Completed'
+    return created_job
+
+
+def submit_training_job():
+    credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
+    try:
+        ml_client = MLClient.from_config(credential=credential,
+                                         logging_enable=True)
+    except Exception:
+        if not azureml_core_installed:
+            print("failed to load azureml.core and mlclient")
+            raise
+        # In case of exception due to config missing, try to get and create config, which may work if in compute instance
+        workspace = Workspace.from_config()
+        workspace.write_config()
+        ml_client = MLClient.from_config(credential=credential,
+                                         logging_enable=True)
+    yaml_filename = "fetch_dbpedia_model.yml"
+    fetch_model_component = load_component(
+        source=yaml_filename
+    )
+
+    compute_name = "cpu-cluster"
+    all_compute_names = [x.name for x in ml_client.compute.list()]
+
+    if compute_name in all_compute_names:
+        print(f"Found existing compute: {compute_name}")
+    else:
+        my_compute = AmlCompute(
+            name=compute_name,
+            size="STANDARD_DS3_V2",
+            min_instances=0,
+            max_instances=4,
+            idle_time_before_scale_down=3600
+        )
+        ml_client.compute.begin_create_or_update(my_compute)
+        print("Initiated compute creation")
+
+    ml_client.components.create_or_update(fetch_model_component)
+
+    model_base_name = "dbpedia_model"
+    model_name_suffix = "1"
+    device = "-1"
+
+    @dsl.pipeline(
+        compute=compute_name,
+        description="Fetch DBPedia Model",
+        experiment_name=f"Fetch_DBPedia_Model_{model_name_suffix}",
+    )
+    def my_training_pipeline(model_base_name, model_name_suffix, device):
+        trained_model = fetch_model_component(
+            model_base_name=model_base_name,
+            model_name_suffix=model_name_suffix,
+            device=device
+        )
+        trained_model.set_limits(timeout=120)
+
+        return {}
+    model_registration_pipeline_job = my_training_pipeline(
+        model_base_name, model_name_suffix, device)
+
+    # This is the actual submission
+    submit_and_wait(ml_client, model_registration_pipeline_job)
+
+
+fetch_and_write_dbpedia_dataset()
+submit_training_job()

--- a/responsibleai/text/jobs/resources/dbpedia_test/MLTable
+++ b/responsibleai/text/jobs/resources/dbpedia_test/MLTable
@@ -1,0 +1,6 @@
+$schema: http://azureml/sdk-2-0/MLTable.json
+type: mltable
+paths:
+  - file: ./dbpedia_test.parquet
+transformations:
+  - read_parquet

--- a/responsibleai/text/jobs/resources/dbpedia_train/MLTable
+++ b/responsibleai/text/jobs/resources/dbpedia_train/MLTable
@@ -1,0 +1,6 @@
+$schema: http://azureml/sdk-2-0/MLTable.json
+type: mltable
+paths:
+  - file: ./dbpedia_train.parquet
+transformations:
+  - read_parquet

--- a/responsibleai/text/jobs/src_dbpedia/fetch_text_model.py
+++ b/responsibleai/text/jobs/src_dbpedia/fetch_text_model.py
@@ -1,0 +1,158 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import logging
+import json
+import os
+import time
+
+
+import mlflow
+import mlflow.pyfunc
+
+import zipfile
+from azureml.core import Run
+
+from transformers import AutoModelForSequenceClassification, \
+    AutoTokenizer, pipeline
+
+from azureml_model_serializer import PyfuncModel
+from raiutils.common.retries import retry_function
+
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
+
+_logger = logging.getLogger(__file__)
+logging.basicConfig(level=logging.INFO)
+
+
+DBPEDIA_MODEL_NAME = "dbpedia_model"
+NUM_LABELS = 9
+
+
+def parse_args():
+    # setup arg parser
+    parser = argparse.ArgumentParser()
+
+    # add arguments
+    parser.add_argument(
+        "--model_output_path", type=str, help="Path to write model info JSON"
+    )
+    parser.add_argument(
+        "--model_base_name", type=str, help="Name of the registered model"
+    )
+    parser.add_argument(
+        "--model_name_suffix", type=int, help="Set negative to use epoch_secs"
+    )
+    parser.add_argument(
+        "--device", type=int, help=(
+            "Device for CPU/GPU supports. Setting this to -1 will leverage "
+            "CPU, >=0 will run the model on the associated CUDA device id.")
+    )
+
+    # parse args
+    args = parser.parse_args()
+
+    # return args
+    return args
+
+
+class FetchModel(object):
+    def __init__(self):
+        pass
+
+    def fetch(self):
+        zipfilename = DBPEDIA_MODEL_NAME + '.zip'
+        url = ('https://publictestdatasets.blob.core.windows.net/models/' +
+               DBPEDIA_MODEL_NAME + '.zip')
+        urlretrieve(url, zipfilename)
+        with zipfile.ZipFile(zipfilename, 'r') as unzip:
+            unzip.extractall(DBPEDIA_MODEL_NAME)
+
+
+def retrieve_dbpedia_model():
+    fetcher = FetchModel()
+    action_name = "Model download"
+    err_msg = "Failed to download model"
+    max_retries = 4
+    retry_delay = 60
+    retry_function(fetcher.fetch, action_name, err_msg,
+                   max_retries=max_retries,
+                   retry_delay=retry_delay)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        DBPEDIA_MODEL_NAME, num_labels=NUM_LABELS)
+    return model
+
+
+def main(args):
+    current_experiment = Run.get_context().experiment
+    tracking_uri = current_experiment.workspace.get_mlflow_tracking_uri()
+    _logger.info("tracking_uri: {0}".format(tracking_uri))
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment(current_experiment.name)
+
+    _logger.info("Getting device")
+    device = args.device
+
+    _logger.info("Loading parquet input")
+
+    # load the model and tokenizer
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+    model = retrieve_dbpedia_model()
+
+    if device >= 0:
+        model = model.cuda()
+
+    # build a pipeline object to do predictions
+    _logger.info("Buildling model")
+    pred = pipeline(
+        "text-classification",
+        model=model,
+        tokenizer=tokenizer,
+        device=device,
+        return_all_scores=True
+    )
+
+    if args.model_name_suffix < 0:
+        suffix = int(time.time())
+    else:
+        suffix = args.model_name_suffix
+    registered_name = "{0}_{1}".format(args.model_base_name, suffix)
+    _logger.info(f"Registering model as {registered_name}")
+
+    my_mlflow = PyfuncModel(pred)
+
+    # Saving model with mlflow
+    _logger.info("Saving with mlflow")
+    mlflow.pyfunc.log_model(
+        python_model=my_mlflow,
+        registered_model_name=registered_name,
+        artifact_path=registered_name,
+    )
+
+    _logger.info("Writing JSON")
+    model_info = {"id": "{0}:1".format(registered_name)}
+    output_path = os.path.join(args.model_output_path, "model_info.json")
+    with open(output_path, "w") as of:
+        json.dump(model_info, fp=of)
+
+
+# run script
+if __name__ == "__main__":
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")
+
+    # parse args
+    args = parse_args()
+
+    # run main function
+    main(args)
+
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")

--- a/responsibleai/vision/components/rai_vision_insights/asset.yaml
+++ b/responsibleai/vision/components/rai_vision_insights/asset.yaml
@@ -1,0 +1,2 @@
+type: component
+spec: spec.yaml

--- a/responsibleai/vision/components/rai_vision_insights/spec.yaml
+++ b/responsibleai/vision/components/rai_vision_insights/spec.yaml
@@ -1,0 +1,54 @@
+$schema: http://azureml/sdk-2-0/CommandComponent.json
+name: rai_vision_insights
+display_name: RAI Vision Insights
+version: 0.0.1.preview
+type: command
+inputs:
+  task_type:
+    type: string
+    enum: ['image_classification']
+  model_input: # mlflow model name:version
+    type: mlflow_model
+    optional: false
+  model_info:
+    type: string # model name:version
+    optional: false
+  train_dataset:
+    type: mltable
+  test_dataset:
+    type: mltable
+  target_column_name:
+    type: string
+  maximum_rows_for_test_dataset:
+    type: integer
+    default: 5000
+  classes:
+    type: string # Optional[List[str]]
+    default: '[]'
+  precompute_explanation:
+    type: boolean
+    default: True
+  model_type:
+    type: string
+    enum: ['pyfunc', 'fastai']
+outputs:
+  dashboard:
+    type: path
+  ux_json:
+    type: path
+code: ../src
+environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/1
+command: >-
+  python ./rai_vision_insights.py
+  --task_type ${{inputs.task_type}}
+  --model_input '${{inputs.model_input}}'
+  --model_info '${{inputs.model_info}}'
+  --train_dataset ${{inputs.train_dataset}}
+  --test_dataset ${{inputs.test_dataset}}
+  --target_column_name ${{inputs.target_column_name}}
+  --maximum_rows_for_test_dataset ${{inputs.maximum_rows_for_test_dataset}}
+  --classes ${{inputs.classes}}
+  --precompute_explanation ${{inputs.precompute_explanation}}
+  --model_type ${{inputs.model_type}}
+  --dashboard ${{outputs.dashboard}}
+  --ux_json ${{outputs.ux_json}}

--- a/responsibleai/vision/components/src/rai_vision_insights.py
+++ b/responsibleai/vision/components/src/rai_vision_insights.py
@@ -1,0 +1,328 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import logging
+import json
+import os
+
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import mltable
+
+from azureml.core import Run
+
+import pandas as pd
+
+from spacy.cli import download
+
+from responsibleai import __version__ as responsibleai_version
+
+from responsibleai_vision import (
+    RAIVisionInsights,
+    __version__ as responsibleai_vision_version,
+)
+from raiutils.data_processing import serialize_json_safe
+
+from azureml_model_serializer import ModelSerializer
+
+print(download("en_core_web_sm"))
+
+_logger = logging.getLogger(__file__)
+logging.basicConfig(level=logging.INFO)
+
+
+IMAGE_DATA_TYPE = "image"
+
+
+class DashboardInfo:
+    MODEL_ID_KEY = "id"  # To match Model schema
+    MODEL_INFO_FILENAME = "model_info.json"
+    TRAIN_FILES_DIR = "train"
+    TEST_FILES_DIR = "test"
+
+    RAI_INSIGHTS_MODEL_ID_KEY = "model_id"
+    RAI_INSIGHTS_RUN_ID_KEY = "rai_insights_parent_run_id"
+    RAI_INSIGHTS_CONSTRUCTOR_ARGS_KEY = "constructor_args"
+    RAI_INSIGHTS_PARENT_FILENAME = "rai_insights.json"
+
+
+class PropertyKeyValues:
+    # The property to indicate the type of Run
+    RAI_INSIGHTS_TYPE_KEY = "_azureml.responsibleai.rai_insights.type"
+    RAI_INSIGHTS_TYPE_CONSTRUCT = "construction"
+    RAI_INSIGHTS_TYPE_CAUSAL = "causal"
+    RAI_INSIGHTS_TYPE_COUNTERFACTUAL = "counterfactual"
+    RAI_INSIGHTS_TYPE_EXPLANATION = "explanation"
+    RAI_INSIGHTS_TYPE_ERROR_ANALYSIS = "error_analysis"
+    RAI_INSIGHTS_TYPE_GATHER = "gather"
+
+    # Property to point at the model under examination
+    RAI_INSIGHTS_MODEL_ID_KEY = "_azureml.responsibleai.rai_insights.model_id"
+
+    # Property for tool runs to point at their constructor run
+    RAI_INSIGHTS_CONSTRUCTOR_RUN_ID_KEY = (
+        "_azureml.responsibleai.rai_insights.constructor_run"
+    )
+
+    # Property to record responsibleai version
+    RAI_INSIGHTS_RESPONSIBLEAI_VERSION_KEY = (
+        "_azureml.responsibleai.rai_insights.responsibleai_version"
+    )
+
+    # Property format to indicate presence of a tool
+    RAI_INSIGHTS_TOOL_KEY_FORMAT = \
+        "_azureml.responsibleai.rai_insights.has_{0}"
+
+    RAI_INSIGHTS_VISION_VERSION_KEY = "responsibleai_vision_version"
+
+    RAI_INSIGHTS_DATA_TYPE_KEY = (
+        "_azureml.responsibleai.rai_insights.data_type"
+    )
+
+
+class RAIToolType:
+    CAUSAL = "causal"
+    COUNTERFACTUAL = "counterfactual"
+    ERROR_ANALYSIS = "error_analysis"
+    EXPLANATION = "explanation"
+
+
+def boolean_parser(target: str) -> bool:
+    true_values = ["True", "true"]
+    false_values = ["False", "false"]
+    if target in true_values:
+        return True
+    if target in false_values:
+        return False
+    raise ValueError("Failed to parse to boolean: {target}")
+
+
+def parse_args():
+    # setup arg parser
+    parser = argparse.ArgumentParser()
+
+    # add arguments
+    parser.add_argument(
+        "--task_type", type=str, required=True,
+        choices=["image_classification"]
+    )
+
+    parser.add_argument(
+        "--model_input", type=str, help="model local path on remote",
+        required=True
+    )
+
+    parser.add_argument(
+        "--model_info", type=str, help="name:version", required=True
+    )
+
+    parser.add_argument("--train_dataset", type=str, required=True)
+    parser.add_argument("--test_dataset", type=str, required=True)
+
+    parser.add_argument("--target_column_name", type=str, required=True)
+
+    parser.add_argument("--maximum_rows_for_test_dataset", type=int,
+                        default=5000)
+    parser.add_argument(
+        "--categorical_column_names", type=str, help="Optional[List[str]]"
+    )
+
+    parser.add_argument("--classes", type=str, help="Optional[List[str]]")
+
+    # Explanations
+    parser.add_argument("--precompute_explanation", type=boolean_parser)
+
+    parser.add_argument(
+        "--model_type", type=str, required=True,
+        choices=["pyfunc", "fastai"]
+    )
+
+    # Outputs
+    parser.add_argument("--dashboard", type=str, required=True)
+    parser.add_argument("--ux_json", type=str, required=True)
+
+    # parse args
+    args = parser.parse_args()
+
+    # return args
+    return args
+
+
+def get_from_args(args, arg_name: str, custom_parser, allow_none: bool) -> Any:
+    _logger.info("Looking for command line argument '{0}'".format(arg_name))
+    result = None
+
+    extracted = getattr(args, arg_name)
+    if extracted is None and not allow_none:
+        raise ValueError("Required argument {0} missing".format(arg_name))
+
+    if custom_parser:
+        if extracted is not None:
+            result = custom_parser(extracted)
+    else:
+        result = extracted
+
+    _logger.info("{0}: {1}".format(arg_name, result))
+
+    return result
+
+
+def json_empty_is_none_parser(target: str) -> Union[Dict, List]:
+    parsed = json.loads(target)
+    if len(parsed) == 0:
+        return None
+    else:
+        return parsed
+
+
+def load_mltable(mltable_path: str) -> pd.DataFrame:
+    _logger.info("Loading MLTable: {0}".format(mltable_path))
+    df: pd.DataFrame = None
+    try:
+        tbl = mltable.load(mltable_path)
+        df: pd.DataFrame = tbl.to_pandas_dataframe()
+    except Exception as e:
+        _logger.info("Failed to load MLTable")
+        _logger.info(e)
+    return df
+
+
+def load_parquet(parquet_path: str) -> pd.DataFrame:
+    _logger.info("Loading parquet file: {0}".format(parquet_path))
+    df = pd.read_parquet(parquet_path)
+    return df
+
+
+def load_dataset(dataset_path: str) -> pd.DataFrame:
+    _logger.info(f"Attempting to load: {dataset_path}")
+    df = load_mltable(dataset_path)
+    if df is None:
+        df = load_parquet(dataset_path)
+    print(df.dtypes)
+    print(df.head(10))
+    return df
+
+
+def fetch_model_id(model_info_path: str):
+    model_info_path = os.path.join(model_info_path,
+                                   DashboardInfo.MODEL_INFO_FILENAME)
+    with open(model_info_path, "r") as json_file:
+        model_info = json.load(json_file)
+    return model_info[DashboardInfo.MODEL_ID_KEY]
+
+
+def add_properties_to_gather_run(
+    dashboard_info: Dict[str, str], tool_present_dict: Dict[str, str]
+):
+    _logger.info("Adding properties to the gather run")
+    gather_run = Run.get_context()
+
+    run_properties = {
+        PropertyKeyValues.RAI_INSIGHTS_TYPE_KEY:
+            PropertyKeyValues.RAI_INSIGHTS_TYPE_GATHER,
+        PropertyKeyValues.RAI_INSIGHTS_RESPONSIBLEAI_VERSION_KEY:
+            responsibleai_version,
+        PropertyKeyValues.RAI_INSIGHTS_VISION_VERSION_KEY:
+            responsibleai_vision_version,
+        PropertyKeyValues.RAI_INSIGHTS_MODEL_ID_KEY: dashboard_info[
+            DashboardInfo.RAI_INSIGHTS_MODEL_ID_KEY
+        ],
+        PropertyKeyValues.RAI_INSIGHTS_DATA_TYPE_KEY:
+            IMAGE_DATA_TYPE
+    }
+
+    _logger.info("Appending tool present information")
+    for k, v in tool_present_dict.items():
+        key = PropertyKeyValues.RAI_INSIGHTS_TOOL_KEY_FORMAT.format(k)
+        run_properties[key] = str(v)
+
+    _logger.info("Making service call")
+    gather_run.add_properties(run_properties)
+    _logger.info("Properties added to gather run")
+
+
+def main(args):
+    _logger.info("Dealing with initialization dataset")
+    train_df = load_dataset(args.train_dataset)
+
+    _logger.info("Dealing with evaluation dataset")
+    test_df = load_dataset(args.test_dataset)
+
+    if args.model_input is None or args.model_info is None:
+        raise ValueError(
+            "Both model info and model input need to be supplied.")
+
+    model_id = args.model_info
+    _logger.info("Loading model: {0}".format(model_id))
+    my_run = Run.get_context()
+    workspace = my_run.experiment.workspace
+    model_serializer = ModelSerializer(model_id, workspace=workspace,
+                                       model_type=args.model_type)
+    image_model = model_serializer.load("Ignored path")
+
+    _logger.info("Creating RAI Vision Insights")
+    rai_vi = RAIVisionInsights(
+        model=image_model,
+        train=train_df,
+        test=test_df,
+        target_column=args.target_column_name,
+        task_type=args.task_type,
+        classes=get_from_args(
+            args, "classes", custom_parser=json_empty_is_none_parser,
+            allow_none=True
+        ),
+        maximum_rows_for_test=args.maximum_rows_for_test_dataset,
+        serializer=model_serializer
+    )
+
+    included_tools: Dict[str, bool] = {
+        RAIToolType.CAUSAL: False,
+        RAIToolType.COUNTERFACTUAL: False,
+        RAIToolType.ERROR_ANALYSIS: False,
+        RAIToolType.EXPLANATION: False,
+    }
+
+    if args.precompute_explanation:
+        _logger.info("Adding explanation")
+        rai_vi.explainer.add()
+        included_tools[RAIToolType.EXPLANATION] = True
+
+    _logger.info("Starting computation")
+    rai_vi.compute()
+    _logger.info("Computation complete")
+
+    rai_vi.save(args.dashboard)
+    _logger.info("Saved dashboard to output")
+
+    rai_data = rai_vi.get_data()
+    rai_dict = serialize_json_safe(rai_data)
+    json_filename = "dashboard.json"
+    output_path = Path(args.ux_json) / json_filename
+    with open(output_path, "w") as json_file:
+        json.dump(rai_dict, json_file)
+    _logger.info("Dashboard JSON written")
+
+    dashboard_info = dict()
+    dashboard_info[DashboardInfo.RAI_INSIGHTS_MODEL_ID_KEY] = model_id
+
+    add_properties_to_gather_run(dashboard_info, included_tools)
+    _logger.info("Processing completed")
+
+
+# run script
+if __name__ == "__main__":
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")
+
+    # parse args
+    args = parse_args()
+
+    # run main function
+    main(args)
+
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")

--- a/responsibleai/vision/jobs/fetch_fridge_model.yml
+++ b/responsibleai/vision/jobs/fetch_fridge_model.yml
@@ -1,0 +1,25 @@
+$schema: http://azureml/sdk-2-0/CommandComponent.json
+name: fetch_fridge_for_rai
+display_name: Fetch model trained on Fridge Dataset and register model for RAI
+version: 0.0.1.preview
+type: command
+inputs:
+  model_base_name:
+    type: string
+  model_name_suffix: # Set negative to use epoch_secs
+    type: integer
+    default: -1
+  device: # set to >= 0 to use GPU
+    type: integer
+    default: 0
+outputs:
+  model_output_path:
+    type: path
+code: ./src_fridge/
+environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/1
+command: >-
+  python ./fetch_image_model.py
+  --model_base_name ${{inputs.model_base_name}}
+  --model_name_suffix ${{inputs.model_name_suffix}}
+  --device ${{inputs.device}}
+  --model_output_path ${{outputs.model_output_path}}

--- a/responsibleai/vision/jobs/pipeline_fridge_analyze.yml
+++ b/responsibleai/vision/jobs/pipeline_fridge_analyze.yml
@@ -1,0 +1,36 @@
+$schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
+experiment_name: fridge_analyze
+type: pipeline
+
+inputs:
+  fridge_model_info: fridge_model_1:1
+  my_training_data:
+    type: mltable
+    path: ./resources/fridge_train
+  my_test_data:
+    type: mltable
+    path: ./resources/fridge_test
+  target_column_name: label
+
+compute: azureml:cpu-cluster
+
+jobs:
+  analyse_model:
+    type: command
+    component: file:../components/rai_vision_insights/spec.yaml
+    limits:
+      timeout: 120
+    inputs:
+      title: Fridge Vision Classification Analysis
+      task_type: image_classification
+      model_input:
+        type: mlflow_model
+        path: azureml:fridge_model_1:1
+      model_info: ${{parent.inputs.fridge_model_info}}
+      train_dataset: ${{parent.inputs.my_training_data}}
+      test_dataset: ${{parent.inputs.my_test_data}}
+      target_column_name: ${{parent.inputs.target_column_name}}
+      maximum_rows_for_test_dataset: 5000
+      classes: '[]'
+      precompute_explanation: True
+      model_type: fastai

--- a/responsibleai/vision/jobs/prepare.py
+++ b/responsibleai/vision/jobs/prepare.py
@@ -1,0 +1,118 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from azure.ai.ml.entities import AmlCompute, PipelineJob
+from azure.ai.ml import dsl, load_component, MLClient
+from azure.identity import DefaultAzureCredential
+import time
+
+
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
+
+try:
+    from azureml.core import Workspace
+    azureml_core_installed = True
+except ImportError:
+    print("azureml.core not found")
+    azureml_core_installed = False
+
+
+def save_fridge_dataset(train_path, test_path):
+    # download data
+    base_url = "https://publictestdatasets.blob.core.windows.net/"
+    fridge_folder = "computervision/fridgeObjects/"
+    train_annotations = "train_annotations.jsonl"
+    test_annotations = "test_annotations.jsonl"
+    train_url = base_url + fridge_folder + train_annotations
+    test_url = base_url + fridge_folder + test_annotations
+    urlretrieve(train_url, filename=train_path)
+    urlretrieve(test_url, filename=test_path)
+
+
+def fetch_and_write_fridge_dataset():
+    train_path = "./resources/fridge_train/fridge_train.jsonl"
+    test_path = "./resources/fridge_test/fridge_test.jsonl"
+
+    save_fridge_dataset(train_path, test_path)
+
+
+def submit_and_wait(ml_client, pipeline_job) -> PipelineJob:
+    created_job = ml_client.jobs.create_or_update(pipeline_job)
+    assert created_job is not None
+
+    while created_job.status not in ['Completed', 'Failed', 'Canceled', 'NotResponding']:
+        time.sleep(30)
+        created_job = ml_client.jobs.get(created_job.name)
+        print("Latest status : {0}".format(created_job.status))
+    assert created_job.status == 'Completed'
+    return created_job
+
+
+def submit_training_job():
+    credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
+    try:
+        ml_client = MLClient.from_config(credential=credential,
+                                         logging_enable=True)
+    except Exception:
+        if not azureml_core_installed:
+            print("failed to load azureml.core and mlclient")
+            raise
+        # In case of exception due to config missing, try to get and create config, which may work if in compute instance
+        workspace = Workspace.from_config()
+        workspace.write_config()
+        ml_client = MLClient.from_config(credential=credential,
+                                         logging_enable=True)
+    yaml_filename = "fetch_fridge_model.yml"
+    fetch_model_component = load_component(
+        source=yaml_filename
+    )
+
+    compute_name = "cpu-cluster"
+    all_compute_names = [x.name for x in ml_client.compute.list()]
+
+    if compute_name in all_compute_names:
+        print(f"Found existing compute: {compute_name}")
+    else:
+        my_compute = AmlCompute(
+            name=compute_name,
+            size="STANDARD_DS3_V2",
+            min_instances=0,
+            max_instances=4,
+            idle_time_before_scale_down=3600
+        )
+        ml_client.compute.begin_create_or_update(my_compute)
+        print("Initiated compute creation")
+
+    ml_client.components.create_or_update(fetch_model_component)
+
+    model_base_name = "fridge_model"
+    model_name_suffix = "1"
+    device = "-1"
+
+    @dsl.pipeline(
+        compute=compute_name,
+        description="Fetch Fridge Model",
+        experiment_name=f"Fetch_Fridge_Model_{model_name_suffix}",
+    )
+    def my_training_pipeline(model_base_name, model_name_suffix, device):
+        trained_model = fetch_model_component(
+            model_base_name=model_base_name,
+            model_name_suffix=model_name_suffix,
+            device=device
+        )
+        trained_model.set_limits(timeout=120)
+
+        return {}
+    model_registration_pipeline_job = my_training_pipeline(
+        model_base_name, model_name_suffix, device)
+
+    # This is the actual submission
+    submit_and_wait(ml_client, model_registration_pipeline_job)
+
+
+fetch_and_write_fridge_dataset()
+submit_training_job()

--- a/responsibleai/vision/jobs/resources/fridge_test/MLTable
+++ b/responsibleai/vision/jobs/resources/fridge_test/MLTable
@@ -1,0 +1,9 @@
+$schema: http://azureml/sdk-2-0/MLTable.json
+type: mltable
+paths:
+ - file: ./fridge_test.jsonl
+transformations:
+  - read_json_lines:
+        encoding: utf8
+        invalid_lines: error
+        include_path_column: false

--- a/responsibleai/vision/jobs/resources/fridge_train/MLTable
+++ b/responsibleai/vision/jobs/resources/fridge_train/MLTable
@@ -1,0 +1,9 @@
+$schema: http://azureml/sdk-2-0/MLTable.json
+type: mltable
+paths:
+ - file: ./fridge_train.jsonl
+transformations:
+  - read_json_lines:
+        encoding: utf8
+        invalid_lines: error
+        include_path_column: false

--- a/responsibleai/vision/jobs/src_fridge/fetch_image_model.py
+++ b/responsibleai/vision/jobs/src_fridge/fetch_image_model.py
@@ -1,0 +1,131 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+import logging
+import json
+import os
+import time
+
+
+import mlflow
+import mlflow.pyfunc
+
+from azureml.core import Run
+
+from fastai.learner import load_learner
+
+from raiutils.common.retries import retry_function
+
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
+_logger = logging.getLogger(__file__)
+logging.basicConfig(level=logging.INFO)
+
+FRIDGE_MODEL_NAME = 'fridge_model'
+
+
+def parse_args():
+    # setup arg parser
+    parser = argparse.ArgumentParser()
+
+    # add arguments
+    parser.add_argument(
+        "--model_output_path", type=str, help="Path to write model info JSON"
+    )
+    parser.add_argument(
+        "--model_base_name", type=str, help="Name of the registered model"
+    )
+    parser.add_argument(
+        "--model_name_suffix", type=int, help="Set negative to use epoch_secs"
+    )
+    parser.add_argument(
+        "--device", type=int, help=(
+            "Device for CPU/GPU supports. Setting this to -1 will leverage "
+            "CPU, >=0 will run the model on the associated CUDA device id.")
+    )
+
+    # parse args
+    args = parser.parse_args()
+
+    # return args
+    return args
+
+
+class FetchModel(object):
+    def __init__(self):
+        pass
+
+    def fetch(self):
+        url = ('https://publictestdatasets.blob.core.windows.net/models/' +
+               FRIDGE_MODEL_NAME)
+        urlretrieve(url, FRIDGE_MODEL_NAME)
+
+
+def main(args):
+    current_experiment = Run.get_context().experiment
+    tracking_uri = current_experiment.workspace.get_mlflow_tracking_uri()
+    _logger.info("tracking_uri: {0}".format(tracking_uri))
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment(current_experiment.name)
+
+    _logger.info("Getting device")
+    device = args.device
+
+    _logger.info("Loading parquet input")
+
+    # Load the fridge fastai model
+    fetcher = FetchModel()
+    action_name = "Model download"
+    err_msg = "Failed to download model"
+    max_retries = 4
+    retry_delay = 60
+    retry_function(fetcher.fetch, action_name, err_msg,
+                   max_retries=max_retries,
+                   retry_delay=retry_delay)
+    model = load_learner(FRIDGE_MODEL_NAME)
+
+    if device >= 0:
+        model = model.cuda()
+
+    if args.model_name_suffix < 0:
+        suffix = int(time.time())
+    else:
+        suffix = args.model_name_suffix
+    registered_name = "{0}_{1}".format(args.model_base_name, suffix)
+    _logger.info(f"Registering model as {registered_name}")
+
+    # Saving model with mlflow
+    _logger.info("Saving with mlflow")
+
+    mlflow.fastai.log_model(
+        model,
+        artifact_path=registered_name,
+        registered_model_name=registered_name
+    )
+
+    _logger.info("Writing JSON")
+    dict = {"id": "{0}:1".format(registered_name)}
+    output_path = os.path.join(args.model_output_path, "model_info.json")
+    with open(output_path, "w") as of:
+        json.dump(dict, fp=of)
+
+
+# run script
+if __name__ == "__main__":
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")
+
+    # parse args
+    args = parse_args()
+
+    # run main function
+    main(args)
+
+    # add space in logs
+    print("*" * 60)
+    print("\n\n")


### PR DESCRIPTION
Add text and vision dpv2 components, jobs and tests to azureml-assets.

This includes:
1.) The RAI Text Insights component and the DBPedia dataset for multiclass text classification
2.) The RAI Vision Insights component and the Fridge dataset for multiclass image classification

This is required to onboard to the azureml preview registry for RAI text and vision components.