### PR TITLE
Update azureml-rag==0.1.13 which adds support for embed task

### DIFF
--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_dataset_to_acs
 display_name: LLM - Dataset to ACS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -349,7 +349,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -357,13 +357,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -376,6 +370,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_acs_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs/spec.yaml
@@ -411,7 +411,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
       acs_config: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.acs_index}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.7
+version: 0.0.8
 name: llm_ingest_dataset_to_acs_basic
 display_name: LLM - Dataset to ACS Pipeline
 is_deterministic: false
@@ -174,7 +174,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -182,13 +182,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -201,6 +195,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_acs_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
@@ -236,7 +236,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
       acs_config: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.acs_index}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.7
+version: 0.0.8
 name: llm_ingest_dataset_to_acs_qa_only
 display_name: LLM - Dataset to ACS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -233,7 +233,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -241,13 +241,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -260,6 +254,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_acs_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_qa_only/spec.yaml
@@ -295,7 +295,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
       acs_config: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.acs_index}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_dataset_to_faiss
 display_name: LLM - Dataset to FAISS Pipeline (With Test Data Generation and Auto Prompt
 is_deterministic: false
@@ -343,7 +343,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -351,13 +351,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -370,6 +364,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_faiss_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss/spec.yaml
@@ -405,7 +405,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.faiss_index}}
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.7
+version: 0.0.8
 name: llm_ingest_dataset_to_faiss_basic
 display_name: LLM - Dataset to FAISS Pipeline
 is_deterministic: false
@@ -165,7 +165,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -173,13 +173,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -192,6 +186,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_faiss_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
@@ -227,7 +227,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.faiss_index}}
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_qa_only/spec.yaml
@@ -287,7 +287,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.faiss_index}}
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.7
+version: 0.0.8
 name: llm_ingest_dataset_to_faiss_qa_only
 display_name: LLM - Dataset to FAISS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -225,7 +225,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -233,13 +233,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -252,6 +246,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_faiss_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
@@ -115,28 +115,48 @@ jobs:
     component: azureml:llm_dbcopilot_grounding:0.0.5
     type: command
   generate_meta_embeddings:
+    type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    environment_variables:
-      AZUREML_WORKSPACE_CONNECTION_ID_AOAI: ${{parent.inputs.embedding_connection}}
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
+        type: uri_folder
         path: ${{parent.jobs.db_meta_loading_generator.outputs.output_chunk_file}}
-      embeddings_model:
-        path: ${{parent.inputs.embeddings_model}}
+      embeddings_model: ${{parent.inputs.embeddings_model}}
     outputs:
       embeddings:
         mode: upload
         type: uri_folder
-    component: azureml:llm_rag_generate_embeddings_parallel:0.0.9
-    type: parallel
+    environment_variables:
+       AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  # generate_meta_embeddings:
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   environment_variables:
+  #     AZUREML_WORKSPACE_CONNECTION_ID_AOAI: ${{parent.inputs.embedding_connection}}
+  #   inputs:
+  #     chunks_source:
+  #       path: ${{parent.jobs.db_meta_loading_generator.outputs.output_chunk_file}}
+  #     embeddings_model:
+  #       path: ${{parent.inputs.embeddings_model}}
+  #   outputs:
+  #     embeddings:
+  #       mode: upload
+  #       type: uri_folder
+  #   component: azureml:llm_rag_generate_embeddings_parallel:0.0.9
+  #   type: parallel
   create_meta_acs_index_job:
     environment_variables:
       AZUREML_WORKSPACE_CONNECTION_ID_AOAI: ${{parent.inputs.embedding_connection}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
@@ -107,28 +107,48 @@ jobs:
     component: azureml:llm_dbcopilot_grounding:0.0.5
     type: command
   generate_meta_embeddings:
+    type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    environment_variables:
-      AZUREML_WORKSPACE_CONNECTION_ID_AOAI: ${{parent.inputs.embedding_connection}}
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
+        type: uri_folder
         path: ${{parent.jobs.db_meta_loading_generator.outputs.output_chunk_file}}
-      embeddings_model:
-        path: ${{parent.inputs.embeddings_model}}
+      embeddings_model: ${{parent.inputs.embeddings_model}}
     outputs:
       embeddings:
         mode: upload
         type: uri_folder
-    component: azureml:llm_rag_generate_embeddings_parallel:0.0.9
-    type: parallel
+    environment_variables:
+       AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  # generate_meta_embeddings:
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   environment_variables:
+  #     AZUREML_WORKSPACE_CONNECTION_ID_AOAI: ${{parent.inputs.embedding_connection}}
+  #   inputs:
+  #     chunks_source:
+  #       path: ${{parent.jobs.db_meta_loading_generator.outputs.output_chunk_file}}
+  #     embeddings_model:
+  #       path: ${{parent.inputs.embeddings_model}}
+  #   outputs:
+  #     embeddings:
+  #       mode: upload
+  #       type: uri_folder
+  #   component: azureml:llm_rag_generate_embeddings_parallel:0.0.9
+  #   type: parallel
   create_meta_faiss_index_job:
     environment_variables:
       AZUREML_WORKSPACE_CONNECTION_ID_AOAI: ${{parent.inputs.embedding_connection}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_git_to_acs
 display_name: LLM - Git to ACS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -380,7 +380,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -388,13 +388,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -407,6 +401,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_acs_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs/spec.yaml
@@ -442,7 +442,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
       acs_config: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.acs_index}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
@@ -267,7 +267,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
       acs_config: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.acs_index}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.7
