### PR TITLE
Fix vulnerability for mldesigner and mldesigner-minimal

### DIFF
--- a/pipelines/environments/mldesigner-minimal/context/conda_dependencies.yaml
+++ b/pipelines/environments/mldesigner-minimal/context/conda_dependencies.yaml
@@ -1,10 +1,8 @@
 name: mldesigner-minimal
 channels:
-- anaconda
 - conda-forge
 dependencies:
 - python=3.8.13
 - pip=21.3.1
 - pip:
   - mldesigner=={{latest-pypi-version:pre}}
-  - wheel==0.38.1

--- a/pipelines/environments/mldesigner-minimal/context/conda_dependencies.yaml
+++ b/pipelines/environments/mldesigner-minimal/context/conda_dependencies.yaml
@@ -7,3 +7,4 @@ dependencies:
 - pip=21.3.1
 - pip:
   - mldesigner=={{latest-pypi-version:pre}}
+  - wheel==0.38.1

--- a/pipelines/environments/mldesigner/context/conda_dependencies.yaml
+++ b/pipelines/environments/mldesigner/context/conda_dependencies.yaml
@@ -1,6 +1,5 @@
 name: mldesigner
 channels:
-- anaconda
 - conda-forge
 dependencies:
 - python=3.8.13
@@ -9,4 +8,3 @@ dependencies:
   - azure-ai-ml=={{latest-pypi-version}}
   - azureml-mlflow=={{latest-pypi-version}}
   - mldesigner=={{latest-pypi-version:pre}}
-  - wheel==0.38.1

--- a/pipelines/environments/mldesigner/context/conda_dependencies.yaml
+++ b/pipelines/environments/mldesigner/context/conda_dependencies.yaml
@@ -9,3 +9,4 @@ dependencies:
   - azure-ai-ml=={{latest-pypi-version}}
   - azureml-mlflow=={{latest-pypi-version}}
   - mldesigner=={{latest-pypi-version:pre}}
+  - wheel==0.38.1


### PR DESCRIPTION
Pin `wheel` to 0.38.1 to resolve vulnerability following this link: <https://github.com/advisories/GHSA-qwmp-2cf2-g9g6>