### PR TITLE
fix responsibleai-vision version

### DIFF
--- a/responsibleai/vision/components/rai_vision_insights/spec.yaml
+++ b/responsibleai/vision/components/rai_vision_insights/spec.yaml
@@ -81,7 +81,7 @@ outputs:
   ux_json:
     type: path
 code: ../src
-environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/22
+environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/21
 command: >-
   python ./rai_vision_insights.py
   --task_type ${{inputs.task_type}}

--- a/responsibleai/vision/jobs/fetch_fridge_model.yml
+++ b/responsibleai/vision/jobs/fetch_fridge_model.yml
@@ -16,7 +16,7 @@ outputs:
   model_output_path:
     type: path
 code: ./src_fridge/
-environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/22
+environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/21
 command: >-
   python ./fetch_image_model.py
   --model_base_name ${{inputs.model_base_name}}


### PR DESCRIPTION
It looks like responsibleai-vision version 22 was not released since image was identical to previous one.  Hence, bumping it back down.