### PR TITLE
Refactor asset publish

### DIFF
--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -187,7 +187,8 @@ def validate_update_command_component(
 
     # TODO: Bug in env list, which does not give complete detail
     # https://github.com/Azure/azure-sdk-for-python/issues/29248
-    component.environment = f"azureml://registries/{registry_name}/environments/{env['name']}/versions/{env['version']}"
+    env_id = f"azureml://registries/{registry_name}/environments/{env['name']}/versions/{env['version']}"
+    component.environment = env_id
     if not update_spec(component, spec_path):
         logger.print(f"Component update failed for asset spec path: {asset.spec_path}")
         return False

--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -28,7 +28,7 @@ from azure.ai.ml.entities import Component, Environment, Model
 
 ASSET_ID_TEMPLATE = Template("azureml://registries/$registry_name/$asset_type/$asset_name/versions/$version")
 TEST_YML = "tests.yml"
-PUBLISH_ORDER = [assets.AssetType.MODEL, assets.AssetType.ENVIRONMENT, assets.AssetType.COMPONENT]
+PUBLISH_ORDER = [assets.AssetType.ENVIRONMENT, assets.AssetType.COMPONENT, assets.AssetType.MODEL]
 WORKSPACE_ASSET_PATTERN = re.compile(r"^(?:azureml:)?(.+)(?::(.+)|@(.+))$")
 REGISTRY_ENV_PATTERN = re.compile(r"^azureml://registries/.+/environments/(.+)/(?:versions/(.+)|labels/(.+))")
 
@@ -188,10 +188,12 @@ def validate_update_command_component(
     # TODO: Bug in env list, which does not give complete detail
     # https://github.com/Azure/azure-sdk-for-python/issues/29248
     env_id = f"azureml://registries/{registry_name}/environments/{env['name']}/versions/{env['version']}"
+    logger.print(f"Updating component env to {env_id}")
     component.environment = env_id
     if not update_spec(component, spec_path):
         logger.print(f"Component update failed for asset spec path: {asset.spec_path}")
         return False
+    return True
 
 
 def run_command(cmd: List[str]):
@@ -258,7 +260,6 @@ def publish_asset(
 
     # Run command
     result = run_command(cmd)
-    debug_mode = True
     if debug_mode:
         # Capture and redact output
         redacted_output = re.sub(r"Bearer.*", "", result.stdout)

--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -14,7 +14,7 @@ from string import Template
 from subprocess import PIPE, STDOUT, run
 from tempfile import TemporaryDirectory
 from collections import defaultdict
-from typing import List, Union
+from typing import Dict, List, Union
 import azureml.assets as assets
 from azureml.assets.model.mlflow_utils import MLFlowModelUtils
 import azureml.assets.util as util
@@ -24,13 +24,12 @@ from azureml.assets.model import ModelDownloadUtils
 from azureml.assets.util import logger
 from azure.ai.ml import MLClient, load_component, load_model
 from azure.ai.ml.entities import Component, Environment, Model
-from azure.identity import AzureCliCredential
 
 
 ASSET_ID_TEMPLATE = Template("azureml://registries/$registry_name/$asset_type/$asset_name/versions/$version")
 TEST_YML = "tests.yml"
 PUBLISH_ORDER = [assets.AssetType.ENVIRONMENT, assets.AssetType.COMPONENT, assets.AssetType.MODEL]
-WORKSPACE_ENV_PATTERN = re.compile(r"^(?:azureml:)?(.+)(?::(.+)|@(.+))$")
+WORKSPACE_ASSET_PATTERN = re.compile(r"^(?:azureml:)?(.+)(?::(.+)|@(.+))$")
 REGISTRY_ENV_PATTERN = re.compile(r"^azureml://registries/.+/environments/(.+)/(?:versions/(.+)|labels/(.+))")
 
 
@@ -139,27 +138,27 @@ def prepare_model(model_config: assets.ModelConfig, spec_file_path: Path, model_
 
 
 def validate_update_command_component(
-    mlclient: MLClient,
     component: Component,
     spec_path: Path,
-    final_version: str
+    final_version: str,
+    registry_name: str,
 ) -> bool:
     """Validate and update command component spec.
 
-    :param mlclient: MLClient object
-    :type mlclient: MLClient
     :param component: A command component
     :type component: Component
     :param spec_path: Path of loaded component
     :type spec_path: Path
     :param final_version: Final version string used to register component
     :type final_version: str
+    :param registry_name: name of the registry to publish component to
+    :type registry_name: str
     :return: True for successful validation and update
     :rtype: bool
     """
     env = component.environment
     match = None
-    for pattern in [REGISTRY_ENV_PATTERN, WORKSPACE_ENV_PATTERN]:
+    for pattern in [REGISTRY_ENV_PATTERN, WORKSPACE_ASSET_PATTERN]:
         if (match := pattern.match(env)) is not None:
             break
 
@@ -179,26 +178,42 @@ def validate_update_command_component(
 
     env = None
     # Check if component's env is registered
-    for version in [env_version, final_version]:
-        try:
-            if (env := mlclient.environments.get(name=env_name, version=version)) is not None:
-                break
-        except Exception as e:
-            logger.print(f"Fetching component env {env_name}:{version} from registry failed. Error: {e}")
+    registered_envs = get_registered_asset_versions(assets.AssetType.ENVIRONMENT, env_name, registry_name)    
+    env = next((x for x in registered_envs if x['version'] in [env_version, final_version] ), None)
 
     if not env:
         logger.print(f"Could not find a registered env for {component.name}. Please retry again!!!")
         return False
 
-    component.environment = env.id
+    component.environment = env["id"]
     if not update_spec(component, spec_path):
         logger.print(f"Component update failed for asset spec path: {asset.spec_path}")
         return False
 
 
-def assemble_command(
+def run_command(cmd: List[str]):
+    """Run the command for and return result."""
+    result = run(cmd, stdout=PIPE, stderr=PIPE, encoding=sys.stdout.encoding, errors="ignore")
+    return result
+
+
+def asset_list_command(
     asset_type: str,
-    # subscription_id: str,
+    asset_name: str,
+    registry_name: str,
+) -> List[str]:
+    """Command to list of registered asset versions."""
+    cmd = [
+        "az", "ml", asset_type, "list",
+        "--name", asset_name,
+        "--registry-name", registry_name,
+    ]
+    print(cmd)
+    return cmd
+
+
+def asset_publish_command(
+    asset_type: str,
     asset_path: str,
     registry_name: str,
     version: str,
@@ -209,7 +224,6 @@ def assemble_command(
     """Assemble the az cli command."""
     cmd = [
         shutil.which("az"), "ml", asset_type, "create",
-        # "--subscription", subscription_id,
         "--file", asset_path,
         "--registry-name", registry_name,
         "--version", version,
@@ -221,32 +235,55 @@ def assemble_command(
     if debug_mode:
         cmd.append("--debug")
     print(cmd)
-
     return cmd
 
 
-def run_command(
-    cmd, failure_list: List, debug_mode: bool = None
+def publish_asset(
+    asset,
+    registry_name,
+    resource_group,
+    workspace_name,
+    version,
+    failure_list,
+    debug_mode: bool = None
 ):
-    """Run the az cli command for pushing the model to registry."""
+    """ Publish asset to registry."""
+    registered_assets = get_registered_asset_versions(asset.type.value, asset.name, registry_name, return_dict=True)
+    if version in registered_assets:
+        print(f"Version already registered. Skipping publish for asset: {asset.name}")
+        return
+
+    cmd = asset_publish_command(
+        asset.type.value, str(asset.spec_with_path),
+        registry_name, version, resource_group, workspace_name, debug_mode
+    )
+
+    # Run command
+    result = run_command(cmd, failure_list, debug_mode)
     if debug_mode:
         # Capture and redact output
-        results = run(
-            cmd,
-            stdout=PIPE,
-            stderr=STDOUT,
-            encoding=sys.stdout.encoding,
-            errors="ignore",
-        )
-        redacted_output = re.sub(r"Bearer.*", "", results.stdout)
-        logger.print(redacted_output)
-    else:
-        results = run(cmd)
+        redacted_output = re.sub(r"Bearer.*", "", result.stdout)
+        print(redacted_output)
 
-    # Check command result
-    if results.returncode != 0:
-        logger.log_warning(f"Error creating {asset.type.value} : {asset.name}")
+    if result.returncode != 0:
+        print(f"Error creating {asset.type.value} : {asset.name}")
         failure_list.append(asset)
+
+
+def get_registered_asset_versions(asset_type: str, asset_name: str, registry_name: str, return_dict=False) -> Union[Dict, List]:
+    """Return list/dict of registered asset versions."""
+    result = run_command(asset_list_command(
+        asset_type=asset_type,
+        asset_name=asset_name,
+        registry_name=registry_name,
+    ))
+    if result.returncode != 0:
+        print(f"Error in listing asset version. stdout:\n{result.stdout}")
+        result = "[]"
+    registered_assets = json.loads(result.stdout)
+    if return_dict:
+        return {x['version']:x for x in registered_assets}
+    return registered_assets
 
 
 def _str2bool(v: str) -> bool:
@@ -324,10 +361,6 @@ if __name__ == "__main__":
     for asset in all_assets:
         assets_by_type[asset.type.value].append(asset)
 
-    # mlclient for the registry
-    credential = AzureCliCredential()
-    mlclient = MLClient(credential=credential, registry_name=registry_name, show_progress=False)
-
     for publish_asset_type in PUBLISH_ORDER:
         logger.print(f"now publishing {publish_asset_type.value}s.")
         if publish_asset_type.value not in publish_list:
@@ -355,7 +388,9 @@ if __name__ == "__main__":
                 logger.print(f"spec's path: {asset.spec_with_path}")
                 component = load_component(asset.spec_with_path)
                 if component.type == "command":
-                    if not validate_update_command_component(mlclient, component, asset.spec_with_path, final_version):
+                    if not validate_update_command_component(
+                        component, asset.spec_with_path, final_version, registry_name
+                    ):
                         failure_list.append(asset)
                         continue
             elif asset.type == assets.AssetType.MODEL:
@@ -369,12 +404,16 @@ if __name__ == "__main__":
                     failure_list.append(asset)
                     continue
 
-            # Assemble command
-            cmd = assemble_command(
-                asset.type.value, str(asset.spec_with_path),
-                registry_name, final_version, resource_group, workspace, debug_mode)
-            # Run command
-            run_command(cmd, failure_list, debug_mode)
+            # publish asset
+            publish_asset(
+                asset=asset,
+                version=final_version,
+                registry_name=registry_name,
+                resource_group=resource_group,
+                workspace_name=workspace,
+                failure_list=failure_list,
+                debug_mode=debug_mode
+            )
 
     if len(failure_list) > 0:
         failed_assets = defaultdict(list)

--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -67,6 +67,13 @@ def preprocess_test_files(test_jobs, asset_ids: dict):
                           sort_keys=False)
 
 
+def sanitize_output(input: str) -> str:
+    """Return sanitized string."""
+    # Remove sensitive token
+    sanitized_output = re.sub(BEARER, "", input)
+    return sanitized_output
+
+
 def update_spec(asset: Union[Component, Environment, Model], spec_path: Path) -> bool:
     """Update the yaml spec file with updated properties in asset.
 
@@ -226,13 +233,6 @@ def asset_publish_command(
     if debug_mode:
         cmd.append("--debug")
     return cmd
-
-
-def sanitize_output(out: str):
-    """Sanitize output."""
-    # Remove sensitive token    
-    sanitized_output = re.sub(BEARER, "", out)
-    return sanitized_output
 
 
 def publish_asset(

--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -247,7 +247,7 @@ def publish_asset(
     failure_list,
     debug_mode: bool = None
 ):
-    """ Publish asset to registry."""
+    """Publish asset to registry."""
     registered_assets = get_registered_asset_versions(asset.type.value, asset.name, registry_name, return_dict=True)
     if version in registered_assets:
         print(f"Version already registered. Skipping publish for asset: {asset.name}")

--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -14,7 +14,7 @@ from string import Template
 from subprocess import run
 from tempfile import TemporaryDirectory
 from collections import defaultdict
-from typing import Dict, List, Union
+from typing import List, Union
 import azureml.assets as assets
 from azureml.assets.model.mlflow_utils import MLFlowModelUtils
 import azureml.assets.util as util

--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 from pathlib import Path
 from string import Template
-from subprocess import PIPE, STDOUT, run
+from subprocess import PIPE, run
 from tempfile import TemporaryDirectory
 from collections import defaultdict
 from typing import Dict, List, Union
@@ -22,7 +22,7 @@ import yaml
 from azureml.assets.config import PathType
 from azureml.assets.model import ModelDownloadUtils
 from azureml.assets.util import logger
-from azure.ai.ml import MLClient, load_component, load_model
+from azure.ai.ml import load_component, load_model
 from azure.ai.ml.entities import Component, Environment, Model
 
 
@@ -178,8 +178,8 @@ def validate_update_command_component(
 
     env = None
     # Check if component's env is registered
-    registered_envs = get_registered_asset_versions(assets.AssetType.ENVIRONMENT, env_name, registry_name)    
-    env = next((x for x in registered_envs if x['version'] in [env_version, final_version] ), None)
+    registered_envs = get_registered_asset_versions(assets.AssetType.ENVIRONMENT, env_name, registry_name)
+    env = next((x for x in registered_envs if x['version'] in [env_version, final_version]), None)
 
     if not env:
         logger.print(f"Could not find a registered env for {component.name}. Please retry again!!!")
@@ -270,7 +270,12 @@ def publish_asset(
         failure_list.append(asset)
 
 
-def get_registered_asset_versions(asset_type: str, asset_name: str, registry_name: str, return_dict=False) -> Union[Dict, List]:
+def get_registered_asset_versions(
+    asset_type: str,
+    asset_name: str,
+    registry_name: str,
+    return_dict=False
+) -> Union[Dict, List]:
     """Return list/dict of registered asset versions."""
     result = run_command(asset_list_command(
         asset_type=asset_type,
@@ -282,7 +287,7 @@ def get_registered_asset_versions(asset_type: str, asset_name: str, registry_nam
         result = "[]"
     registered_assets = json.loads(result.stdout)
     if return_dict:
-        return {x['version']:x for x in registered_assets}
+        return {x['version']: x for x in registered_assets}
     return registered_assets
 
 

--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -271,9 +271,8 @@ def get_registered_asset_versions(
     asset_type: str,
     asset_name: str,
     registry_name: str,
-    return_dict=False
-) -> Union[Dict, List]:
-    """Return list/dict of registered asset versions."""
+) -> List:
+    """Return list of registered asset versions."""
     cmd = [
         "az", "ml", asset_type, "list",
         "--name", asset_name,
@@ -285,8 +284,6 @@ def get_registered_asset_versions(
         logger.log_warning(msg)
         raise Exception(msg)
     registered_assets = json.loads(result.stdout)
-    if return_dict:
-        return {x['version']: x for x in registered_assets}
     return registered_assets
 
 
@@ -402,8 +399,8 @@ if __name__ == "__main__":
                     # check if model is already registered
                     final_version = asset.version
                     registered_assets = get_registered_asset_versions(
-                        asset.type.value, asset.name, registry_name, return_dict=True)
-                    if final_version in registered_assets:
+                        asset.type.value, asset.name, registry_name)
+                    if final_version in [x['version'] for x in registered_assets]:
                         logger.print(f"Version already registered. Skipping publish for asset: {asset.name}")
                         continue
 

--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -28,7 +28,7 @@ from azure.ai.ml.entities import Component, Environment, Model
 
 ASSET_ID_TEMPLATE = Template("azureml://registries/$registry_name/$asset_type/$asset_name/versions/$version")
 TEST_YML = "tests.yml"
-PUBLISH_ORDER = [assets.AssetType.ENVIRONMENT, assets.AssetType.COMPONENT, assets.AssetType.MODEL]
+PUBLISH_ORDER = [assets.AssetType.MODEL, assets.AssetType.ENVIRONMENT, assets.AssetType.COMPONENT]
 WORKSPACE_ASSET_PATTERN = re.compile(r"^(?:azureml:)?(.+)(?::(.+)|@(.+))$")
 REGISTRY_ENV_PATTERN = re.compile(r"^azureml://registries/.+/environments/(.+)/(?:versions/(.+)|labels/(.+))")
 
@@ -258,10 +258,13 @@ def publish_asset(
 
     # Run command
     result = run_command(cmd)
+    debug_mode = True
     if debug_mode:
         # Capture and redact output
         redacted_output = re.sub(r"Bearer.*", "", result.stdout)
-        print(redacted_output)
+        redacted_err = re.sub(r"Bearer.*", "", result.stderr)
+        print(f"stdout: {redacted_output}")
+        print(f"stderr: {redacted_err}")
 
     if result.returncode != 0:
         print(f"Error creating {asset.type.value} : {asset.name}")
@@ -369,61 +372,62 @@ if __name__ == "__main__":
         if publish_asset_type.value not in publish_list:
             continue
         for asset in assets_by_type.get(publish_asset_type.value, []):
-            asset_names = publish_list.get(asset.type.value, [])
-            if not ("*" in asset_names or asset.name in asset_names):
-                logger.print(
-                    f"Skipping registering asset {asset.name} because it is not in the publish list")
-                continue
-            logger.print(f"Registering {asset}")
-            final_version = asset.version + "-" + \
-                passed_version if passed_version else asset.version
-            logger.print(f"final version: {final_version}")
-            asset_ids[asset.name] = ASSET_ID_TEMPLATE.substitute(
-                registry_name=registry_name,
-                asset_type=f"{asset.type.value}s",
-                asset_name=asset.name,
-                version=final_version,
-            )
+            with TemporaryDirectory() as work_dir:
+                asset_names = publish_list.get(asset.type.value, [])
+                if not ("*" in asset_names or asset.name in asset_names):
+                    logger.print(
+                        f"Skipping registering asset {asset.name} because it is not in the publish list")
+                    continue
+                logger.print(f"Registering {asset}")
+                final_version = asset.version + "-" + \
+                    passed_version if passed_version else asset.version
+                logger.print(f"final version: {final_version}")
+                asset_ids[asset.name] = ASSET_ID_TEMPLATE.substitute(
+                    registry_name=registry_name,
+                    asset_type=f"{asset.type.value}s",
+                    asset_name=asset.name,
+                    version=final_version,
+                )
 
-            # Handle specific asset types
-            if asset.type == assets.AssetType.COMPONENT:
-                # load component and check if environment exists
-                logger.print(f"spec's path: {asset.spec_with_path}")
-                component = load_component(asset.spec_with_path)
-                if component.type == "command":
-                    if not validate_update_command_component(
-                        component, asset.spec_with_path, final_version, registry_name
-                    ):
+                # Handle specific asset types
+                if asset.type == assets.AssetType.COMPONENT:
+                    # load component and check if environment exists
+                    logger.print(f"spec's path: {asset.spec_with_path}")
+                    component = load_component(asset.spec_with_path)
+                    if component.type == "command":
+                        if not validate_update_command_component(
+                            component, asset.spec_with_path, final_version, registry_name
+                        ):
+                            failure_list.append(asset)
+                            continue
+                elif asset.type == assets.AssetType.MODEL:
+                    # check if model is already registered
+                    final_version = asset.version
+                    registered_assets = get_registered_asset_versions(
+                        asset.type.value, asset.name, registry_name, return_dict=True)
+                    if final_version in registered_assets:
+                        print(f"Version already registered. Skipping publish for asset: {asset.name}")
+                        continue
+
+                    try:
+                        model_config = asset.extra_config_as_object()
+                        if not prepare_model(model_config, asset.spec_with_path, Path(work_dir)):
+                            raise Exception(f"Could not prepare model at {asset.spec_with_path}")
+                    except Exception as e:
+                        logger.log_error(f"Model prepare exception. Error => {e}")
                         failure_list.append(asset)
                         continue
-            elif asset.type == assets.AssetType.MODEL:
-                final_version = asset.version
-                registered_assets = get_registered_asset_versions(
-                    asset.type.value, asset.name, registry_name, return_dict=True)
-                if final_version in registered_assets:
-                    print(f"Version already registered. Skipping publish for asset: {asset.name}")
-                    continue
 
-                try:
-                    model_config = asset.extra_config_as_object()
-                    with TemporaryDirectory() as tempdir:
-                        if not prepare_model(model_config, asset.spec_with_path, Path(tempdir)):
-                            raise Exception(f"Could not prepare model at {asset.spec_with_path}")
-                except Exception as e:
-                    logger.log_error(f"Model prepare exception. Error => {e}")
-                    failure_list.append(asset)
-                    continue
-
-            # publish asset
-            publish_asset(
-                asset=asset,
-                version=final_version,
-                registry_name=registry_name,
-                resource_group=resource_group,
-                workspace_name=workspace,
-                failure_list=failure_list,
-                debug_mode=debug_mode
-            )
+                # publish asset
+                publish_asset(
+                    asset=asset,
+                    version=final_version,
+                    registry_name=registry_name,
+                    resource_group=resource_group,
+                    workspace_name=workspace,
+                    failure_list=failure_list,
+                    debug_mode=debug_mode
+                )
 
     if len(failure_list) > 0:
         failed_assets = defaultdict(list)


### PR DESCRIPTION
**Problem**
- Using MLClient is consistently causing failures in fetching token from environment.
- MLClient was used to fetch if env version exists before component publish. 

**Solution**
- Used az ml cli to perform the same operations
- Created a thread internally to discuss mlclient issue
- Tested locally and triggering a test release