### PR TITLE
update RAI images to raiwidgets and responsibleai 0.24.1

### DIFF
--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
 
-ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-vision
+ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-text
 
 # Prepend path to AzureML conda environment
 ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -17,8 +17,8 @@ dependencies:
     - scikit-learn
     - mlflow
     - azureml-mlflow
-    - responsibleai~=0.23.0
-    - raiwidgets~=0.23.0
+    - responsibleai~=0.24.0
+    - raiwidgets~=0.24.0
     # Limit markupsafe version is a workaround to resolve the issue from markupsafe's breaking change: https://github.com/aws/aws-sam-cli/issues/3661
     - markupsafe<2.1.0
     # Workaround to fix import failure related to itsdangerous's latest release: https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -32,4 +32,4 @@ dependencies:
     - click<8.0.0
     - mltable==0.1.0b4
     - transformers>=4.17.0
-    - ml-wrappers==0.2.2
+    - ml-wrappers==0.4.2

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -17,8 +17,8 @@ dependencies:
     - scikit-learn
     - mlflow
     - azureml-mlflow
-    - responsibleai~=0.24.0
-    - raiwidgets~=0.24.0
+    - responsibleai~=0.24.1
+    - raiwidgets~=0.24.1
     # Limit markupsafe version is a workaround to resolve the issue from markupsafe's breaking change: https://github.com/aws/aws-sam-cli/issues/3661
     - markupsafe<2.1.0
     # Workaround to fix import failure related to itsdangerous's latest release: https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/responsibleai_text_sample_test.py
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/responsibleai_text_sample_test.py
@@ -7,12 +7,14 @@ import time
 from pathlib import Path
 from azure.ai.ml import MLClient
 from azure.ai.ml import command
+from azure.ai.ml._restclient.models import JobStatus
 from azure.ai.ml.entities import Environment, BuildContext
 from azure.identity import AzureCliCredential
 
 BUILD_CONTEXT = Path("../context")
 JOB_SOURCE_CODE = "src"
 TIMEOUT_MINUTES = os.environ.get("timeout_minutes", 30)
+STD_LOG = Path("artifacts/user_logs/std_log.txt")
 
 
 def test_responsibleai_text():
@@ -54,8 +56,17 @@ def test_responsibleai_text():
     timeout = time.time() + (TIMEOUT_MINUTES * 60)
     while time.time() <= timeout:
         current_status = ml_client.jobs.get(returned_job.name).status
-        if current_status in ["Completed", "Failed"]:
+        if current_status in [JobStatus.COMPLETED, JobStatus.FAILED]:
             break
         time.sleep(30)  # sleep 30 seconds
 
-    assert current_status == "Completed"
+    if current_status == JobStatus.FAILED:
+        ml_client.jobs.download(returned_job.name)
+        if STD_LOG.exists():
+            print(f"*** BEGIN {STD_LOG} ***")
+            with open(STD_LOG, "r") as f:
+                print(f.read(), end="")
+            print(f"*** END {STD_LOG} ***")
+        else:
+            ml_client.jobs.stream(returned_job.name)
+    assert current_status == JobStatus.COMPLETED

--- a/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/responsibleai_text_sample_test.py
+++ b/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/tests/responsibleai_text_sample_test.py
@@ -69,4 +69,5 @@ def test_responsibleai_text():
             print(f"*** END {STD_LOG} ***")
         else:
             ml_client.jobs.stream(returned_job.name)
+
     assert current_status == JobStatus.COMPLETED

--- a/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -6,8 +6,8 @@ dependencies:
 - python=3.8
 - pip=21.3.1
 - pip:
-  - responsibleai~=0.23.0
-  - raiwidgets~=0.23.0
+  - responsibleai~=0.24.0
+  - raiwidgets~=0.24.0
   - pyarrow
   - markupsafe<=2.0.1
   - itsdangerous==2.0.1

--- a/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -6,8 +6,8 @@ dependencies:
 - python=3.8
 - pip=21.3.1
 - pip:
-  - responsibleai~=0.24.0
-  - raiwidgets~=0.24.0
+  - responsibleai~=0.24.1
+  - raiwidgets~=0.24.1
   - pyarrow
   - markupsafe<=2.0.1
   - itsdangerous==2.0.1

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -29,6 +29,6 @@ dependencies:
     - https://publictestdatasets.blob.core.windows.net/packages/pypi/azureml-model-serializer/azureml_model_serializer-0.0.2-py3-none-any.whl
     - click<8.0.0
     - mltable==0.1.0b4
-    - ml-wrappers==0.2.2
+    - ml-wrappers==0.4.2
     - fastai
     - opencv-python

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -16,8 +16,8 @@ dependencies:
     - scikit-learn
     - azure-core==1.25.1
     - mlflow
-    - responsibleai~=0.24.0
-    - raiwidgets~=0.24.0
+    - responsibleai~=0.24.1
+    - raiwidgets~=0.24.1
     # Limit markupsafe version is a workaround to resolve the issue from markupsafe's breaking change: https://github.com/aws/aws-sam-cli/issues/3661
     - markupsafe<2.1.0
     # Workaround to fix import failure related to itsdangerous's latest release: https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous

--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -16,8 +16,8 @@ dependencies:
     - scikit-learn
     - azure-core==1.25.1
     - mlflow
-    - responsibleai~=0.23.0
-    - raiwidgets~=0.23.0
+    - responsibleai~=0.24.0
+    - raiwidgets~=0.24.0
     # Limit markupsafe version is a workaround to resolve the issue from markupsafe's breaking change: https://github.com/aws/aws-sam-cli/issues/3661
     - markupsafe<2.1.0
     # Workaround to fix import failure related to itsdangerous's latest release: https://stackoverflow.com/questions/71189819/python-docker-importerror-cannot-import-name-json-from-itsdangerous


### PR DESCRIPTION
Update RAI images to raiwidgets and responsibleai 0.24.1, specifically the images:

- responsibleai (tabular)
- responsibleai-text
- responsibleai-vision
Also update ml-wrapper to latest pypi 0.4.2.