### PR TITLE
Fix potentially stuck import jobs: Use same compute for local validation

### DIFF
--- a/assets/training/model_management/components/import_model/spec.yaml
+++ b/assets/training/model_management/components/import_model/spec.yaml
@@ -24,14 +24,6 @@ inputs:
     description: Instance type to be used for the component in case of serverless compute, eg. STANDARD_NC6s_v3. 
       The parameter compute must be set to 'serverless' for instance_type to be used
 
-  local_validation_compute:
-    type: string
-    optional: true
-    default: serverless
-    description: Compute for Model local validation. Please make sure to provide a compute that is large enough to load the model and perform local inferencing. 
-      eg. provide 'FT-Cluster' if your compute is named 'FT-Cluster'. Special characters like \ and ' are invalid in the parameter value.
-      If compute name is provided, instance_type field will be ignored and the respective cluster will be used.
-
   ## Inputs for download model
   model_source:
     type: string

--- a/assets/training/model_management/components/import_model/spec.yaml
+++ b/assets/training/model_management/components/import_model/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: import_model
 display_name: Import model
 description: Import a model into a workspace or a registry
-version: 0.0.10
+version: 0.0.11
 
 # Pipeline inputs
 inputs:
@@ -217,7 +217,7 @@ jobs:
 
   mlflow_model_local_validation:
     component: azureml:mlflow_model_local_validation:0.0.3
-    compute: ${{parent.inputs.local_validation_compute}}
+    compute: ${{parent.inputs.compute}}
     resources:
       instance_type: '${{parent.inputs.instance_type}}'
     inputs:


### PR DESCRIPTION
Model local validation defaults to serverless potentially resulting in runs getting stuck when GPU compute is not available. This defaults the compute to standard one. 

Example stuck job: [Link](https://ml.azure.com/runs/crimson_airport_65qxbmry5l?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourcegroups/sasik_rg/workspaces/sasik_ws_eastus2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)