### PR TITLE
[Model Monitor] - Update Evaluate Threshold signature to OutputV2

### DIFF
--- a/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_drift_compute_metrics
 display_name: Data Drift - Compute Metrics
 description: Compute data drift metrics given a baseline and a deployment's model data input.
-version: 0.3.3
+version: 0.3.4
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_drift_signal_monitor
 display_name: Data Drift - Signal Monitor
 description: Computes the data drift between a baseline and production data assets.
-version: 0.3.4
+version: 0.3.5
 is_deterministic: true
 
 inputs:
@@ -87,7 +87,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.3
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.4
     inputs:
       production_dataset:
         type: mltable

--- a/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
@@ -193,7 +193,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.0
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.1
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/data_quality/data_quality_metrics_joiner/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_metrics_joiner/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_quality_metrics_joiner
 display_name:  Data Quality - Metrics Joiner
 description: Join baseline and target data quality metrics into a single output.
-version: 0.3.0
+version: 0.3.1
 is_deterministic: true
 
 inputs:

--- a/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_quality_signal_monitor
 display_name: Data Quality - Signal Monitor
 description: Computes the data quality of a target dataset with reference to a baseline.
-version: 0.3.4
+version: 0.3.5
 is_deterministic: true
 
 inputs:
@@ -146,7 +146,7 @@ jobs:
       type: aml_token
   join_data_quality_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_metrics_joiner/versions/0.3.0
+    component: azureml://registries/azureml/components/data_quality_metrics_joiner/versions/0.3.1
     inputs:
       baseline_metrics:
         type: mltable
@@ -187,7 +187,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.0
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.1
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_compute_metrics/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/SparkComponent.json
 type: spark
 
 name: feature_attribution_drift_compute_metrics
-version: 0.3.2
+version: 0.3.3
 display_name: Feature Attribution Drift - Compute Metrics
 is_deterministic: true
 description: Feature attribution drift using model monitoring.

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: feature_attribution_drift_signal_monitor
 display_name: Feature Attribution Drift - Signal Monitor
 description: Computes the feature attribution between a baseline and production data assets.
-version: 0.3.3
+version: 0.3.4
 is_deterministic: true
 
 inputs:
@@ -68,7 +68,7 @@ jobs:
       type: aml_token
   compute_feature_attribution:
     type: spark
-    component: azureml://registries/azureml/components/feature_attribution_drift_compute_metrics/versions/0.3.2
+    component: azureml://registries/azureml/components/feature_attribution_drift_compute_metrics/versions/0.3.3
     inputs:
       production_data:
         type: mltable

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: feature_attribution_drift_signal_monitor
 display_name: Feature Attribution Drift - Signal Monitor
 description: Computes the feature attribution between a baseline and production data assets.
-version: 0.3.2
+version: 0.3.3
 is_deterministic: true
 
 inputs:
@@ -68,7 +68,7 @@ jobs:
       type: aml_token
   compute_feature_attribution:
     type: spark
-    component: azureml://registries/azureml/components/feature_attribution_drift_compute_metrics/versions/0.3.1
+    component: azureml://registries/azureml/components/feature_attribution_drift_compute_metrics/versions/0.3.2
     inputs:
       production_data:
         type: mltable
@@ -108,7 +108,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.0
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.1
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
@@ -3,7 +3,7 @@ type: spark
 
 name: model_monitor_evaluate_metrics_threshold
 display_name: Model Monitor - Evaluate Metrics Threshold
-description: Evaluate the metrics against the threshold provided in the model monitor.
+description: Evaluate signal metrics against the threshold provided in the model monitor.
 version: 0.3.1
 is_deterministic: true
 

--- a/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_evaluate_metrics_threshold
 display_name: Model Monitor - Evaluate Metrics Threshold
 description: Evaluate the metrics against the threshold provided in the model monitor.
-version: 0.3.0
+version: 0.3.1
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
@@ -3,7 +3,7 @@ type: spark
 
 name: model_monitor_evaluate_metrics_threshold
 display_name: Model Monitor - Evaluate Metrics Threshold
