### PR TITLE
update mltable dependency to 1.0.0 in RAI images

### DIFF
--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -12,7 +12,7 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
     conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
     conda clean -a -y
 
-RUN pip install --pre 'azure-ai-ml'
+RUN pip install --pre 'azure-ai-ml' 'azure-storage-blob<=12.13.0' 'numpy<1.24.0'
 
 # Workaround for dependency conflict around tqdm with nlp-feature-extractors
 RUN pip install 'datasets==1.18.4'

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -30,6 +30,6 @@ dependencies:
     - https://publictestdatasets.blob.core.windows.net/packages/pypi/responsibleai-text/responsibleai_text-0.0.7-py3-none-any.whl
     - https://publictestdatasets.blob.core.windows.net/packages/pypi/azureml-model-serializer/azureml_model_serializer-0.0.2-py3-none-any.whl
     - click<8.0.0
-    - mltable==0.1.0b4
+    - mltable==1.0.0
     - transformers>=4.17.0
     - ml-wrappers==0.2.2

--- a/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -15,7 +15,7 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
     conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
     conda clean -a -y
 
-RUN pip install --pre 'azure-ai-ml'
+RUN pip install --pre 'azure-ai-ml' 'azure-storage-blob<=12.13.0' 'numpy<1.24.0'
 
 # no-deps install for domonic due to unresolvable dependencies requirment on urllib3 and requests.
 # score card rendering is using domonic only for the html elements composer which does not involve requests or urllib3

--- a/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -20,4 +20,4 @@ dependencies:
   - azureml-dataset-runtime=={{latest-pypi-version}}
   - azureml-mlflow=={{latest-pypi-version}}
   - azureml-telemetry=={{latest-pypi-version}}
-  - mltable==0.1.0b4
+  - mltable==1.0.0

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -17,7 +17,7 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
     conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
     conda clean -a -y
 
-RUN pip install --pre 'azure-ai-ml'
+RUN pip install --pre 'azure-ai-ml' 'azure-storage-blob<=12.13.0' 'numpy<1.24.0'
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -28,7 +28,7 @@ dependencies:
     - https://publictestdatasets.blob.core.windows.net/packages/pypi/responsibleai-vision/responsibleai_vision-0.0.8-py3-none-any.whl
     - https://publictestdatasets.blob.core.windows.net/packages/pypi/azureml-model-serializer/azureml_model_serializer-0.0.2-py3-none-any.whl
     - click<8.0.0
-    - mltable==0.1.0b4
+    - mltable==1.0.0
     - ml-wrappers==0.2.2
     - fastai
     - opencv-python


### PR DESCRIPTION
update mltable dependency to 1.0.0 in RAI images

One of our customers ran into an issue where the decimal columns were treated as string in a loaded mltable in the dpv2 components.  This bug is fixed in mltable 1.0.0 dependency.  This PR fixes the customer issue by upgrading our images to use the latest mltable==1.0.0.

Also updated the packages: 'azure-storage-blob<=12.13.0' 'numpy<1.24.0'
to fix image build failures.  The numpy pin is due to newest numpy release not being compatible with latest numba, and azure-storage-blob pin is to remain compatible with both latest azure-ai-ml and latest azureml-mlflow packages and their dependencies.