### PR TITLE
public preview release of RAI Text Insights and RAI Vision Insights components

### DIFF
--- a/responsibleai/text/components/rai_text_insights/asset.yaml
+++ b/responsibleai/text/components/rai_text_insights/asset.yaml
@@ -1,2 +1,3 @@
 type: component
 spec: spec.yaml
+categories: ["Responsible AI"]

--- a/responsibleai/text/components/rai_text_insights/spec.yaml
+++ b/responsibleai/text/components/rai_text_insights/spec.yaml
@@ -1,7 +1,9 @@
 $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: rai_text_insights
 display_name: RAI Text Insights
-version: 0.0.4.preview
+version: 0.0.5
+tags:
+  Preview: ""
 type: command
 inputs:
   task_type:

--- a/responsibleai/vision/components/rai_vision_insights/asset.yaml
+++ b/responsibleai/vision/components/rai_vision_insights/asset.yaml
@@ -1,2 +1,3 @@
 type: component
 spec: spec.yaml
+categories: ["Responsible AI"]

--- a/responsibleai/vision/components/rai_vision_insights/spec.yaml
+++ b/responsibleai/vision/components/rai_vision_insights/spec.yaml
@@ -1,7 +1,9 @@
 $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: rai_vision_insights
 display_name: RAI Vision Insights
-version: 0.0.4.preview
+version: 0.0.5
+tags:
+  Preview: ""
 type: command
 inputs:
   task_type:


### PR DESCRIPTION
public preview release of RAI Text Insights and RAI Vision Insights components

Specifically:
Removed the .preview from the component versions
Added a Preview tag to the components
Add RAI category which seems to now be required for public components