### PR TITLE
update ft recommended sku as Standard_NC24rs_v3

### DIFF
--- a/common/components/deploy_model/asset.yaml
+++ b/common/components/deploy_model/asset.yaml
@@ -1,2 +1,3 @@
 type: component
 spec: spec.yaml
+categories: ["Models"]

--- a/common/components/deploy_model/spec.yaml
+++ b/common/components/deploy_model/spec.yaml
@@ -94,6 +94,7 @@ inputs:
       - Standard_NC16as_T4_v3
       - Standard_NC24s_v2
       - Standard_NC24s_v3
+      - Standard_NC24rs_v3
       - Standard_NC64as_T4_v3
       - Standard_ND40rs_v2
       - Standard_ND96asr_v4

--- a/models/system/bert-base-cased/asset.yaml
+++ b/models/system/bert-base-cased/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/bert-base-cased/spec.yaml
+++ b/models/system/bert-base-cased/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/bert-base-cased/spec.yaml
+++ b/models/system/bert-base-cased/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_NC24s_v3
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/bert-base-cased/spec.yaml
+++ b/models/system/bert-base-cased/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_NC24rs_v3
+  finetune-recommended-sku: Standard_NC24s_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/bert-base-uncased/asset.yaml
+++ b/models/system/bert-base-uncased/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/bert-base-uncased/spec.yaml
+++ b/models/system/bert-base-uncased/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/bert-large-cased/asset.yaml
+++ b/models/system/bert-large-cased/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/bert-large-cased/spec.yaml
+++ b/models/system/bert-large-cased/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 4|0|14|28
   evaluation-recommended-sku: Standard_DS3_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 4|0|14|28
   inference-recommended-sku: Standard_DS3_v2

--- a/models/system/bert-large-uncased/asset.yaml
+++ b/models/system/bert-large-uncased/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/bert-large-uncased/spec.yaml
+++ b/models/system/bert-large-uncased/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 4|0|14|28
   evaluation-recommended-sku: Standard_DS3_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 4|0|14|28
   inference-recommended-sku: Standard_DS3_v2

--- a/models/system/camembert-base/asset.yaml
+++ b/models/system/camembert-base/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/camembert-base/spec.yaml
+++ b/models/system/camembert-base/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/deepset-minilm-uncased-squad2/asset.yaml
+++ b/models/system/deepset-minilm-uncased-squad2/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/deepset-minilm-uncased-squad2/spec.yaml
+++ b/models/system/deepset-minilm-uncased-squad2/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/deepset-roberta-base-squad2/asset.yaml
+++ b/models/system/deepset-roberta-base-squad2/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/deepset-roberta-base-squad2/spec.yaml
+++ b/models/system/deepset-roberta-base-squad2/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/distilbert-base-cased-distilled-squad/asset.yaml
+++ b/models/system/distilbert-base-cased-distilled-squad/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/distilbert-base-cased-distilled-squad/spec.yaml
+++ b/models/system/distilbert-base-cased-distilled-squad/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/distilbert-base-cased/spec.yaml
+++ b/models/system/distilbert-base-cased/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/distilbert-base-uncased-distilled-squad/asset.yaml
+++ b/models/system/distilbert-base-uncased-distilled-squad/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/distilbert-base-uncased-distilled-squad/spec.yaml
+++ b/models/system/distilbert-base-uncased-distilled-squad/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/distilbert-base-uncased-finetuned-sst-2-english/asset.yaml
+++ b/models/system/distilbert-base-uncased-finetuned-sst-2-english/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/distilbert-base-uncased-finetuned-sst-2-english/spec.yaml
+++ b/models/system/distilbert-base-uncased-finetuned-sst-2-english/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/distilbert-base-uncased/asset.yaml
+++ b/models/system/distilbert-base-uncased/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/distilbert-base-uncased/spec.yaml
+++ b/models/system/distilbert-base-uncased/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/distilgpt2/asset.yaml
+++ b/models/system/distilgpt2/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/distilgpt2/spec.yaml
+++ b/models/system/distilgpt2/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/distilroberta-base/asset.yaml
+++ b/models/system/distilroberta-base/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/distilroberta-base/spec.yaml
+++ b/models/system/distilroberta-base/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/facebook-bart-large-cnn/asset.yaml
+++ b/models/system/facebook-bart-large-cnn/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/facebook-bart-large-cnn/spec.yaml
+++ b/models/system/facebook-bart-large-cnn/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 8|0|28|56
   evaluation-recommended-sku: Standard_DS4_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: summarization, translation
   inference-min-sku-spec: 8|0|28|56
   inference-recommended-sku: Standard_DS4_v2

--- a/models/system/finiteautomata-bertweet-base-sentiment-analysis/asset.yaml
+++ b/models/system/finiteautomata-bertweet-base-sentiment-analysis/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/finiteautomata-bertweet-base-sentiment-analysis/spec.yaml
+++ b/models/system/finiteautomata-bertweet-base-sentiment-analysis/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/gpt2-large/asset.yaml
+++ b/models/system/gpt2-large/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/gpt2-large/spec.yaml
+++ b/models/system/gpt2-large/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 8|0|28|56
   evaluation-recommended-sku: Standard_DS4_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification
   inference-min-sku-spec: 8|0|28|56
   inference-recommended-sku: Standard_DS4_v2

