### PR TITLE
Fix failed_assets yaml dump

### DIFF
--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -605,7 +605,7 @@ if __name__ == "__main__":
         # the following dump process will generate a yaml file for the report
         # process in the end of the publishing script
         with open(failed_list_file, "w") as file:
-            yaml.dump(failed_assets, file)
+            yaml.dump(json.loads(json.dumps(failed_assets)), file)
 
     if tests_dir:
         logger.print("Locating test files")

--- a/scripts/release/asset_publish.py
+++ b/scripts/release/asset_publish.py
@@ -605,7 +605,7 @@ if __name__ == "__main__":
         # the following dump process will generate a yaml file for the report
         # process in the end of the publishing script
         with open(failed_list_file, "w") as file:
-            yaml.dump(json.loads(json.dumps(failed_assets)), file)
+            yaml.dump(dict(failed_assets), file)
 
     if tests_dir:
         logger.print("Locating test files")


### PR DESCRIPTION
**Error**

2023-04-11 11:09:05.712443:     raise RepresenterError(_F('cannot represent an object: {data!s}', data=data))
2023-04-11 11:09:05.712451: ruamel.yaml.representer.RepresenterError: cannot represent an object: defaultdict(<class 'list'>, {'component': [****]})