### PR TITLE
Run uniqueness checks even on unchanged assets

### DIFF
--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -273,7 +273,7 @@ def validate_assets(input_dirs: List[Path],
         bool: True if assets were successfully validated, otherwise False.
     """
     # Gather list of just changed assets, for later filtering
-    changed_assets = util.find_asset_config_files(input_dirs, asset_config_filename, changed_files) if changed_files else None  # noqa
+    changed_assets = util.find_asset_config_files(input_dirs, asset_config_filename, changed_files) if changed_files else None  # noqa: E501
 
     # Find assets under input dirs
     asset_count = 0

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -289,9 +289,11 @@ def validate_assets(input_dirs: List[Path],
         try:
             asset_config = assets.AssetConfig(asset_config_path)
         except Exception as e:
-            _log_error(asset_config_path, e)
             if validate_this:
+                _log_error(asset_config_path, e)
                 error_count += 1
+            else:
+                _log_warning(asset_config_path, e)
             continue
 
         # Populate dictionary of asset names to asset config paths
@@ -309,9 +311,11 @@ def validate_assets(input_dirs: List[Path],
                     image_name = f"{environment_config.publish_location.value}/{image_name}"
                 image_names[image_name].append(asset_config.file_path)
             except Exception as e:
-                _log_error(environment_config.file_name_with_path, e)
                 if validate_this:
+                    _log_error(environment_config.file_name_with_path, e)
                     error_count += 1
+                else:
+                    _log_warning(environment_config.file_name_with_path, e)
 
         # Checks for changed assets only, or all assets if changed_files was None
         if validate_this:

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -337,7 +337,7 @@ def validate_assets(input_dirs: List[Path],
                 if not assets.Config._contains_template(spec.name) and asset_config.name != spec.name:
                     raise ValidationException(f"Asset and spec name mismatch: {asset_config.name} != {spec.name}")
                 if not assets.Config._contains_template(spec.version) and asset_config.version != spec.version:
-                    raise ValidationException(f"Asset and spec version mismatch: {asset_config.version} != {spec.version}")
+                    raise ValidationException(f"Asset and spec version mismatch: {asset_config.version} != {spec.version}")  # noqa: E501
             except Exception as e:
                 _log_error(spec.file_name_with_path, e)
                 error_count += 1


### PR DESCRIPTION
The previous version of this script would ignore any assets that were unchanged, which prevented detection of non-unique assets and images in the repo.