### PR TITLE
Add debugpy package to training environments

### DIFF
--- a/training/general/src/environments/pytorch-1.11-ubuntu20.04-py38-cuda11-gpu/context/conda_dependencies.yaml
+++ b/training/general/src/environments/pytorch-1.11-ubuntu20.04-py38-cuda11-gpu/context/conda_dependencies.yaml
@@ -30,3 +30,4 @@ dependencies:
   - future==0.18.2
   - torch-tb-profiler==0.3.1
   - msrest==0.6.21
+  - debugpy~=1.6.3

--- a/training/general/src/environments/sklearn-1.1-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/training/general/src/environments/sklearn-1.1-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -18,3 +18,4 @@ dependencies:
   - azureml-mlflow=={{latest-pypi-version}}
   - azureml-telemetry=={{latest-pypi-version}}
   - scikit-learn~=1.1.0
+  - debugpy~=1.6.3

--- a/training/general/src/environments/tensorflow-2.8-ubuntu20.04-py38-cuda11-gpu/context/conda_dependencies.yaml
+++ b/training/general/src/environments/tensorflow-2.8-ubuntu20.04-py38-cuda11-gpu/context/conda_dependencies.yaml
@@ -21,3 +21,4 @@ dependencies:
   - tensorboard~=2.8.0
   - tensorflow-gpu~=2.8.0
   - tensorflow-datasets~=4.5.0
+  - debugpy~=1.6.3

--- a/training/general/src/environments/tensorflow-2.9-ubuntu20.04-py38-cuda11-gpu/context/conda_dependencies.yaml
+++ b/training/general/src/environments/tensorflow-2.9-ubuntu20.04-py38-cuda11-gpu/context/conda_dependencies.yaml
@@ -20,3 +20,4 @@ dependencies:
   - tensorboard~=2.9.0
   - tensorflow-gpu~=2.9.0
   - tensorflow-datasets~=4.5.0
+  - debugpy~=1.6.3


### PR DESCRIPTION
This will assist in debugging when using interactive training jobs on these published environments.
In advanced scenarios, this package can be used to attach debugger and run the training script by user, for example:
```
python-m debugpy --listen localhost:5678 --wait-for-client train.py
```
For more details on the package and compatibility:
https://github.com/microsoft/debugpy
