### PR TITLE
Enable filtering via regex

### DIFF
--- a/scripts/azureml-assets/azureml/assets/__init__.py
+++ b/scripts/azureml-assets/azureml/assets/__init__.py
@@ -18,7 +18,6 @@ from .config import (
     Spec,
 )
 from .update_assets import (
-    get_release_tag_name,
     pin_env_files,
     release_tag_exists,
     update_asset,

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -707,7 +707,7 @@ class AssetType(Enum):
 DEFAULT_ASSET_FILENAME = "asset.yaml"
 VERSION_AUTO = "auto"
 FULL_ASSET_NAME_TEMPLATE = "{type}/{name}/{version}"
-FULL_NAME_DELIMITER = "/"
+FULL_ASSET_NAME_DELIMITER = "/"
 
 
 @total_ordering
@@ -845,7 +845,7 @@ class AssetConfig(Config):
         Returns:
             Tuple[assets.AssetType, str, str]: Asset type, name, and version
         """
-        tag_parts = full_name.split(FULL_NAME_DELIMITER)
+        tag_parts = full_name.split(FULL_ASSET_NAME_DELIMITER)
         if len(tag_parts) != 3:
             raise ValueError(f"Invalid full name: {full_name}")
 

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -8,7 +8,7 @@ from enum import Enum
 from functools import total_ordering
 from pathlib import Path
 from setuptools._vendor.packaging import version
-from typing import Dict, List
+from typing import Dict, List, Tuple
 from yaml import safe_load
 
 
@@ -706,6 +706,8 @@ class AssetType(Enum):
 
 DEFAULT_ASSET_FILENAME = "asset.yaml"
 VERSION_AUTO = "auto"
+FULL_ASSET_NAME_TEMPLATE = "{type}/{name}/{version}"
+FULL_NAME_DELIMITER = "/"
 
 
 @total_ordering
@@ -827,6 +829,27 @@ class AssetConfig(Config):
                 raise ValidationException(f"Tried to read asset name from spec, "
                                           f"but it includes a template tag: {name}")
         return name
+
+    @property
+    def full_name(self) -> str:
+        """Full asset name, including type and version."""
+        return FULL_ASSET_NAME_TEMPLATE.format(type=self.type.value, name=self.name, version=self.version)
+
+    @staticmethod
+    def parse_full_name(full_name: str) -> Tuple[AssetType, str, str]:
+        """Parse a full name into its asset type, name, and version.
+
+        Args:
+            full_name (str): Full name to parse
+
+        Returns:
+            Tuple[assets.AssetType, str, str]: Asset type, name, and version
+        """
+        tag_parts = full_name.split(FULL_NAME_DELIMITER)
+        if len(tag_parts) != 3:
+            raise ValueError(f"Invalid full name: {full_name}")
+
+        return AssetType(tag_parts[0]), tag_parts[1], tag_parts[2]
 
     @property
     def _version(self) -> str:

--- a/scripts/azureml-assets/azureml/assets/copy_unreleased_assets.py
+++ b/scripts/azureml-assets/azureml/assets/copy_unreleased_assets.py
@@ -4,6 +4,7 @@
 """Copy unreleased assets from release directory to output directory."""
 
 import argparse
+import re
 from pathlib import Path
 
 import azureml.assets as assets
@@ -38,7 +39,8 @@ def copy_unreleased_asset(asset_config: assets.AssetConfig,
 def copy_unreleased_assets(release_directory_root: Path,
                            output_directory_root: Path,
                            asset_config_filename: str,
-                           use_version_dirs: bool = False):
+                           use_version_dirs: bool = False,
+                           pattern: re.Pattern = None):
     """Copy unreleased assets from release directory to output directory.
 
     Args:
@@ -46,11 +48,12 @@ def copy_unreleased_assets(release_directory_root: Path,
         output_directory_root (Path, optional): Output directory
         asset_config_filename (str): Asset config filename to search for.
         use_version_dirs (bool, optional): Use version directories for output. Defaults to False.
+        pattern (re.Pattern, optional): Regex pattern for assets to copy. Defaults to None.
     """
     # Find assets under release dir
     asset_count = 0
     copied_count = 0
-    for asset_config in util.find_assets(release_directory_root, asset_config_filename):
+    for asset_config in util.find_assets(release_directory_root, asset_config_filename, pattern=pattern):
         asset_count += 1
 
         # Copy asset if tag doesn't exist
@@ -78,10 +81,13 @@ if __name__ == '__main__':
                         help="Asset config file name to search for")
     parser.add_argument("-v", "--use-version-dirs", action="store_true",
                         help="Use version directories when storing assets in output directory")
+    parser.add_argument("-t", "--pattern", type=re.compile,
+                        help="Regex pattern to select assets to copy, in the format <type>/<name>/<version>")
     args = parser.parse_args()
 
     # Release assets
     copy_unreleased_assets(release_directory_root=args.release_directory,
                            output_directory_root=args.output_directory,
                            asset_config_filename=args.asset_config_filename,
-                           use_version_dirs=args.use_version_dirs)
+                           use_version_dirs=args.use_version_dirs,
+                           pattern=args.pattern)

--- a/scripts/azureml-assets/azureml/assets/tag_released_assets.py
+++ b/scripts/azureml-assets/azureml/assets/tag_released_assets.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+"""Create tags for released assets."""
+
 import argparse
 from git import Repo
 from pathlib import Path
@@ -15,6 +17,15 @@ def tag_released_assets(input_directory: Path,
                         release_directory_root: Path,
                         git_username: str = None,
                         git_email: str = None):
+    """Create tags for released assets.
+
+    Args:
+        input_directory (Path): Directory containing released assets.
+        asset_config_filename (str): Asset config filename to search for.
+        release_directory_root (Path): Release directory location.
+        git_username (str, optional): User name to use for tag creation. Defaults to None.
+        git_email (str, optional): Email address to use for tag creation. Defaults to None.
+    """
     repo = Repo(release_directory_root)
 
     # Set username and email

--- a/scripts/azureml-assets/azureml/assets/tag_released_assets.py
+++ b/scripts/azureml-assets/azureml/assets/tag_released_assets.py
@@ -26,7 +26,7 @@ def tag_released_assets(input_directory: Path,
     # Create tags locally
     tag_refs = []
     for asset_config in util.find_assets(input_directory, asset_config_filename):
-        tag = assets.get_release_tag_name(asset_config)
+        tag = asset_config.full_name
         message = f"Release {asset_config}"
 
         logger.print(f"Creating tag {tag}")

--- a/scripts/azureml-assets/azureml/assets/update_assets.py
+++ b/scripts/azureml-assets/azureml/assets/update_assets.py
@@ -48,20 +48,6 @@ def pin_env_files(env_config: assets.EnvironmentConfig):
             logger.log_warning(f"Failed to pin versions in {file_to_pin}: File not found")
 
 
-def get_release_tag_name(asset_config: assets.AssetConfig) -> str:
-    """Generate the Git release tag for an asset.
-
-    Args:
-        asset_config (assets.AssetConfig): Asset config
-
-    Returns:
-        str: Release tag
-    """
-    version = asset_config.spec_as_object().version
-    return util.RELEASE_TAG_VERSION_TEMPLATE.format(type=asset_config.type.value, name=asset_config.name,
-                                                    version=version)
-
-
 def release_tag_exists(asset_config: assets.AssetConfig, release_directory_root: Path) -> bool:
     """Check repo for an asset's release tag.
 
@@ -74,8 +60,7 @@ def release_tag_exists(asset_config: assets.AssetConfig, release_directory_root:
     """
     # Check git repo for version-specific tag
     repo = Repo(release_directory_root)
-    tag = get_release_tag_name(asset_config)
-    return tag in repo.tags
+    return asset_config.full_name in repo.tags
 
 
 def update_asset(asset_config: assets.AssetConfig,

--- a/scripts/azureml-assets/azureml/assets/util/__init__.py
+++ b/scripts/azureml-assets/azureml/assets/util/__init__.py
@@ -4,7 +4,6 @@
 from .logger import logger
 from .template import render
 from .util import (
-    RELEASE_TAG_VERSION_TEMPLATE,
     apply_tag_template,
     apply_version_template,
     are_dir_trees_equal,
@@ -18,6 +17,5 @@ from .util import (
     get_asset_output_dir_from_parts,
     get_asset_release_dir,
     get_asset_release_dir_from_parts,
-    parse_release_tag,
     load_yaml,
 )

--- a/test/test_update_assets.py
+++ b/test/test_update_assets.py
@@ -62,7 +62,7 @@ def test_update_assets(test_subdir: str, skip_unreleased: bool, create_tag: bool
         # Create tag
         if create_tag:
             asset_config = util.find_assets(input_dirs=temp_release_path)[0]
-            repo.create_tag(assets.get_release_tag_name(asset_config))
+            repo.create_tag(asset_config.full_name)
 
         # Create updatable expected dir
         if expected_dir.exists():


### PR DESCRIPTION
* Refactor handling of an asset's "full name", which is \<type\>/\<name\>/\<version\>
* Use `re.Pattern` where possible instead of `str`
* Add `--pattern` arg to copy_unreleased_assets.py script