+version: 0.0.8
 name: llm_ingest_git_to_acs_basic
 display_name: LLM - Git to ACS Pipeline
 is_deterministic: false
@@ -205,7 +205,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -213,13 +213,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -232,6 +226,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_acs_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.7
+version: 0.0.8
 name: llm_ingest_git_to_acs_qa_only
 display_name: LLM - Git to ACS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -265,7 +265,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -273,13 +273,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -292,6 +286,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_acs_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_qa_only/spec.yaml
@@ -327,7 +327,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
       acs_config: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.acs_index}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss/spec.yaml
@@ -440,7 +440,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.faiss_index}}
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.20
+version: 0.0.21
 name: llm_ingest_git_to_faiss
 display_name: LLM - Git to FAISS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -378,7 +378,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -386,13 +386,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -405,6 +399,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_faiss_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
@@ -260,7 +260,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.faiss_index}}
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.7
+version: 0.0.8
 name: llm_ingest_git_to_faiss_basic
 display_name: LLM - Git to FAISS Pipeline
 is_deterministic: false
@@ -198,7 +198,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -206,13 +206,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -225,6 +219,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_faiss_index_job:
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_qa_only/spec.yaml
@@ -321,7 +321,7 @@ jobs:
     inputs:
       embeddings:
         type: uri_folder
