### PR TITLE
Bump mltable to 1.4.1 to fix cryptography vulnerability

### DIFF
--- a/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -17,6 +17,6 @@ dependencies:
     - pdfkit==1.0.0
     - plotly==5.6.0
     - kaleido==0.2.1
-    - mltable==1.0.0
+    - mltable==1.4.1
     - responsibleai-tabular-automl==0.4.0
     - https://publictestdatasets.blob.core.windows.net/packages/pypi/raiwidgets_big_data/raiwidgets_big_data-0.4.0-py3-none-any.whl


### PR DESCRIPTION
This is for the responsibleai tabular image only. mltable has already been upgraded in text and vision images.

This is identical to https://github.com/Azure/RAI-vNext-Preview/pull/195