### PR TITLE
Vuln fix for acft nlp gpu image

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -8,6 +8,6 @@ RUN pip install --upgrade pip
 
 COPY requirements.txt .
 
-RUN pip install "azureml-evaluate-mlflow"
+RUN pip install "azureml-evaluate-mlflow=={{latest-pypi-version}}"
 RUN pip install -r requirements.txt --no-cache-dir
 RUN python -m nltk.downloader punkt

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -8,6 +8,6 @@ RUN pip install --upgrade pip
 
 COPY requirements.txt .
 
-RUN pip install "azureml-evaluate-mlflow==0.0.16"
+RUN pip install "azureml-evaluate-mlflow"
 RUN pip install -r requirements.txt --no-cache-dir
 RUN python -m nltk.downloader punkt

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -14,7 +14,7 @@ rouge-score==0.1.2
 sacrebleu==2.2.1
 bitsandbytes==0.41.0
 einops==0.6.1
-cryptography==41.0.2
+cryptography==41.0.3
 scipy==1.10.0
 aiohttp==3.8.5
 certifi==2023.07.22

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -14,7 +14,6 @@ rouge-score==0.1.2
 sacrebleu==2.2.1
 bitsandbytes==0.41.0
 einops==0.6.1
-cryptography==41.0.3
 scipy==1.10.0
 aiohttp==3.8.5
 certifi==2023.07.22


### PR DESCRIPTION
1. Removing pinned cryptography from requirement.txt as the latest mltable has the fixed cryptography version
2. Unpinning azureml-evaluate-mlflow package for future vuln fixes