-        path: ${{parent.jobs.embeddings_parallel_job.outputs.embeddings}}
+        path: ${{parent.jobs.embeddings_job.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.faiss_index}}
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.7
+version: 0.0.8
 name: llm_ingest_git_to_faiss_qa_only
 display_name: LLM - Git to FAISS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -259,7 +259,7 @@ jobs:
       embedding_connection: ${{parent.inputs.embedding_connection}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
   ############
-  embeddings_parallel_job:
+  embeddings_job:
     type: command
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
@@ -267,13 +267,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    retry_settings:
-      timeout: 3600
-      max_retries: 3
-    mini_batch_size: "3"
-    mini_batch_error_threshold: 0
-    logging_level: "INFO"
-    component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.1'
     inputs:
       chunks_source:
         type: uri_folder
@@ -286,6 +280,34 @@ jobs:
         type: uri_folder
     environment_variables:
        AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
+  ############
+  # embeddings_parallel_job:
+  #   type: command
+  #   resources:
+  #     instance_count: ${{parent.inputs.serverless_instance_count}}
+  #     instance_type: ${{parent.inputs.serverless_instance_type}}
+  #     properties:
+  #       compute_specification:
+  #         automatic: true
+  #   retry_settings:
+  #     timeout: 3600
+  #     max_retries: 3
+  #   mini_batch_size: "3"
+  #   mini_batch_error_threshold: 0
+  #   logging_level: "INFO"
+  #   component: 'azureml:llm_rag_generate_embeddings_parallel:0.0.9'
+  #   inputs:
+  #     chunks_source:
+  #       type: uri_folder
+  #       path: ${{parent.jobs.data_chunking_job.outputs.output_chunks}}
+  #     embeddings_container: ${{parent.inputs.embeddings_container}}
+  #     embeddings_model: ${{parent.inputs.embeddings_model}}
+  #     deployment_validation: ${{parent.jobs.validate_deployments_job.outputs.output_data}}
+  #   outputs:
+  #     embeddings:
+  #       type: uri_folder
+  #   environment_variables:
+  #      AZUREML_WORKSPACE_CONNECTION_ID_AOAI : ${{parent.inputs.embedding_connection}}
   ############
   create_faiss_index_job:
     type: command

--- a/assets/large_language_models/rag/components/generate_embeddings/asset.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings/asset.yaml
@@ -1,0 +1,3 @@
+type: component
+spec: spec.yaml
+categories: ["Retrieval Augmented Generation"]

--- a/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
@@ -1,0 +1,65 @@
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
+type: command
+
+tags:
+    Preview: ""
+
+version: 0.0.1
+name: llm_rag_generate_embeddings
+display_name: LLM - Generate Embeddings
+is_deterministic: true
+
+description: |
+  Generates embeddings vectors for data chunks read from `chunks_source`.
+
+  `chunks_source` is expected to contain `csv` files containing two columns:
+  - "Chunk" - Chunk of text to be embedded
+  - "Metadata" - JSON object containing metadata for the chunk
+
+  If `embeddings_container` is supplied, input chunks are compared to existing chunks in the Embeddings Container and only changed/new chunks are embedded, existing chunks being reused.
+
+inputs:
+  chunks_source:
+    type: uri_folder
+    description: "Folder containing chunks to be embedded."
+  # If adding to previously generated Embeddings
+  embeddings_container:
+    type: uri_folder
+    optional: true
+    mode: direct
+    description: "Folder containing previously generated embeddings. Should be parent folder of the 'embeddings' output path used for for this component. Will compare input data to existing embeddings and only embed changed/new data, reusing existing chunks."
+  # Embeddings settings
+  embeddings_model:
+    type: string
+    default: "hugging_face://model/sentence-transformers/all-mpnet-base-v2"
+    description: "The model to use to embed data. E.g. 'hugging_face://model/sentence-transformers/all-mpnet-base-v2' or 'azure_open_ai://deployment/{deployment_name}/model/{model_name}'"
+  batch_size:
+    type: integer
+    default: 100
+    description: "Batch size to use when embedding data"
+  num_workers:
+    type: integer
+    default: -1
+    description: "Number of workers to use when embedding data. -1 means use half all available CPUs"
+
+  deployment_validation:
+     type: uri_file
+     description: "Uri file containing information on if the Azure OpenAI deployments, if used, have been validated"
+     optional: True
+
+outputs:
+  embeddings:
+    type: uri_folder
+    description: "Where to save data with embeddings. This should be a subfolder of previous embeddings if supplied, typically named using '${name}'. e.g. /my/prev/embeddings/${name}"
+    mode: rw_mount
+
+environment: azureml:llm-rag-embeddings@latest
+code: '../src'
+command: >-
+  python -m azureml.rag.tasks.embed
+    --chunks_source ${{inputs.chunks_source}}
+    --embeddings_model ${{inputs.embeddings_model}}
+    $[[--embeddings_container ${{inputs.embeddings_container}}]]
+    --output ${{outputs.embeddings}}
+    --batch_size ${{inputs.batch_size}}
+    --num_workers ${{inputs.num_workers}}

--- a/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
@@ -7,7 +7,7 @@ dependencies:
 - pip=21.3.1
 - scikit-learn==0.24.1
 - pip:
-  - azureml-rag[cognitive_search,data_generation]>=0.1.11
+  - azureml-rag[cognitive_search,data_generation]>=0.1.13
   - psutil~=5.8.0
   - pandas~=1.1.5
   - openai~=0.27.4

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
@@ -6,7 +6,7 @@ dependencies:
 - python=3.8
 - pip=21.3.1
 - pip:
-  - azureml-rag[faiss,cognitive_search,document_parsing,data_generation]>=0.1.11
+  - azureml-rag[faiss,cognitive_search,document_parsing,data_generation]>=0.1.13
   - psutil~=5.8.0
   - pandas~=1.1.5
   - GitPython>=3.1


### PR DESCRIPTION
The new generate_embeddings component leverages the embed task to do embeddings without PRS.