### PR TITLE
Pin langchain in rag envs to 0.0.220 

### DIFF
--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.31
+version: 0.0.32
 name: llm_ingest_dataset_to_acs
 display_name: LLM - Dataset to ACS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -230,7 +230,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -333,7 +333,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -351,7 +351,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -401,7 +401,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.10'
+    component: 'azureml:llm_rag_update_acs_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -421,7 +421,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_dataset_to_acs_basic
 display_name: LLM - Dataset to ACS Pipeline
 is_deterministic: false
@@ -136,7 +136,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -159,7 +159,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -176,7 +176,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -226,7 +226,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.10'
+    component: 'azureml:llm_rag_update_acs_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -246,7 +246,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_dataset_to_acs_qa_only
 display_name: LLM - Dataset to ACS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -160,7 +160,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -218,7 +218,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -235,7 +235,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -285,7 +285,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.10'
+    component: 'azureml:llm_rag_update_acs_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -305,7 +305,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.31
+version: 0.0.32
 name: llm_ingest_dataset_to_faiss
 display_name: LLM - Dataset to FAISS Pipeline (With Test Data Generation and Auto Prompt
 is_deterministic: false
@@ -218,7 +218,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -324,7 +324,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -342,7 +342,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -392,7 +392,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.10'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -410,7 +410,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_dataset_to_faiss_basic
 display_name: LLM - Dataset to FAISS Pipeline
 is_deterministic: false
@@ -125,7 +125,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -148,7 +148,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -165,7 +165,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -215,7 +215,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.10'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -233,7 +233,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_dataset_to_faiss_qa_only
 display_name: LLM - Dataset to FAISS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -149,7 +149,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -207,7 +207,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -224,7 +224,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -274,7 +274,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.10'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -292,7 +292,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
@@ -6,7 +6,7 @@ tags:
 
 name: llm_ingest_db_to_acs
 display_name: LLM - SQL Datastore to ACS Pipeline
-version: 0.0.10
+version: 0.0.11
 
 description: Single job pipeline to chunk data from AzureML sql data store, and create ACS embeddings index
 
@@ -112,7 +112,7 @@ jobs:
       output_chunk_file:
         type: uri_folder
       output_grounding_context_file: ${{parent.outputs.db_context}}
-    component: azureml:llm_dbcopilot_grounding:0.0.7
+    component: azureml:llm_dbcopilot_grounding:0.0.8
     type: command
   generate_meta_embeddings:
     type: command
@@ -122,7 +122,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -173,7 +173,7 @@ jobs:
       acs_config: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.grounding_index}}
-    component: azureml:llm_rag_update_acs_index:0.0.10
+    component: azureml:llm_rag_update_acs_index:0.0.11
     type: command
   register_mlindex_asset_job:
     resources:
@@ -190,7 +190,7 @@ jobs:
     outputs:
       asset_id:
         type: uri_file
-    component: azureml:llm_rag_register_mlindex_asset:0.0.10
+    component: azureml:llm_rag_register_mlindex_asset:0.0.11
     type: command
   create_prompt_flow:
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
@@ -6,7 +6,7 @@ tags:
 
 name: llm_ingest_db_to_faiss
 display_name: LLM - SQL Datastore to FAISS Pipeline
-version: 0.0.10
+version: 0.0.11
 
 description: Single job pipeline to chunk data from AzureML sql data store, and create FAISS embeddings index
 
@@ -104,7 +104,7 @@ jobs:
       output_chunk_file:
         type: uri_folder
       output_grounding_context_file: ${{parent.outputs.db_context}}
-    component: azureml:llm_dbcopilot_grounding:0.0.7
+    component: azureml:llm_dbcopilot_grounding:0.0.8
     type: command
   generate_meta_embeddings:
     type: command
@@ -114,7 +114,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -163,7 +163,7 @@ jobs:
         path: ${{parent.jobs.generate_meta_embeddings.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.grounding_index}}
-    component: azureml:llm_rag_create_faiss_index:0.0.10
+    component: azureml:llm_rag_create_faiss_index:0.0.11
     type: command
   register_mlindex_asset_job:
     resources:
@@ -180,7 +180,7 @@ jobs:
     outputs:
       asset_id:
         type: uri_file
-    component: azureml:llm_rag_register_mlindex_asset:0.0.10
+    component: azureml:llm_rag_register_mlindex_asset:0.0.11
     type: command
   create_prompt_flow:
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_existing_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_existing_acs/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.29
+version: 0.0.30
 name: llm_ingest_existing_acs
 display_name: LLM - Existing ACS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -237,7 +237,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.jobs.data_import_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -338,7 +338,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -354,7 +354,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.data_import_job.outputs.ml_index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.13
+version: 0.0.14
 name: llm_ingest_existing_acs_basic
 display_name: LLM - Existing ACS Pipeline
 is_deterministic: false
@@ -119,7 +119,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.jobs.data_import_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -140,7 +140,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -155,7 +155,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.data_import_job.outputs.ml_index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.16
+version: 0.0.17
 name: llm_ingest_existing_acs_qa_only
 display_name: LLM - Existing ACS Pipeline (Only Test Data)
 is_deterministic: false
