### PR TITLE
Fix vulnerability issues for mldesigner environments

### DIFF
--- a/pipelines/environments/mldesigner-minimal/context/conda_dependencies.yaml
+++ b/pipelines/environments/mldesigner-minimal/context/conda_dependencies.yaml
@@ -6,5 +6,3 @@ dependencies:
 - pip=21.3.1
 - pip:
   - mldesigner=={{latest-pypi-version:pre}}
-  - cryptography==39.0.1
-  - requests==2.31.0

--- a/pipelines/environments/mldesigner/context/conda_dependencies.yaml
+++ b/pipelines/environments/mldesigner/context/conda_dependencies.yaml
@@ -8,5 +8,3 @@ dependencies:
   - azure-ai-ml=={{latest-pypi-version}}
   - azureml-mlflow=={{latest-pypi-version}}
   - mldesigner=={{latest-pypi-version:pre}}
-  - cryptography==39.0.1
-  - requests==2.31.0


### PR DESCRIPTION
As we have `conda-forge` channel, so we don't need to explicitly specify package version in `conda_dependencies.yaml`. Clean redundant lines.