### PR TITLE
Add shm size parameter to pt jobs, fix syntax issues with component-based pipelines

### DIFF
--- a/benchmark/src/components/pytorch_benchmark/image_classifier_spec.yaml
+++ b/benchmark/src/components/pytorch_benchmark/image_classifier_spec.yaml
@@ -111,28 +111,28 @@ command: >-
   --train_images ${{inputs.train_images}}
   --valid_images ${{inputs.valid_images}}
 
-  [--batch_size ${{inputs.batch_size}}]
-  [--num_workers ${{inputs.num_workers}}]
-  [--prefetch_factor ${{inputs.prefetch_factor}}]
-  [--persistent_workers ${{inputs.persistent_workers}}]
-  [--pin_memory ${{inputs.pin_memory}}]
-  [--non_blocking ${{inputs.non_blocking}}]
+  $[[--batch_size ${{inputs.batch_size}}]]
+  $[[--num_workers ${{inputs.num_workers}}]]
+  $[[--prefetch_factor ${{inputs.prefetch_factor}}]]
+  $[[--persistent_workers ${{inputs.persistent_workers}}]]
+  $[[--pin_memory ${{inputs.pin_memory}}]]
+  $[[--non_blocking ${{inputs.non_blocking}}]]
 
-  [--model_arch ${{inputs.model_arch}}]
-  [--model_arch_pretrained ${{inputs.model_arch_pretrained}}]
+  $[[--model_arch ${{inputs.model_arch}}]]
+  $[[--model_arch_pretrained ${{inputs.model_arch_pretrained}}]]
 
-  [--num_epochs ${{inputs.num_epochs}}]
-  [--learning_rate ${{inputs.learning_rate}}]
-  [--momentum ${{inputs.momentum}}]
+  $[[--num_epochs ${{inputs.num_epochs}}]]
+  $[[--learning_rate ${{inputs.learning_rate}}]]
+  $[[--momentum ${{inputs.momentum}}]]
 
   --model_output ${{outputs.trained_model}}
   --checkpoints ${{outputs.checkpoints}}
-  [--register_model_as ${{inputs.register_model_as}}]
+  $[[--register_model_as ${{inputs.register_model_as}}]]
 
   --cudnn_autotuner ${{inputs.cudnn_autotuner}}
   --enable_profiling ${{inputs.enable_profiling}}
-  [--multiprocessing_sharing_strategy ${{inputs.multiprocessing_sharing_strategy}}]
-  [--distributed_sampling ${{inputs.distributed_sampling}}]
+  $[[--multiprocessing_sharing_strategy ${{inputs.multiprocessing_sharing_strategy}}]]
+  $[[--distributed_sampling ${{inputs.distributed_sampling}}]]
 
 distribution:
   # NOTE: using type:pytorch will use all the right env variables for pytorch init_process_group

--- a/benchmark/src/components/tensorflow_benchmark/image_segmentation_spec.yaml
+++ b/benchmark/src/components/tensorflow_benchmark/image_segmentation_spec.yaml
@@ -112,26 +112,26 @@ command: >-
   --images_filename_pattern "${{inputs.images_filename_pattern}}"
   --masks_filename_pattern "${{inputs.masks_filename_pattern}}"
 
-  [--batch_size ${{inputs.batch_size}}]
-  [--num_workers ${{inputs.num_workers}}]
-  [--prefetch_factor ${{inputs.prefetch_factor}}]
-  [--cache ${{inputs.cache}}]
+  $[[--batch_size ${{inputs.batch_size}}]]
+  $[[--num_workers ${{inputs.num_workers}}]]
+  $[[--prefetch_factor ${{inputs.prefetch_factor}}]]
+  $[[--cache ${{inputs.cache}}]]
 
-  [--model_arch ${{inputs.model_arch}}]
+  $[[--model_arch ${{inputs.model_arch}}]]
   --num_classes ${{inputs.num_classes}}
-  [--model_input_size ${{inputs.model_input_size}}]
+  $[[--model_input_size ${{inputs.model_input_size}}]]
 
-  [--num_epochs ${{inputs.num_epochs}}]
-  [--optimizer ${{inputs.optimizer}}]
-  [--loss ${{inputs.loss}}]
+  $[[--num_epochs ${{inputs.num_epochs}}]]
+  $[[--optimizer ${{inputs.optimizer}}]]
+  $[[--loss ${{inputs.loss}}]]
 
-  [--num_gpus ${{inputs.num_gpus}}]
+  $[[--num_gpus ${{inputs.num_gpus}}]]
 
   --model_output ${{outputs.trained_model}}
   --checkpoints ${{outputs.checkpoints}}
 
-  [--distributed_strategy ${{inputs.distributed_strategy}}]
-  [--distributed_backend ${{inputs.distributed_backend}}]
+  $[[--distributed_strategy ${{inputs.distributed_strategy}}]]
+  $[[--distributed_backend ${{inputs.distributed_backend}}]]
 
 distribution:
   # NOTE: using type:tensorflow will use all the right env variables (ex: TF_CONFIG)

--- a/benchmark/src/jobs/benchmark/pt_dogs.yml
+++ b/benchmark/src/jobs/benchmark/pt_dogs.yml
@@ -114,6 +114,7 @@ environment_variables:
 compute: azureml:gpu-cluster
 resources:
     instance_count: 1 # number of nodes
+    shm_size: 64g # shared memory size in GB
 
 distribution:
     # NOTE: using type:pytorch will use all the right env variables for pytorch init_process_group

--- a/benchmark/src/jobs/benchmark/pt_dogs_sweep_datafetching.yml
+++ b/benchmark/src/jobs/benchmark/pt_dogs_sweep_datafetching.yml
@@ -67,6 +67,7 @@ trial:
 
     resources:
         instance_count: 1 # number of nodes
+        shm_size: 64g # shared memory size in GB
 
     distribution:
         # NOTE: using type:pytorch will use all the right env variables for pytorch init_process_group

--- a/benchmark/src/pipelines/benchmark/pt_image_classification.yml
+++ b/benchmark/src/pipelines/benchmark/pt_image_classification.yml
@@ -23,7 +23,7 @@ settings:
 jobs:
   train:
     type: command
-    component: file:../../components/pytorch_image_classifier/spec.yaml
+    component: file:../../components/pytorch_benchmark/image_classifier_spec.yaml
     compute: azureml:gpu-cluster
     resources:
       instance_count: 1 # number of nodes

--- a/benchmark/src/pipelines/benchmark/pt_image_classification.yml
+++ b/benchmark/src/pipelines/benchmark/pt_image_classification.yml
@@ -27,6 +27,7 @@ jobs:
     compute: azureml:gpu-cluster
     resources:
       instance_count: 1 # number of nodes
+      shm_size: 64g # shared memory size in GB
     distribution:
       type: pytorch
       process_count_per_instance: 1 # number of gpus

--- a/benchmark/src/pipelines/benchmark/tf_unet_pets.yml
+++ b/benchmark/src/pipelines/benchmark/tf_unet_pets.yml
@@ -31,7 +31,7 @@ settings:
 jobs:
   train:
     type: command
-    component: file:../../components/tensorflow_image_segmentation/spec.yaml
+    component: file:../../components/tensorflow_benchmark/image_segmentation_spec.yaml
     compute: azureml:gpu-cluster
     resources:
       instance_count: 1 # number of nodes


### PR DESCRIPTION
This PR refreshes the CLI yaml of the benchmark pipeline jobs by:
- adding shm_size in the pytorch jobs
- using `$[[]]` for optional arguments