### PR TITLE
Add Deepspeed MII deployment component

### DIFF
--- a/common/components/deepspeed_mii_deploy_model/asset.yaml
+++ b/common/components/deepspeed_mii_deploy_model/asset.yaml
@@ -1,3 +1,3 @@
 type: component
 spec: spec.yaml
-categories: ["Deepspeed", "Model Deploy"]
+categories: ["DeepSpeed", "Model Deploy"]

--- a/common/components/deepspeed_mii_deploy_model/asset.yaml
+++ b/common/components/deepspeed_mii_deploy_model/asset.yaml
@@ -1,0 +1,3 @@
+type: component
+spec: spec.yaml
+categories: ["Deepspeed", "Model Deploy"]

--- a/common/components/deepspeed_mii_deploy_model/spec.yaml
+++ b/common/components/deepspeed_mii_deploy_model/spec.yaml
@@ -105,7 +105,7 @@ inputs:
     type: integer
     default: 60000
     optional: true
-    description: Request timeout in ms. Max limit is 90000.
+    description: Request timeout in ms. Max is 90000.
 
   max_queue_wait_ms:
     type: integer

--- a/common/components/deepspeed_mii_deploy_model/spec.yaml
+++ b/common/components/deepspeed_mii_deploy_model/spec.yaml
@@ -93,7 +93,7 @@ inputs:
     type: integer
     optional: true
     default: 1
-    description: Number of instances you want to use for deployment. Make sure instance type have enough quota available.
+    description: Number of instances you want to use for deployment. Make sure the instance type has enough quota available.
 
   max_concurrent_requests_per_instance:
     type: integer

--- a/common/components/deepspeed_mii_deploy_model/spec.yaml
+++ b/common/components/deepspeed_mii_deploy_model/spec.yaml
@@ -42,7 +42,7 @@ inputs:
   # Model details
   hf_model_id:
     type: string
-    description: Hugging face model id 
+    description: Hugging Face model ID
 
   hf_task_name:
     type: string

--- a/common/components/deepspeed_mii_deploy_model/spec.yaml
+++ b/common/components/deepspeed_mii_deploy_model/spec.yaml
@@ -7,7 +7,7 @@ is_deterministic: True
 
 display_name: DeepSpeed MII deploy Hugging Face model
 description: |
