### PR TITLE
Update basic pipelines to not validate completion deployment and PF creation to use backup placeholder

### DIFF
--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
@@ -125,7 +125,7 @@ jobs:
       llm_config: ${{parent.inputs.llm_config}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
       check_embeddings: "True"
-      check_completion: "True"
+      check_completion: "False"
     outputs:
       output_data:
         type: uri_file

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
@@ -117,7 +117,7 @@ jobs:
       llm_config: ${{parent.inputs.llm_config}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
       check_embeddings: "True"
-      check_completion: "True"
+      check_completion: "False"
     outputs:
       output_data:
         type: uri_file

--- a/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_basic/spec.yaml
@@ -97,28 +97,6 @@ inputs:
 #  compute: azureml:cpu-cluster
 jobs:
   #############
-  validate_deployments_job:
-    type: command
-    resources:
-      instance_count: ${{parent.inputs.serverless_instance_count}}
-      instance_type: ${{parent.inputs.serverless_instance_type}}
-      properties:
-        compute_specification:
-          automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.9'
-    identity:
-      type: user_identity
-    inputs:
-      llm_config: ${{parent.inputs.llm_config}}
-      check_embeddings: "False"
-      check_completion: "True"
-    outputs:
-      output_data:
-        type: uri_file
-    environment_variables:
-       AZUREML_WORKSPACE_CONNECTION_ID_AOAI_EMBEDDING : ${{parent.inputs.embedding_connection}}
-       AZUREML_WORKSPACE_CONNECTION_ID_AOAI_COMPLETION: ${{parent.inputs.llm_connection}}
-  #############
   data_import_job:
     type: command
     resources:

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
@@ -136,7 +136,7 @@ jobs:
       llm_config: ${{parent.inputs.llm_config}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
       check_embeddings: "True"
-      check_completion: "True"
+      check_completion: "False"
     outputs:
       output_data:
         type: uri_file

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
@@ -129,7 +129,7 @@ jobs:
       llm_config: ${{parent.inputs.llm_config}}
       embeddings_model: ${{parent.inputs.embeddings_model}}
       check_embeddings: "True"
-      check_completion: "True"
+      check_completion: "False"
     outputs:
       output_data:
         type: uri_file

--- a/assets/large_language_models/rag/components/src/flow_creation.py
+++ b/assets/large_language_models/rag/components/src/flow_creation.py
@@ -141,9 +141,9 @@ def main(args, ws, current_run, activity_logger: Logger):
     completion_connection_name = get_connection_name(
         args.llm_connection_name)
     completion_config = json.loads(args.llm_config)
-    completion_model_name = completion_config.get("model_name")
+    completion_model_name = completion_config.get("model_name", "gpt-35-turbo")
     completion_deployment_name = completion_config.get(
-        "deployment_name")
+        "deployment_name", "gpt-35-turbo")
     embedding_connection_name = get_connection_name(
         args.embedding_connection)
     if (completion_connection_name == "azureml-rag-default-aoai" and


### PR DESCRIPTION
ES RAG API will update soon to not infer deployment for basic pipelines (as it is not needed for Vector Index creation)
As a result, completion deployment should not be validated in Basic pipelines, and PF Creation component should use placeholder deployment_name if not available.