--- a/models/system/gpt2-medium/asset.yaml
+++ b/models/system/gpt2-medium/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/gpt2-medium/spec.yaml
+++ b/models/system/gpt2-medium/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 4|0|14|28
   evaluation-recommended-sku: Standard_DS3_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification
   inference-min-sku-spec: 4|0|14|28
   inference-recommended-sku: Standard_DS3_v2

--- a/models/system/gpt2/asset.yaml
+++ b/models/system/gpt2/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/gpt2/spec.yaml
+++ b/models/system/gpt2/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/jean-baptiste-camembert-ner/asset.yaml
+++ b/models/system/jean-baptiste-camembert-ner/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/jean-baptiste-camembert-ner/spec.yaml
+++ b/models/system/jean-baptiste-camembert-ner/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/microsoft-deberta-base-mnli/asset.yaml
+++ b/models/system/microsoft-deberta-base-mnli/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/microsoft-deberta-base-mnli/spec.yaml
+++ b/models/system/microsoft-deberta-base-mnli/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/microsoft-deberta-base/asset.yaml
+++ b/models/system/microsoft-deberta-base/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/microsoft-deberta-base/spec.yaml
+++ b/models/system/microsoft-deberta-base/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 4|0|14|28
   evaluation-recommended-sku: Standard_DS3_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 4|0|14|28
   inference-recommended-sku: Standard_DS3_v2

--- a/models/system/microsoft-deberta-large-mnli/asset.yaml
+++ b/models/system/microsoft-deberta-large-mnli/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/microsoft-deberta-large-mnli/spec.yaml
+++ b/models/system/microsoft-deberta-large-mnli/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/microsoft-deberta-large/asset.yaml
+++ b/models/system/microsoft-deberta-large/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/microsoft-deberta-large/spec.yaml
+++ b/models/system/microsoft-deberta-large/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 4|0|14|28
   evaluation-recommended-sku: Standard_DS3_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 4|0|14|28
   inference-recommended-sku: Standard_DS3_v2

--- a/models/system/microsoft-deberta-xlarge/asset.yaml
+++ b/models/system/microsoft-deberta-xlarge/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/microsoft-deberta-xlarge/spec.yaml
+++ b/models/system/microsoft-deberta-xlarge/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 8|0|28|56
   evaluation-recommended-sku: Standard_DS4_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 8|0|28|56
   inference-recommended-sku: Standard_DS4_v2

--- a/models/system/roberta-base-openai-detector/asset.yaml
+++ b/models/system/roberta-base-openai-detector/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/roberta-base-openai-detector/spec.yaml
+++ b/models/system/roberta-base-openai-detector/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/roberta-base/asset.yaml
+++ b/models/system/roberta-base/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/roberta-base/spec.yaml
+++ b/models/system/roberta-base/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/roberta-large-mnli/asset.yaml
+++ b/models/system/roberta-large-mnli/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/roberta-large-mnli/spec.yaml
+++ b/models/system/roberta-large-mnli/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/roberta-large-openai-detector/asset.yaml
+++ b/models/system/roberta-large-openai-detector/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/roberta-large-openai-detector/spec.yaml
+++ b/models/system/roberta-large-openai-detector/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/roberta-large/asset.yaml
+++ b/models/system/roberta-large/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/roberta-large/spec.yaml
+++ b/models/system/roberta-large/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 4|0|14|28
   evaluation-recommended-sku: Standard_DS3_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: text-classification, token-classification, question-answering
   inference-min-sku-spec: 4|0|14|28
   inference-recommended-sku: Standard_DS3_v2

--- a/models/system/sshleifer-distilbart-cnn-12-6/asset.yaml
+++ b/models/system/sshleifer-distilbart-cnn-12-6/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/sshleifer-distilbart-cnn-12-6/spec.yaml
+++ b/models/system/sshleifer-distilbart-cnn-12-6/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: summarization, translation
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2

--- a/models/system/t5-base/asset.yaml
+++ b/models/system/t5-base/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/t5-base/spec.yaml
+++ b/models/system/t5-base/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 4|0|14|28
   evaluation-recommended-sku: Standard_DS3_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: summarization, translation
   inference-min-sku-spec: 4|0|14|28
   inference-recommended-sku: Standard_DS3_v2

--- a/models/system/t5-large/asset.yaml
+++ b/models/system/t5-large/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/t5-large/spec.yaml
+++ b/models/system/t5-large/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 8|0|28|56
   evaluation-recommended-sku: Standard_DS4_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: summarization, translation
   inference-min-sku-spec: 8|0|28|56
   inference-recommended-sku: Standard_DS4_v2

--- a/models/system/t5-small/asset.yaml
+++ b/models/system/t5-small/asset.yaml
@@ -1,3 +1,4 @@
 extra_config: model.yaml
 spec: spec.yaml
 type: model
+categories: ["Models"]

--- a/models/system/t5-small/spec.yaml
+++ b/models/system/t5-small/spec.yaml
@@ -7,7 +7,7 @@ properties:
   evaluation-min-sku-spec: 2|0|7|14
   evaluation-recommended-sku: Standard_DS2_v2
   finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_ND40RS_v2
+  finetune-recommended-sku: Standard_NC24rs_v3
   finetuning-tasks: summarization, translation
   inference-min-sku-spec: 2|0|7|14
   inference-recommended-sku: Standard_DS2_v2


### PR DESCRIPTION
Fix for [Bug 2375196](https://msdata.visualstudio.com/Vienna/_workitems/edit/2375196): Update model tags and samples with the GPU sku recommended by the compute team

Per Pavan - Standard_NC24rs_v3 is the compute we have been using so far for testing.
