### PR TITLE
Adding Unit Tests for Numerical and Categorical Drift Metrics

### DIFF
--- a/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_drift_compute_metrics
 display_name: Data Drift - Compute Metrics
 description: Compute data drift metrics given a baseline and a deployment's model data input.
-version: 0.3.2
+version: 0.3.3
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_drift_signal_monitor
 display_name: Data Drift - Signal Monitor
 description: Computes the data drift between a baseline and production data assets.
-version: 0.3.3
+version: 0.3.4
 is_deterministic: true
 
 inputs:
@@ -87,7 +87,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.2
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.3
     inputs:
       production_dataset:
         type: mltable

--- a/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: prediction_drift_signal_monitor
 display_name: Prediction Drift - Signal Monitor
 description: Computes the prediction drift between a baseline and a target data assets.
-version: 0.3.3
+version: 0.3.4
 is_deterministic: true
 
 inputs:
@@ -67,7 +67,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.2
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.3
     inputs:
       production_dataset:
         type: mltable

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/categorical_data_drift_metrics.py
@@ -149,7 +149,6 @@ def _chisquaretest(
     chisqtest_rows = []
 
     for column in categorical_columns:
-        print(column)
         baseline_prod_unique_values = (
             production_df.select(column).union(baseline_df.select(column)).distinct()
         )

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/categorical_data_drift_metrics.py
@@ -113,8 +113,13 @@ def _psi_categorical(
         baseline_frequencies = {**all_unique_values_dict, **count_baseline_df_dict}
 
         baseline_ratios = {}
+        number_of_categories_baseline = len(baseline_frequencies)
+        # Add 1 to every bin to avoid infinity when bin is 0 (laplace smoothing)
+        # Modfiy denomitatior to keep ratios normalized
         for value in baseline_frequencies:
-            baseline_ratios[value] = (baseline_frequencies[value] + 1) / baseline_count
+            baseline_ratios[value] = (
+                baseline_frequencies[value] + 1
+                ) / (baseline_count + number_of_categories_baseline)
 
         count_prod_df = production_df.groupBy(column).count()
         count_prod_df_dict = {
@@ -123,11 +128,13 @@ def _psi_categorical(
         production_frequencies = {**all_unique_values_dict, **count_prod_df_dict}
 
         production_ratios = {}
+        number_of_categories_production = len(production_frequencies)
+        # Add 1 to every bin to avoid infinity when bin is 0 (laplace smoothing)
+        # Modfiy denomitatior to keep ratios normalized
         for value in production_frequencies:
-            # Add 1 to every value to avoid infinity when value is 0
             production_ratios[value] = (
                 production_frequencies[value] + 1
-            ) / production_count
+            ) / (production_count + number_of_categories_production)
 
         psi = 0
         for i in baseline_ratios:

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/numerical_data_drift_metrics.py
@@ -187,7 +187,6 @@ def _ks2sample_pandas_impl(
             rows.append(row)
 
         output_df = get_output_spark_df(rows)
-        output_df.show(truncate=False)
         return output_df
     else:
         raise Exception(

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/numerical_data_drift_metrics.py
@@ -221,11 +221,14 @@ def _psi_numerical(
         production_hist_count = prod_histograms[column][1]
         production_hist_count = [count + 1 for count in production_hist_count]
 
+        # Normalize counts to get percentages. Note that we had to add the number of histogram bins
+        # to the denominator to account for the laplace smoothing
         baseline_percent = [
-            (count / baseline_df_count) for count in baseline_hist_count
+            (count / (baseline_df_count + len(baseline_hist_count))) for count in baseline_hist_count
         ]
+
         production_percent = [
-            (count / production_df_count) for count in production_hist_count
+            (count / (production_df_count + len(production_hist_count))) for count in production_hist_count
         ]
 
         psi = 0.0

--- a/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
@@ -24,158 +24,74 @@ distance_measures = [
     "PearsonsChiSquaredTest",
 ]
 
-# Sample strings to generate categorical variables
-s_a=('a'* 100 + 
-     'b'* 100 + 
-     'c'* 100 + 
-     'd'* 100 + 
-     'e'* 100 + 
-     'f'* 100 + 
-     'g'* 100 + 
-     'h'* 100)
-
-s_b=('a'* 97 + 
-     'b'* 105 + 
-     'c'* 99 + 
-     'd'* 98 + 
-     'e'* 101 + 
-     'f'* 102 + 
-     'g'* 97 + 
-     'h'* 103)
-
-s_c=('a'* 10 + 
-     'b'* 11 + 
-     'c'* 9 + 
-     'd'* 10 + 
-     'e'* 10 + 
-     'f'* 10 + 
-     'g'* 13 + 
-     'h'* 10)
-
-s_d=('a'* 180 + 
-     'b'* 80 + 
-     'c'* 70 + 
-     'd'* 170 + 
-     'e'* 200 + 
-     'f'* 10 + 
-     'g'* 130 + 
-     'h'* 100)
-
-
-s_e=('a'* 100 + 
-     'b'* 100 + 
-     'c'* 100 + 
-     'd'* 100 + 
-     'e'* 100 + 
-     'f'* 100 + 
-     'g'* 100 +
-     'h'* 1)
-
-s_f=('a'* 100 + 
-     'b'* 100 + 
-     'c'* 100 + 
-     'f'* 100 + 
-     'g'* 100 +
-     'h'* 1)
-
-s_g=('i'* 1 +
-     'j'* 1 +
-     'k'* 2)
-
-s_h=('a'* 100 +
-     'b'* 100)
-
-s_i=('a'* 34 +
-     'b'* 34)
-
-s_j=('a'* 92 +
-     'b'* 23)
-
-s_k=('c'* 100 +
-     'd'* 100)
-
-
-# convert to lists
-a_list = [letter for letter in s_a]
-b_list = [letter for letter in s_b]
-c_list = [letter for letter in s_c]
-d_list = [letter for letter in s_d]
-e_list = [letter for letter in s_e]
-f_list = [letter for letter in s_f]
-g_list = [letter for letter in s_g]
-h_list = [letter for letter in s_h]
-i_list = [letter for letter in s_i]
-j_list = [letter for letter in s_j]
-k_list = [letter for letter in s_k]
-
-# shuffle lists
-random.shuffle(a_list)
-random.shuffle(b_list)
-random.shuffle(c_list)
-random.shuffle(d_list)
-random.shuffle(e_list)
-random.shuffle(f_list)
-random.shuffle(g_list)
-random.shuffle(h_list)
-random.shuffle(i_list)
-random.shuffle(j_list)
-random.shuffle(k_list)
+# Sample categorical distributions
+s_a = 'a'*100 + 'b'*100 + 'c'*100 + 'd'*100 + 'e'*100 + 'f'*100 + 'g'*100 + 'h'*100
+s_b = 'a'*97  + 'b'*105 + 'c'*99  + 'd'*98  + 'e'*101 + 'f'*102 + 'g'*97  + 'h'*103  
+s_c = 'a'*10  + 'b'*11  + 'c'*9   + 'd'*10  + 'e'*10  + 'f'*10  + 'g'*13  + 'h'*10  
+s_d = 'a'*180 + 'b'*80  + 'c'*70  + 'd'*170 + 'e'*200 + 'f'*10  + 'g'*130 + 'h'*100  
+s_e = 'a'*100 + 'b'*100 + 'c'*100 + 'd'*100 + 'e'*100 + 'f'*100 + 'g'*100 + 'h'*1  
+s_f = 'a'*100 + 'b'*100 + 'c'*100 + 'f'*100 + 'g'*100 + 'h'*1  
+s_g = 'i'*1   + 'j'*1   + 'k'*2  
+s_h = 'a'*100 + 'b'*100  
+s_i = 'a'*34  + 'b'*34  
+s_j = 'a'*92  + 'b'*23  
+s_k = 'c'*100 + 'd'*100  
 
 test_cases = [
     {"name": "1a",
      "scenario": "Distance between identical distributions should be exaclty 0.",
-     "baseline_col": b_list,
-     "production_col": b_list,
+     "baseline_col": s_b,
+     "production_col": s_b,
     },
     {"name": "1b",
      "scenario": "Minimal drift. Both distributions contain the same categories.",
-     "baseline_col": a_list,
-     "production_col": b_list,
+     "baseline_col": s_a,
+     "production_col": s_b,
     },
     {"name": "1c",
      "scenario": "Marginal drift. Both distributions contain the same categories.",
-     "baseline_col": a_list,
-     "production_col": c_list,
+     "baseline_col": s_a,
+     "production_col": s_c,
     },
     {"name": "1d",
      "scenario": "Drifted distributions. Both distributions contain the same categories.",
-     "baseline_col": a_list,
-     "production_col": d_list,
+     "baseline_col": s_a,
+     "production_col": s_d,
     },
     {"name": "1e",
      "scenario": "Drift caused by a single category. Both distributions contain the same categories.",
-     "baseline_col": a_list,
-     "production_col": e_list,
+     "baseline_col": s_a,
+     "production_col": s_e,
     },
     {"name": "1f",
      "scenario": "Drifted distributions. Production dataset is missing some categories.",
-     "baseline_col": a_list,
-     "production_col": f_list,
+     "baseline_col": s_a,
+     "production_col": s_f,
     },
     {"name": "1g",
      "scenario": "Distributions with no categories in common. Bound distance measures (Jensen-Shannon) should reach their maximum theoretical value.",
-     "baseline_col": a_list,
-     "production_col": g_list,
+     "baseline_col": s_a,
+     "production_col": s_g,
     },
     {"name": "2a",
      "scenario": "Dual value identical distributions with the same sample size. Distance measures should be 0.",
-     "baseline_col": h_list,
-     "production_col": h_list,
+     "baseline_col": s_h,
+     "production_col": s_h,
     },
     {"name": "2b",
      "scenario": "Dual value identical distributions with different sample sizes. Distance measures should be 0.",
-     "baseline_col": h_list,
-     "production_col": i_list,
+     "baseline_col": s_h,
+     "production_col": s_i,
     },
     {"name": "2c",
      "scenario": "Drifted Dual value distributions.",
-     "baseline_col": h_list,
-     "production_col": j_list,
+     "baseline_col": s_h,
+     "production_col": s_j,
     },
     {"name": "2d",
      "scenario": "Dual value distributions with different values. Bound distance measures (Jensen-Shannon) should reach their maximum theoretical value.",
-     "baseline_col": h_list,
-     "production_col": k_list,
+     "baseline_col": s_h,
+     "production_col": s_k,
     },
 ]
 
@@ -196,6 +112,7 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
        
     def get_metric_value(self, df: pyspark_sql.DataFrame, metric_name: str):
         """Get metric value of the first row of a given column from a dataframe."""
+        #df.show()
         return df.filter(f"metric_name = '{metric_name}'").first().metric_value
 
     def create_spark_df(self, categorical_data):
@@ -203,6 +120,12 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         pd_df = pd.DataFrame(data=categorical_data, columns=column_values)
         df = self.spark.createDataFrame(pd_df)
         return df
+
+    def create_categorical_data_from_string(self, sample_string: str):
+        cat_list = [letter for letter in sample_string]
+        random.shuffle(cat_list)
+        return cat_list
+
 
     # # # EXPECTED JENSEN-SHANNON DISTANCE # # # 
 
@@ -269,8 +192,8 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
             print(f'###########################################')
 
             for test_case in test_cases:
-                x = test_case['baseline_col']
-                y = test_case['production_col']
+                x = self.create_categorical_data_from_string(test_case['baseline_col'])
+                y = self.create_categorical_data_from_string(test_case['production_col'])
 
                 if distance_measure == "JensenShannonDistance":
                     expected_distance = self.jensen_shannon_distance_categorical(x,y)

--- a/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
@@ -111,9 +111,7 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     """Test class for data drift compute metrics component and utilities."""
 
     def __init__(self, *args, **kwargs):
-        """
-        Initialize TestComputeDataDriftMetrics with the provided arguments and initialize the Spark session.
-        """
+        """Initialize TestComputeDataDriftMetrics with the provided arguments and initialize the Spark session."""
         super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)
         self.spark = init_spark()
 

--- a/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
@@ -3,7 +3,7 @@
 
 """
 This file contains unit tests for the Categorical Data Drift Metrics.
-It compares the drift measures of metrics implemented in Spark against their SciPy implementation 
+It compares the drift measures of metrics implemented in Spark against their SciPy implementation
 """
 
 from data_drift_compute_metrics.categorical_data_drift_metrics import compute_categorical_data_drift_measures_tests
@@ -24,74 +24,83 @@ distance_measures = [
     "PearsonsChiSquaredTest",
 ]
 
-# Sample categorical distributions
-s_a = 'a'*100 + 'b'*100 + 'c'*100 + 'd'*100 + 'e'*100 + 'f'*100 + 'g'*100 + 'h'*100
-s_b = 'a'*97  + 'b'*105 + 'c'*99  + 'd'*98  + 'e'*101 + 'f'*102 + 'g'*97  + 'h'*103  
-s_c = 'a'*10  + 'b'*11  + 'c'*9   + 'd'*10  + 'e'*10  + 'f'*10  + 'g'*13  + 'h'*10  
-s_d = 'a'*180 + 'b'*80  + 'c'*70  + 'd'*170 + 'e'*200 + 'f'*10  + 'g'*130 + 'h'*100  
-s_e = 'a'*100 + 'b'*100 + 'c'*100 + 'd'*100 + 'e'*100 + 'f'*100 + 'g'*100 + 'h'*1  
-s_f = 'a'*100 + 'b'*100 + 'c'*100 + 'f'*100 + 'g'*100 + 'h'*1  
-s_g = 'i'*1   + 'j'*1   + 'k'*2  
-s_h = 'a'*100 + 'b'*100  
-s_i = 'a'*34  + 'b'*34  
-s_j = 'a'*92  + 'b'*23  
-s_k = 'c'*100 + 'd'*100  
 
 test_cases = [
-    {"name": "1a",
+    {
+     "name": "1a",
      "scenario": "Distance between identical distributions should be exactly 0.",
-     "baseline_col": s_b,
-     "production_col": s_b,
+     "baseline_col": {'a': 97, 'b': 105, 'c': 99, 'd': 98, 'e': 101, 'f': 102, 'g': 97, 'h': 103},
+     "production_col": {'a': 97, 'b': 105, 'c': 99, 'd': 98, 'e': 101, 'f': 102, 'g': 97, 'h': 103},
     },
-    {"name": "1b",
+    {
+     "name": "1b",
      "scenario": "Minimal drift. Both distributions contain the same categories.",
-     "baseline_col": s_a,
-     "production_col": s_b,
+     "baseline_col": {'a': 100, 'b': 100, 'c': 100, 'd': 100, 'e': 100, 'f': 100, 'g': 100, 'h': 100},
+     "production_col": {'a': 97, 'b': 105, 'c': 99, 'd': 98, 'e': 101, 'f': 102, 'g': 97, 'h': 103},
     },
-    {"name": "1c",
+    {
+     "name": "1c",
      "scenario": "Marginal drift. Both distributions contain the same categories.",
-     "baseline_col": s_a,
-     "production_col": s_c,
+     "baseline_col": {'a': 100, 'b': 100, 'c': 100, 'd': 100, 'e': 100, 'f': 100, 'g': 100, 'h': 100},
+     "production_col": {'a': 100, 'b': 110, 'c': 90, 'd': 100, 'e': 100, 'f': 100, 'g': 110, 'h': 100},
     },
-    {"name": "1d",
+    {
+     "name": "1d",
+     "scenario": "Marginal drift with different sample size. Metric value should be very similar to test 1c.",
+     "baseline_col": {'a': 100, 'b': 100, 'c': 100, 'd': 100, 'e': 100, 'f': 100, 'g': 100, 'h': 100},
+     "production_col": {'a': 10, 'b': 11, 'c': 9, 'd': 10, 'e': 10, 'f': 10, 'g': 11, 'h': 10},
+    },
+    {
+     "name": "1e",
      "scenario": "Drifted distributions. Both distributions contain the same categories.",
-     "baseline_col": s_a,
-     "production_col": s_d,
+     "baseline_col": {'a': 100, 'b': 100, 'c': 100, 'd': 100, 'e': 100, 'f': 100, 'g': 100, 'h': 100},
+     "production_col": {'a': 180, 'b': 80, 'c': 70, 'd': 170, 'e': 200, 'f': 10, 'g': 130, 'h': 100},
     },
-    {"name": "1e",
+    {
+     "name": "1f",
      "scenario": "Drift caused by a single category. Both distributions contain the same categories.",
-     "baseline_col": s_a,
-     "production_col": s_e,
+     "baseline_col": {'a': 100, 'b': 100, 'c': 100, 'd': 100, 'e': 100, 'f': 100, 'g': 100, 'h': 100},
+     "production_col": {'a': 100, 'b': 100, 'c': 100, 'd': 100, 'e': 100, 'f': 100, 'g': 100, 'h': 1},
     },
-    {"name": "1f",
+    {
+     "name": "1g",
      "scenario": "Drifted distributions. Production dataset is missing some categories.",
-     "baseline_col": s_a,
-     "production_col": s_f,
+     "baseline_col": {'a': 100, 'b': 100, 'c': 100, 'd': 100, 'e': 100, 'f': 100, 'g': 100, 'h': 100},
+     "production_col": {'a': 100, 'b': 100, 'c': 100, 'f': 100, 'g': 100, 'h': 1},
     },
-    {"name": "1g",
-     "scenario": "Distributions with no categories in common. Bound distance measures (Jensen-Shannon) should reach their maximum theoretical value.",
-     "baseline_col": s_a,
-     "production_col": s_g,
+    {
+     "name": "1h",
+     "scenario": (
+         "Distributions with no categories in common. "
+         "Bound distance measures (Jensen-Shannon) should reach their maximum theoretical value."),
+     "baseline_col": {'a': 100, 'b': 100, 'c': 100, 'd': 100, 'e': 100, 'f': 100, 'g': 100, 'h': 100},
+     "production_col": {'i': 1, 'j': 1, 'k': 2},
     },
-    {"name": "2a",
+    {
+     "name": "2a",
      "scenario": "Dual value identical distributions with the same sample size. Distance measures should be 0.",
-     "baseline_col": s_h,
-     "production_col": s_h,
+     "baseline_col": {'a': 100, 'b': 100},
+     "production_col": {'a': 100, 'b': 100},
     },
-    {"name": "2b",
+    {
+     "name": "2b",
      "scenario": "Dual value identical distributions with different sample sizes. Distance measures should be 0.",
-     "baseline_col": s_h,
-     "production_col": s_i,
+     "baseline_col": {'a': 100, 'b': 100},
+     "production_col": {'a': 34, 'b': 34},
     },
-    {"name": "2c",
+    {
+     "name": "2c",
      "scenario": "Drifted Dual value distributions.",
-     "baseline_col": s_h,
-     "production_col": s_j,
+     "baseline_col": {'a': 100, 'b': 100},
+     "production_col": {'a': 92, 'b': 23},
     },
-    {"name": "2d",
-     "scenario": "Dual value distributions with different values. Bound distance measures (Jensen-Shannon) should reach their maximum theoretical value.",
-     "baseline_col": s_h,
-     "production_col": s_k,
+    {
+     "name": "2d",
+     "scenario": (
+         "Dual value distributions with different values. "
+         "Bound distance measures (Jensen-Shannon) should reach their maximum theoretical value."),
+     "baseline_col": {'a': 100, 'b': 100},
+     "production_col": {'c': 100, 'd': 100},
     },
 ]
 
@@ -99,56 +108,57 @@ test_cases = [
 @pytest.mark.unit
 class TestComputeDataDriftMetrics(unittest.TestCase):
     """Test class for data drift compute metrics component component and utilities."""
-    
-    def __init__(self, *args, **kwargs):  
-        super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)  
-        self.spark = init_spark()  
 
-    def round_to_n_significant_digits(self, number, n):  
-        if number == 0:  
-            return 0  
-        else:  
-            return round(number, n - int(math.floor(math.log10(abs(number)))) - 1)  
-       
+    def __init__(self, *args, **kwargs):
+        super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)
+        self.spark = init_spark()
+
+    def round_to_n_significant_digits(self, number, n):
+        if number == 0:
+            return 0
+        else:
+            return round(number, n - int(math.floor(math.log10(abs(number)))) - 1)
+
     def get_metric_value(self, df: pyspark_sql.DataFrame, metric_name: str):
         """Get metric value of the first row of a given column from a dataframe."""
-        #df.show()
         return df.filter(f"metric_name = '{metric_name}'").first().metric_value
 
     def create_spark_df(self, categorical_data):
-        column_values=['column1']
+        column_values = ['column1']
         pd_df = pd.DataFrame(data=categorical_data, columns=column_values)
         df = self.spark.createDataFrame(pd_df)
         return df
 
-    def create_categorical_data_from_string(self, sample_string: str):
-        cat_list = [letter for letter in sample_string]
+    def create_categorical_data_from_dict(self, sample_dict: dict):
+        cat_list = []
+        for key, value in sample_dict.items():
+            for i in range(value):
+                cat_list.append(key)
         random.shuffle(cat_list)
         return cat_list
 
-
-    # # # EXPECTED JENSEN-SHANNON DISTANCE # # # 
+    # # # EXPECTED JENSEN-SHANNON DISTANCE # # #
 
     def jensen_shannon_distance_categorical(self, x_list, y_list):
-    
+
         # unique values observed in x and y
         values = set(x_list + y_list)
-        
+
         x_counts = np.array([x_list.count(value) for value in values])
         y_counts = np.array([y_list.count(value) for value in values])
-    
-        x_ratios = x_counts / np.sum(x_counts)  #Optional as JS-D normalizes probability vectors
+
+        x_ratios = x_counts / np.sum(x_counts)  # Optional as JS-D normalizes probability vectors
         y_ratios = y_counts / np.sum(y_counts)
 
         return distance.jensenshannon(x_ratios, y_ratios, base=2)
 
     # # # EXPECTED PSI # # #
-    
+
     def psi_categorical(self, x_list, y_list):
-        
+
         # unique values observed in x and y
         values = set(x_list + y_list)
-        
+
         x_counts = np.array([x_list.count(value) for value in values])
         y_counts = np.array([y_list.count(value) for value in values])
 
@@ -163,14 +173,14 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         psi = 0
         for i in range(len(x_ratios)):
             psi += (y_ratios[i] - x_ratios[i]) * np.log(y_ratios[i] / x_ratios[i])
-    
+
         return psi
 
-    # # # EXPECTED CHI SQUARED TEST # # # 
+    # # # EXPECTED CHI SQUARED TEST # # #
 
     def chi_squared_test_categorical(self, x_list, y_list):
         values = set(x_list + y_list)
-        
+
         x_counts = np.array([x_list.count(value) for value in values])
         y_counts = np.array([y_list.count(value) for value in values])
 
@@ -178,8 +188,8 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         expected_y_counts = x_ratios * len(y_list)
 
         return chisquare(y_counts, expected_y_counts).pvalue
-    
-    # # # MAIN TEST FUNCTION # # # 
+
+    # # # MAIN TEST FUNCTION # # #
 
     def test_compute_categorical_data_drift_metrics(self):
         """Test compute distance measures for categorical metrics."""
@@ -187,20 +197,20 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         numerical_threshold = 0.1
 
         for distance_measure in distance_measures:
-            print(f'###########################################')
+            print('#########################################################################################')
             print(f'TESTING DISTANCE MEASURE: {distance_measure}')
-            print(f'###########################################')
+            print('#########################################################################################')
 
             for test_case in test_cases:
-                x = self.create_categorical_data_from_string(test_case['baseline_col'])
-                y = self.create_categorical_data_from_string(test_case['production_col'])
+                x = self.create_categorical_data_from_dict(test_case['baseline_col'])
+                y = self.create_categorical_data_from_dict(test_case['production_col'])
 
                 if distance_measure == "JensenShannonDistance":
-                    expected_distance = self.jensen_shannon_distance_categorical(x,y)
+                    expected_distance = self.jensen_shannon_distance_categorical(x, y)
                 elif distance_measure == "PopulationStabilityIndex":
-                    expected_distance = self.psi_categorical(x,y)
+                    expected_distance = self.psi_categorical(x, y)
                 elif distance_measure == "PearsonsChiSquaredTest":
-                    expected_distance = self.chi_squared_test_categorical(x,y)    
+                    expected_distance = self.chi_squared_test_categorical(x, y)
                 else:
                     raise ValueError(f"Distance measure {distance_measure} not in {distance_measures}")
 
@@ -209,8 +219,6 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
                 x_count = x_df.count()
                 y_count = y_df.count()
 
-
-                    
                 output_df = compute_categorical_data_drift_measures_tests(
                     x_df,
                     y_df,
@@ -221,14 +229,14 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
                     numerical_threshold)
 
                 metric_value = self.get_metric_value(output_df, distance_measure)
-            
+
                 print('-------------------------')
                 print(f'test: {test_case["name"]}')
                 print(f'test scenario: {test_case["scenario"]}')
-                print(f'expected value: {self.round_to_n_significant_digits(expected_distance,4)}') 
+                print(f'expected value: {self.round_to_n_significant_digits(expected_distance,4)}')
                 print(f'measured value: {self.round_to_n_significant_digits(metric_value,4)}')
 
-                if(abs(expected_distance) < 1e-6):
+                if (abs(expected_distance) < 1e-6):
                     self.assertAlmostEqual(metric_value, 0, 6)
                 else:
                     self.assertAlmostEqual(float(expected_distance)/metric_value, 1.0, 1)

--- a/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
@@ -3,6 +3,7 @@
 
 """
 This file contains unit tests for the Categorical Data Drift Metrics.
+
 It compares the drift measures of metrics implemented in Spark against their SciPy implementation
 """
 
@@ -107,13 +108,23 @@ test_cases = [
 
 @pytest.mark.unit
 class TestComputeDataDriftMetrics(unittest.TestCase):
-    """Test class for data drift compute metrics component component and utilities."""
+    """Test class for data drift compute metrics component and utilities."""
 
     def __init__(self, *args, **kwargs):
+        """
+        Initialize TestComputeDataDriftMetrics with the provided arguments and initialize the Spark session.
+        """
         super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)
         self.spark = init_spark()
 
     def round_to_n_significant_digits(self, number, n):
+        """
+        Round a given number to n significant digits.
+
+        :param number: The number to round.
+        :param n: The number of significant digits to round to.
+        :return: The rounded number.
+        """
         if number == 0:
             return 0
         else:
@@ -124,12 +135,24 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         return df.filter(f"metric_name = '{metric_name}'").first().metric_value
 
     def create_spark_df(self, categorical_data):
+        """
+        Create a Spark DataFrame from the given categorical data.
+
+        :param categorical_data: A list of categorical data.
+        :return: A Spark DataFrame with the categorical data.
+        """
         column_values = ['column1']
         pd_df = pd.DataFrame(data=categorical_data, columns=column_values)
         df = self.spark.createDataFrame(pd_df)
         return df
 
     def create_categorical_data_from_dict(self, sample_dict: dict):
+        """
+        Create a list of categorical data from the given dictionary.
+
+        :param sample_dict: A dictionary mapping categories to their frequencies.
+        :return: A list of categorical data.
+        """
         cat_list = []
         for key, value in sample_dict.items():
             for i in range(value):
@@ -140,7 +163,13 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     # # # EXPECTED JENSEN-SHANNON DISTANCE # # #
 
     def jensen_shannon_distance_categorical(self, x_list, y_list):
+        """
+        Compute the Jensen-Shannon distance between two lists of categorical data.
 
+        :param x_list: A list of categorical data for the first distribution.
+        :param y_list: A list of categorical data for the second distribution.
+        :return: The Jensen-Shannon distance between the two distributions.
+        """
         # unique values observed in x and y
         values = set(x_list + y_list)
 
@@ -155,7 +184,13 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     # # # EXPECTED PSI # # #
 
     def psi_categorical(self, x_list, y_list):
+        """
+        Compute the Population Stability Index (PSI) between two lists of categorical data.
 
+        :param x_list: A list of categorical data for the first distribution.
+        :param y_list: A list of categorical data for the second distribution.
+        :return: The PSI between the two distributions.
+        """
         # unique values observed in x and y
         values = set(x_list + y_list)
 
@@ -179,6 +214,13 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     # # # EXPECTED CHI SQUARED TEST # # #
 
     def chi_squared_test_categorical(self, x_list, y_list):
+        """
+        Compute the Pearson's Chi-squared test between two lists of categorical data.
+
+        :param x_list: A list of categorical data for the first distribution.
+        :param y_list: A list of categorical data for the second distribution.
+        :return: The p-value of the Pearson's Chi-squared test between the two distributions.
+        """
         values = set(x_list + y_list)
 
         x_counts = np.array([x_list.count(value) for value in values])

--- a/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
@@ -103,6 +103,12 @@ test_cases = [
      "baseline_col": {'a': 100, 'b': 100},
      "production_col": {'c': 100, 'd': 100},
     },
+    {
+     "name": "3a",
+     "scenario": "Distributions with low sample sizes.",
+     "baseline_col": {'a': 3, 'b': 1, 'c': 4},
+     "production_col": {'a': 2, 'b': 3},
+    },
 ]
 
 

--- a/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
@@ -39,7 +39,7 @@ s_k = 'c'*100 + 'd'*100
 
 test_cases = [
     {"name": "1a",
-     "scenario": "Distance between identical distributions should be exaclty 0.",
+     "scenario": "Distance between identical distributions should be exactly 0.",
      "baseline_col": s_b,
      "production_col": s_b,
     },

--- a/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
@@ -144,7 +144,7 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
 
     # # # EXPECTED PSI # # #
     
-    def psi_categorical(self, x_list, y_list, smoothing = 'evi'):
+    def psi_categorical(self, x_list, y_list):
         
         # unique values observed in x and y
         values = set(x_list + y_list)

--- a/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
@@ -1,0 +1,311 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""
+This file contains unit tests for the Categorical Data Drift Metrics.
+It compares the drift measures of metrics implemented in Spark against their SciPy implementation 
+"""
+
+from data_drift_compute_metrics.categorical_data_drift_metrics import compute_categorical_data_drift_measures_tests
+from shared_utilities.io_utils import init_spark
+from scipy.spatial import distance
+from scipy.stats import chisquare
+import pandas as pd
+import pyspark.sql as pyspark_sql
+import pytest
+import numpy as np
+import unittest
+import math
+import random
+
+distance_measures = [
+    "JensenShannonDistance",
+    "PopulationStabilityIndex",
+    "PearsonsChiSquaredTest",
+]
+
+# Sample strings to generate categorical variables
+s_a=('a'* 100 + 
+     'b'* 100 + 
+     'c'* 100 + 
+     'd'* 100 + 
+     'e'* 100 + 
+     'f'* 100 + 
+     'g'* 100 + 
+     'h'* 100)
+
+s_b=('a'* 97 + 
+     'b'* 105 + 
+     'c'* 99 + 
+     'd'* 98 + 
+     'e'* 101 + 
+     'f'* 102 + 
+     'g'* 97 + 
+     'h'* 103)
+
+s_c=('a'* 10 + 
+     'b'* 11 + 
+     'c'* 9 + 
+     'd'* 10 + 
+     'e'* 10 + 
+     'f'* 10 + 
+     'g'* 13 + 
+     'h'* 10)
+
+s_d=('a'* 180 + 
+     'b'* 80 + 
+     'c'* 70 + 
+     'd'* 170 + 
+     'e'* 200 + 
+     'f'* 10 + 
+     'g'* 130 + 
+     'h'* 100)
+
+
+s_e=('a'* 100 + 
+     'b'* 100 + 
+     'c'* 100 + 
+     'd'* 100 + 
+     'e'* 100 + 
+     'f'* 100 + 
+     'g'* 100 +
+     'h'* 1)
+
+s_f=('a'* 100 + 
+     'b'* 100 + 
+     'c'* 100 + 
+     'f'* 100 + 
+     'g'* 100 +
+     'h'* 1)
+
+s_g=('i'* 1 +
+     'j'* 1 +
+     'k'* 2)
+
+s_h=('a'* 100 +
+     'b'* 100)
+
+s_i=('a'* 34 +
+     'b'* 34)
+
+s_j=('a'* 92 +
+     'b'* 23)
+
+s_k=('c'* 100 +
+     'd'* 100)
+
+
+# convert to lists
+a_list = [letter for letter in s_a]
+b_list = [letter for letter in s_b]
+c_list = [letter for letter in s_c]
+d_list = [letter for letter in s_d]
+e_list = [letter for letter in s_e]
+f_list = [letter for letter in s_f]
+g_list = [letter for letter in s_g]
+h_list = [letter for letter in s_h]
+i_list = [letter for letter in s_i]
+j_list = [letter for letter in s_j]
+k_list = [letter for letter in s_k]
+
+# shuffle lists
+random.shuffle(a_list)
+random.shuffle(b_list)
+random.shuffle(c_list)
+random.shuffle(d_list)
+random.shuffle(e_list)
+random.shuffle(f_list)
+random.shuffle(g_list)
+random.shuffle(h_list)
+random.shuffle(i_list)
+random.shuffle(j_list)
+random.shuffle(k_list)
+
+test_cases = [
+    {"name": "1a",
+     "scenario": "Distance between identical distributions should be exaclty 0.",
+     "baseline_col": b_list,
+     "production_col": b_list,
+    },
+    {"name": "1b",
+     "scenario": "Minimal drift. Both distributions contain the same categories.",
+     "baseline_col": a_list,
+     "production_col": b_list,
+    },
+    {"name": "1c",
+     "scenario": "Marginal drift. Both distributions contain the same categories.",
+     "baseline_col": a_list,
+     "production_col": c_list,
+    },
+    {"name": "1d",
+     "scenario": "Drifted distributions. Both distributions contain the same categories.",
+     "baseline_col": a_list,
+     "production_col": d_list,
+    },
+    {"name": "1e",
+     "scenario": "Drift caused by a single category. Both distributions contain the same categories.",
+     "baseline_col": a_list,
+     "production_col": e_list,
+    },
+    {"name": "1f",
+     "scenario": "Drifted distributions. Production dataset is missing some categories.",
+     "baseline_col": a_list,
+     "production_col": f_list,
+    },
+    {"name": "1g",
+     "scenario": "Distributions with no categories in common. Bound distance measures (Jensen-Shannon) should reach their maximum theoretical value.",
+     "baseline_col": a_list,
+     "production_col": g_list,
+    },
+    {"name": "2a",
+     "scenario": "Dual value identical distributions with the same sample size. Distance measures should be 0.",
+     "baseline_col": h_list,
+     "production_col": h_list,
+    },
+    {"name": "2b",
+     "scenario": "Dual value identical distributions with different sample sizes. Distance measures should be 0.",
+     "baseline_col": h_list,
+     "production_col": i_list,
+    },
+    {"name": "2c",
+     "scenario": "Drifted Dual value distributions.",
+     "baseline_col": h_list,
+     "production_col": j_list,
+    },
+    {"name": "2d",
+     "scenario": "Dual value distributions with different values. Bound distance measures (Jensen-Shannon) should reach their maximum theoretical value.",
+     "baseline_col": h_list,
+     "production_col": k_list,
+    },
+]
+
+
+@pytest.mark.unit
+class TestComputeDataDriftMetrics(unittest.TestCase):
+    """Test class for data drift compute metrics component component and utilities."""
+    
+    def __init__(self, *args, **kwargs):  
+        super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)  
+        self.spark = init_spark()  
+
+    def round_to_n_significant_digits(self, number, n):  
+        if number == 0:  
+            return 0  
+        else:  
+            return round(number, n - int(math.floor(math.log10(abs(number)))) - 1)  
+       
+    def get_metric_value(self, df: pyspark_sql.DataFrame, metric_name: str):
+        """Get metric value of the first row of a given column from a dataframe."""
+        return df.filter(f"metric_name = '{metric_name}'").first().metric_value
+
+    def create_spark_df(self, categorical_data):
+        column_values=['column1']
+        pd_df = pd.DataFrame(data=categorical_data, columns=column_values)
+        df = self.spark.createDataFrame(pd_df)
+        return df
+
+    # # # EXPECTED JENSEN-SHANNON DISTANCE # # # 
+
+    def jensen_shannon_distance_categorical(self, x_list, y_list):
+    
+        # unique values observed in x and y
+        values = set(x_list + y_list)
+        
+        x_counts = np.array([x_list.count(value) for value in values])
+        y_counts = np.array([y_list.count(value) for value in values])
+    
+        x_ratios = x_counts / np.sum(x_counts)  #Optional as JS-D normalizes probability vectors
+        y_ratios = y_counts / np.sum(y_counts)
+
+        return distance.jensenshannon(x_ratios, y_ratios, base=2)
+
+    # # # EXPECTED PSI # # #
+    
+    def psi_categorical(self, x_list, y_list, smoothing = 'evi'):
+        
+        # unique values observed in x and y
+        values = set(x_list + y_list)
+        
+        x_counts = np.array([x_list.count(value) for value in values])
+        y_counts = np.array([y_list.count(value) for value in values])
+
+        # Laplace smoothing (incrementing the count of each bin by 1)
+        # to avoid zero values in bins and have the SPI value be finit
+        x_counts = x_counts + 1
+        y_counts = y_counts + 1
+
+        x_ratios = x_counts / np.sum(x_counts)
+        y_ratios = y_counts / np.sum(y_counts)
+
+        psi = 0
+        for i in range(len(x_ratios)):
+            psi += (y_ratios[i] - x_ratios[i]) * np.log(y_ratios[i] / x_ratios[i])
+    
+        return psi
+
+    # # # EXPECTED CHI SQUARED TEST # # # 
+
+    def chi_squared_test_categorical(self, x_list, y_list):
+        values = set(x_list + y_list)
+        
+        x_counts = np.array([x_list.count(value) for value in values])
+        y_counts = np.array([y_list.count(value) for value in values])
+
+        x_ratios = x_counts / np.sum(x_counts)
+        expected_y_counts = x_ratios * len(y_list)
+
+        return chisquare(y_counts, expected_y_counts).pvalue
+    
+    # # # MAIN TEST FUNCTION # # # 
+
+    def test_compute_categorical_data_drift_metrics(self):
+        """Test compute distance measures for categorical metrics."""
+        column_values = ['column1']
+        numerical_threshold = 0.1
+
+        for distance_measure in distance_measures:
+            print(f'###########################################')
+            print(f'TESTING DISTANCE MEASURE: {distance_measure}')
+            print(f'###########################################')
+
+            for test_case in test_cases:
+                x = test_case['baseline_col']
+                y = test_case['production_col']
+
+                if distance_measure == "JensenShannonDistance":
+                    expected_distance = self.jensen_shannon_distance_categorical(x,y)
+                elif distance_measure == "PopulationStabilityIndex":
+                    expected_distance = self.psi_categorical(x,y)
+                elif distance_measure == "PearsonsChiSquaredTest":
+                    expected_distance = self.chi_squared_test_categorical(x,y)    
+                else:
+                    raise ValueError(f"Distance measure {distance_measure} not in {distance_measures}")
+
+                x_df = self.create_spark_df(x)
+                y_df = self.create_spark_df(y)
+                x_count = x_df.count()
+                y_count = y_df.count()
+
+
+                    
+                output_df = compute_categorical_data_drift_measures_tests(
+                    x_df,
+                    y_df,
+                    x_count,
+                    y_count,
+                    distance_measure,
+                    column_values,
+                    numerical_threshold)
+
+                metric_value = self.get_metric_value(output_df, distance_measure)
+            
+                print('-------------------------')
+                print(f'test: {test_case["name"]}')
+                print(f'test scenario: {test_case["scenario"]}')
+                print(f'expected value: {self.round_to_n_significant_digits(expected_distance,4)}') 
+                print(f'measured value: {self.round_to_n_significant_digits(metric_value,4)}')
+
+                if(abs(expected_distance) < 1e-6):
+                    self.assertAlmostEqual(metric_value, 0, 6)
+                else:
+                    self.assertAlmostEqual(float(expected_distance)/metric_value, 1.0, 1)

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -3,7 +3,7 @@
 
 """
 This file contains unit tests for the Numerical Data Drift Metrics.
-It compares the drift measures of metrics implemented in Spark against their SciPy implementation 
+It compares the drift measures of metrics implemented in Spark against their SciPy implementation.
 """
 
 from data_drift_compute_metrics.numerical_data_drift_metrics import compute_numerical_data_drift_measures_tests
@@ -26,8 +26,9 @@ distance_measures = [
 
 
 test_cases = [
-    {"name": "1a",
-     "scenario": "Distance between identical distributions should be exactly 0",
+    {
+     "name": "1a",
+     "scenario": "Distance between identical distributions should be exactly 0.",
      "x_mean": 50,
      "y_mean": 50,
      "x_std_dev": 15,
@@ -35,8 +36,9 @@ test_cases = [
      "x_obs": 100_000,
      "y_obs": 100_000,
     },
-    {"name": "1b",
-     "scenario": "Distance between two samples of the different sizes of the same distributions should be close to 0",
+    {
+     "name": "1b",
+     "scenario": "Distance between two samples of the different sizes of the same distributions should be close to 0.",
      "x_mean": 50,
      "y_mean": 50,
      "x_std_dev": 15,
@@ -44,8 +46,9 @@ test_cases = [
      "x_obs": 100_000,
      "y_obs": 10_000,
     },
-    {"name": "1c",
-     "scenario": "Non-zero distance between distributions with the same mean and sample size, but different std_dev",
+    {
+     "name": "1c",
+     "scenario": "Non-zero distance between distributions with the same mean and sample size, but different std_dev.",
      "x_mean": 50,
      "y_mean": 50,
      "x_std_dev": 15,
@@ -53,8 +56,9 @@ test_cases = [
      "x_obs": 100_000,
      "y_obs": 100_000,
     },
-    {"name": "2a",
-    "scenario": "Confirming distance of moderately drifted distribution against SciPy",
+    {
+     "name": "2a",
+     "scenario": "Confirming distance of moderately drifted distribution against SciPy.",
      "x_mean": 50,
      "y_mean": 53,
      "x_std_dev": 15,
@@ -62,8 +66,9 @@ test_cases = [
      "x_obs": 100_000,
      "y_obs": 100_000,
     },
-    {"name": "2b",
-    "scenario": "Weak distance value dependence on sample size. Distance should be close to test 2a.",
+    {
+     "name": "2b",
+     "scenario": "Weak distance value dependence on sample size. Distance should be close to test 2a.",
      "x_mean": 50,
      "y_mean": 53,
      "x_std_dev": 15,
@@ -71,8 +76,9 @@ test_cases = [
      "x_obs": 100_000,
      "y_obs": 10_000,
     },
-    {"name": "2c",
-    "scenario": "Decreasing std_dev in prodcution dataset. Increase in distance expected when compared to test 2a.",
+    {
+     "name": "2c",
+     "scenario": "Decreasing std_dev in prodcution dataset. Increase in distance expected when compared to test 2a.",
      "x_mean": 50,
      "y_mean": 53,
      "x_std_dev": 15,
@@ -80,8 +86,9 @@ test_cases = [
      "x_obs": 100_000,
      "y_obs": 100_000,
     },
-    {"name": "2d",
-    "scenario": "Decreasing both sample size and std_dev in prodcution dataset. Similar distance as test 2c expected.",
+    {
+     "name": "2d",
+     "scenario": "Decreasing both sample size and std_dev in prodcution dataset. Similar values as test 2c expected.",
      "x_mean": 50,
      "y_mean": 53,
      "x_std_dev": 15,
@@ -89,8 +96,9 @@ test_cases = [
      "x_obs": 100_000,
      "y_obs": 10_000,
     },
-    {"name": "3a",
-    "scenario": "Large drift. Bound distnace measures (Jensen-Shannon) approaching maximum theoretical values.",
+    {
+     "name": "3a",
+     "scenario": "Large drift. Bound distnace measures (Jensen-Shannon) approaching maximum theoretical values.",
      "x_mean": 50,
      "y_mean": 100,
      "x_std_dev": 15,
@@ -98,8 +106,9 @@ test_cases = [
      "x_obs": 100_000,
      "y_obs": 100_000,
     },
-    {"name": "3b",
-    "scenario": "Extreme drift scenario. Bound distnace measures (Jensen-Shannon) should reach their maximum theoretical value.",
+    {
+     "name": "3b",
+     "scenario": "Extreme drift scenario. Bound distnace measures (JSD) should reach their maximum theoretical value.",
      "x_mean": 50,
      "y_mean": 250,
      "x_std_dev": 15,
@@ -107,8 +116,9 @@ test_cases = [
      "x_obs": 100_000,
      "y_obs": 100_000,
     },
-    {"name": "4a",
-    "scenario": "Extreme drift scenario. All values the same, but different in baseline and prod.",
+    {
+     "name": "4a",
+     "scenario": "Extreme drift scenario. All values the same, but different in baseline and prod.",
      "x_mean": 50,
      "y_mean": 51,
      "x_std_dev": 0,
@@ -116,8 +126,9 @@ test_cases = [
      "x_obs": 9_000,
      "y_obs": 9_000,
     },
-    {"name": "5a",
-     "scenario": "Distance between identical distributions should be exaclty 0",
+    {
+     "name": "5a",
+     "scenario": "Distance between identical distributions should be exaclty 0.",
      "x_mean": 50,
      "y_mean": 50,
      "x_std_dev": 15,
@@ -125,8 +136,9 @@ test_cases = [
      "x_obs": 9_000,
      "y_obs": 9_000,
     },
-    {"name": "5b",
-     "scenario": "Distance between two samples of the different sizes of the same distributions should be close to 0",
+    {
+     "name": "5b",
+     "scenario": "Distance between two samples of the different sizes of the same distributions should be close to 0.",
      "x_mean": 50,
      "y_mean": 50,
      "x_std_dev": 15,
@@ -134,8 +146,9 @@ test_cases = [
      "x_obs": 9_000,
      "y_obs": 900,
     },
-    {"name": "5c",
-     "scenario": "Non-zero distance between distributions with the same mean and sample size, but differnt std_dev",
+    {
+     "name": "5c",
+     "scenario": "Non-zero distance between distributions with the same mean and sample size, but differnt std_dev.",
      "x_mean": 50,
      "y_mean": 50,
      "x_std_dev": 15,
@@ -143,8 +156,9 @@ test_cases = [
      "x_obs": 9_000,
      "y_obs": 9_000,
     },
-    {"name": "6a",
-    "scenario": "Confirming distance of moderately drifted distribution against Scipy",
+    {
+     "name": "6a",
+     "scenario": "Confirming distance of moderately drifted distribution against Scipy.",
      "x_mean": 50,
      "y_mean": 51,
      "x_std_dev": 15,
@@ -152,8 +166,11 @@ test_cases = [
      "x_obs": 9_000,
      "y_obs": 9_000,
     },
-    {"name": "6b",
-    "scenario": "Weak distance value dependence on sample size. Distance should be close to test 6a.",
+    {
+     "name": "6b",
+     "scenario": (
+         "Weak distance value dependence on sample size. " 
+         "Distance should be close to test 6a (might not be the case for KS-Test)."),
      "x_mean": 50,
      "y_mean": 51,
      "x_std_dev": 15,
@@ -161,8 +178,9 @@ test_cases = [
      "x_obs": 9_000,
      "y_obs": 900,
     },
-    {"name": "6c",
-    "scenario": "Decreasing std_dev in prodcution dataset. Increase in distance expected when compared to test 6a.",
+    {
+     "name": "6c",
+     "scenario": "Decreasing std_dev in prodcution dataset. Increase in distance expected when compared to test 6a.",
      "x_mean": 50,
      "y_mean": 51,
      "x_std_dev": 15,
@@ -170,8 +188,9 @@ test_cases = [
      "x_obs": 9_000,
      "y_obs": 9_000,
     },
-    {"name": "6d",
-    "scenario": "Decreasing both sample size and std_dev in prodcution dataset. Similar distance as test 6c expected.",
+    {
+     "name": "6d",
+     "scenario": "Decreasing both sample size and std_dev in production dataset. Similar values as test 6c expected.",
      "x_mean": 50,
      "y_mean": 51,
      "x_std_dev": 15,
@@ -182,28 +201,26 @@ test_cases = [
 ]
 
 
-
 @pytest.mark.unit
 class TestComputeDataDriftMetrics(unittest.TestCase):
     """Test class for data drift compute metrics component component and utilities."""
-    
-    def __init__(self, *args, **kwargs):  
-        super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)  
-        self.spark = init_spark()  
 
-    def round_to_n_significant_digits(self, number, n):  
-        if number == 0:  
-            return 0  
-        else:  
-            return round(number, n - int(math.floor(math.log10(abs(number)))) - 1)  
-    
-    
+    def __init__(self, *args, **kwargs):
+        super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)
+        self.spark = init_spark()
+
+    def round_to_n_significant_digits(self, number, n):
+        if number == 0:
+            return 0
+        else:
+            return round(number, n - int(math.floor(math.log10(abs(number)))) - 1)
+
     def get_metric_value(self, df: pyspark_sql.DataFrame, metric_name: str):
         """Get metric value of the first row of a given column from a dataframe."""
         return df.filter(f"metric_name = '{metric_name}'").first().metric_value
 
     def create_spark_df(self, numerical_data):
-        column_values=['column1']
+        column_values = ['column1']
         pd_df = pd.DataFrame(data=numerical_data, columns=column_values)
         df = self.spark.createDataFrame(pd_df)
         return df
@@ -213,42 +230,41 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         x = np.random.normal(dist_params["x_mean"], dist_params["x_std_dev"], dist_params["x_obs"])
         np.random.seed(0)
         y = np.random.normal(dist_params["y_mean"], dist_params["y_std_dev"], dist_params["y_obs"])
-        return x,y
+        return x, y
 
+    def compute_optimal_histogram_bin_edges(self, x_array, y_array):
 
-    def compute_optimal_histogram_bin_edges(self, x_array,y_array):
-    
-        #find overall min and max values for both distributions
+        # find overall min and max values for both distributions
         min_value = min(np.amin(x_array), np.amin(y_array))
         max_value = max(np.amax(x_array), np.amax(y_array))
-    
-        #add overall min and max value to both distributions in order estimate the appropriate number of bins
-        #for both samples that span the entire range of data.
-        x_array_extended = np.append(x_array,[min_value, max_value])
-        y_array_extended = np.append(y_array,[min_value, max_value])    
 
-        #select the amount of bins used. The smaller amount of bins is recommended to ensure both x_array and y_array have well populated histograms 
+        # add overall min and max value to both distributions in order estimate the appropriate number of bins
+        # for both samples that span the entire range of data.
+        x_array_extended = np.append(x_array, [min_value, max_value])
+        y_array_extended = np.append(y_array, [min_value, max_value])
+
+        # select the amount of bins used.
+        # The smaller amount of bins is recommended to ensure both x_array and y_array have well populated histograms.
         if min_value == max_value:
             number_of_bins = 1
             bin_edges = np.array([min_value/1.01, min_value*1.01])
-    
+
         else:
-            #compute optimal bin edges for both distributions after having been extended to [min_value,max_value]
-            x_bin_edges=np.histogram_bin_edges(x_array_extended, bins='sturges')
-            y_bin_edges=np.histogram_bin_edges(y_array_extended, bins='sturges')
+            # compute optimal bin edges for both distributions after having been extended to [min_value,max_value]
+            x_bin_edges = np.histogram_bin_edges(x_array_extended, bins='sturges')
+            y_bin_edges = np.histogram_bin_edges(y_array_extended, bins='sturges')
             number_of_bins = min(len(x_bin_edges), len(y_bin_edges))
-            bin_edges=np.linspace(min_value, max_value, number_of_bins)
+            bin_edges = np.linspace(min_value, max_value, number_of_bins)
 
         return bin_edges
 
-
-    # # # EXPECTED NORMALIZED WASSERSTEIN DISTANCE # # # 
+    # # # EXPECTED NORMALIZED WASSERSTEIN DISTANCE # # #
 
     def normed_wasserstein_distance_numerical(self, x_array, y_array):
-        norm = max(np.std(x_array),0.001)
+        norm = max(np.std(x_array), 0.001)
         return wasserstein_distance(x_array, y_array) / norm
 
-    # # # EXPECTED JENSEN-SHANNON DISTANCE # # # 
+    # # # EXPECTED JENSEN-SHANNON DISTANCE # # #
 
     def jensen_shannon_distance_numerical(self, x_array, y_array):
         bin_edges = self.compute_optimal_histogram_bin_edges(x_array, y_array)
@@ -258,20 +274,20 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         return distance.jensenshannon(x_percent, y_percent, base=2)
 
     # # # EXPECTED PSI # # #
-    
+
     def psi_numerical(self, x_array, y_array):
         bin_edges = self.compute_optimal_histogram_bin_edges(x_array, y_array)
 
         x_count = np.histogram(x_array, bins=bin_edges)[0]
-        y_count = np.histogram(y_array, bins=bin_edges)[0] 
-        
+        y_count = np.histogram(y_array, bins=bin_edges)[0]
+
         # Laplace smoothing (incrementing the count of each bin by 1)
         # to avoid zero values in bins and have the SPI value be finit
         x_count = x_count + 1
-        y_count = y_count + 1 
+        y_count = y_count + 1
 
-        x_percent = x_count / len(x_array) 
-        y_percent = y_count / len(y_array)   
+        x_percent = x_count / len(x_array)
+        y_percent = y_count / len(y_array)
 
         psi = 0.0
         for i in range(len(x_percent)):
@@ -279,12 +295,12 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
 
         return psi
 
-    # # # EXPECTED TWO SAMPLE KS TEST # # # 
+    # # # EXPECTED TWO SAMPLE KS TEST # # #
 
     def two_sample_ks_test_numerical(self, x_array, y_array):
         return ks_2samp(x_array, y_array).pvalue
-    
-    # # # MAIN TEST FUNCTION # # # 
+
+    # # # MAIN TEST FUNCTION # # #
 
     def test_compute_numerical_data_drift_metrics(self):
         """Test compute distance measures for numerical metrics."""
@@ -292,21 +308,21 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         numerical_threshold = 0.1
 
         for distance_measure in distance_measures:
-            print(f'###########################################')
+            print('#########################################################################################')
             print(f'TESTING DISTANCE MEASURE: {distance_measure}')
-            print(f'###########################################')
+            print('#########################################################################################')
 
             for test_case in test_cases:
-                x,y = self.create_test_distributions(test_case)
+                x, y = self.create_test_distributions(test_case)
 
                 if distance_measure == "NormalizedWassersteinDistance":
-                    expected_distance = self.normed_wasserstein_distance_numerical(x,y)
+                    expected_distance = self.normed_wasserstein_distance_numerical(x, y)
                 elif distance_measure == "JensenShannonDistance":
-                    expected_distance = self.jensen_shannon_distance_numerical(x,y)
+                    expected_distance = self.jensen_shannon_distance_numerical(x, y)
                 elif distance_measure == "PopulationStabilityIndex":
-                    expected_distance = self.psi_numerical(x,y)
+                    expected_distance = self.psi_numerical(x, y)
                 elif distance_measure == "TwoSampleKolmogorovSmirnovTest":
-                    expected_distance = self.two_sample_ks_test_numerical(x,y)    
+                    expected_distance = self.two_sample_ks_test_numerical(x, y)
                 else:
                     raise ValueError(f"Distance measure {distance_measure} not in {distance_measures}")
 
@@ -315,10 +331,10 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
                 x_count = x_df.count()
                 y_count = y_df.count()
 
-                #Excluding KS-tess with more than 10k samples
-                if not (distance_measure == "TwoSampleKolmogorovSmirnovTest" 
-                    and (x_count >= 10_000  or y_count >= 10_000)):
-                    
+                # Excluding KS-tess with more than 10k samples
+                if not (distance_measure == "TwoSampleKolmogorovSmirnovTest"
+                        and (x_count >= 10_000 or y_count >= 10_000)):
+
                     output_df = compute_numerical_data_drift_measures_tests(
                         x_df,
                         y_df,
@@ -329,14 +345,14 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
                         numerical_threshold)
 
                     metric_value = self.get_metric_value(output_df, distance_measure)
-            
+
                     print('-------------------------')
                     print(f'test: {test_case["name"]}')
                     print(f'test scenario: {test_case["scenario"]}')
-                    print(f'expected value: {self.round_to_n_significant_digits(expected_distance,4)}') 
+                    print(f'expected value: {self.round_to_n_significant_digits(expected_distance,4)}')
                     print(f'measured value: {self.round_to_n_significant_digits(metric_value,4)}')
 
-                    if(abs(expected_distance) < 1e-6):
+                    if (abs(expected_distance) < 1e-6):
                         self.assertAlmostEqual(metric_value, 0, 6)
                     else:
                         self.assertAlmostEqual(float(expected_distance)/metric_value, 1.0, 1)

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -27,7 +27,7 @@ distance_measures = [
 
 test_cases = [
     {"name": "1a",
-     "scenario": "Distance between identical distributions should be exaclty 0",
+     "scenario": "Distance between identical distributions should be exactly 0",
      "x_mean": 50,
      "y_mean": 50,
      "x_std_dev": 15,
@@ -45,7 +45,7 @@ test_cases = [
      "y_obs": 10_000,
     },
     {"name": "1c",
-     "scenario": "Non-zero distance between distributions with the same mean and sample size, but differnt std_dev",
+     "scenario": "Non-zero distance between distributions with the same mean and sample size, but different std_dev",
      "x_mean": 50,
      "y_mean": 50,
      "x_std_dev": 15,
@@ -54,7 +54,7 @@ test_cases = [
      "y_obs": 100_000,
     },
     {"name": "2a",
-    "scenario": "Confirming distance of moderately drifted distribution against Scipy",
+    "scenario": "Confirming distance of moderately drifted distribution against SciPy",
      "x_mean": 50,
      "y_mean": 53,
      "x_std_dev": 15,

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -99,7 +99,7 @@ test_cases = [
     },
     {
      "name": "3a",
-     "scenario": "Large drift. Bound distnace measures (Jensen-Shannon) approaching maximum theoretical values.",
+     "scenario": "Large drift. Bound distance measures (Jensen-Shannon) approaching maximum theoretical values.",
      "x_mean": 50,
      "y_mean": 100,
      "x_std_dev": 15,
@@ -109,7 +109,7 @@ test_cases = [
     },
     {
      "name": "3b",
-     "scenario": "Extreme drift scenario. Bound distnace measures (JSD) should reach their maximum theoretical value.",
+     "scenario": "Extreme drift scenario. Bound distance measures (JSD) should reach their maximum theoretical value.",
      "x_mean": 50,
      "y_mean": 250,
      "x_std_dev": 15,
@@ -149,7 +149,7 @@ test_cases = [
     },
     {
      "name": "5c",
-     "scenario": "Non-zero distance between distributions with the same mean and sample size, but differnt std_dev.",
+     "scenario": "Non-zero distance between distributions with the same mean and sample size, but different std_dev.",
      "x_mean": 50,
      "y_mean": 50,
      "x_std_dev": 15,
@@ -198,6 +198,26 @@ test_cases = [
      "y_std_dev": 5,
      "x_obs": 9_000,
      "y_obs": 900,
+    },
+    {
+     "name": "7a",
+     "scenario": "Very low sample size test. n_obs = 100.",
+     "x_mean": 50,
+     "y_mean": 52,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 100,
+     "y_obs": 100,
+    },
+    {
+     "name": "7b",
+     "scenario": "Extremely low sample size test. n_obs = 20.",
+     "x_mean": 50,
+     "y_mean": 52,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 20,
+     "y_obs": 20,
     },
 ]
 
@@ -334,8 +354,10 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         x_count = x_count + 1
         y_count = y_count + 1
 
-        x_percent = x_count / len(x_array)
-        y_percent = y_count / len(y_array)
+        # normalize counts to get percentages. Note that we had to add the number of histogram bins
+        # to the denominator to account for the laplace smoothing
+        x_percent = x_count / (len(x_array) + len(x_count))
+        y_percent = y_count / (len(y_array) + len(y_count))
 
         psi = 0.0
         for i in range(len(x_percent)):

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -1,87 +1,345 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-"""This file contains unit tests for the Data Drift compute metrics component component."""
+"""
+This file contains unit tests for the Numerical Data Drift Metrics.
+It compares the drift measures of metrics implemented in Spark against their Scipy implementation 
+"""
 
 from data_drift_compute_metrics.numerical_data_drift_metrics import compute_numerical_data_drift_measures_tests
 from shared_utilities.io_utils import init_spark
+from scipy.stats import ks_2samp, wasserstein_distance
+from scipy.spatial import distance
 import pandas as pd
 import pyspark.sql as pyspark_sql
 import pytest
 import numpy as np
 import unittest
+import math
+
+distance_measures = [
+    "NormalizedWassersteinDistance",
+    "JensenShannonDistance",
+    "PopulationStabilityIndex",
+    "TwoSampleKolmogorovSmirnovTest",
+]
+
 
 test_cases = [
-                [100_000, 10_000, 50, 50, 0.01],
-                [100_000, 100_000, 50, 100, 3.32],
-                [100_000, 100_000, 50, 250, 13.32],
-             ]
+    {"name": "1a",
+     "scenario": "Distance between identical distributions should be exaclty 0",
+     "x_mean": 50,
+     "y_mean": 50,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 100_000,
+     "y_obs": 100_000,
+    },
+    {"name": "1b",
+     "scenario": "Distance between two samples of the different sizes of the same distributions should be close to 0",
+     "x_mean": 50,
+     "y_mean": 50,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 100_000,
+     "y_obs": 10_000,
+    },
+    {"name": "1c",
+     "scenario": "Non-zero distance between distributions with the same mean and sample size, but differnt std_dev",
+     "x_mean": 50,
+     "y_mean": 50,
+     "x_std_dev": 15,
+     "y_std_dev": 10,
+     "x_obs": 100_000,
+     "y_obs": 100_000,
+    },
+    {"name": "2a",
+    "scenario": "Confirming distance of moderately drifted distribution against Scipy",
+     "x_mean": 50,
+     "y_mean": 53,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 100_000,
+     "y_obs": 100_000,
+    },
+    {"name": "2b",
+    "scenario": "Weak distance value dependence on sample size. Distance should be close to test 2a.",
+     "x_mean": 50,
+     "y_mean": 53,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 100_000,
+     "y_obs": 10_000,
+    },
+    {"name": "2c",
+    "scenario": "Decreasing std_dev in prodcution dataset. Increase in distance expected when compared to test 2a.",
+     "x_mean": 50,
+     "y_mean": 53,
+     "x_std_dev": 15,
+     "y_std_dev": 5,
+     "x_obs": 100_000,
+     "y_obs": 100_000,
+    },
+    {"name": "2d",
+    "scenario": "Decreasing both sample size and std_dev in prodcution dataset. Similar distance as test 2c expected.",
+     "x_mean": 50,
+     "y_mean": 53,
+     "x_std_dev": 15,
+     "y_std_dev": 5,
+     "x_obs": 100_000,
+     "y_obs": 10_000,
+    },
+    {"name": "3a",
+    "scenario": "Large drift. Bound distnace measures (Jensen-Shannon) approaching maximum theoretical values.",
+     "x_mean": 50,
+     "y_mean": 100,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 100_000,
+     "y_obs": 100_000,
+    },
+    {"name": "3b",
+    "scenario": "Extreme drift scenario. Bound distnace measures (Jensen-Shannon) should reach their maximum theoretical value.",
+     "x_mean": 50,
+     "y_mean": 250,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 100_000,
+     "y_obs": 100_000,
+    },
+    {"name": "4a",
+    "scenario": "Extreme drift scenario. All values the same, but different in baseline and prod.",
+     "x_mean": 50,
+     "y_mean": 51,
+     "x_std_dev": 0,
+     "y_std_dev": 0,
+     "x_obs": 9_000,
+     "y_obs": 9_000,
+    },
+    {"name": "5a",
+     "scenario": "Distance between identical distributions should be exaclty 0",
+     "x_mean": 50,
+     "y_mean": 50,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 9_000,
+     "y_obs": 9_000,
+    },
+    {"name": "5b",
+     "scenario": "Distance between two samples of the different sizes of the same distributions should be close to 0",
+     "x_mean": 50,
+     "y_mean": 50,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 9_000,
+     "y_obs": 900,
+    },
+    {"name": "5c",
+     "scenario": "Non-zero distance between distributions with the same mean and sample size, but differnt std_dev",
+     "x_mean": 50,
+     "y_mean": 50,
+     "x_std_dev": 15,
+     "y_std_dev": 10,
+     "x_obs": 9_000,
+     "y_obs": 9_000,
+    },
+    {"name": "6a",
+    "scenario": "Confirming distance of moderately drifted distribution against Scipy",
+     "x_mean": 50,
+     "y_mean": 51,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 9_000,
+     "y_obs": 9_000,
+    },
+    {"name": "6b",
+    "scenario": "Weak distance value dependence on sample size. Distance should be close to test 6a.",
+     "x_mean": 50,
+     "y_mean": 51,
+     "x_std_dev": 15,
+     "y_std_dev": 15,
+     "x_obs": 9_000,
+     "y_obs": 900,
+    },
+    {"name": "6c",
+    "scenario": "Decreasing std_dev in prodcution dataset. Increase in distance expected when compared to test 6a.",
+     "x_mean": 50,
+     "y_mean": 51,
+     "x_std_dev": 15,
+     "y_std_dev": 5,
+     "x_obs": 9_000,
+     "y_obs": 9_000,
+    },
+    {"name": "6d",
+    "scenario": "Decreasing both sample size and std_dev in prodcution dataset. Similar distance as test 6c expected.",
+     "x_mean": 50,
+     "y_mean": 51,
+     "x_std_dev": 15,
+     "y_std_dev": 5,
+     "x_obs": 9_000,
+     "y_obs": 900,
+    },
+]
+
 
 
 @pytest.mark.unit
 class TestComputeDataDriftMetrics(unittest.TestCase):
     """Test class for data drift compute metrics component component and utilities."""
+    
+    def __init__(self, *args, **kwargs):  
+        super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)  
+        self.spark = init_spark()  
 
+    def round_to_n_significant_digits(self, number, n):  
+        if number == 0:  
+            return 0  
+        else:  
+            return round(number, n - int(math.floor(math.log10(abs(number)))) - 1)  
+    
+    
     def get_metric_value(self, df: pyspark_sql.DataFrame, metric_name: str):
         """Get metric value of the first row of a given column from a dataframe."""
+        #df.show()
         return df.filter(f"metric_name = '{metric_name}'").first().metric_value
 
-    def test_compute_numerical_data_drift_metrics_normalized_wasserstein_distance_identical_distribution(self):
-        """Test compute normalized wasserstein distance for numerical metrics when inputs are identitcal."""
-        x_n_obs = 100_000
-        x_mean = 50
-        std_dev = 15
+    def create_spark_df(self, numerical_data):
+        column_values=['column1']
+        pd_df = pd.DataFrame(data=numerical_data, columns=column_values)
+        df = self.spark.createDataFrame(pd_df)
+        return df
+
+    def create_test_distributions(self, dist_params: dict):
+        np.random.seed(0)
+        x = np.random.normal(dist_params["x_mean"], dist_params["x_std_dev"], dist_params["x_obs"])
+        np.random.seed(0)
+        y = np.random.normal(dist_params["y_mean"], dist_params["y_std_dev"], dist_params["y_obs"])
+        return x,y
+
+
+    def compute_optimal_histogram_bin_edges(self, x_array,y_array):
+    
+        #find overall min and max values for both distributions
+        min_value = min(np.amin(x_array), np.amin(y_array))
+        max_value = max(np.amax(x_array), np.amax(y_array))
+    
+        #add overall min and max value to both distributions in order estimate the appropriate number of bins
+        #for both samples that span the entire range of data.
+        x_array_extended = np.append(x_array,[min_value, max_value])
+        y_array_extended = np.append(y_array,[min_value, max_value])    
+
+        #select the amount of bins used. The smaller amount of bins is recommended to ensure both x_array and y_array have well populated histograms 
+        if min_value == max_value:
+            number_of_bins = 1
+            bin_edges = np.array([min_value/1.01, min_value*1.01])
+    
+        else:
+            #compute optimal bin edges for both distributions after having been extended to [min_value,max_value]
+            x_bin_edges=np.histogram_bin_edges(x_array_extended, bins='sturges')
+            y_bin_edges=np.histogram_bin_edges(y_array_extended, bins='sturges')
+            number_of_bins = min(len(x_bin_edges), len(y_bin_edges))
+            bin_edges=np.linspace(min_value, max_value, number_of_bins)
+
+        return bin_edges
+
+
+    # # # EXPECTED NORMALIZED WASSERSTEIN DISTANCE # # # 
+
+    def normed_wasserstein_distance_numerical(self, x_array, y_array):
+        norm = max(np.std(x_array),0.001)
+        return wasserstein_distance(x_array, y_array) / norm
+
+    # # # EXPECTED JENSEN-SHANNON DISTANCE # # # 
+
+    def jensen_shannon_distance_numerical(self, x_array, y_array):
+        bin_edges = self.compute_optimal_histogram_bin_edges(x_array, y_array)
+        x_percent = np.histogram(x_array, bins=bin_edges)[0] / len(x_array)
+        y_percent = np.histogram(y_array, bins=bin_edges)[0] / len(y_array)
+
+        return distance.jensenshannon(x_percent, y_percent, base=2)
+
+    # # # EXPECTED PSI # # #
+    
+    def psi_numerical(self, x_array, y_array):
+        bin_edges = self.compute_optimal_histogram_bin_edges(x_array, y_array)
+
+        x_count = np.histogram(x_array, bins=bin_edges)[0]
+        y_count = np.histogram(y_array, bins=bin_edges)[0] 
+        
+        # Laplace smoothing (incrementing the count of each bin by 1)
+        # to avoid zero values in bins and have the SPI value be finit
+        x_count = x_count + 1
+        y_count = y_count + 1 
+
+        x_percent = x_count / len(x_array) 
+        y_percent = y_count / len(y_array)   
+
+        psi = 0.0
+        for i in range(len(x_percent)):
+            psi += (y_percent[i] - x_percent[i]) * np.log(y_percent[i] / x_percent[i])
+
+        return psi
+
+    # # # EXPECTED TWO SAMPLE KS TEST # # # 
+
+    def two_sample_ks_test_numerical(self, x_array, y_array):
+        return ks_2samp(x_array, y_array).pvalue
+    
+    # # # MAIN TEST FUNCTION # # # 
+
+    def test_compute_numerical_data_drift_metrics(self):
+        """Test compute distance measures for numerical metrics."""
         column_values = ['column1']
-        numerical_threshold = 100
+        numerical_threshold = 0.1
 
-        x = np.random.normal(x_mean, std_dev, x_n_obs)
+        for distance_measure in distance_measures:
+            print(f'###########################################')
+            print(f'TESTING DISTANCE MEASURE: {distance_measure}')
+            print(f'###########################################')
 
-        x_pd_df = pd.DataFrame(data=x, columns=column_values)
-        y_pd_df = pd.DataFrame(data=x, columns=column_values)
+            for test_case in test_cases:
+                x,y = self.create_test_distributions(test_case)
 
-        spark = init_spark()
+                if distance_measure == "NormalizedWassersteinDistance":
+                    expected_distance = self.normed_wasserstein_distance_numerical(x,y)
+                elif distance_measure == "JensenShannonDistance":
+                    expected_distance = self.jensen_shannon_distance_numerical(x,y)
+                elif distance_measure == "PopulationStabilityIndex":
+                    expected_distance = self.psi_numerical(x,y)
+                elif distance_measure == "TwoSampleKolmogorovSmirnovTest":
+                    expected_distance = self.two_sample_ks_test_numerical(x,y)    
+                else:
+                    raise ValueError(f"Distance measure {distance_measure} not in {distance_measures}")
 
-        x_df = spark.createDataFrame(x_pd_df)
-        y_df = spark.createDataFrame(y_pd_df)
+                x_df = self.create_spark_df(x)
+                y_df = self.create_spark_df(y)
+                x_count = x_df.count()
+                y_count = y_df.count()
 
-        output_df = compute_numerical_data_drift_measures_tests(
-                x_df,
-                y_df,
-                x_df.count(),
-                y_df.count(),
-                "NormalizedWassersteinDistance",
-                column_values,
-                numerical_threshold)
+                #Excluding KS-tess with more than 10k samples
+                if not (distance_measure == "TwoSampleKolmogorovSmirnovTest" 
+                    and (x_count >= 10_000  or y_count >= 10_000)):
+                    
+                    output_df = compute_numerical_data_drift_measures_tests(
+                        x_df,
+                        y_df,
+                        x_count,
+                        y_count,
+                        distance_measure,
+                        column_values,
+                        numerical_threshold)
 
-        metric_value = self.get_metric_value(output_df, "NormalizedWassersteinDistance")
-        self.assertAlmostEqual(0.0, metric_value, 4)
+                    metric_value = self.get_metric_value(output_df, distance_measure)
+            
+                    print('-------------------------')
+                    print(f'test: {test_case["name"]}')
+                    print(f'test scenario: {test_case["scenario"]}')
+                    print((
+                        f'expected value:{self.round_to_n_significant_digits(expected_distance,4)},' 
+                        f'measured value:{self.round_to_n_significant_digits(metric_value,4)}'
+                        ))
 
-    def test_compute_numerical_data_drift_metrics_normalized_wasserstein_distance(self):
-        """Test compute normalized wasserstein distance for numerical metrics."""
-        std_dev = 15
-        column_values = ['column1']
-        numerical_threshold = 100
-
-        for x_n_obs, y_n_obs, x_mean, y_mean, expected in test_cases:
-            x = np.random.normal(x_mean, std_dev, x_n_obs)
-            y = np.random.normal(y_mean, std_dev, y_n_obs)
-
-            x_pd_df = pd.DataFrame(data=x, columns=column_values)
-            y_pd_df = pd.DataFrame(data=y, columns=column_values)
-
-            spark = init_spark()
-
-            x_df = spark.createDataFrame(x_pd_df)
-            y_df = spark.createDataFrame(y_pd_df)
-
-            output_df = compute_numerical_data_drift_measures_tests(
-                x_df,
-                y_df,
-                x_df.count(),
-                y_df.count(),
-                "NormalizedWassersteinDistance",
-                column_values,
-                numerical_threshold)
-
-            metric_value = self.get_metric_value(output_df, "NormalizedWassersteinDistance")
-            self.assertAlmostEqual(float(expected), metric_value, 1)
+                    if(abs(expected_distance) < 1e-6):
+                        self.assertAlmostEqual(metric_value, 0, 6)
+                    else:
+                        self.assertAlmostEqual(float(expected_distance)/metric_value, 1.0, 1)

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -169,7 +169,7 @@ test_cases = [
     {
      "name": "6b",
      "scenario": (
-         "Weak distance value dependence on sample size. " 
+         "Weak distance value dependence on sample size. "
          "Distance should be close to test 6a (might not be the case for KS-Test)."),
      "x_mean": 50,
      "y_mean": 51,

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -3,7 +3,7 @@
 
 """
 This file contains unit tests for the Numerical Data Drift Metrics.
-It compares the drift measures of metrics implemented in Spark against their Scipy implementation 
+It compares the drift measures of metrics implemented in Spark against their SciPy implementation 
 """
 
 from data_drift_compute_metrics.numerical_data_drift_metrics import compute_numerical_data_drift_measures_tests
@@ -200,7 +200,6 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     
     def get_metric_value(self, df: pyspark_sql.DataFrame, metric_name: str):
         """Get metric value of the first row of a given column from a dataframe."""
-        #df.show()
         return df.filter(f"metric_name = '{metric_name}'").first().metric_value
 
     def create_spark_df(self, numerical_data):
@@ -334,10 +333,8 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
                     print('-------------------------')
                     print(f'test: {test_case["name"]}')
                     print(f'test scenario: {test_case["scenario"]}')
-                    print((
-                        f'expected value:{self.round_to_n_significant_digits(expected_distance,4)},' 
-                        f'measured value:{self.round_to_n_significant_digits(metric_value,4)}'
-                        ))
+                    print(f'expected value: {self.round_to_n_significant_digits(expected_distance,4)}') 
+                    print(f'measured value: {self.round_to_n_significant_digits(metric_value,4)}')
 
                     if(abs(expected_distance) < 1e-6):
                         self.assertAlmostEqual(metric_value, 0, 6)

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -3,6 +3,7 @@
 
 """
 This file contains unit tests for the Numerical Data Drift Metrics.
+
 It compares the drift measures of metrics implemented in Spark against their SciPy implementation.
 """
 
@@ -206,10 +207,20 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     """Test class for data drift compute metrics component component and utilities."""
 
     def __init__(self, *args, **kwargs):
+        """
+        Initialize TestComputeDataDriftMetrics with the provided arguments and initialize the Spark session.
+        """
         super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)
         self.spark = init_spark()
 
     def round_to_n_significant_digits(self, number, n):
+        """
+        Round a given number to n significant digits.
+
+        :param number: The number to round.
+        :param n: The number of significant digits to round to.
+        :return: The rounded number.
+        """
         if number == 0:
             return 0
         else:
@@ -220,12 +231,24 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         return df.filter(f"metric_name = '{metric_name}'").first().metric_value
 
     def create_spark_df(self, numerical_data):
+        """
+        Create a Spark DataFrame from the given numerical data.
+
+        :param numerical_data: A list of numerical data.
+        :return: A Spark DataFrame with the numerical data.
+        """
         column_values = ['column1']
         pd_df = pd.DataFrame(data=numerical_data, columns=column_values)
         df = self.spark.createDataFrame(pd_df)
         return df
 
     def create_test_distributions(self, dist_params: dict):
+        """
+        Create test distributions based on the given parameters.
+
+        :param dist_params: A dictionary containing distribution parameters.
+        :return: A tuple of two numpy arrays representing the test distributions.
+        """
         np.random.seed(0)
         x = np.random.normal(dist_params["x_mean"], dist_params["x_std_dev"], dist_params["x_obs"])
         np.random.seed(0)
@@ -233,7 +256,13 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
         return x, y
 
     def compute_optimal_histogram_bin_edges(self, x_array, y_array):
+        """
+        Compute the optimal histogram bin edges for two arrays of numerical data.
 
+        :param x_array: A numpy array of the first distribution's data.
+        :param y_array: A numpy array of the second distribution's data.
+        :return: A numpy array of the optimal bin edges.
+        """
         # find overall min and max values for both distributions
         min_value = min(np.amin(x_array), np.amin(y_array))
         max_value = max(np.amax(x_array), np.amax(y_array))
@@ -261,12 +290,26 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     # # # EXPECTED NORMALIZED WASSERSTEIN DISTANCE # # #
 
     def normed_wasserstein_distance_numerical(self, x_array, y_array):
+        """
+        Compute the normalized Wasserstein distance between two arrays of numerical data.
+
+        :param x_array: A numpy array of the first distribution's data.
+        :param y_array: A numpy array of the second distribution's data.
+        :return: The normalized Wasserstein distance between the two distributions.
+        """
         norm = max(np.std(x_array), 0.001)
         return wasserstein_distance(x_array, y_array) / norm
 
     # # # EXPECTED JENSEN-SHANNON DISTANCE # # #
 
     def jensen_shannon_distance_numerical(self, x_array, y_array):
+        """
+        Compute the Jensen-Shannon distance between two arrays of numerical data.
+
+        :param x_array: A numpy array of the first distribution's data.
+        :param y_array: A numpy array of the second distribution's data.
+        :return: The Jensen-Shannon distance between the two distributions.
+        """
         bin_edges = self.compute_optimal_histogram_bin_edges(x_array, y_array)
         x_percent = np.histogram(x_array, bins=bin_edges)[0] / len(x_array)
         y_percent = np.histogram(y_array, bins=bin_edges)[0] / len(y_array)
@@ -276,6 +319,13 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     # # # EXPECTED PSI # # #
 
     def psi_numerical(self, x_array, y_array):
+        """
+        Compute the Population Stability Index (PSI) between two arrays of numerical data.
+
+        :param x_array: A numpy array of the first distribution's data.
+        :param y_array: A numpy array of the second distribution's data.
+        :return: The PSI between the two distributions.
+        """
         bin_edges = self.compute_optimal_histogram_bin_edges(x_array, y_array)
 
         x_count = np.histogram(x_array, bins=bin_edges)[0]
@@ -298,6 +348,13 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     # # # EXPECTED TWO SAMPLE KS TEST # # #
 
     def two_sample_ks_test_numerical(self, x_array, y_array):
+        """
+        Compute the Two-Sample Kolmogorov-Smirnov test between two arrays of numerical data.
+
+        :param x_array: A numpy array of the first distribution's data.
+        :param y_array: A numpy array of the second distribution's data.
+        :return: The two sample ks-test between the two distributions.
+        """
         return ks_2samp(x_array, y_array).pvalue
 
     # # # MAIN TEST FUNCTION # # #

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -207,9 +207,7 @@ class TestComputeDataDriftMetrics(unittest.TestCase):
     """Test class for data drift compute metrics component component and utilities."""
 
     def __init__(self, *args, **kwargs):
-        """
-        Initialize TestComputeDataDriftMetrics with the provided arguments and initialize the Spark session.
-        """
+        """Initialize TestComputeDataDriftMetrics with the provided arguments and initialize the Spark session."""
         super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)
         self.spark = init_spark()
 


### PR DESCRIPTION
This pull request adds unit tests for all numerical and categorical data drift metrics currently implemented. Unit tests assert whether the drift metric values implemented in this codebase match produced by the SciPy Python package with a 10% tolerance. Currently the match is much better that that tolerance. Metric values can depend on, for example, the data binning and Laplace smoothing strategies used. Test cases cover common drift scenarios, as well as edge cases (e.g., identical distributions, distributions with no values in common), but more test cases can be added easily.

Unit tests run using `pytest` but also show human-readable output describing the test scenario and expected and measured outputs for better understanding:      

```
#######################################################
TESTING DISTANCE MEASURE: NormalizedWassersteinDistance
#######################################################
-------------------------
test: 1a
test scenario: Distance between identical distributions should be exactly 0
expected value: 0
measured value: 0
-------------------------
test: 1b
test scenario: Distance between two samples of the different sizes of the same distributions should be close to 0
expected value: 0.02335
measured value: 0.02335
-------------------------
test: 1c
test scenario: Non-zero distance between distributions with the same mean and sample size, but different std_dev
expected value: 0.2656
measured value: 0.2656
-------------------------
test: 2a
test scenario: Confirming distance of moderately drifted distribution against SciPy
expected value: 0.2005
measured value: 0.2005
-------------------------
test: 2b
test scenario: Weak distance value dependence on sample size. Distance should be close to test 2a.
expected value: 0.1805
measured value: 0.1805
-------------------------
```
When re-implementing the Spark code from SynapseML, these tests should provide all the necessary checks we need to ensure their accuracy before deployment.

This PR also contains a small bug fix for the categorical PSI metric definition uncovered when running these tests. All current metric definitions seem accurate now. 

**IMPORTANT** - I am not sure which environment you use to run these tests. I ran them on a AzureML Notebook with Serverless Spark compute attached. You might need to modify them slightly for them to run in your environment.