### PR TITLE
add number_of_workers and random_seed parameters

### DIFF
--- a/training/vision/components/image_classification/spec.yaml
+++ b/training/vision/components/image_classification/spec.yaml
@@ -104,12 +104,20 @@ inputs:
     type: integer
     optional: true
     min: 1
+  number_of_workers:
+    description: Number of subprocesses to use for data loading (PyTorch only). 0 means that the data will be loaded in the main process.
+    type: integer
+    optional: true
   optimizer:
     description: Type of optimizer
     type: string
     optional: true
     default: sgd
     enum: ['sgd', 'adam', 'adamw']
+  random_seed:
+    description: Random seed that will be set at the beginning of training.
+    type: integer
+    optional: true
   step_lr_gamma:
     description: Value of gamma when learning rate scheduler is step. Please check for https://learn.microsoft.com/azure/machine-learning/reference-automl-images-hyperparameters more information.
     type: number
@@ -199,7 +207,9 @@ command: >-
   $[[--momentum  ${{inputs.momentum}}]]
   $[[--nesterov  ${{inputs.nesterov}}]]
   $[[--number_of_epochs ${{inputs.number_of_epochs}}]]
+  $[[--number_of_workers ${{inputs.number_of_workers}}]]
   $[[--optimizer ${{inputs.optimizer}}]]
+  $[[--random_seed ${{inputs.random_seed}}]]
   $[[--step_lr_gamma  ${{inputs.step_lr_gamma}}]]
   $[[--step_lr_step_size  ${{inputs.step_lr_step_size}}]]
   $[[--training_batch_size ${{inputs.training_batch_size}}]]

--- a/training/vision/components/instance_segmentation/spec.yaml
+++ b/training/vision/components/instance_segmentation/spec.yaml
@@ -127,12 +127,20 @@ inputs:
     type: integer
     optional: true
     min: 1
+  number_of_workers:
+    description: Number of subprocesses to use for data loading (PyTorch only). 0 means that the data will be loaded in the main process.
+    type: integer
+    optional: true
   optimizer:
     description: Type of optimizer
     type: string
     optional: true
     default: sgd
     enum: ['sgd', 'adam', 'adamw']
+  random_seed:
+    description: Random seed that will be set at the beginning of training.
+    type: integer
+    optional: true
   step_lr_gamma:
     description: Value of gamma when learning rate scheduler is step. Please check for https://learn.microsoft.com/azure/machine-learning/reference-automl-images-hyperparameters more information.
     type: number
@@ -235,7 +243,9 @@ command: >-
   $[[--nesterov  ${{inputs.nesterov}}]]
   $[[--nms_iou_thresh  ${{inputs.nms_iou_threshold}}]]
   $[[--number_of_epochs ${{inputs.number_of_epochs}}]]
+  $[[--number_of_workers ${{inputs.number_of_workers}}]]
   $[[--optimizer ${{inputs.optimizer}}]]
+  $[[--random_seed ${{inputs.random_seed}}]]
   $[[--step_lr_gamma  ${{inputs.step_lr_gamma}}]]
   $[[--step_lr_step_size  ${{inputs.step_lr_step_size}}]]
   $[[--tile_grid_size  ${{inputs.tile_grid_size}}]]

--- a/training/vision/components/object_detection/spec.yaml
+++ b/training/vision/components/object_detection/spec.yaml
@@ -137,12 +137,20 @@ inputs:
     type: integer
     optional: true
     min: 1
+  number_of_workers:
+    description: Number of subprocesses to use for data loading (PyTorch only). 0 means that the data will be loaded in the main process.
+    type: integer
+    optional: true
   optimizer:
     description: Type of optimizer
     type: string
     optional: true
     default: sgd
     enum: ['sgd', 'adam', 'adamw']
+  random_seed:
+    description: Random seed that will be set at the beginning of training.
+    type: integer
+    optional: true
   step_lr_gamma:
     description: Value of gamma when learning rate scheduler is step. Must be a float in the range [0, 1].
     type: number
@@ -246,7 +254,9 @@ command: >-
   $[[--nesterov  ${{inputs.nesterov}}]]
   $[[--nms_iou_thresh  ${{inputs.nms_iou_threshold}}]]
   $[[--number_of_epochs ${{inputs.number_of_epochs}}]]
+  $[[--number_of_workers ${{inputs.number_of_workers}}]]
   $[[--optimizer ${{inputs.optimizer}}]]
+  $[[--random_seed ${{inputs.random_seed}}]]
   $[[--step_lr_gamma  ${{inputs.step_lr_gamma}}]]
   $[[--step_lr_step_size  ${{inputs.step_lr_step_size}}]]
   $[[--tile_grid_size  ${{inputs.tile_grid_size}}]]


### PR DESCRIPTION
Adding number_of_workers and random_seed parameter to image components.

Test run
https://ml.azure.com/runs/88ede6cf-a93a-4f9b-babc-e920029b0bd2?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/automlimage_eastus2_rg/providers/Microsoft.MachineLearningServices/workspaces/risha-ws-centraluseuap&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#