### PR TITLE
Handle env refs with @latest labels

### DIFF
--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -189,6 +189,8 @@ def validate_update_command_component(
 
     if env_label:
         if env_label == LATEST_LABEL:
+            # TODO: Use a more direct approach like this, when supported by Azure CLI:
+            # az ml environment show --name sklearn-1.1-ubuntu20.04-py38-cpu --registry-name azureml --label latest
             versions = get_asset_versions(assets.AssetType.ENVIRONMENT.value, env_name, registry_name)
             if versions:
                 # List is returned with the latest version at the beginning


### PR DESCRIPTION
Adds support to create components that reference registry environments using the `latest` label. Doesn't support curated environments, since these can't be looked up via `az ml environment list`.

Also includes some refactoring and cleanup.