### PR TITLE
Fix image build error due to Cython changes

### DIFF
--- a/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -12,6 +12,7 @@ dependencies:
   - torchvision
   - captum
   - cpuonly
+  - pycocotools==2.0.4
   - pip:
     - numpy==1.22.0
     - responsibleai~=0.29.0

--- a/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -9,7 +9,6 @@ dependencies:
   - python=3.8
   - pip
   - pytorch
-  - torchvision
   - captum
   - cpuonly
   - pycocotools==2.0.4

--- a/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -11,6 +11,7 @@ dependencies:
   - torchvision
   - captum
   - cpuonly
+  - pycocotools==2.0.4
   - pip:
     - responsibleai~=0.29.0
     - raiwidgets~=0.29.0


### PR DESCRIPTION
This PR fixes below error:
ERROR: Failed building wheel for pycocotools
ERROR: Could not build wheels for pycocotools, which is required to install pyproject.toml-based projects

Verified that I was able to build the image successfully with changes in this PR: https://ml.azure.com/environments/AML-RAI-Text-Environment-CPU/version/2023071806?wsid=/subscriptions/3d6da6ed-6af5-4a74-87c6-da367514f8e0/resourceGroups/ResponsibleAIE2E/providers/Microsoft.MachineLearningServices/workspaces/ResponsibleAIE2ETest&flight=RAIAutomlIntegration&tid=72f988bf-86f1-41af-91ab-2d7cd011db47 