-  Deploy a Huggingface model using Deepspeed MII (https://github.com/microsoft/DeepSpeed-MII).
+  Deploy a Huggingface model using DeepSpeed MII (https://github.com/microsoft/DeepSpeed-MII).
   The component works on compute with [MSI](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-manage-compute-instance?tabs=python) attached.
   You can also use Azure OBO (On Behalf Of) identity while submitting jobs. Read more at: [AzureML OBO](https://learn.microsoft.com/en-us/samples/azure/azureml-examples/azureml---on-behalf-of-feature/)
 

--- a/common/components/deepspeed_mii_deploy_model/spec.yaml
+++ b/common/components/deepspeed_mii_deploy_model/spec.yaml
@@ -46,7 +46,7 @@ inputs:
 
   hf_task_name:
     type: string
-    description: Hugging face task name. Check (DeepSpeed-MII) for supported tasks
+    description: Hugging Face task name. Check (DeepSpeed-MII) for supported tasks
 
   registration_details:
     type: uri_file

--- a/common/components/deepspeed_mii_deploy_model/spec.yaml
+++ b/common/components/deepspeed_mii_deploy_model/spec.yaml
@@ -174,7 +174,7 @@ inputs:
     enum:
       - enabled
       - disabled
-    description: Setting it to disabled secures the deployment by restricting communication between the deployment and the Azure resources used by it
+    description: Setting it to disabled secures the deployment by restricting communication between the deployment and the Azure resources it uses
 
 outputs:
   deployment_details:

--- a/common/components/deepspeed_mii_deploy_model/spec.yaml
+++ b/common/components/deepspeed_mii_deploy_model/spec.yaml
@@ -1,0 +1,182 @@
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
+name: ds_mii_deploy_model
+version: 0.0.1
+type: command
+
+is_deterministic: True
+
+display_name: Deepseed MII deploy Huggingface model
+description: |
+  Deploy a Huggingface model using Deepspeed MII (https://github.com/microsoft/DeepSpeed-MII).
+  The component works on compute with [MSI](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-manage-compute-instance?tabs=python) attached.
+  You can also use Azure OBO (On Behalf Of) identity while submitting jobs. Read more at: [AzureML OBO](https://learn.microsoft.com/en-us/samples/azure/azureml-examples/azureml---on-behalf-of-feature/)
+
+environment: azureml://registries/azureml/environments/python-sdk-v2/versions/2
+
+code: ../../src/deepspeed_mii_deployment
+command: >-
+  python deploy.py
+  --hf_model_id ${{inputs.hf_model_id}}
+  --hf_task_name ${{inputs.hf_task_name}}
+  --registration_details ${{inputs.registration_details}}
+  $[[--inference_payload ${{inputs.inference_payload}}]]
+  $[[--endpoint_name ${{inputs.endpoint_name}}]]
+  $[[--deployment_name ${{inputs.deployment_name}}]]
+  $[[--instance_type ${{inputs.instance_type}}]]
+  $[[--instance_count ${{inputs.instance_count}}]]
+  $[[--max_concurrent_requests_per_instance ${{inputs.max_concurrent_requests_per_instance}}]] 
+  $[[--request_timeout_ms ${{inputs.request_timeout_ms}}]]
+  $[[--max_queue_wait_ms ${{inputs.max_queue_wait_ms}}]]
+  $[[--failure_threshold_readiness_probe ${{inputs.failure_threshold_readiness_probe}}]]
+  $[[--success_threshold_readiness_probe ${{inputs.success_threshold_readiness_probe}}]]
+  $[[--timeout_readiness_probe ${{inputs.timeout_readiness_probe}}]]
+  $[[--period_readiness_probe ${{inputs.period_readiness_probe}}]]
+  $[[--initial_delay_readiness_probe ${{inputs.initial_delay_readiness_probe}}]]
+  $[[--failure_threshold_liveness_probe ${{inputs.failure_threshold_liveness_probe}}]]
+  $[[--timeout_liveness_probe ${{inputs.timeout_liveness_probe}}]]
+  $[[--period_liveness_probe ${{inputs.period_liveness_probe}}]]
+  $[[--initial_delay_liveness_probe ${{inputs.initial_delay_liveness_probe}}]]
+  $[[--egress_public_network_access ${{inputs.egress_public_network_access}}]]
+
+inputs:
+  # Model details
+  hf_model_id:
+    type: string
+    description: Hugging face model id 
+
+  hf_task_name:
+    type: string
+    description: Hugging face task name. Check (DeepSpeed-MII) for supported tasks
+
+  registration_details:
+    type: uri_file
+    description: File containing model registration details
+
+  inference_payload:
+    type: uri_file
+    optional: true
+    description: JSON payload which would be used to validate deployment
+
+  # Endpoint params
+  endpoint_name:
+    type: string
+    optional: true
+    description: Name of the endpoint
+
+  # Deployment params
+  deployment_name:
+    type: string
+    default: default
+    description: Name of the deployment
+
+  instance_type:
+    type: string
+    enum:
+      - Standard_NC4as_T4_v3
+      - Standard_NC6s_v2
+      - Standard_NC6s_v3
+      - Standard_NC8as_T4_v3
+      - Standard_NC12s_v2
+      - Standard_NC12s_v3
+      - Standard_NC16as_T4_v3
+      - Standard_NC24s_v2
+      - Standard_NC24s_v3
+      - Standard_NC24rs_v3
+      - Standard_NC64as_T4_v3
+      - Standard_ND40rs_v2
+      - Standard_ND96asr_v4
+      - Standard_ND96amsr_A100_v4
+    default: Standard_NC24s_v3
+    description: Compute instance type to deploy model. Make sure that instance type is available and have enough quota available.
+
+  instance_count:
+    type: integer
+    optional: true
+    default: 1
+    description: Number of instances you want to use for deployment. Make sure instance type have enough quota available.
+
+  max_concurrent_requests_per_instance:
+    type: integer
+    default: 1
+    optional: true
+    description: Maximum concurrent requests to be handled per instance
+
+  request_timeout_ms:
+    type: integer
+    default: 60000
+    optional: true
+    description: Request timeout in ms. Max limit is 90000.
+
+  max_queue_wait_ms:
+    type: integer
+    default: 60000
+    optional: true
+    description: Maximum queue wait time of a request in ms
+  
+  failure_threshold_readiness_probe:
+    type: integer
+    default: 10
+    optional: true 
+    description: The number of times system will try after failing the readiness probe
+
+  success_threshold_readiness_probe:
+    type: integer
+    default: 1
+    optional: true 
+    description: The minimum consecutive successes for the readiness probe to be considered successful after having failed
+  
+  timeout_readiness_probe:
+    type: integer
+    default: 10
+    optional: true
+    description: The number of seconds after which the readiness probe times out
+
+  period_readiness_probe:
+    type: integer
+    default: 10
+    optional: true
+    description: How often (in seconds) to perform the readiness probe
+
+  initial_delay_readiness_probe:
+    type: integer
+    default: 10
+    optional: true
+    description: The number of seconds after the container has started before the readiness probe is initiated
+
+  failure_threshold_liveness_probe:
+    type: integer
+    default: 30
+    optional: true 
+    description: The number of times system will try after failing the liveness probe
+  
+  timeout_liveness_probe:
+    type: integer
+    default: 10
+    optional: true
+    description: The number of seconds after which the liveness probe times out
+
+  period_liveness_probe:
+    type: integer
+    default: 10
+    optional: true 
+    description:  How often (in seconds) to perform the liveness probe
+
+  initial_delay_liveness_probe:
+    type: integer
+    default: 10
+    optional: true
+    description: The number of seconds after the container has started before the liveness probe is initiated
+  
+  egress_public_network_access:
+    type: string
+    default: enabled
+    optional: true 
+    enum:
+      - enabled
+      - disabled
+    description: Setting it to disabled secures the deployment by restricting communication between the deployment and the Azure resources used by it
+
+outputs:
+  deployment_details:
+    type: uri_file
+    description: JSON file with Model deployment details

--- a/common/components/deepspeed_mii_deploy_model/spec.yaml
+++ b/common/components/deepspeed_mii_deploy_model/spec.yaml
@@ -5,7 +5,7 @@ type: command
 
 is_deterministic: True
 
-display_name: Deepseed MII deploy Huggingface model
+display_name: DeepSpeed MII deploy Hugging Face model
 description: |
   Deploy a Huggingface model using Deepspeed MII (https://github.com/microsoft/DeepSpeed-MII).
   The component works on compute with [MSI](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-create-manage-compute-instance?tabs=python) attached.

--- a/common/components/deepspeed_mii_deploy_model/spec.yaml
+++ b/common/components/deepspeed_mii_deploy_model/spec.yaml
@@ -87,7 +87,7 @@ inputs:
       - Standard_ND96asr_v4
       - Standard_ND96amsr_A100_v4
     default: Standard_NC24s_v3
-    description: Compute instance type to deploy model. Make sure that instance type is available and have enough quota available.
+    description: Compute instance type to deploy model. Make sure that instance type and sufficient quota are available.
 
   instance_count:
     type: integer

--- a/common/environments/deepspeed-mii-deployment/asset.yaml
+++ b/common/environments/deepspeed-mii-deployment/asset.yaml
@@ -1,0 +1,5 @@
+name: deepspeed-mii-deployment
+version: auto
+type: environment
+spec: spec.yaml
+extra_config: environment.yaml

--- a/common/environments/deepspeed-mii-deployment/context/Dockerfile
+++ b/common/environments/deepspeed-mii-deployment/context/Dockerfile
@@ -1,0 +1,44 @@
+FROM nvidia/cuda:11.3.1-devel-ubuntu18.04:{{latest-image-tag}}
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 DEBIAN_FRONTEND=noninteractive CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+    AML_APP_ROOT=/var/azureml-model/code BUILD_DIR=/tmp/build AZUREML_MODEL_DIR=/var/azureml-model \
+    MII_MODEL_DIR=/var/azureml-model AZUREML_ENTRY_SCRIPT=score.py MII_CACHE_PATH=/tmp/mii_cache
+
+COPY . $BUILD_DIR
+
+RUN mkdir -p $BUILD_DIR && apt-get update && \
+    apt-get install -y --no-install-recommends nginx-light wget sudo runit rsyslog libcurl3 unzip git-all && \
+    apt-get autoremove -y && apt-get clean -y && rm -rf /usr/share/man/* /var/lib/apt/lists/* && \
+    mv "$BUILD_DIR/gunicorn_app" /etc/nginx/sites-available/ && \
+    rm /etc/nginx/sites-enabled/default && \
+    ln -s /etc/nginx/sites-available/gunicorn_app /etc/nginx/sites-enabled/ &&\
+    mkdir -p /opt/miniconda /var/azureml-logger /var/azureml-util && cp -r "$BUILD_DIR/runit" /var && \
+    mkdir -p {$AZUREML_MODEL_DIR,$MII_CACHE_PATH} && chmod 775 {$AZUREML_MODEL_DIR,$MII_CACHE_PATH}
+
+ENV PATH=/opt/miniconda/envs/amlenv/bin:/opt/miniconda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    AZUREML_CONDA_ENVIRONMENT_PATH=/opt/miniconda/envs/amlenv \
+    LD_LIBRARY_PATH=/usr/local/:/usr/local/lib:/usr/local/cuda:/usr/local/nvidia/lib:$LD_LIBRARY_PATH \
+    SVDIR=/var/runit \
+    AZUREML_INFERENCE_SERVER_HTTP_ENABLED=True
+
+SHELL ["/bin/bash", "-c"]
+
+RUN cd ~ && \
+    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    chmod +x Miniconda3-latest-Linux-x86_64.sh && \
+    bash ./Miniconda3-latest-Linux-x86_64.sh -bf -p /opt/miniconda && \
+    conda create -n amlenv python=3.8 -y
+
+ENV PATH="/opt/miniconda/envs/amlenv/bin:$AML_APP_ROOT:$PATH" \
+    CUDA_HOME=/usr/local/cuda \
+    LD_LIBRARY_PATH="/opt/miniconda/envs/amlenv/lib:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:$LD_LIBRARY_PATH" \
+    CONDA_DEFAULT_ENV=amlenv \
+    PATH=$PATH:/usr/local/cuda/bin
+
+RUN /opt/miniconda/envs/amlenv/bin/pip install -r "$BUILD_DIR/requirements.txt"
+
+EXPOSE 5001
+
+WORKDIR $AZUREML_MODEL_DIR/code
+CMD sudo service nginx start && \
+    cd $AZUREML_MODEL_DIR/code && azmlinfsrv --model_dir $AZUREML_MODEL_DIR --entry_script $AZUREML_MODEL_DIR/code/score.py --port 31311

--- a/common/environments/deepspeed-mii-deployment/context/gunicorn_app
+++ b/common/environments/deepspeed-mii-deployment/context/gunicorn_app
@@ -1,0 +1,23 @@
+upstream gunicorn {
+    server 127.0.0.1:31311;
+}
+
+server {
+listen *:5001;
+    location / {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300;
+        proxy_connect_timeout 300;
+        proxy_send_timeout 300;
+        proxy_redirect off;
+        proxy_buffering off;
+        proxy_pass http://gunicorn;
+    }
+}
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+  }

--- a/common/environments/deepspeed-mii-deployment/context/requirements.txt
+++ b/common/environments/deepspeed-mii-deployment/context/requirements.txt
@@ -1,0 +1,14 @@
+--extra-index-url https://download.pytorch.org/whl/cu113
+grpcio=={{latest-pypi-version}}
+grpcio-tools=={{latest-pypi-version}}
+pydantic=={{latest-pypi-version}}
+asyncio=={{latest-pypi-version}}
+azureml-inference-server-http=={{latest-pypi-version}}
+torch==1.12.0
+transformers==4.21.2
+
+# TODO: remove once MII updated changes are pushed to pypi
+# 0.0.4 is pointing to an older change
+# https://pypi.org/project/deepspeed-mii
+git+https://github.com/microsoft/deepspeed.git@cc1054d9
+git+https://github.com/microsoft/DeepSpeed-MII.git@6116e98

--- a/common/environments/deepspeed-mii-deployment/context/runit/gunicorn/finish
+++ b/common/environments/deepspeed-mii-deployment/context/runit/gunicorn/finish
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+exit_code="$1" # The exit code from gunicorn
+signal="$2"    # The signal which caused gunicorn to exit (or 0)
+
+echo "`date -uIns` - gunicorn/finish $@"
+echo "`date -uIns` - Exit code $exit_code is not normal. Killing image."
+
+killall -SIGHUP runsvdir

--- a/common/environments/deepspeed-mii-deployment/context/runit/gunicorn/run
+++ b/common/environments/deepspeed-mii-deployment/context/runit/gunicorn/run
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+
+SCRIPT_PATH=$(dirname $(realpath -s "$0"))
+
+# Error handling that sleeps so logs are properly sent
+handle_error () {
+  echo "Error occurred. Sleeping to send error logs."
+  # Sleep 45 seconds
+  sleep 45
+  exit 95
+}
+
+format_print () {
+    echo "$(date -uIns) | gunicorn/run | $1"
+}
+
+echo "`date -uIns` - gunicorn/run $@"
+
+format_print ""
+format_print "###############################################"
+format_print "AzureML Container Runtime Information"
+format_print "###############################################"
+format_print ""
+
+
+if [[ -z "${AZUREML_CONDA_ENVIRONMENT_PATH}" ]]; then
+    # If AZUREML_CONDA_ENVIRONMENT_PATH exists, add to the front of the LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH="$(conda info --root)/lib:$LD_LIBRARY_PATH"
+else
+    # Otherwise, take the conda root and add that to the front of the LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH="$AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH"
+fi
+
+if [[ -f "/IMAGE_INFORMATION" ]]; then
+    format_print ""
+    format_print "AzureML image information: $(cat /IMAGE_INFORMATION)"
+    format_print ""
+fi
+
+format_print ""
+format_print "PATH environment variable: $PATH"
+format_print "PYTHONPATH environment variable: $PYTHONPATH"
+format_print ""
+format_print "Pip Dependencies (before dynamic installation)"
+echo
+pip freeze
+echo
+
+if [[ -n "$AZUREML_INFERENCE_SERVER_HTTP_ENABLED" ]]; then
+    # Currently locking this feature to inference images.
+
+    if [[ -n "$AZUREML_ENTRY_SCRIPT" ]]; then
+        # Remove leading forward slash if it exists and then append the directory to the AML_APP_ROOT
+        export ENTRY_SCRIPT_DIR="${AML_APP_ROOT:-/var/azureml-app}/$(dirname "${AZUREML_ENTRY_SCRIPT#/}")"
+    else
+        export ENTRY_SCRIPT_DIR=${AML_APP_ROOT:-/var/azureml-app}
+    fi
+
+    format_print ""
+    format_print "Entry script directory: $ENTRY_SCRIPT_DIR"
+    format_print ""
+    format_print "###############################################"
+    format_print "Dynamic Python Package Installation"
+    format_print "###############################################"
+    format_print ""
+
+
+    if [[ -n "$AZUREML_EXTRA_PYTHON_LIB_PATH" ]]; then
+        # Pre-installed mounted dependencies, check for the variable and if the folder exists.
+
+        export EXTRA_PYTHON_LIB_FULL_PATH="${ENTRY_SCRIPT_DIR}/${AZUREML_EXTRA_PYTHON_LIB_PATH}"
+
+        if [[ -d $EXTRA_PYTHON_LIB_FULL_PATH ]]; then
+            format_print "Adding ${EXTRA_PYTHON_LIB_FULL_PATH} in PYTHONPATH"
+            export PYTHONPATH="${EXTRA_PYTHON_LIB_FULL_PATH}:$PYTHONPATH"
+        else
+            format_print "Expected folder with pre-installed packages not found: ${EXTRA_PYTHON_LIB_FULL_PATH}. Exiting with error ..."
+            exit 97
+        fi
+    elif [[ -n "$AZUREML_EXTRA_CONDA_YAML_ABS_PATH" || -n "$AZUREML_EXTRA_CONDA_YAML" ]]; then
+        # Dynamic installation conda.yml, check for the variable and if the file exists for relative and absolute paths.
+        # Need the absolute path for the MLFlow scenario where yaml could exist outside of azureml-app folder.
+
+        if [[ -n "$AZUREML_EXTRA_CONDA_YAML_ABS_PATH" ]]; then
+            export CONDA_FULL_PATH="$AZUREML_EXTRA_CONDA_YAML_ABS_PATH"
+        else
+            export CONDA_FULL_PATH="${ENTRY_SCRIPT_DIR}/${AZUREML_EXTRA_CONDA_YAML}"
+        fi
+
+        # NOTE: This may take a very long time if existing dependencies are added!
+        # Source: https://stackoverflow.com/questions/53250933/conda-takes-20-minutes-to-solve-environment-when-package-is-already-installed
+        if [[ -f $CONDA_FULL_PATH ]]; then
+            format_print "Updating conda environment from ${CONDA_FULL_PATH} !"
+
+            # Extract version from amlenv
+            # If this is not installed, the value is empty. There will be a Warning output that states that the package is not installed.
+            SERVER_VERSION="$(pip show azureml-inference-server-http | grep Version | sed -e 's/.*: //')"
+
+            if [ -z "$SERVER_VERSION" ]; then
+                format_print "azureml-inference-server-http not installed"
+                exit 96
+            fi
+
+            # Copy user conda.yml to tmp folder since we don't have write access to user folder
+            # Write access to folder is required for conda env create, and tmp folder has write access
+            export CONDA_FILENAME="${TMPDIR:=/tmp}/copied_env_$(date +%s%N).yaml"
+
+            cp "${CONDA_FULL_PATH}" "${CONDA_FILENAME}"
+
+            # Create a userenv from the conda yaml that replaces the existing amlenv
+            conda env create -n userenv -f "${CONDA_FILENAME}" || { handle_error ; }
+
+            export AZUREML_CONDA_ENVIRONMENT_PATH="/opt/miniconda/envs/userenv"
+            export PATH="/opt/miniconda/envs/userenv/bin:$PATH"
+            export LD_LIBRARY_PATH="$AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH"
+
+            # Install the same version of the http server
+            pip install azureml-inference-server-http=="$SERVER_VERSION" || { handle_error ; }
+
+        else
+            format_print "Dynamic Python packages installation is enabled but expected conda yaml file not found: ${CONDA_FULL_PATH}. Exiting with error ..."
+            exit 98
+        fi
+    elif [[ -n "$AZUREML_EXTRA_REQUIREMENTS_TXT" ]]; then
+        # Dynamic installation requirements.txt, check for the variable and if the file exists for relative and absolute paths.
+
+        export REQUIREMENTS_TXT_FULL_PATH="${ENTRY_SCRIPT_DIR}/${AZUREML_EXTRA_REQUIREMENTS_TXT}"
+
+        if [[ -f $REQUIREMENTS_TXT_FULL_PATH ]]; then
+            format_print "Installing Python packages from ${REQUIREMENTS_TXT_FULL_PATH} !"
+            pip install -r "$REQUIREMENTS_TXT_FULL_PATH" || { handle_error ; }
+        else
+            format_print "Dynamic Python packages installation is enabled but expected requirements file not found: ${REQUIREMENTS_TXT_FULL_PATH}. Exiting with error ..."
+            exit 99
+        fi
+    else
+        format_print "Dynamic Python package installation is disabled."
+    fi
+fi
+
+format_print ""
+format_print "###############################################"
+format_print "AzureML Inference Server"
+format_print "###############################################"
+format_print ""
+
+cd "${AML_APP_ROOT:-/var/azureml-app}"
+
+# Check the result of $(pip show ...) instead of $(which azmlinfsrv). If we launch azmlinfsrv we need to make sure it is
+# from the active python environment. $(which azmlinfsrv) may point to the azmlinfsrv in a different virtual env.
+if [[ -n "$AZUREML_INFERENCE_SERVER_HTTP_ENABLED" || -n "$(pip show azureml-inference-server-http 2>/dev/null)" ]]; then
+    format_print "Starting AzureML Inference Server HTTP."
+
+    # Ensure the presence of debugpy if the user enabled local debugging. See ensure_debugpy.py for more details.
+    if [[ -n $AZUREML_DEBUG_PORT ]]; then
+        python $SCRIPT_PATH/ensure_debugpy.py
+        if [[ $? -ne 0 ]]; then
+            format_print "Exiting because debugpy cannot be not injected into entry.py."
+            exit 94
+        fi
+    fi
+
+    exec azmlinfsrv --entry_script "${AZUREML_ENTRY_SCRIPT:-main.py}" --port 31311
+else
+    format_print ""
+    format_print "Starting HTTP server"
+    format_print ""
+
+    export PYTHONPATH="${AML_SERVER_ROOT:-/var/azureml-server}:$PYTHONPATH"
+    exec gunicorn -c "${AML_SERVER_ROOT:-/var/azureml-server}/gunicorn_conf.py" "entry:app"
+fi

--- a/common/environments/deepspeed-mii-deployment/environment.yaml
+++ b/common/environments/deepspeed-mii-deployment/environment.yaml
@@ -9,4 +9,4 @@ image:
     - requirements.txt
 publish:
   location: mcr
-  visibility: unlisted
+  visibility: public

--- a/common/environments/deepspeed-mii-deployment/environment.yaml
+++ b/common/environments/deepspeed-mii-deployment/environment.yaml
@@ -1,0 +1,12 @@
+image:
+  name: deepspeed-mii-deployment
+  os: linux
+  context:
+    dir: context
+    dockerfile: Dockerfile
+    template_files:
+    - Dockerfile
+    - requirements.txt
+publish:
+  location: mcr
+  visibility: unlisted

--- a/common/environments/deepspeed-mii-deployment/spec.yaml
+++ b/common/environments/deepspeed-mii-deployment/spec.yaml
@@ -1,0 +1,22 @@
+$schema: https://azuremlschemas.azureedge.net/latest/environment.schema.json
+description: Deepspeed MII model deployment environment
+
+name: "{{asset.name}}"
+version: "{{asset.version}}"
+
+inference_config:
+  liveness_route:
+    path: /
+    port: 5001
+  readiness_route:
+    path: /
+    port: 5001
+  scoring_route:
+    path: /score
+    port: 5001  
+
+build:
+  path: "{{image.context.path}}"
+  dockerfile_path: "{{image.dockerfile.path}}"
+
+os_type: linux

--- a/common/environments/deepspeed-mii-deployment/spec.yaml
+++ b/common/environments/deepspeed-mii-deployment/spec.yaml
@@ -1,5 +1,5 @@
 $schema: https://azuremlschemas.azureedge.net/latest/environment.schema.json
-description: Deepspeed MII model deployment environment
+description: DeepSpeed MII model deployment environment
 
 name: "{{asset.name}}"
 version: "{{asset.version}}"

--- a/common/src/deepspeed_mii_deployment/deploy.py
+++ b/common/src/deepspeed_mii_deployment/deploy.py
@@ -112,11 +112,9 @@ def create_endpoint_and_deployment(ml_client, model_id, endpoint_name, deploymen
     deployment = ManagedOnlineDeployment(
         name=deployment_name,
         code_configuration=code_configuration,
-        name=deployment_name,
         endpoint_name=endpoint_name,
         environment=DEPLOYMENT_ENV_ASSET_URI,
         environment_variables=env_vars,
-        endpoint_name=endpoint_name,
         model=model_id,
         instance_type=args.instance_type,
         instance_count=args.instance_count,

--- a/common/src/deepspeed_mii_deployment/deploy.py
+++ b/common/src/deepspeed_mii_deployment/deploy.py
@@ -1,0 +1,381 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Run MII Model deployment module."""
+
+import argparse
+import json
+import logging
+import os
+import re
+import time
+from azure.ai.ml import MLClient
+from azure.ai.ml.entities import (
+    ManagedOnlineEndpoint,
+    ManagedOnlineDeployment,
+    OnlineRequestSettings,
+    CodeConfiguration,
+    ProbeSettings,
+)
+from azure.ai.ml.identity import AzureMLOnBehalfOfCredential
+from azure.identity import ManagedIdentityCredential
+from azureml.core.run import Run
+from pathlib import Path
+
+
+CODE = "script"
+SCORE = "predict.py"
+DEPLOYMENT_ENV_ASSET_URI = "azureml://registries/azureml/environments/python-sdk-v2/versions/1"
+
+# Env vars
+MODEL_MOUNT_PATH = "/var/azureml-model"
+AML_APP_ROOT = f"{MODEL_MOUNT_PATH}/{CODE}"
+
+# PROBE CONSTANTS
+PROBE_FAILURE_THRESHOLD = 50
+PROBE_SUCCESS_THRESHOLD = 50
+PROBE_TIMEOUT = 500
+PROBE_PERIOD = 500
+PROBE_INITIAL_DELAY = 500
+
+MAX_REQUEST_TIMEOUT = 90000
+MAX_INSTANCE_COUNT = 20
+
+
+def get_mlclient(registry_name=None):
+    """Return ML client."""
+    credential = AzureMLOnBehalfOfCredential()
+    try:
+        # Check if given credential can get token successfully.
+        credential.get_token("https://management.azure.com/.default")
+    except Exception as ex:
+        # Fall back to ManagedIdentityCredential in case AzureMLOnBehalfOfCredential not work
+        print(f"Failed to get obo credentials - {ex}")
+        msi_client_id = os.environ.get("DEFAULT_IDENTITY_CLIENT_ID")
+        credential = ManagedIdentityCredential(client_id=msi_client_id)
+    try:
+        credential.get_token("https://management.azure.com/.default")
+    except Exception as ex:
+        raise (f"Failed to get credentials : {ex}")
+
+    if registry_name:
+        return MLClient(
+            credential=credential,
+            registry_name=registry_name,
+        )
+
+    run = Run.get_context(allow_offline=False)
+    ws = run.experiment.workspace
+    mlclient = MLClient(
+        credential=credential,
+        subscription_id=ws._subscription_id,
+        resource_group_name=ws._resource_group,
+        workspace_name=ws._workspace_name,
+    )
+    return mlclient
+
+
+def create_endpoint_and_deployment(ml_client, model_id, endpoint_name, deployment_name, args):
+    """Create endpoint and deployment and return details."""
+    env_vars = {
+        "AML_APP_ROOT": AML_APP_ROOT,
+        "AZUREML_LOG_LEVEL": "DEBUG",
+        "LOG_IO": 1,
+        "WORKER_TIMEOUT": 2400
+    }
+    endpoint = ManagedOnlineEndpoint(name=endpoint_name, auth_mode="key")
+
+    code_configuration = CodeConfiguration(code=CODE, scoring_script=SCORE)
+    request_settings = OnlineRequestSettings(
+        max_concurrent_requests_per_instance=args.max_concurrent_requests_per_instance,
+        request_timeout_ms=args.request_timeout_ms,
+        max_queue_wait_ms=args.max_queue_wait_ms,
+    )
+
+    liveness_probe_settings = ProbeSettings(
+        failure_threshold=args.failure_threshold_liveness_probe,
+        timeout=args.timeout_liveness_probe,
+        period=args.period_liveness_probe,
+        initial_delay=args.initial_delay_liveness_probe,
+    )
+
+    readiness_probe_settings = ProbeSettings(
+        failure_threshold=args.failure_threshold_readiness_probe,
+        success_threshold=args.success_threshold_readiness_probe,
+        timeout=args.timeout_readiness_probe,
+        period=args.period_readiness_probe,
+        initial_delay=args.initial_delay_readiness_probe,
+    )
+
+    # deployment
+    deployment = ManagedOnlineDeployment(
+        name=deployment_name,
+        code_configuration=code_configuration,
+        name=deployment_name,
+        endpoint_name=endpoint_name,
+        environment=DEPLOYMENT_ENV_ASSET_URI,
+        environment_variables=env_vars,
+        endpoint_name=endpoint_name,
+        model=model_id,
+        instance_type=args.instance_type,
+        instance_count=args.instance_count,
+        request_settings=request_settings,
+        liveness_probe=liveness_probe_settings,
+        readiness_probe=readiness_probe_settings,
+        egress_public_network_access=args.egress_public_network_access,
+    )
+
+    try:
+        print(f"Creating endpoint {endpoint_name}")
+        ml_client.begin_create_or_update(endpoint).wait()
+    except Exception as e:
+        error_msg = f"Error occured while creating endpoint - {e}"
+        logging.error(error_msg)
+        raise Exception(error_msg)
+
+    try:
+        print(f"Creating deployment {deployment}")
+        ml_client.online_deployments.begin_create_or_update(deployment).wait()
+    except Exception as e:
+        error_msg = f"Error occured while creating deployment - {e}"
+        logging.error(error_msg)
+        raise Exception(error_msg)
+
+    print(f"Deployment successful. Updating endpoint to take 100% traffic for deployment {deployment_name}")
+
+    # deployment to take 100% traffic
+    endpoint.traffic = {deployment.name: 100}
+    try:
+        ml_client.begin_create_or_update(endpoint).wait()
+        endpoint = ml_client.online_endpoints.get(endpoint.name)
+    except Exception as e:
+        error_msg = f"Error occured while updating endpoint traffic - {e}"
+        logging.error(error_msg)
+        raise Exception(error_msg)
+
+    return endpoint, deployment
+
+
+def parse_args():
+    """Return arguments."""
+    parser = argparse.ArgumentParser()
+    # add arguments
+    parser.add_argument("--hf_model_id", type=str, required=True, help="Hugging face model id")
+    parser.add_argument("--hf_task_name", type=str, required=True, help="Hugging face model task")
+    parser.add_argument(
+        "--registration_details",
+        type=Path,
+        help="Json file that contains the ID of registered model to be deployed",
+    )
+    parser.add_argument(
+        "--inference_payload",
+        type=Path,
+        help="Json file with inference endpoint payload.",
+    )
+    parser.add_argument(
+        "--endpoint_name",
+        type=str,
+        help="Name of the endpoint",
+    )
+    parser.add_argument("--deployment_name", type=str, help="Name of the the deployment")
+    parser.add_argument(
+        "--instance_type",
+        type=str,
+        help="Compute instance type to deploy model",
+        default="Standard_NC24s_v3",
+    )
+    parser.add_argument(
+        "--instance_count",
+        type=int,
+        help="Number of compute instances to deploy model",
+        default=1,
+        choices=range(1, MAX_INSTANCE_COUNT),
+    )
+    parser.add_argument(
+        "--max_concurrent_requests_per_instance",
+        type=int,
+        default=1,
+        help="Maximum concurrent requests to be handled per instance",
+    )
+    parser.add_argument(
+        "--request_timeout_ms",
+        type=int,
+        default=60000,  # 1min
+        help="Request timeout in ms.",
+    )
+    parser.add_argument(
+        "--max_queue_wait_ms",
+        type=int,
+        default=60000,  # 1min
+        help="Maximum queue wait time of a request in ms",
+    )
+    parser.add_argument(
+        "--failure_threshold_readiness_probe",
+        type=int,
+        default=10,
+        help="No of times system will try after failing the readiness probe",
+        choices=range(1, PROBE_FAILURE_THRESHOLD),
+    )
+    parser.add_argument(
+        "--success_threshold_readiness_probe",
+        type=int,
+        default=1,
+        help="The minimum consecutive successes for the readiness probe to be considered successful, after fail",
+        choices=range(1, PROBE_SUCCESS_THRESHOLD),
+    )
+    parser.add_argument(
+        "--timeout_readiness_probe",
+        type=int,
+        default=10,
+        help="The number of seconds after which the readiness probe times out",
+        choices=range(1, PROBE_TIMEOUT)
+    )
+    parser.add_argument(
+        "--period_readiness_probe",
+        type=int,
+        default=10,
+        help="How often (in seconds) to perform the readiness probe",
+        choices=range(1, PROBE_PERIOD),
+    )
+    parser.add_argument(
+        "--initial_delay_readiness_probe",
+        type=int,
+        default=10,
+        help="The number of seconds after the container has started before the readiness probe is initiated",
+        choices=range(1, PROBE_INITIAL_DELAY),
+    )
+    parser.add_argument(
+        "--failure_threshold_liveness_probe",
+        type=int,
+        default=30,
+        help="No of times system will try after failing the liveness probe",
+        choices=range(1, PROBE_FAILURE_THRESHOLD),
+    )
+    parser.add_argument(
+        "--timeout_liveness_probe",
+        type=int,
+        default=10,
+        help="The number of seconds after which the liveness probe times out",
+        choices=range(1, PROBE_TIMEOUT),
+    )
+    parser.add_argument(
+        "--period_liveness_probe",
+        type=int,
+        default=10,
+        help="How often (in seconds) to perform the liveness probe",
+        choices=range(1, PROBE_PERIOD),
+    )
+    parser.add_argument(
+        "--initial_delay_liveness_probe",
+        type=int,
+        default=10,
+        help="The number of seconds after the container has started before the liveness probe is initiated",
+        choices=range(1, PROBE_INITIAL_DELAY),
+    )
+    parser.add_argument(
+        "--egress_public_network_access",
+        type=str,
+        default="enabled",
+        help="Secures the deployment by restricting interaction between deployment and Azure resources used by it",
+    )
+    parser.add_argument(
+        "--model_deployment_details",
+        type=str,
+        help="Json file to which deployment details will be written",
+    )
+    # parse args
+    args = parser.parse_args()
+    print("args received ", args)
+
+    # Validating passed input values
+    if args.max_concurrent_requests_per_instance < 1:
+        parser.error("Arg max_concurrent_requests_per_instance cannot be less than 1")
+    if args.request_timeout_ms < 1 or args.request_timeout_ms > MAX_REQUEST_TIMEOUT:
+        parser.error(f"Arg request_timeout_ms should lie between 1 and {MAX_REQUEST_TIMEOUT}")
+    if args.max_queue_wait_ms < 1 or args.max_queue_wait_ms > MAX_REQUEST_TIMEOUT:
+        parser.error(f"Arg max_queue_wait_ms should lie between 1 and {MAX_REQUEST_TIMEOUT}")
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    # Model params
+    hf_model_id = args.hf_model_id
+    hf_task_name = args.hf_task_name
+    registration_details_path = args.registration_details
+
+    print("##### logger.info args #####")
+    for arg, value in args.__dict__.items():
+        print(f"{arg} => {value}")
+
+    mlclient = get_mlclient()
+
+    model_info = {}
+    with open(args.registration_details) as f:
+        model_info = json.load(f)
+    model_id = model_info['id']
+    model_name = model_info['name']
+
+    # Endpoint has following restrictions:
+    # 1. Name must begin with lowercase letter
+    # 2. Followed by lowercase letters, hyphen or numbers
+    # 3. End with a lowercase letter or number
+
+    # 1. Replace underscores and slashes by hyphens and convert them to lower case.
+    # 2. Take 21 chars from model name and append '-' & timstamp(10chars) to it
+    endpoint_name = re.sub('[^A-Za-z0-9]', '-', model_name).lower()[:21]
+    endpoint_name = f"{endpoint_name}-{int(time.time())}"
+    endpoint_name = endpoint_name
+
+    endpoint_name = args.endpoint_name if args.endpoint_name else endpoint_name
+    deployment_name = args.deployment_name if args.deployment_name else "default"
+
+    scoring_details = {
+        "model_name": hf_model_id,
+        "task_name": hf_task_name,
+    }
+
+    # used in scoring script
+    dump_path = "code/model_details.json"
+    with open(dump_path, "w") as f:
+        json.dump(scoring_details, f)
+
+    endpoint, deployment = create_endpoint_and_deployment(
+        mlclient=mlclient,
+        endpoint_name=endpoint_name,
+        deployment_name=deployment_name,
+        model_id=model_id,
+        args=args
+    )
+
+    if args.inference_payload:
+        print("Invoking inference with test payload ...")
+        try:
+            response = mlclient.online_endpoints.invoke(
+                endpoint_name=endpoint_name,
+                deployment_name=deployment_name,
+                request_file=args.inference_payload,
+            )
+            print(f"Response:\n{response}")
+        except Exception as e:
+            print(f"Invocation failed with error: {e}")
+            raise e
+
+    print("Saving deployment details ...")
+
+    # write deployment details to file
+    endpoint_type = "aml_online_inference"
+    deployment_details = {
+        "endpoint_name": endpoint.name,
+        "deployment_name": deployment.name,
+        "endpoint_uri": endpoint.__dict__["_scoring_uri"],
+        "endpoint_type": endpoint_type,
+        "instance_type": args.instance_type,
+        "instance_count": args.instance_count,
+        "max_concurrent_requests_per_instance": args.max_concurrent_requests_per_instance,
+    }
+    json_object = json.dumps(deployment_details, indent=4)
+    with open(args.model_deployment_details, "w") as outfile:
+        outfile.write(json_object)

--- a/common/src/deepspeed_mii_deployment/script/predict.py
+++ b/common/src/deepspeed_mii_deployment/script/predict.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-"""Scoring script to infer Deepspeed MII deployed model."""
+"""Scoring script to infer DeepSpeed MII deployed model."""
 
 import json
 import torch

--- a/common/src/deepspeed_mii_deployment/script/predict.py
+++ b/common/src/deepspeed_mii_deployment/script/predict.py
@@ -1,0 +1,106 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Scoring script to infer Deepspeed MII deployed model."""
+
+import json
+import torch
+import mii
+from pathlib import Path
+
+
+model = None
+PARENT_DIR = Path().parent.resolve()
+MODEL_INFO_FILE = "model_details.json"
+
+
+def get_mii_configs():
+    """Return MII config."""
+    model_info_path = PARENT_DIR / MODEL_INFO_FILE
+    with open(model_info_path) as f:
+        model_info = json.load(f)
+
+    model_name = model_info["model_name"]
+    task_name = model_info["task_name"]
+
+    return {
+        'ds_config': None,
+        'ds_optimize': True,
+        'ds_zero': False,
+        'mii_configs': {
+            'checkpoint_dict': None,
+            'deploy_rank': [0],
+            'dtype': torch.float32,
+            'enable_cuda_graph': False,
+            'hf_auth_token': None,
+            'load_with_sys_mem': False,
+            'port_number': 50050,
+            'profile_model_time': False,
+            'replace_with_kernel_inject': True,
+            'skip_model_check': False,
+            'tensor_parallel': 1,
+            'torch_dist_port': 29500
+        },
+        'model_path': '',
+        'model_name': model_name,
+        'task_name': task_name,
+    }
+
+
+def init():
+    """Init MII server."""
+    print(f"init(): configs=> \n{configs}")
+    model_path = mii.utils.full_model_path(configs.get(mii.constants.MODEL_PATH_KEY, ""))
+
+    model_name = configs[mii.constants.MODEL_NAME_KEY]
+    task = configs[mii.constants.TASK_NAME_KEY]
+
+    assert model_name is not None, "The model name should be set before calling init"
+    assert task is not None, "The task name should be set before calling init"
+
+    mii.MIIServer(task,
+                  model_name,
+                  model_path,
+                  ds_optimize=configs[mii.constants.ENABLE_DEEPSPEED_KEY],
+                  ds_zero=configs[mii.constants.ENABLE_DEEPSPEED_ZERO_KEY],
+                  ds_config=configs[mii.constants.DEEPSPEED_CONFIG_KEY],
+                  mii_configs=configs[mii.constants.MII_CONFIGS_KEY])
+
+    global model
+    model = None
+
+    # In AML deployments both the GRPC client and server are used in the same process
+    if mii.utils.is_aml():
+        model = mii.MIIClient(task, mii_configs=configs[mii.constants.MII_CONFIGS_KEY])
+        print(f"Model:\n\n {model}\n\n")
+
+
+def run(request):
+    """Invoke MII query and return response."""
+    global model
+    assert model is not None, "grpc client has not been setup when this model was created"
+    request_dict = json.loads(request)
+
+    print(f"request_dict {request_dict}\n\n")
+    query_dict = mii.utils.extract_query_dict(configs[mii.constants.TASK_NAME_KEY],
+                                              request_dict)
+    print(f"query_dict {query_dict}\n\n")
+
+    response = model.query(query_dict, **request_dict)
+    time_taken = response.time_taken
+
+    print(f"type(response): {type(response)}")
+    if hasattr(response, "response"):
+        print(f"type(response.response) => {type(response.response)}")
+    if not isinstance(response.response, str):
+        response = [r for r in response.response]
+    if not isinstance(response.response, str):
+        response = [r for r in response.response]
+    result_dict = {'responses': response.response, 'time': time_taken}
+    print(result_dict)
+    return json.dumps(result_dict)
+
+
+configs = get_mii_configs()
+print(configs)


### PR DESCRIPTION
**Problem**
Deepspeed MII offers low-latency, low-cost inference of supported models. With this component the aim is to provide a solid comparison ground b/w a normal and Deepspeed MII based deployments and showcase how using Deepspeed for supported models can really bring benefits in terms of QPS, hardware requirement, resource utilization and cost of inference.

More details on MII: https://github.com/microsoft/DeepSpeed-MII

**Solution**
Added component and environment spec and source.