-description: Evaluate signal metrics against the threshold provided in the model monitor.
+description: Evaluate signal metrics against the threshold provided in the monitoring signal.
 version: 0.3.1
 is_deterministic: true
 

--- a/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
@@ -67,7 +67,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.3
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.4
     inputs:
       production_dataset:
         type: mltable

--- a/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: prediction_drift_signal_monitor
 display_name: Prediction Drift - Signal Monitor
 description: Computes the prediction drift between a baseline and a target data assets.
-version: 0.3.4
+version: 0.3.5
 is_deterministic: true
 
 inputs:
@@ -113,7 +113,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.0
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.1
     inputs:
       signal_metrics: 
         type: mltable

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/categorical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/categorical_data_drift_metrics.py
@@ -78,7 +78,7 @@ def _jensen_shannon_categorical(
             production_frequencies,
             base=2)
 
-        row = [column, float(js_distance), "Categorical", "JensenShannonDistance"]
+        row = [column, float(js_distance), "Categorical", "JensenShannonDistance", column, ""]
         rows.append(row)
 
     output_df = get_output_spark_df(rows)
@@ -142,7 +142,7 @@ def _psi_categorical(
                 production_ratios[i] / baseline_ratios[i]
             )
 
-        psi_row = [column, float(psi), "Categorical", "PopulationStabilityIndex"]
+        psi_row = [column, float(psi), "Categorical", "PopulationStabilityIndex", column, ""]
         psi_rows.append(psi_row)
 
     output_df = get_output_spark_df(psi_rows)
@@ -196,6 +196,8 @@ def _chisquaretest(
             float(chisqtest_val),
             "Categorical",
             "PearsonsChiSquaredTest",
+            column,
+            ""
         ]
         chisqtest_rows.append(chisqtest_row)
 

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
@@ -89,7 +89,7 @@ def compute_data_drift_measures_tests(
     ]
     row_count_metric_df = get_output_spark_df([baseline_count_row, target_count_row])
     row_count_metric_df = row_count_metric_df \
-        .withColumn("threshold_value", F.lit("nan").cast("float")) 
+        .withColumn("threshold_value", F.lit("nan").cast("float"))
     output_df = output_df.union(row_count_metric_df)
 
     return output_df

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
@@ -84,9 +84,10 @@ def compute_data_drift_measures_tests(
         "TargetRowCount",
     ]
     row_count_metric_df = get_output_spark_df([baseline_count_row, target_count_row])
-    row_count_metric_df = row_count_metric_df.withColumn(
-        "threshold_value", F.lit("nan").cast("float")
-    )
+    row_count_metric_df = row_count_metric_df \
+        .withColumn("threshold_value", F.lit("nan").cast("float")) \
+        .withColumn("group", F.lit("")) \
+        .withColumn("group_pivot", F.lit(""))
     output_df = output_df.union(row_count_metric_df)
 
     return output_df

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
@@ -76,18 +76,20 @@ def compute_data_drift_measures_tests(
         float(baseline_df_count),
         "",
         "BaselineRowCount",
+        "",
+        ""
     ]
     target_count_row = [
         "",
         float(production_df_count),
         "",
         "TargetRowCount",
+        "",
+        ""
     ]
     row_count_metric_df = get_output_spark_df([baseline_count_row, target_count_row])
     row_count_metric_df = row_count_metric_df \
-        .withColumn("threshold_value", F.lit("nan").cast("float")) \
-        .withColumn("group", F.lit("")) \
-        .withColumn("group_pivot", F.lit(""))
+        .withColumn("threshold_value", F.lit("nan").cast("float")) 
     output_df = output_df.union(row_count_metric_df)
 
     return output_df

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/io_utils.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/io_utils.py
@@ -20,6 +20,8 @@ def _get_output_spark_df_schema():
             StructField("metric_value", FloatType(), True),
             StructField("data_type", StringType(), True),
             StructField("metric_name", StringType(), True),
