### PR TITLE
update RAI text and vision components to latest released images

### DIFF
--- a/responsibleai/text/components/rai_text_insights/spec.yaml
+++ b/responsibleai/text/components/rai_text_insights/spec.yaml
@@ -1,5 +1,5 @@
 $schema: http://azureml/sdk-2-0/CommandComponent.json
-name: microsoft_azureml_rai_text_insights
+name: rai_text_insights
 display_name: RAI Text Insights
 version: 0.0.3.preview
 type: command
@@ -41,7 +41,7 @@ outputs:
   ux_json:
     type: path
 code: ../src
-environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/15
+environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/16
 command: >-
   python ./rai_text_insights.py
   --task_type ${{inputs.task_type}}

--- a/responsibleai/text/jobs/fetch_dbpedia_model.yml
+++ b/responsibleai/text/jobs/fetch_dbpedia_model.yml
@@ -16,7 +16,7 @@ outputs:
   model_output_path:
     type: path
 code: ./src_dbpedia/
-environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/15
+environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/16
 command: >-
   python fetch_text_model.py
   --model_base_name ${{inputs.model_base_name}}

--- a/responsibleai/vision/components/rai_vision_insights/spec.yaml
+++ b/responsibleai/vision/components/rai_vision_insights/spec.yaml
@@ -1,5 +1,5 @@
 $schema: http://azureml/sdk-2-0/CommandComponent.json
-name: microsoft_azureml_rai_vision_insights
+name: rai_vision_insights
 display_name: RAI Vision Insights
 version: 0.0.3.preview
 type: command
@@ -73,7 +73,7 @@ outputs:
   ux_json:
     type: path
 code: ../src
-environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/16
+environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/17
 command: >-
   python ./rai_vision_insights.py
   --task_type ${{inputs.task_type}}

--- a/responsibleai/vision/jobs/fetch_fridge_model.yml
+++ b/responsibleai/vision/jobs/fetch_fridge_model.yml
@@ -16,7 +16,7 @@ outputs:
   model_output_path:
     type: path
 code: ./src_fridge/
-environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/16
+environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/17
 command: >-
   python ./fetch_image_model.py
   --model_base_name ${{inputs.model_base_name}}


### PR DESCRIPTION
version bump for text and vision components (not yet released) to new corresponding environment versions that were just released:
![image](https://user-images.githubusercontent.com/24683184/235978565-70a04f5d-e7d2-4648-aecc-00271d03b57f.png)

Update: I have also changed component names back in this PR to remove microsoft_azureml_ as it seems it goes against latest component naming guidelines