### PR TITLE
Update to the latest tj-actions/changed-files action

### DIFF
--- a/.github/workflows/assets-test.yaml
+++ b/.github/workflows/assets-test.yaml
@@ -67,7 +67,7 @@ jobs:
       
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v24
+        uses: tj-actions/changed-files@v35
         with:
           files_separator: ','
           separator: ','

--- a/.github/workflows/environments-ci.yaml
+++ b/.github/workflows/environments-ci.yaml
@@ -62,7 +62,7 @@ jobs:
       
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v24
+        uses: tj-actions/changed-files@v35
         with:
           files_separator: ','
           separator: ','

--- a/.github/workflows/scripts-syntax.yaml
+++ b/.github/workflows/scripts-syntax.yaml
@@ -32,7 +32,7 @@ jobs:
       
       - name: Get changed Python scripts
         id: changed-scripts
-        uses: tj-actions/changed-files@v24
+        uses: tj-actions/changed-files@v35
         with:
           files_separator: ','
           separator: ','


### PR DESCRIPTION
This should resolve these warnings:

**Identify updated assets**
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/