### PR TITLE
MMDetection model conversion to pyfunc mlflow

### DIFF
--- a/training/model_management/components/convert_model_to_mlflow/spec.yaml
+++ b/training/model_management/components/convert_model_to_mlflow/spec.yaml
@@ -36,7 +36,7 @@ inputs:
       - mmlab_pyfunc
     default: transformers
     optional: false
-    description: Mlflow flavor to convert model into.
+    description: Mlflow flavor to convert model into. Please note that, mmlab_pyfunc flavor is only supported for image object detection models.
 
   task_name:
     type: string

--- a/training/model_management/components/convert_model_to_mlflow/spec.yaml
+++ b/training/model_management/components/convert_model_to_mlflow/spec.yaml
@@ -18,7 +18,7 @@ command: >
   $[[--task-name ${{inputs.task_name}}]]
   $[[--model-download-metadata ${{inputs.model_download_metadata}}]]
   $[[--license-file-path ${{inputs.license_file_path}}]]
-  --mlflow-flavor transformers
+  --mlflow-flavor ${{inputs.mlflow_flavor}}
   --model-path ${{inputs.model_path}}
   --mlflow-model-output-dir ${{outputs.mlflow_model_folder}}
   --model-import-job-path ${{outputs.model_import_job_path}}
@@ -28,6 +28,15 @@ inputs:
     type: string
     description: Huggingface model id (https://huggingface.co/<model_id>). A required parameter for transformers flavor. Can be provided as input here or in model_download_metadata JSON file.
     optional: true
+  
+  mlflow_flavor:
+    type: string
+    enum:
+      - transformers
+      - pyfunc
+    default: transformers
+    optional: false
+    description: Mlflow flavor to convert model into.
 
   task_name:
     type: string
@@ -41,6 +50,7 @@ inputs:
       - text-classification
       - translation
       - image-classification
+      - image-object-detection
       - text-to-image
     description: A Hugging face task on which model was trained on. A required parameter for transformers mlflow flavor. Can be provided as input here or in model_download_metadata JSON file.
     optional: true

--- a/training/model_management/components/convert_model_to_mlflow/spec.yaml
+++ b/training/model_management/components/convert_model_to_mlflow/spec.yaml
@@ -33,7 +33,7 @@ inputs:
     type: string
     enum:
       - transformers
-      - pyfunc
+      - mmlab_pyfunc
     default: transformers
     optional: false
     description: Mlflow flavor to convert model into.

--- a/training/model_management/src/azureml/model/mgmt/config.py
+++ b/training/model_management/src/azureml/model/mgmt/config.py
@@ -23,7 +23,7 @@ class ModelFlavor(_CustomEnum):
     """Enum for the Flavors accepted in ModelConfig."""
 
     TRANSFORMERS = "transformers"
-    PYFUNC = "pyfunc"
+    MMLAB_PYFUNC = "mmlab_pyfunc"
 
 
 class PathType(_CustomEnum):

--- a/training/model_management/src/azureml/model/mgmt/config.py
+++ b/training/model_management/src/azureml/model/mgmt/config.py
@@ -23,6 +23,7 @@ class ModelFlavor(_CustomEnum):
     """Enum for the Flavors accepted in ModelConfig."""
 
     TRANSFORMERS = "transformers"
+    PYFUNC = "pyfunc"
 
 
 class PathType(_CustomEnum):

--- a/training/model_management/src/azureml/model/mgmt/processors/preprocess.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/preprocess.py
@@ -25,7 +25,7 @@ def run_preprocess(mlflow_flavor: str, model_path: Path, output_dir: Path, **pre
     print(f"Run preprocess for model with flavor: {mlflow_flavor} at path: {model_path}")
     if mlflow_flavor == ModelFlavor.TRANSFORMERS.value:
         transformers.to_mlflow(model_path, output_dir, preprocess_args)
-    elif mlflow_flavor == ModelFlavor.PYFUNC.value:
+    elif mlflow_flavor == ModelFlavor.MMLAB_PYFUNC.value:
         pyfunc.to_mlflow(model_path, output_dir, preprocess_args)
     else:
         raise Exception(f"Unsupported model flavor: {mlflow_flavor}.")

--- a/training/model_management/src/azureml/model/mgmt/processors/preprocess.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/preprocess.py
@@ -5,6 +5,7 @@
 
 import azureml.model.mgmt.processors.transformers as transformers
 from azureml.model.mgmt.config import ModelFlavor
+from azureml.model.mgmt.processors import pyfunc
 from pathlib import Path
 from typing import Dict
 
@@ -24,6 +25,8 @@ def run_preprocess(mlflow_flavor: str, model_path: Path, output_dir: Path, **pre
     print(f"Run preprocess for model with flavor: {mlflow_flavor} at path: {model_path}")
     if mlflow_flavor == ModelFlavor.TRANSFORMERS.value:
         transformers.to_mlflow(model_path, output_dir, preprocess_args)
+    elif mlflow_flavor == ModelFlavor.PYFUNC.value:
+        pyfunc.to_mlflow(model_path, output_dir, preprocess_args)
     else:
         raise Exception(f"Unsupported model flavor: {mlflow_flavor}.")
     print("Model prepocessing completed !!!")

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/__init__.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Module init file."""
+# flake8: noqa
+
+from .convert import to_mlflow

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
@@ -18,7 +18,8 @@ from .vision.config import MLFlowSchemaLiterals, MMDetLiterals, Tasks
 
 
 def _prepare_artifacts_dict(input_dir: Path) -> Dict:
-    """Prepare artifacts dict for mlflow model
+    """Prepare artifacts dict for mlflow model.
+
     :param input_dir: input directory
     :type input_dir: Path
     :return: artifacts dict
@@ -36,7 +37,8 @@ def _prepare_artifacts_dict(input_dir: Path) -> Dict:
 
 
 def _get_mlflow_signature(task_type: str) -> ModelSignature:
-    """Return mlflow model signature with input and output schema given the input task type
+    """Return mlflow model signature with input and output schema given the input task type.
+
     :param task_type: Task type used in training
     :type task_type: str
     :return: mlflow model signature.
@@ -58,6 +60,7 @@ def _get_mlflow_signature(task_type: str) -> ModelSignature:
 @log_execution_time
 def to_mlflow(input_dir: Path, output_dir: Path, translate_params: Dict) -> None:
     """Convert Hugging face pytorch model to Mlflow.
+
     :param input_dir: model input directory
     :type input_dir: Path
     :param output_dir: output directory

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
@@ -32,16 +32,7 @@ def _prepare_artifacts_dict(input_dir: Path) -> Dict:
         MMDetLiterals.CONFIG_PATH: os.path.join(input_dir, metadata.get("pytorch_model_path")),
         MMDetLiterals.WEIGHTS_PATH: os.path.join(input_dir, metadata.get("model_weights_path_or_url")),
     }
-
-    config_dir = os.path.join(input_dir, "model")
-    if not os.path.exists(config_dir):
-        return artifacts_dict
-
-    extra_config_files = {
-        file: os.path.join(config_dir, file) for file in os.listdir(config_dir) if file.endswith(".py")
-    }
-    extra_config_files.update(artifacts_dict)
-    return extra_config_files
+    return artifacts_dict
 
 
 def _get_mlflow_signature(task_type: str) -> ModelSignature:

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
@@ -1,0 +1,102 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""HFTransformers convert model."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Dict
+
+import mlflow
+from azureml.model.mgmt.utils.common_utils import log_execution_time
+from mlflow.models.signature import ModelSignature
+from mlflow.types.schema import ColSpec, Schema
+
+from .vision.config import MLFlowSchemaLiterals, MMDetLiterals, Tasks
+
+
+def _prepare_artifacts_dict(input_dir: Path) -> Dict:
+    """Prepare artifacts dict for mlflow model
+    :param input_dir: input directory
+    :type input_dir: Path
+    :return: artifacts dict
+    :rtype: Dict
+    """
+    metadata_path = os.path.join(input_dir, "model_selector_args.json")
+    with open(metadata_path) as f:
+        metadata = json.load(f)
+
+    artifacts_dict = {
+        MMDetLiterals.CONFIG_PATH: os.path.join(input_dir, metadata.get("pytorch_model_path")),
+        MMDetLiterals.WEIGHTS_PATH: os.path.join(input_dir, metadata.get("model_weights_path_or_url")),
+    }
+
+    config_dir = os.path.join(input_dir, "model")
+    if not os.path.exists(config_dir):
+        return artifacts_dict
+
+    extra_config_files = {
+        file: os.path.join(config_dir, file) for file in os.listdir(config_dir) if file.endswith(".py")
+    }
+    extra_config_files.update(artifacts_dict)
+    return extra_config_files
+
+
+def _get_mlflow_signature(task_type: str) -> ModelSignature:
+    """Return mlflow model signature with input and output schema given the input task type
+    :param task_type: Task type used in training
+    :type task_type: str
+    :return: mlflow model signature.
+    :rtype: mlflow.models.signature.ModelSignature
+    """
+    input_schema = Schema(
+        [ColSpec(MLFlowSchemaLiterals.INPUT_COLUMN_IMAGE_DATA_TYPE, MLFlowSchemaLiterals.INPUT_COLUMN_IMAGE)]
+    )
+
+    if task_type == Tasks.MM_OBJECT_DETECTION.value:
+        output_schema = Schema(
+            [
+                ColSpec(MLFlowSchemaLiterals.OUTPUT_COLUMN_DATA_TYPE, MLFlowSchemaLiterals.OUTPUT_COLUMN_BOXES),
+            ]
+        )
+    return ModelSignature(inputs=input_schema, outputs=output_schema)
+
+
+@log_execution_time
+def to_mlflow(input_dir: Path, output_dir: Path, translate_params: Dict) -> None:
+    """Convert Hugging face pytorch model to Mlflow.
+    :param input_dir: model input directory
+    :type input_dir: Path
+    :param output_dir: output directory
+    :type output_dir: Path
+    :param translate_params: mlflow translation params
+    :type translate_params: Dict
+    """
+    model_name = translate_params.get("model_id")
+    task = translate_params["task"]
+
+    sys.path.append(os.path.join(os.path.dirname(__file__), "vision"))
+    from detection_predict import ImagesDetectionMLFlowModelWrapper
+
+    mlflow_model_wrapper = ImagesDetectionMLFlowModelWrapper(task_type=task)
+    artifacts_dict = _prepare_artifacts_dict(input_dir)
+    pip_requirements = os.path.join(os.path.dirname(__file__), "vision", "requirements.txt")
+    code_path = [
+        os.path.join(os.path.dirname(__file__), "vision", "detection_predict.py"),
+        os.path.join(os.path.dirname(__file__), "vision", "config.py"),
+    ]
+    signatures = translate_params.get("signature") or _get_mlflow_signature(task)
+
+    mlflow.pyfunc.save_model(
+        path=output_dir,
+        python_model=mlflow_model_wrapper,
+        artifacts=artifacts_dict,
+        pip_requirements=pip_requirements,
+        signature=signatures,
+        code_path=code_path,
+        metadata={"model_name": model_name},
+    )
+
+    print("Model saved!!!")

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
@@ -54,6 +54,8 @@ def _get_mlflow_signature(task_type: str) -> ModelSignature:
                 ColSpec(MLFlowSchemaLiterals.OUTPUT_COLUMN_DATA_TYPE, MLFlowSchemaLiterals.OUTPUT_COLUMN_BOXES),
             ]
         )