+            StructField("group", StringType(), True),
+            StructField("group_pivot", StringType(), True),
         ]
     )
     return schema

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/numerical_data_drift_metrics.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/numerical_data_drift_metrics.py
@@ -130,7 +130,7 @@ def _jensen_shannon_numerical(
             prod_histograms_percent[column],
             base=2)
 
-        row = [column, float(js_distance), "Numerical", "JensenShannonDistance"]
+        row = [column, float(js_distance), "Numerical", "JensenShannonDistance", column, ""]
         rows.append(row)
 
     output_df = get_output_spark_df(rows)
@@ -163,7 +163,7 @@ def _normalized_wasserstein(
         norm = max(std_dev, 0.001)
 
         normalized_distance = distance / norm
-        row = [column, float(normalized_distance), "Numerical", "NormalizedWassersteinDistance"]
+        row = [column, float(normalized_distance), "Numerical", "NormalizedWassersteinDistance", column, ""]
         rows.append(row)
 
     output_df = get_output_spark_df(rows)
@@ -183,7 +183,7 @@ def _ks2sample_pandas_impl(
             baseline_col = pd.Series(baseline_df[column])
             production_col = pd.Series(production_df[column])
             ks2s = ks_2samp(baseline_col, production_col).pvalue
-            row = [column, float(ks2s), "Numerical", "TwoSampleKolmogorovSmirnovTest"]
+            row = [column, float(ks2s), "Numerical", "TwoSampleKolmogorovSmirnovTest", column, ""]
             rows.append(row)
 
         output_df = get_output_spark_df(rows)
@@ -237,7 +237,7 @@ def _psi_numerical(
                 production_percent[i] / baseline_percent[i]
             )
 
-        row = [column, float(psi), "Numerical", "PopulationStabilityIndex"]
+        row = [column, float(psi), "Numerical", "PopulationStabilityIndex", column, ""]
         rows.append(row)
 
     output_df = get_output_spark_df(rows)

--- a/assets/model_monitoring/components/src/data_quality_metrics_joiner/run.py
+++ b/assets/model_monitoring/components/src/data_quality_metrics_joiner/run.py
@@ -4,7 +4,7 @@
 """Entry script for Data Quality Metrics Joiner Spark Component."""
 
 import argparse
-from pyspark.sql.functions import col, when
+from pyspark.sql.functions import col, when, lit
 from shared_utilities.io_utils import read_mltable_in_spark, save_spark_df_as_mltable
 
 
@@ -42,6 +42,8 @@ def run():
         result_df.withColumnRenamed("featureName", "feature_name")
         .withColumnRenamed("metricName", "metric_name")
         .withColumnRenamed("dataType", "data_type")
+        .withColumn("group", col("feature_name"))
+        .withColumn("group_pivot", lit(""))
         .withColumn("metric_value", col("target_metric_value"))
     )
 

--- a/assets/model_monitoring/components/src/feature_importance_metrics/compute_feature_attribution_drift.py
+++ b/assets/model_monitoring/components/src/feature_importance_metrics/compute_feature_attribution_drift.py
@@ -69,18 +69,24 @@ def compute_ndcg_and_write_to_mltable(baseline_explanations, production_explanat
                                 constants.METRIC_VALUE_COLUMN: feature_attribution_drift,
                                 constants.METRIC_NAME_COLUMN: "NormalizedDiscountedCumulativeGain",
                                 constants.FEATURE_CATEGORY_COLUMN: "",
+                                constants.GROUP_COLUMN: "",
+                                constants.GROUP_PIVOT_COLUMN: "",
                                 constants.THRESHOLD_VALUE: float("nan")}, index=[0])
     data.append(ndcg_metric)
     baseline_row_count_data = pd.DataFrame({constants.FEATURE_NAME_COLUMN: "",
                                             constants.METRIC_VALUE_COLUMN: baseline_row_count,
                                             constants.METRIC_NAME_COLUMN: "BaselineRowCount",
                                             constants.FEATURE_CATEGORY_COLUMN: "",
+                                            constants.GROUP_COLUMN: "",
+                                            constants.GROUP_PIVOT_COLUMN: "",
                                             constants.THRESHOLD_VALUE: float("nan")}, index=[0])
     data.append(baseline_row_count_data)
     production_row_count_data = pd.DataFrame({constants.FEATURE_NAME_COLUMN: "",
                                               constants.METRIC_VALUE_COLUMN: production_row_count,
                                               constants.METRIC_NAME_COLUMN: "TargetRowCount",
                                               constants.FEATURE_CATEGORY_COLUMN: "",
+                                              constants.GROUP_COLUMN: "",
+                                              constants.GROUP_PIVOT_COLUMN: "",
                                               constants.THRESHOLD_VALUE: float("nan")}, index=[0])
     data.append(production_row_count_data)
 
