### PR TITLE
[eval comp] fix image logger

### DIFF
--- a/training/model_evaluation/components/compute_metrics/spec.yaml
+++ b/training/model_evaluation/components/compute_metrics/spec.yaml
@@ -3,7 +3,7 @@ name: compute_metrics
 display_name: Compute Metrics
 description: Calculate model performance metics, given ground truth and prediction data.
 
-version: 0.0.7
+version: 0.0.8
 type: command
 
 tags:

--- a/training/model_evaluation/components/evaluate_model/spec.yaml
+++ b/training/model_evaluation/components/evaluate_model/spec.yaml
@@ -3,7 +3,7 @@ name: evaluate_model
 display_name: Evaluate Model
 description: Evaluate MLFlow models for supported task types.
 
-version: 0.0.7
+version: 0.0.8
 
 tags:
   type: evaluation

--- a/training/model_evaluation/components/model_prediction/spec.yaml
+++ b/training/model_evaluation/components/model_prediction/spec.yaml
@@ -3,7 +3,7 @@ name: model_prediction
 display_name: Model Prediction
 description: Generate predictions on a given mlflow model for supported tasks.
 
-version: 0.0.7
+version: 0.0.8
 tags:
   type: evaluation
   sub_type: inference

--- a/training/model_evaluation/components/pipeline_component/spec.yaml
+++ b/training/model_evaluation/components/pipeline_component/spec.yaml
@@ -85,7 +85,7 @@ outputs:
 jobs:
   model_prediction:
     type: command
-    component: azureml://registries/azureml/components/model_prediction/versions/0.0.7
+    component: azureml://registries/azureml/components/model_prediction/versions/0.0.8
     inputs:
       task: ${{parent.inputs.task}}
       test_data: ${{parent.inputs.test_data}}
@@ -101,7 +101,7 @@ jobs:
   
   compute_metrics:
     type: command
-    component: azureml://registries/azureml/components/compute_metrics/versions/0.0.7
+    component: azureml://registries/azureml/components/compute_metrics/versions/0.0.8
     inputs:
       task: ${{parent.inputs.task}}
       ground_truth: ${{parent.jobs.model_prediction.outputs.ground_truth}}

--- a/training/model_evaluation/src/image_classification_dataset.py
+++ b/training/model_evaluation/src/image_classification_dataset.py
@@ -26,7 +26,7 @@ from azureml.core.run import Run
 
 from logging_utilities import get_logger
 
-logger = get_logger(__name__)
+logger = get_logger(name=__name__)
 
 
 class SettingLiterals:


### PR DESCRIPTION
image evaluation failing because of incorrect logger initialization

test_runs:
https://ml.azure.com/experiments/id/fa3f7af4-f096-4172-9356-03ccb77d496f/runs/fe410fae-2b59-4d6b-b8dc-4289ec117052?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/automlimage_eastus2_rg/providers/Microsoft.MachineLearningServices/workspaces/madhumaddi-aml-demo&tid=72f988bf-86f1-41af-91ab-2d7cd011db47