+    else:
+        raise NotImplementedError(f"Task type: {task_type} is not supported yet.")
     return ModelSignature(inputs=input_schema, outputs=output_schema)
 
 

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/config.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/config.py
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""HFTransformers Config."""
+
+from enum import Enum
+
+
+MLFLOW_ARTIFACT_DIRECTORY = "mlflow_model_folder"
+
+
+class _CustomEnum(Enum):
+    @classmethod
+    def has_value(cls, value):
+        return value in cls._value2member_map_
+
+
+class Tasks(_CustomEnum):
+    """Tasks supported for All Frameworks"""
+
+    MM_OBJECT_DETECTION = "image-object-detection"
+    MM_INSTANCE_SEGMENTATION = "image-instance-segmentation"
+
+
+class MMDetLiterals:
+    """MMDetection constants"""
+
+    CONFIG_PATH = "config_path"
+    WEIGHTS_PATH = "weights_path"
+    AUGMENTATIONS_PATH = "augmentations_path"
+
+
+class MLFlowSchemaLiterals:
+    """MLFlow model signature related schema"""
+
+    INPUT_IMAGE_KEY = "image_base64"
+    INPUT_COLUMN_IMAGE_DATA_TYPE = "string"
+    INPUT_COLUMN_IMAGE = "image"
+    OUTPUT_COLUMN_DATA_TYPE = "string"
+    OUTPUT_COLUMN_FILENAME = "filename"
+    OUTPUT_COLUMN_PROBS = "probs"
+    OUTPUT_COLUMN_LABELS = "labels"
+    OUTPUT_COLUMN_BOXES = "boxes"
+    BATCH_SIZE_KEY = "batch_size"
+    SCHEMA_SIGNATURE = "signature"
+    TRAIN_LABEL_LIST = "train_label_list"
+    WRAPPER = "images_model_wrapper"
+    THRESHOLD = "threshold"
+
+
+class ODLiterals:
+    """OD constants"""
+
+    LABEL = "label"
+    BOXES = "boxes"
+    SCORE = "score"
+    BOX = "box"
+    TOP_X = "topX"
+    TOP_Y = "topY"
+    BOTTOM_X = "bottomX"
+    BOTTOM_Y = "bottomY"

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/config.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/config.py
@@ -16,14 +16,14 @@ class _CustomEnum(Enum):
 
 
 class Tasks(_CustomEnum):
-    """Tasks supported for All Frameworks"""
+    """Tasks supported for All Frameworks."""
 
     MM_OBJECT_DETECTION = "image-object-detection"
     MM_INSTANCE_SEGMENTATION = "image-instance-segmentation"
 
 
 class MMDetLiterals:
-    """MMDetection constants"""
+    """MMDetection constants."""
 
     CONFIG_PATH = "config_path"
     WEIGHTS_PATH = "weights_path"
@@ -31,7 +31,7 @@ class MMDetLiterals:
 
 
 class MLFlowSchemaLiterals:
-    """MLFlow model signature related schema"""
+    """MLFlow model signature related schema."""
 
     INPUT_IMAGE_KEY = "image_base64"
     INPUT_COLUMN_IMAGE_DATA_TYPE = "string"
@@ -49,7 +49,7 @@ class MLFlowSchemaLiterals:
 
 
 class ODLiterals:
-    """OD constants"""
+    """OD constants."""
 
     LABEL = "label"
     BOXES = "boxes"

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -115,7 +115,7 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
             # Install mmcv and mmdet using mim, with pip installation is not working
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmcv-full==1.7.1"])
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmdet==2.28.2"])
-            subprocess.check_call([sys.executable, "-m", "pip", "install", 
+            subprocess.check_call([sys.executable, "-m", "pip", "install",
                                    "opencv-python-headless==4.7.0.72", "--force-reinstall"])
 
             # importing mmdet/mmcv afte installing using mim

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -1,0 +1,183 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Mlflow PythonModel wrapper class that loads the Mlflow model, preprocess inputs and performs inference."""
+
+import base64
+import io
+import re
+import subprocess
+import sys
+import tempfile
+
+import mlflow
+import numpy as np
+import pandas as pd
+import requests
+import torch
+from PIL import Image
+
+from config import Tasks, MMDetLiterals, MLFlowSchemaLiterals, ODLiterals
+
+
+def _create_temp_file(request_body: bytes, parent_dir: str) -> str:
+    """Create temporory file, save image and return path to the file.
+
+    :param request_body: Image
+    :type request_body: bytes
+    :param parent_dir: directory name
+    :type parent_dir: str
+    :return: Path to the file
+    :rtype: str
+    """
+    with tempfile.NamedTemporaryFile(dir=parent_dir, mode="wb", delete=False) as image_file_fp:
+        # image_file_fp.write(request_body)
+        img_path = image_file_fp.name + ".png"
+        img = Image.open(io.BytesIO(request_body))
+        img.save(img_path)
+        return img_path
+
+
+def _process_image(img: pd.Series) -> pd.Series:
+    """If input image is in base64 string format, decode it to bytes. If input image is in url format,
+    download it and return bytes.
+    https://github.com/mlflow/mlflow/blob/master/examples/flower_classifier/image_pyfunc.py
+    :param img: pandas series with image in base64 string format or url
+    :type img: pd.Series
+    :return: decoded image in pandas series format.
+    :rtype: Pandas Series
+    """
+    image = img[0]
+    if _is_valid_url(image):
+        image = requests.get(image).content
+        return pd.Series(image)
+    try:
+        return pd.Series(base64.b64decode(image))
+    except Exception:
+        raise ValueError("Invalid image format")
+
+
+def _is_valid_url(text: str) -> bool:
+    """check if text is url or base64 string
+    :param text: text to validate
+    :type text: str
+    :return: True if url else false
+    :rtype: bool
+    """
+    regex = (
+        "((http|https)://)(www.)?"
+        + "[a-zA-Z0-9@:%._\\+~#?&//=]"
+        + "{2,256}\\.[a-z]"
+        + "{2,6}\\b([-a-zA-Z0-9@:%"
+        + "._\\+~#?&//=]*)"
+    )
+    p = re.compile(regex)
+
+    # If the string is empty
+    # return false
+    if str is None:
+        return False
+
+    # Return if the string
+    # matched the ReGex
+    if re.search(p, text):
+        return True
+    else:
+        return False
+
+
+class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
+    """MLFlow model wrapper for AutoML for Images models."""
+
+    def __init__(
+        self,
+        task_type: str,
+    ) -> None:
+        """This method is called when the python model wrapper is initialized.
+
+        :param task_type: Task type used in training.
+        :type task_type: str
+        """
+        super().__init__()
+        self._model = None
+        self._inference_detector = None
+        self._task_type = task_type
+
+    def load_context(self, context: mlflow.pyfunc.PythonModelContext) -> None:
+        """This method is called when loading a Mlflow model with pyfunc.load_model().
+
+        :param context: Mlflow context containing artifacts that the model can use for inference
+        :type context: mlflow.pyfunc.PythonModelContext
+        """
+        print("Inside load_context()")
+
+        if self._task_type == Tasks.MM_OBJECT_DETECTION.value:
+            # Install mmcv and mmdet using mim, with pip installation is not working
+            subprocess.check_call([sys.executable, "-m", "mim", "install", "mmcv-full==1.7.1"])
+            subprocess.check_call([sys.executable, "-m", "mim", "install", "mmdet==2.28.2"])
+
+            # importing mmdet/mmcv afte installing using mim
+            from mmcv import Config
+            from mmdet.apis import inference_detector, init_detector
+            self._inference_detector = inference_detector
+            
+            try:
+                model_config_path = context.artifacts[MMDetLiterals.CONFIG_PATH]
+                model_weights_path = context.artifacts[MMDetLiterals.WEIGHTS_PATH]
+
+                _map_location = "cuda" if torch.cuda.is_available() else "cpu"
+                _config = Config.fromfile(model_config_path)
+                self._model = init_detector(_config, model_weights_path, device=_map_location)
+
+                print("Model loaded successfully")
+            except Exception:
+                print("Failed to load the the model.")
+                raise
+        else:
+            raise ValueError(f"invalid task type {self._task_type}")
+
+    def predict(self, context: mlflow.pyfunc.PythonModelContext, input_data: pd.DataFrame) -> pd.DataFrame:
+        """This method performs inference on the input data.
+
+        :param context: Mlflow context containing artifacts that the model can use for inference
+        :type context: mlflow.pyfunc.PythonModelContext
+        :param input_data: Input images for prediction
+        :type input_data: Pandas DataFrame with a first column name ["image"] of images where each
+        image is in base64 String format.
+        :return: Output of inferencing
+        :rtype: Pandas DataFrame with columns ["boxes"] for object detection
+        """
+
+        # process the images in image column
+        processed_images = input_data.loc[:, [MLFlowSchemaLiterals.INPUT_COLUMN_IMAGE]].apply(
+            axis=1, func=_process_image
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_output_dir:
+            image_path_list = (
+                processed_images.iloc[:, 0].map(lambda row: _create_temp_file(row, tmp_output_dir)).tolist()
+            )
+            results = self._inference_detector(imgs=image_path_list, model=self._model)
+
+            predictions = []
+            for result in results:
+                bboxes = np.vstack(result)
+                labels = [np.full(bbox.shape[0], i, dtype=np.int32) for i, bbox in enumerate(result)]
+                labels = np.concatenate(labels)
+
+                cur_image_preds = {ODLiterals.BOXES: []}
+                for bbox, label in zip(bboxes, labels):
+                    cur_image_preds[ODLiterals.BOXES].append(
+                        {
+                            ODLiterals.BOX: {
+                                ODLiterals.TOP_X: str(bbox[0]),
+                                ODLiterals.TOP_Y: str(bbox[1]),
+                                ODLiterals.BOTTOM_X: str(bbox[2]),
+                                ODLiterals.BOTTOM_Y: str(bbox[3]),
+                            },
+                            ODLiterals.LABEL: self._model.CLASSES[label],
+                            ODLiterals.SCORE: str(bbox[4]),
+                        }
+                    )
+                predictions.append(cur_image_preds)
+        return pd.DataFrame(predictions)

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -39,10 +39,8 @@ def _create_temp_file(request_body: bytes, parent_dir: str) -> str:
 
 
 def _process_image(img: pd.Series) -> pd.Series:
-    """If input image is in base64 string format, decode it to bytes. If input image is in url format,
-    download it and return bytes.
+    """Process the image input (image url or base64 string) and return bytes.
 
-    https://github.com/mlflow/mlflow/blob/master/examples/flower_classifier/image_pyfunc.py
     :param img: pandas series with image in base64 string format or url
     :type img: pd.Series
     :return: decoded image in pandas series format.
@@ -59,7 +57,7 @@ def _process_image(img: pd.Series) -> pd.Series:
 
 
 def _is_valid_url(text: str) -> bool:
-    """check if text is url or base64 string.
+    """Check if text is url or base64 string.
 
     :param text: text to validate
     :type text: str
@@ -95,7 +93,7 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
         self,
         task_type: str,
     ) -> None:
-        """MLFlow model wrapper for AutoML for Images models.
+        """Mlflow model wrapper for AutoML for Images models.
 
         :param task_type: Task type used in training.
         :type task_type: str
@@ -117,12 +115,14 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
             # Install mmcv and mmdet using mim, with pip installation is not working
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmcv-full==1.7.1"])
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmdet==2.28.2"])
-            subprocess.check_call([sys.executable, "-m", "pip", "install",
-                                   "opencv-python-headless==4.7.0.72", "--force-reinstall"])
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "opencv-python-headless==4.7.0.72", "--force-reinstall"]
+            )
 
             # importing mmdet/mmcv afte installing using mim
             from mmdet.apis import inference_detector, init_detector
             from mmcv import Config
+
             self._inference_detector = inference_detector
             try:
                 model_config_path = context.artifacts[MMDetLiterals.CONFIG_PATH]
@@ -140,7 +140,7 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
             raise ValueError(f"invalid task type {self._task_type}")
 
     def predict(self, context: mlflow.pyfunc.PythonModelContext, input_data: pd.DataFrame) -> pd.DataFrame:
-        """Performs inference on the input data.
+        """Perform inference on the input data.
 
         :param context: Mlflow context containing artifacts that the model can use for inference
         :type context: mlflow.pyfunc.PythonModelContext

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -173,13 +173,13 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
                     cur_image_preds[ODLiterals.BOXES].append(
                         {
                             ODLiterals.BOX: {
-                                ODLiterals.TOP_X: str(bbox[0]),
-                                ODLiterals.TOP_Y: str(bbox[1]),
-                                ODLiterals.BOTTOM_X: str(bbox[2]),
-                                ODLiterals.BOTTOM_Y: str(bbox[3]),
+                                ODLiterals.TOP_X: float(bbox[0]),
+                                ODLiterals.TOP_Y: float(bbox[1]),
+                                ODLiterals.BOTTOM_X: float(bbox[2]),
+                                ODLiterals.BOTTOM_Y: float(bbox[3]),
                             },
                             ODLiterals.LABEL: self._model.CLASSES[label],
-                            ODLiterals.SCORE: str(bbox[4]),
+                            ODLiterals.SCORE: float(bbox[4]),
                         }
                     )
                 predictions.append(cur_image_preds)

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -115,12 +115,12 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
             # Install mmcv and mmdet using mim, with pip installation is not working
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmcv-full==1.7.1"])
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmdet==2.28.2"])
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "opencv-python-headless==4.7.0.72", "--force-reinstall"])
 
             # importing mmdet/mmcv afte installing using mim
