### PR TITLE
Updating class names of numerical and categorical data drift unit tests

### DIFF
--- a/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_categorical_data_drift_metrics.py
@@ -113,12 +113,12 @@ test_cases = [
 
 
 @pytest.mark.unit
-class TestComputeDataDriftMetrics(unittest.TestCase):
-    """Test class for data drift compute metrics component and utilities."""
+class TestComputeCategoricalDataDriftMetrics(unittest.TestCase):
+    """Test class for categorical data drift compute metrics component and utilities."""
 
     def __init__(self, *args, **kwargs):
-        """Initialize TestComputeDataDriftMetrics with the provided arguments and initialize the Spark session."""
-        super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)
+        """Initialize TestComputeCategoricalDataDriftMetrics and initialize the Spark session."""
+        super(TestComputeCategoricalDataDriftMetrics, self).__init__(*args, **kwargs)
         self.spark = init_spark()
 
     def round_to_n_significant_digits(self, number, n):

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -227,7 +227,7 @@ class TestComputeNumericalDataDriftMetrics(unittest.TestCase):
     """Test class for numerical data drift compute metrics component and utilities."""
 
     def __init__(self, *args, **kwargs):
-        """Initialize TestComputeNumericalDataDriftMetrics and initialize the Spark session"""
+        """Initialize TestComputeNumericalDataDriftMetrics and initialize the Spark session."""
         super(TestComputeNumericalDataDriftMetrics, self).__init__(*args, **kwargs)
         self.spark = init_spark()
 

--- a/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_numerical_data_drift_metrics.py
@@ -223,12 +223,12 @@ test_cases = [
 
 
 @pytest.mark.unit
-class TestComputeDataDriftMetrics(unittest.TestCase):
-    """Test class for data drift compute metrics component component and utilities."""
+class TestComputeNumericalDataDriftMetrics(unittest.TestCase):
+    """Test class for numerical data drift compute metrics component and utilities."""
 
     def __init__(self, *args, **kwargs):
-        """Initialize TestComputeDataDriftMetrics with the provided arguments and initialize the Spark session."""
-        super(TestComputeDataDriftMetrics, self).__init__(*args, **kwargs)
+        """Initialize TestComputeNumericalDataDriftMetrics and initialize the Spark session"""
+        super(TestComputeNumericalDataDriftMetrics, self).__init__(*args, **kwargs)
         self.spark = init_spark()
 
     def round_to_n_significant_digits(self, number, n):


### PR DESCRIPTION
The categorical and numerical unit tests were sharing the same class name `TestComputeDataDriftMetrics`. 

I have updated the class name to: 
- `TestComputeCategoricalDataDriftMetrics` for the categorical data drift metrics
- `TestComputeNumericalDataDriftMetrics` for the numerical data drift metrics

to avoid any potential issue or confusion of defining two classes with the same name in this codebase. 