### PR TITLE
Add ml-flow signature in vision ml-flow converter

### DIFF
--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/convertors.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/convertors.py
@@ -214,6 +214,7 @@ class VisionMLflowConvertor(HFMLFLowConvertor):
         self._hf_model_cls = self._hf_model_cls if self._hf_model_cls else AutoModelForImageClassification
         self._hf_config_cls = self._hf_config_cls if self._hf_config_cls else AutoConfig
         self._hf_tokenizer_cls = self._hf_tokenizer_cls if self._hf_tokenizer_cls else AutoImageProcessor
+        self._signatures = self._signatures or self.get_model_signature()
 
         hf_conf[HF_CONF.HF_CONFIG_CLASS.value] = self._hf_config_cls.__name__
         hf_conf[HF_CONF.HF_PRETRAINED_CLASS.value] = self._hf_model_cls.__name__


### PR DESCRIPTION
Mlflow converted vision model is not having the signature. Hence, added the function call while converting.