-            from mmcv import Config
             from mmdet.apis import inference_detector, init_detector
+            from mmcv import Config
             self._inference_detector = inference_detector
-            
             try:
                 model_config_path = context.artifacts[MMDetLiterals.CONFIG_PATH]
                 model_weights_path = context.artifacts[MMDetLiterals.WEIGHTS_PATH]

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -41,6 +41,7 @@ def _create_temp_file(request_body: bytes, parent_dir: str) -> str:
 def _process_image(img: pd.Series) -> pd.Series:
     """If input image is in base64 string format, decode it to bytes. If input image is in url format,
     download it and return bytes.
+
     https://github.com/mlflow/mlflow/blob/master/examples/flower_classifier/image_pyfunc.py
     :param img: pandas series with image in base64 string format or url
     :type img: pd.Series
@@ -58,7 +59,8 @@ def _process_image(img: pd.Series) -> pd.Series:
 
 
 def _is_valid_url(text: str) -> bool:
-    """check if text is url or base64 string
+    """check if text is url or base64 string.
+
     :param text: text to validate
     :type text: str
     :return: True if url else false
@@ -93,7 +95,7 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
         self,
         task_type: str,
     ) -> None:
-        """This method is called when the python model wrapper is initialized.
+        """MLFlow model wrapper for AutoML for Images models.
 
         :param task_type: Task type used in training.
         :type task_type: str
@@ -104,7 +106,7 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
         self._task_type = task_type
 
     def load_context(self, context: mlflow.pyfunc.PythonModelContext) -> None:
-        """This method is called when loading a Mlflow model with pyfunc.load_model().
+        """Load a Mlflow model with pyfunc.load_model().
 
         :param context: Mlflow context containing artifacts that the model can use for inference
         :type context: mlflow.pyfunc.PythonModelContext
@@ -138,7 +140,7 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
             raise ValueError(f"invalid task type {self._task_type}")
 
     def predict(self, context: mlflow.pyfunc.PythonModelContext, input_data: pd.DataFrame) -> pd.DataFrame:
-        """This method performs inference on the input data.
+        """Performs inference on the input data.
 
         :param context: Mlflow context containing artifacts that the model can use for inference
         :type context: mlflow.pyfunc.PythonModelContext
@@ -148,7 +150,6 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
         :return: Output of inferencing
         :rtype: Pandas DataFrame with columns ["boxes"] for object detection
         """