@@ -91,12 +97,16 @@ def compute_ndcg_and_write_to_mltable(baseline_explanations, production_explanat
                     constants.METRIC_VALUE_COLUMN: baseline_feature[constants.METRIC_VALUE_COLUMN],
                     constants.FEATURE_CATEGORY_COLUMN: baseline_feature[constants.FEATURE_CATEGORY_COLUMN],
                     constants.METRIC_NAME_COLUMN: "BaselineFeatureImportance",
+                    constants.GROUP_COLUMN: baseline_feature[constants.FEATURE_CATEGORY_COLUMN],
+                    constants.GROUP_PIVOT_COLUMN: "",
                     constants.THRESHOLD_VALUE: float("nan")}, index=[0])
         production_feature_importance_data = pd.DataFrame({
             constants.FEATURE_NAME_COLUMN: production_feature[constants.FEATURE_COLUMN],
             constants.METRIC_VALUE_COLUMN: production_feature[constants.METRIC_VALUE_COLUMN],
             constants.FEATURE_CATEGORY_COLUMN: production_feature[constants.FEATURE_CATEGORY_COLUMN],
             constants.METRIC_NAME_COLUMN: "ProductionFeatureImportance",
+            constants.GROUP_COLUMN: baseline_feature[constants.FEATURE_CATEGORY_COLUMN],
+            constants.GROUP_PIVOT_COLUMN: "",
             constants.THRESHOLD_VALUE: float("nan")}, index=[0])
         data.append(baseline_feature_importance_data)
         data.append(production_feature_importance_data)
@@ -106,6 +116,8 @@ def compute_ndcg_and_write_to_mltable(baseline_explanations, production_explanat
                      constants.METRIC_VALUE_COLUMN,
                      constants.FEATURE_CATEGORY_COLUMN,
                      constants.METRIC_NAME_COLUMN,
+                     constants.GROUP_COLUMN,
+                     constants.GROUP_PIVOT_COLUMN,
                      constants.THRESHOLD_VALUE])
     metrics_data = pd.concat(data)
     spark_data = convert_pandas_to_spark(metrics_data)

--- a/assets/model_monitoring/components/src/feature_importance_metrics/compute_feature_attribution_drift.py
+++ b/assets/model_monitoring/components/src/feature_importance_metrics/compute_feature_attribution_drift.py
@@ -70,6 +70,8 @@ def compute_ndcg_and_write_to_mltable(baseline_explanations, production_explanat
                                          constants.METRIC_VALUE_COLUMN,
                                          constants.FEATURE_CATEGORY_COLUMN,
                                          constants.METRIC_NAME_COLUMN,
+                                         constants.GROUP_COLUMN,
+                                         constants.GROUP_PIVOT_COLUMN,
                                          constants.THRESHOLD_VALUE])
     feature_attribution_drift = calculate_attribution_drift(baseline_explanations, production_explanations)
 