@@ -168,7 +168,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.jobs.data_import_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -224,7 +224,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -239,7 +239,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.data_import_job.outputs.ml_index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.31
+version: 0.0.32
 name: llm_ingest_git_to_acs
 display_name: LLM - Git to ACS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -241,7 +241,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.10'
+    component: 'azureml:llm_rag_git_clone:0.0.11'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -261,7 +261,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -364,7 +364,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -382,7 +382,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -432,7 +432,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.10'
+    component: 'azureml:llm_rag_update_acs_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -452,7 +452,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_git_to_acs_basic
 display_name: LLM - Git to ACS Pipeline
 is_deterministic: false
@@ -147,7 +147,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.10'
+    component: 'azureml:llm_rag_git_clone:0.0.11'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -167,7 +167,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -190,7 +190,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -207,7 +207,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -257,7 +257,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.10'
+    component: 'azureml:llm_rag_update_acs_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -277,7 +277,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_git_to_acs_qa_only
 display_name: LLM - Git to ACS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -172,7 +172,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.10'
+    component: 'azureml:llm_rag_git_clone:0.0.11'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -192,7 +192,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -250,7 +250,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -267,7 +267,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -317,7 +317,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.10'
+    component: 'azureml:llm_rag_update_acs_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -337,7 +337,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.32
+version: 0.0.33
 name: llm_ingest_git_to_faiss
 display_name: LLM - Git to FAISS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -233,7 +233,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.10'
+    component: 'azureml:llm_rag_git_clone:0.0.11'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -253,7 +253,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -359,7 +359,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -377,7 +377,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -427,7 +427,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.10'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -445,7 +445,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_git_to_faiss_basic
 display_name: LLM - Git to FAISS Pipeline
 is_deterministic: false
@@ -137,7 +137,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.10'
+    component: 'azureml:llm_rag_git_clone:0.0.11'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -157,7 +157,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -180,7 +180,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -197,7 +197,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -247,7 +247,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.10'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -265,7 +265,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_ingest_git_to_faiss_qa_only
 display_name: LLM - Git to FAISS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -163,7 +163,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.10'
+    component: 'azureml:llm_rag_git_clone:0.0.11'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -183,7 +183,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.11'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.12'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -241,7 +241,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.22'
+    component: 'azureml:llm_rag_create_promptflow:0.0.23'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -258,7 +258,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.5'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.6'
     inputs:
       chunks_source:
         type: uri_folder
@@ -308,7 +308,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.10'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.11'
     inputs:
       embeddings:
         type: uri_folder
@@ -326,7 +326,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.10'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.11'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/dbcopilot/components/llm_dbcopilot_grounding/spec.yaml
+++ b/assets/large_language_models/dbcopilot/components/llm_dbcopilot_grounding/spec.yaml
@@ -6,7 +6,7 @@ tags:
 
 name: llm_dbcopilot_grounding
 display_name: LLM - DBCopilot Grounding DB
-version: 0.0.7
+version: 0.0.8
 
 inputs:
   asset_uri:

--- a/assets/large_language_models/dbcopilot/environments/dbcopilot_grounding/context/conda_dependencies.yaml
+++ b/assets/large_language_models/dbcopilot/environments/dbcopilot_grounding/context/conda_dependencies.yaml
@@ -7,6 +7,7 @@ dependencies:
   - pip=21.3.1
   - pip:
       - azureml-rag[cognitive_search,data_generation]>=0.1.16
+      - langchain==0.0.220
       - azureml-contrib-services
       - azure-identity==1.12.0
       - azureml-core=={{latest-pypi-version}}

--- a/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.11
+version: 0.0.12
 name: llm_rag_crack_and_chunk
 display_name: LLM - Crack and Chunk Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
+++ b/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.10
+version: 0.0.11
 name: llm_rag_create_faiss_index
 display_name: LLM - Create FAISS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_promptflow/spec.yaml
+++ b/assets/large_language_models/rag/components/create_promptflow/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.22
+version: 0.0.23
 name: llm_rag_create_promptflow
 display_name: LLM - Create Prompt Flow
 is_deterministic: true

--- a/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.5
+version: 0.0.6
 name: llm_rag_generate_embeddings
 display_name: LLM - Generate Embeddings
 is_deterministic: true

--- a/assets/large_language_models/rag/components/git_clone/spec.yaml
+++ b/assets/large_language_models/rag/components/git_clone/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.10
+version: 0.0.11
 name: llm_rag_git_clone
 display_name: LLM - Clone Git Repo
 is_deterministic: true

--- a/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
+++ b/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.10
+version: 0.0.11
 name: llm_rag_register_mlindex_asset
 display_name: LLM - Register Vector Index Asset
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_acs_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_acs_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.10
+version: 0.0.11
 name: llm_rag_update_acs_index
 display_name: LLM - Update ACS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
@@ -7,6 +7,7 @@ dependencies:
 - pip=21.3.1
 - pip:
   - azureml-rag[faiss,cognitive_search,document_parsing,data_generation]>=0.1.16
+  - langchain==0.0.220
   - psutil~=5.8.0
   - pandas~=1.1.5
   - GitPython>=3.1


### PR DESCRIPTION
To ensure that faiss langchain indexes are PromptFlow compatible.