### PR TITLE
Enable feature_metadata in RAI components

### DIFF
--- a/responsibleai/tabular/components/src/_score_card/_rai_insight_data.py
+++ b/responsibleai/tabular/components/src/_score_card/_rai_insight_data.py
@@ -81,9 +81,12 @@ class RaiInsightData:
         self._set_component_paths_prefix()
         self._set_json_paths()
 
-        self.y_pred = self.raiinsight.model.predict(
-            self.raiinsight.test.drop(columns=self.raiinsight.target_column)
-        )
+        test_data = self.raiinsight.test.drop(columns=self.raiinsight.target_column)
+        if self.raiinsight._feature_metadata is not None\
+                and self.raiinsight._feature_metadata.dropped_features is not None:
+            test_data = test_data.drop(
+                self.raiinsight._feature_metadata.dropped_features, axis=1)
+        self.y_pred = self.raiinsight.model.predict(test_data)
 
     def _set_component_paths_prefix(self):
         for c in self.components:

--- a/responsibleai/tabular/components/src/create_rai_insights.py
+++ b/responsibleai/tabular/components/src/create_rai_insights.py
@@ -100,9 +100,9 @@ def create_constructor_arg_dict(args):
     )
     feature_metadata = FeatureMetadata()
     if 'dropped_features' in feature_metadata_dict.keys():
-        feature_metadata.dropped_features=feature_metadata_dict['dropped_features']
+        feature_metadata.dropped_features = feature_metadata_dict['dropped_features']
     if 'identity_feature_name' in feature_metadata_dict.keys():
-        feature_metadata.identity_feature_name=feature_metadata_dict['identity_feature_name']
+        feature_metadata.identity_feature_name = feature_metadata_dict['identity_feature_name']
 
     result["target_column"] = args.target_column_name
     result["task_type"] = args.task_type

--- a/responsibleai/tabular/components/src/create_rai_insights.py
+++ b/responsibleai/tabular/components/src/create_rai_insights.py
@@ -7,18 +7,22 @@ import logging
 import os
 import shutil
 
+
 from azureml.core import Run
 
 from responsibleai import RAIInsights
+from responsibleai.feature_metadata import FeatureMetadata
 
 from constants import DashboardInfo
-from arg_helpers import get_from_args, json_empty_is_none_parser
+from arg_helpers import boolean_parser, get_from_args, json_empty_is_none_parser
 from rai_component_utilities import (
     load_dataset,
+    default_json_handler,
     fetch_model_id,
     load_mlflow_model,
     get_train_dataset_id,
     get_test_dataset_id,
+    UserConfigError
 )
 
 from _telemetry._loggerfactory import _LoggerFactory, track
@@ -66,7 +70,9 @@ def parse_args():
 
     parser.add_argument("--classes", type=str, help="Optional[List[str]]")
 
-    parser.add_argument("--use_model_dependency", type=bool, help="Use model dependency")
+    parser.add_argument("--feature_metadata", type=str, help="identity_feature_name:Optional[str], dropped_features:Optional[List[str]]")
+
+    parser.add_argument("--use_model_dependency", type=boolean_parser, help="Use model dependency")
 
     parser.add_argument("--output_path", type=str, help="Path to output JSON")
 
@@ -79,7 +85,6 @@ def parse_args():
 
 def create_constructor_arg_dict(args):
     """Create a kwarg dict for RAIInsights constructor
-
     Only does the 'parameters' for the component, not the
     input ports
     """
@@ -91,11 +96,20 @@ def create_constructor_arg_dict(args):
     class_names = get_from_args(
         args, "classes", custom_parser=json_empty_is_none_parser, allow_none=True
     )
+    feature_metadata_dict = get_from_args(
+        args, "feature_metadata", custom_parser=json.loads, allow_none=True
+    )
+    feature_metadata = FeatureMetadata()
+    if 'dropped_features' in feature_metadata_dict.keys():
+        feature_metadata.dropped_features=feature_metadata_dict['dropped_features']
+    if 'identity_feature_name' in feature_metadata_dict.keys():
+        feature_metadata.identity_feature_name=feature_metadata_dict['identity_feature_name']
 
     result["target_column"] = args.target_column_name
     result["task_type"] = args.task_type
     result["categorical_features"] = cat_col_names
     result["classes"] = class_names
+    result["feature_metadata"] = feature_metadata
     result["maximum_rows_for_test"] = args.maximum_rows_for_test_dataset
 
     return result
@@ -133,7 +147,7 @@ def main(args):
     if args.model_info_path is None and (
         args.model_input is None or args.model_info is None
     ):
-        raise ValueError("Either model info or model input needs to be supplied.")
+        raise UserConfigError("Either model info or model input needs to be supplied.")
 
     model_estimator = None
     model_id = None
@@ -176,7 +190,7 @@ def main(args):
         args.output_path, DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
     )
     with open(output_file, "w") as of:
-        json.dump(output_dict, of)
+        json.dump(output_dict, of, default=default_json_handler)
 
     _logger.info("Copying train data files")
     copy_input_data(

--- a/responsibleai/tabular/components/src/create_rai_insights.py
+++ b/responsibleai/tabular/components/src/create_rai_insights.py
@@ -7,7 +7,6 @@ import logging
 import os
 import shutil
 
-
 from azureml.core import Run
 
 from responsibleai import RAIInsights

--- a/responsibleai/tabular/components/src/gather_rai_insights.py
+++ b/responsibleai/tabular/components/src/gather_rai_insights.py
@@ -20,6 +20,7 @@ from rai_component_utilities import (
     create_rai_tool_directories,
     create_rai_insights_from_port_path,
     copy_insight_to_raiinsights,
+    default_json_handler,
     load_dashboard_info_file,
     add_properties_to_gather_run,
     print_dir_tree,
@@ -137,7 +138,7 @@ def main(args):
             args.dashboard, DashboardInfo.RAI_INSIGHTS_PARENT_FILENAME
         )
         with open(output_file, "w") as of:
-            json.dump(dashboard_info, of)
+            json.dump(dashboard_info, of, default=default_json_handler)
 
         _logger.info("Saved dashboard to output")
 

--- a/responsibleai/tabular/components/src/rai_component_utilities.py
+++ b/responsibleai/tabular/components/src/rai_component_utilities.py
@@ -329,7 +329,7 @@ def get_dataset_name_version(run, dataset_input_name):
 
 
 def default_json_handler(data):
-    if  isinstance(data, FeatureMetadata): 
+    if isinstance(data, FeatureMetadata):
         meta_dict = data.__dict__
         type_name = type(data).__name__
         meta_dict[data_type] = type_name


### PR DESCRIPTION
This PR adds feature_metadata to create_rai_insights, so users can pass dropped_features or identity_feature_name etc to RAIInsights