### PR TITLE
drop metadata columns in production dataset

### DIFF
--- a/responsibleai/model_monitor/components/feature_attribution/spec.yaml
+++ b/responsibleai/model_monitor/components/feature_attribution/spec.yaml
@@ -1,6 +1,6 @@
 $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: feature_attribution_drift_compute_metrics
-version: 0.0.2
+version: 0.0.3
 display_name: Feature Attribution Drift - Compute Metrics
 is_deterministic: False
 type: command

--- a/responsibleai/model_monitor/components/src/compute_attribution_drift.py
+++ b/responsibleai/model_monitor/components/src/compute_attribution_drift.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 
 from sklearn.metrics import ndcg_score
-from azureml.exceptions import UserErrorException
 from feature_importance_utilities import get_model_wrapper, compute_explanations,  compute_categorical_features, drop_metadata_columns
 from io_utils import load_mltable_to_df, save_df_as_mltable
 

--- a/responsibleai/model_monitor/components/src/compute_attribution_drift.py
+++ b/responsibleai/model_monitor/components/src/compute_attribution_drift.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from sklearn.metrics import ndcg_score
 from azureml.exceptions import UserErrorException
-from feature_importance_utilities import get_model_wrapper, compute_explanations,  compute_categorical_features
+from feature_importance_utilities import get_model_wrapper, compute_explanations,  compute_categorical_features, drop_metadata_columns
 from io_utils import load_mltable_to_df, save_df_as_mltable
 
 
@@ -43,7 +43,6 @@ def calculate_attribution_drift(baseline_explanations, production_explanations):
     true_relevance = np.asarray([baseline_explanations])
     relevance_score = np.asarray([production_explanations])
     feature_attribution_drift = ndcg_score(true_relevance, relevance_score)
-    # just log for now, eventually we will have to write the output
     _logger.info(f"feature attribution drift calculated: {feature_attribution_drift}")
     return feature_attribution_drift
 
@@ -65,8 +64,7 @@ def compute_attribution_drift(task_type, target_column, baseline_dataframe, prod
       :return: the ndcg metric between the baseline and production data
       :rtype: float
     """
-    if len(baseline_dataframe.columns.difference(production_dataframe.columns)) > 0:
-        raise UserErrorException("Dataset columns differ in baseline and production datasets")
+    production_dataframe = drop_metadata_columns(baseline_dataframe, production_dataframe)
 
     model_wrapper = get_model_wrapper(task_type, target_column, baseline_dataframe, production_dataframe)
 
@@ -78,10 +76,10 @@ def compute_attribution_drift(task_type, target_column, baseline_dataframe, prod
     production_explanations = compute_explanations(model_wrapper, production_dataframe, categorical_features, target_column, task_type)
     _logger.info("Successfully computed explanations for production dataset")
 
-    write_to_mltable(baseline_explanations, production_explanations, feature_attribution_data)
+    compute_ndcg_and_write_to_mltable(baseline_explanations, production_explanations, feature_attribution_data)
 
 
-def write_to_mltable(baseline_explanations, production_explanations, feature_attribution_data):
+def compute_ndcg_and_write_to_mltable(baseline_explanations, production_explanations, feature_attribution_data):
     """write feature importance values to mltable
       :param explanations: list of feature importances in the order of the baseline columns
       :type explanations: list[float]

--- a/responsibleai/model_monitor/components/src/feature_importance_utilities.py
+++ b/responsibleai/model_monitor/components/src/feature_importance_utilities.py
@@ -81,6 +81,7 @@ def get_model_wrapper(task_type, target_column, baseline_dataframe, production_d
     _logger.info("Created ml wrapper")
     return model_wrapper
 
+
 def drop_metadata_columns(baseline_dataframe, production_dataframe):
     """Drop any columns from production dataframe that are not in the baseline
        dataframe; necessary because the production dataframe could contain extra
@@ -99,8 +100,8 @@ def drop_metadata_columns(baseline_dataframe, production_dataframe):
             production_dataframe = production_dataframe.drop([column], axis=1)
             _logger.info(f"Dropped {column} column in production dataset")
     return production_dataframe
-        
-        
+
+
 def compute_categorical_features(baseline_dataframe, target_column):
     """Compute which features are categorical based on data type of the columns.
 

--- a/responsibleai/model_monitor/components/src/feature_importance_utilities.py
+++ b/responsibleai/model_monitor/components/src/feature_importance_utilities.py
@@ -81,7 +81,26 @@ def get_model_wrapper(task_type, target_column, baseline_dataframe, production_d
     _logger.info("Created ml wrapper")
     return model_wrapper
 
-
+def drop_metadata_columns(baseline_dataframe, production_dataframe):
+    """Drop any columns from production dataframe that are not in the baseline
+       dataframe; necessary because the production dataframe could contain extra
+       metadata columns which should be removed.
+       :param baseline_dataframe: The baseline data meaning the data used to create the
+      model monitor
+      :type baseline_dataframe: pandas.DataFrame
+      :param production_dataframe: The production data meaning the most recent set of data
+      sent to the model monitor, the current set of data
+      :type production_dataframe: pandas.DataFrame
+      :return: production dataframe with removed columns
+      :rtype: pandas.DataFrame
+    """
+    for column in production_dataframe.columns:
+        if column not in baseline_dataframe.columns:
+            production_dataframe = production_dataframe.drop([column], axis=1)
+            _logger.info(f"Dropped {column} column in production dataset")
+    return production_dataframe
+        
+        
 def compute_categorical_features(baseline_dataframe, target_column):
     """Compute which features are categorical based on data type of the columns.
 


### PR DESCRIPTION
Remove columns in production dataset that aren't present in baseline dataset. There could be columns in the production dataset that are not in the baseline dataset in the case that there's added mlflow metadata and we should not throw an error in this case. Instead, use the baseline dataset as the ground truth for columns and remove any columns in the production dataset that do not appear in the baseline dataset. 