@@ -83,12 +85,16 @@ def compute_ndcg_and_write_to_mltable(baseline_explanations, production_explanat
                                constants.METRIC_VALUE_COLUMN: baseline_row_count,
                                constants.METRIC_NAME_COLUMN: "BaselineRowCount",
                                constants.FEATURE_CATEGORY_COLUMN: "",
+                               constants.GROUP_COLUMN: "",
+                               constants.GROUP_PIVOT_COLUMN: "",
                                constants.THRESHOLD_VALUE: float("nan")}
     metrics_data = metrics_data.append(baseline_row_count_data, ignore_index=True)
     production_row_count_data = {constants.FEATURE_NAME_COLUMN: "",
                                  constants.METRIC_VALUE_COLUMN: production_row_count,
                                  constants.METRIC_NAME_COLUMN: "TargetRowCount",
                                  constants.FEATURE_CATEGORY_COLUMN: "",
+                                 constants.GROUP_COLUMN: "",
+                                 constants.GROUP_PIVOT_COLUMN: "",
                                  constants.THRESHOLD_VALUE: float("nan")}
     metrics_data = metrics_data.append(production_row_count_data, ignore_index=True)
 
@@ -99,12 +105,16 @@ def compute_ndcg_and_write_to_mltable(baseline_explanations, production_explanat
             constants.METRIC_VALUE_COLUMN: baseline_feature[constants.METRIC_VALUE_COLUMN],
             constants.FEATURE_CATEGORY_COLUMN: baseline_feature[constants.FEATURE_CATEGORY_COLUMN],
             constants.METRIC_NAME_COLUMN: "BaselineFeatureImportance",
+            constants.GROUP_COLUMN: production_feature[constants.FEATURE_CATEGORY_COLUMN],
+            constants.GROUP_PIVOT_COLUMN: "",
             constants.THRESHOLD_VALUE: float("nan")}
         production_feature_importance_data = {
             constants.FEATURE_NAME_COLUMN: production_feature[constants.FEATURE_COLUMN],
             constants.METRIC_VALUE_COLUMN: production_feature[constants.METRIC_VALUE_COLUMN],
             constants.FEATURE_CATEGORY_COLUMN: production_feature[constants.FEATURE_CATEGORY_COLUMN],
             constants.METRIC_NAME_COLUMN: "ProductionFeatureImportance",
+            constants.GROUP_COLUMN: production_feature[constants.FEATURE_CATEGORY_COLUMN],
+            constants.GROUP_PIVOT_COLUMN: "",
             constants.THRESHOLD_VALUE: float("nan")}
         metrics_data = metrics_data.append(baseline_feature_importance_data, ignore_index=True)
         metrics_data = metrics_data.append(production_feature_importance_data, ignore_index=True)

--- a/assets/model_monitoring/components/src/model_monitor_evaluate_metrics_threshold/evaluate_metrics_threshold.py
+++ b/assets/model_monitoring/components/src/model_monitor_evaluate_metrics_threshold/evaluate_metrics_threshold.py
@@ -9,7 +9,7 @@ from shared_utilities.event_utils import post_warning_event, post_email_event
 
 def _generate_error_message(df, signal_name: str):
     """Generate the error message for the given thresholds."""
-    df = df.select("feature_name", "data_type", "metric_name", "threshold_value")
+    df = df.select("group", "metric_value", "metric_name", "threshold_value")
     features_violating_threshold = df.toJSON().collect()
     error_message = f"The signal '{signal_name}' has failed due to one or more features violating metric thresholds.\n"
     error_message += "The feature names and their corresponding computed metric values violating "

--- a/assets/model_monitoring/components/src/shared_utilities/constants.py
+++ b/assets/model_monitoring/components/src/shared_utilities/constants.py
@@ -5,6 +5,8 @@
 
 # Column Names of Computed Metrics Parquet
 FEATURE_NAME_COLUMN = 'feature_name'
+GROUP_COLUMN = 'group'
+GROUP_PIVOT_COLUMN = 'group_pivot'
 FEATURE_CATEGORY_COLUMN = 'data_type'
 METRIC_NAME_COLUMN = 'metric_name'
 METRIC_VALUE_COLUMN = 'metric_value'


### PR DESCRIPTION
Change evaluate threshold to leverage "group" rather than feature_name & data_type.
Change all signals to also output both group and group_pivot as part of their output.