### PR TITLE
Add support for PRS in build config scripts

### DIFF
--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -156,6 +156,13 @@ class Config:
         return [path]
 
 
+class ComponentType(Enum):
+    """Enum for path types supported for model publishing."""
+
+    PIPELINE = "component"  # A pipeline component which allows multi-stage jobs.
+    PARALLEL = "parallel" # A parallel component, aka PRSv2.
+    COMMAND = "command" # A command component.
+
 class Spec(Config):
     """Load and access spec file properties.
 
@@ -220,6 +227,9 @@ class Spec(Config):
     @property
     def code_dir(self) -> str:
         """Component code directory."""
+        if(self._yaml.get('type') == ComponentType.PARALLEL):
+            task = self._yaml.get('task')
+            return None if task is None else task.get('code')
         return self._yaml.get('code')
 
     @property

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -160,8 +160,8 @@ class ComponentType(Enum):
     """Enum for component types."""
 
     PIPELINE = "pipeline"  # A pipeline component which allows multi-stage jobs.
-    PARALLEL = "parallel" # A parallel component, aka PRSv2.
-    COMMAND = "command" # A command component.
+    PARALLEL = "parallel"  # A parallel component, aka PRSv2.
+    COMMAND = "command"  # A command component.
 
 
 class Spec(Config):
@@ -228,8 +228,7 @@ class Spec(Config):
     @property
     def code_dir(self) -> str:
         """Component code directory."""
-        if(self._yaml.get('type') == ComponentType.PARALLEL.value):
-
+        if self._yaml.get('type') == ComponentType.PARALLEL.value:
             task = self._yaml.get('task')
             return None if task is None else task.get('code')
         return self._yaml.get('code')

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -163,6 +163,7 @@ class ComponentType(Enum):
     PARALLEL = "parallel" # A parallel component, aka PRSv2.
     COMMAND = "command" # A command component.
 
+
 class Spec(Config):
     """Load and access spec file properties.
 

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -159,7 +159,7 @@ class Config:
 class ComponentType(Enum):
     """Enum for component types."""
 
-    PIPELINE = "component"  # A pipeline component which allows multi-stage jobs.
+    PIPELINE = "pipeline"  # A pipeline component which allows multi-stage jobs.
     PARALLEL = "parallel" # A parallel component, aka PRSv2.
     COMMAND = "command" # A command component.
 

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -157,7 +157,7 @@ class Config:
 
 
 class ComponentType(Enum):
-    """Enum for path types supported for model publishing."""
+    """Enum for component types."""
 
     PIPELINE = "component"  # A pipeline component which allows multi-stage jobs.
     PARALLEL = "parallel" # A parallel component, aka PRSv2.

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -228,7 +228,8 @@ class Spec(Config):
     @property
     def code_dir(self) -> str:
         """Component code directory."""
-        if(self._yaml.get('type') == ComponentType.PARALLEL):
+        if(self._yaml.get('type') == ComponentType.PARALLEL.value):
+
             task = self._yaml.get('task')
             return None if task is None else task.get('code')
         return self._yaml.get('code')


### PR DESCRIPTION
Parallel run steps leverage `task.code` for the reference to its code asset whilst component uses `code`.
In order to support parallel run steps, I have added support for 
- Detecting the component type in the spec configuration
- Fetching the code directory from task.code rather than code in the case of a parallel run step type