### PR TITLE
Update min sku requirement for whisper

### DIFF
--- a/models/system/openai-whisper-large/spec.yaml
+++ b/models/system/openai-whisper-large/spec.yaml
@@ -3,7 +3,7 @@ name: openai-whisper-large
 path: ./
 properties:
   SHA: e80f01dc6f24d14fdb05a0a3cfdb7f0ab2ec17fe
-  inference-min-sku-spec: 8|0|28|56
+  inference-min-sku-spec: 4|0|28|32
   inference-recommended-sku: Standard_DS4_v2
   languages: en, zh, de, es, ru, ko, fr, ja, pt, tr, pl, ca, nl, ar, sv, it, id, hi,
     fi, vi, he, uk, el, ms, cs, ro, da, hu, ta, no, th, ur, hr, bg, lt, la, mi, ml,


### PR DESCRIPTION
Update the min sku spec for whisper to allow skus with fewer cores.

Test deployments:
NC6s_v3 (Successful): https://ml.azure.com/endpoints/realtime/gpu-image-testing-kbdcs/detail?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourcegroups/hbendapudi/providers/Microsoft.MachineLearningServices/workspaces/gpu-image-testing&tid=72f988bf-86f1-41af-91ab-2d7cd011db47 
E4s_v3 (Successful): https://ml.azure.com/endpoints/realtime/gpu-image-testing-wfzaa/detail?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourcegroups/hbendapudi/providers/Microsoft.MachineLearningServices/workspaces/gpu-image-testing&tid=72f988bf-86f1-41af-91ab-2d7cd011db47
E2s_v3 (Failed due to memory insufficient): https://ml.azure.com/endpoints/realtime/gpu-image-testing-vvoth/detail?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourcegroups/hbendapudi/providers/Microsoft.MachineLearningServices/workspaces/gpu-image-testing&tid=72f988bf-86f1-41af-91ab-2d7cd011db47