### PR TITLE
Update RAI images to fix dependency vulnerability

### DIFF
--- a/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -30,7 +30,12 @@ RUN pip install 'azureml-dataset-runtime==1.48.0' \
 RUN pip install 'ml-wrappers~=0.4.2' \
                 'shap==0.40.0' \
                 'interpret-community==0.28.0' \
-                'Pillow>=9.1.0'
+                'Pillow>=9.1.0' \
+                'dask>=2021.10.0' \
+                'distributed>=2021.10.0' \
+                'onnx>=1.13.0' \
+                'setuptools>=65.5.1' \
+                'joblib>=1.2.0'
 
 RUN pip freeze
 


### PR DESCRIPTION
We have 5 vulnerabilities:
https://github.com/advisories/GHSA-ffxj-547x-5j7c
https://github.com/advisories/GHSA-r9hx-vwmv-q579
https://github.com/advisories/GHSA-6hrg-qmvc-2xh8
https://github.com/advisories/GHSA-hwqr-f3v9-hwxr
https://github.com/advisories/GHSA-j8fq-86c5-5v2r

This PR pins those package versions to resolve dependency vulnerability issue.