### PR TITLE
Vision mlflow model signature change to support batch deployment

### DIFF
--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convert.py
@@ -61,7 +61,7 @@ def _get_mlflow_signature(task_type: str) -> ModelSignature:
 
 @log_execution_time
 def to_mlflow(input_dir: Path, output_dir: Path, translate_params: Dict) -> None:
-    """Convert Hugging face pytorch model to Mlflow.
+    """Convert pytorch model to Mlflow.
 
     :param input_dir: model input directory
     :type input_dir: Path

--- a/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/config.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/config.py
@@ -5,6 +5,8 @@
 
 from enum import Enum
 
+from mlflow.types import DataType
+
 
 MLFLOW_ARTIFACT_DIRECTORY = "mlflow_model_folder"
 
@@ -34,9 +36,9 @@ class MLFlowSchemaLiterals:
     """MLFlow model signature related schema."""
 
     INPUT_IMAGE_KEY = "image_base64"
-    INPUT_COLUMN_IMAGE_DATA_TYPE = "string"
+    INPUT_COLUMN_IMAGE_DATA_TYPE = DataType.binary
     INPUT_COLUMN_IMAGE = "image"
-    OUTPUT_COLUMN_DATA_TYPE = "string"
+    OUTPUT_COLUMN_DATA_TYPE = DataType.string
     OUTPUT_COLUMN_FILENAME = "filename"
     OUTPUT_COLUMN_PROBS = "probs"
     OUTPUT_COLUMN_LABELS = "labels"

--- a/training/model_management/src/azureml/model/mgmt/processors/transformers/convert.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/transformers/convert.py
@@ -47,7 +47,7 @@ def _get_default_task_signatures(task) -> Dict:
         }
     elif SupportedVisionTasks.has_value(task):
         return {
-            "inputs": '[{"name": "image", "type": "string"}]',
+            "inputs": '[{"name": "image", "type": "binary"}]',
             "outputs": '[{"name": "probs", "type": "string"}, {"name": "labels", "type": "string"}]',
         }
     elif SupportedNLPTasks.has_value(task):

--- a/training/model_management/src/azureml/model/mgmt/processors/transformers/vision/predict.py
+++ b/training/model_management/src/azureml/model/mgmt/processors/transformers/vision/predict.py
@@ -7,7 +7,6 @@ import base64
 import io
 import logging
 
-import numpy as np
 import pandas as pd
 import tempfile
 
@@ -23,7 +22,7 @@ from transformers import (
     TrainingArguments,
     Trainer,
 )
-from typing import List, Dict, Any, Optional, Tuple
+from typing import List, Dict, Any, Tuple
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
PR contains:
1. Vision model signature change to accept image in binary format. This is required to support batch deployment.
2. Return list of all labels instead of just predicted one to have similarity with automl models.
3. Handle binary image format in predict script.

Successful runs: https://ml.azure.com/experiments/id/36802a41-551a-4fcc-8e22-654d3488f542?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/rupaljain-rg/providers/Microsoft.MachineLearningServices/workspaces/rupal-ws-canary&tid=72f988bf-86f1-41af-91ab-2d7cd011db47

Deployments: https://ml.azure.com/endpoints/batch/batch-deployment-test-klofl/detail?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/rupaljain-rg/providers/Microsoft.MachineLearningServices/workspaces/rupal-ws-canary&tid=72f988bf-86f1-41af-91ab-2d7cd011db47