### PR TITLE
Remove the preview tag from forecasting demand components.

### DIFF
--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference/spec.yaml
@@ -5,8 +5,6 @@ name: automl_hts_inference
 display_name: AutoML Hierarchical Timeseries Forecasting - Inference
 description: Enables inference for hts components.
 version: 0.0.1
-tags:
-  Preview: ''
 is_deterministic: false
 
 inputs:

--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_collect/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_collect/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_hts_inference_collect_step
 version: 0.0.1
-tags:
-  Preview: ''
 display_name: AutoML HTS - Inference Collect
 type: command
 

--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_setup/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_setup/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_hts_inference_setup_step
 version: 0.0.1
-tags:
-  Preview: ''
 display_name: AutoML HTS - Inference Setup
 type: command
 

--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_prs_inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_prs_inference/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
 type: parallel
 version: 0.0.1
-tags:
-  Preview: ''
 
 name: automl_hts_prs_inference_step
 display_name: AutoML HTS - Inference Step

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_data_agg/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_data_agg/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/parallelComponent.schema.json
 type: parallel
 version: 0.0.1
-tags:
-  Preview: ''
 
 name: automl_hts_data_aggregation_step
 display_name: AutoML HTS - Training Data Aggregation

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_prs_train/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_prs_train/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/parallelComponent.schema.json
 type: parallel
 version: 0.0.1
-tags:
-  Preview: ''
 
 name: automl_hts_automl_training_step
 display_name: AutoML HTS - AutoML Training

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train/spec.yaml
@@ -5,8 +5,6 @@ name: automl_hts_training
 display_name: AutoML Hierarchical Timeseries Forecasting - Training
 description: Enables AutoML Training for hts components.
 version: 0.0.1
-tags:
-  Preview: ''
 is_deterministic: false
 
 inputs:

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_collect/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_collect/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_hts_training_collect_step
 version: 0.0.1
-tags:
-  Preview: ''
 display_name: AutoML HTS - Collection Training Results
 type: command
 

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_setup/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_setup/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_hts_training_setup_step
 version: 0.0.1
-tags:
-  Preview: ''
 display_name: AutoML HTS - Training Setup
 type: command
 

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_prs_train/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_prs_train/spec.yaml
@@ -3,8 +3,6 @@ $schema: https://azuremlschemas.azureedge.net/latest/parallelComponent.schema.js
 name: automl_many_models_training_step
 display_name: AutoML Many Models - AutoML Training
 version: 0.0.1
-tags:
-  Preview: ''
 is_deterministic: false
 
 type: parallel

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training/spec.yaml
@@ -5,8 +5,6 @@ name: automl_many_models_training
 display_name: AutoML - Many Models Training
 description: Enables AutoML many models training.
 version: 0.0.1
-tags:
-  Preview: ''
 is_deterministic: false
 
 inputs:

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_collect/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_collect/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_many_models_training_collection_step
 version: 0.0.1
-tags:
-  Preview: ''
 display_name: AutoML Many Models - Collection Training Results
 is_deterministic: false
 type: command

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_setup/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_setup/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_many_models_training_setup_step
 version: 0.0.1
-tags:
-  Preview: ''
 display_name: AutoML Many Models - Training Setup Step
 is_deterministic: false
 type: command

--- a/assets/training/forecasting_demand/automl-many-models-train/components/spark_partition/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/spark_partition/spec.yaml
@@ -4,8 +4,6 @@ type: spark
 display_name: AutoML - Tabular Data Partitioning
 description: Enables dataset partitioning for AutoML many models and hierarchical timeseries solution accelerators using spark.
 version: 0.0.2
-tags:
-  Preview: ''
 is_deterministic: false
 
 code: ../../src/spark_partition/

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_model_inferencing/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_model_inferencing/spec.yaml
@@ -5,8 +5,6 @@ name: automl_many_models_inference
 display_name: AutoML Many Models - Inference
 description: Inference components for AutoML many model.
 version: 0.0.1
-tags:
-  Preview: ''
 is_deterministic: false
 
 inputs:

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_collect_inf/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_collect_inf/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_many_models_inference_collect_step
 version: 0.0.1
-tags:
-  Preview: ''
 display_name: AutoML Many Models - Collection Inference Results
 is_deterministic: false
 type: command

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_prs_inferencing/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_prs_inferencing/spec.yaml
@@ -3,8 +3,6 @@ $schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
 name: automl_many_models_inference_step
 display_name: AutoML Many Models - Inference Step
 version: 0.0.1
-tags:
-  Preview: ''
 is_deterministic: false
 
 type: parallel

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_setup_inf/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_setup_inf/spec.yaml
@@ -1,8 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_many_models_inference_setup_step
 version: 0.0.1
-tags:
-  Preview: ''
 display_name: AutoML Many Models - Inference Setup Step
 is_deterministic: false
 type: command

--- a/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
@@ -5,9 +5,6 @@ description: Inference component for AutoML Forecasting.
 version: 0.0.2
 type: command
 
-tags:
-  Preview: ""
-
 inputs:
   test_data:
     type: uri_folder


### PR DESCRIPTION
After we have done the testing of component in the public preview repository, we will need to remove the preview tag.
See Task 2545946