-
         # process the images in image column
         processed_images = input_data.loc[:, [MLFlowSchemaLiterals.INPUT_COLUMN_IMAGE]].apply(
             axis=1, func=_process_image

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -31,7 +31,6 @@ def _create_temp_file(request_body: bytes, parent_dir: str) -> str:
     :rtype: str
     """
     with tempfile.NamedTemporaryFile(dir=parent_dir, mode="wb", delete=False) as image_file_fp:
-        # image_file_fp.write(request_body)
         img_path = image_file_fp.name + ".png"
         img = Image.open(io.BytesIO(request_body))
         img.save(img_path)
@@ -115,6 +114,8 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
             # Install mmcv and mmdet using mim, with pip installation is not working
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmcv-full==1.7.1"])
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmdet==2.28.2"])
+            # mmdet installs opencv-python but it results in error while importing libGL.so.1. So, we
+            # need to re-install headless version of opencv-python.
             subprocess.check_call(
                 [sys.executable, "-m", "pip", "install", "opencv-python-headless==4.7.0.72", "--force-reinstall"]
             )

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -115,7 +115,8 @@ class ImagesDetectionMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
             # Install mmcv and mmdet using mim, with pip installation is not working
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmcv-full==1.7.1"])
             subprocess.check_call([sys.executable, "-m", "mim", "install", "mmdet==2.28.2"])
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "opencv-python-headless==4.7.0.72", "--force-reinstall"])
+            subprocess.check_call([sys.executable, "-m", "pip", "install", 
+                                   "opencv-python-headless==4.7.0.72", "--force-reinstall"])
 
             # importing mmdet/mmcv afte installing using mim
             from mmdet.apis import inference_detector, init_detector

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/requirements.txt
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/requirements.txt
@@ -1,0 +1,7 @@
+mlflow
+cloudpickle==2.2.2
+datasets==2.3.2
+openmim
+torch==1.11.0
+torchvision
+transformers==4.25.1

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/requirements.txt
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/requirements.txt
@@ -1,7 +1,5 @@
-mlflow
-cloudpickle==2.2.2
-datasets==2.3.2
-openmim
+mlflow==2.3.0
+cloudpickle==2.2.1
+openmim==0.3.7
 torch==1.11.0
-torchvision
-transformers==4.25.1
+torchvision==0.12.0

--- a/training/model_management/src/run_model_preprocess.py
+++ b/training/model_management/src/run_model_preprocess.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
 
     if mlflow_flavor == ModelFlavor.TRANSFORMERS.value:
         _validate_transformers_args(preprocess_args)
-    elif mlflow_flavor == ModelFlavor.PYFUNC.value:
+    elif mlflow_flavor == ModelFlavor.MMLAB_PYFUNC.value:
         _validate_pyfunc_args(preprocess_args)
 
     run_preprocess(mlflow_flavor, model_path, mlflow_model_output_dir, **preprocess_args)


### PR DESCRIPTION
Convert MM Detection model to mlflow format in pyfunc flavor.

For MM openlab model, we need to use Image "Object Detection and Instance Segmentation MMDetection Model Import" component to download the models from model name. This output is given to next component i.e, "Convert model to MLFlow component" to model_path port. It will produce mlflow output in the format 

New UI for for Convert model to [MLFlow format](https://ml.azure.com/model/mmcv1:1/artifacts?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourcegroups/grajguru-resource-group/workspaces/grajguru-workspace&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)

![image](https://user-images.githubusercontent.com/24417856/235659628-9e24c4b1-6147-4fab-97c0-abd488e7313d.png)




[Test run](https://ml.azure.com/experiments/id/52c64e94-2c68-4cf6-bffe-042284314c76/runs/3702e994-7ca1-4f18-aec2-98bb22c23388?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourcegroups/grajguru-resource-group/workspaces/grajguru-workspace&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)