### PR TITLE
Handle invalid patches in model predicted polygon

### DIFF
--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -121,14 +121,13 @@ def _normalize_polygon(polygon: List[np.ndarray], image_size: Tuple[int, int]) -
     return normalized_polygon
 
 
-def _remove_invalid_patches(polygon: List[List[float]]) -> List[List[float]]:
-        """Remove invalid patches. Patch is valid if it contains more than or equal to 6 co-ordinates.
+def _remove_invalid_segments(polygon: List[List[float]]) -> List[List[float]]:
+    """Remove invalid segments. Segment is valid if it contains more than or equal to 6 co-ordinates (triangle).
 
-        :param polygon: List of polygon.
-        :return: List of polygon.
-        """
-        
-        return [pathches for pathches in polygon if len(pathches) >= 6]
+    :param polygon: List of polygon.
+    :return: List of polygon.
+    """
+    return [segment for segment in polygon if len(segment) >= 6]
 
 
 class ImagesDetectionMLflowModelWrapper(mlflow.pyfunc.PythonModel):
@@ -215,7 +214,7 @@ class ImagesDetectionMLflowModelWrapper(mlflow.pyfunc.PythonModel):
             cur_image_preds = {ISLiterals.BOXES: []}
             for bbox, label, mask in zip(bboxes, labels, masks):
                 polygon, _ = bitmap_to_polygon(mask)
-                polygon = _remove_invalid_patches(polygon)
+                polygon = _remove_invalid_segments(polygon)
                 if len(polygon) > 0:
                     cur_image_preds[ISLiterals.BOXES].append(
                         {

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -121,6 +121,16 @@ def _normalize_polygon(polygon: List[np.ndarray], image_size: Tuple[int, int]) -
     return normalized_polygon
 
 
+def _remove_invalid_patches(polygon: List[List[float]]) -> List[List[float]]:
+        """Remove invalid patches. Patch is valid if it contains more than or equal to 6 co-ordinates.
+
+        :param polygon: List of polygon.
+        :return: List of polygon.
+        """
+        
+        return [pathches for pathches in polygon if len(pathches) >= 6]
+
+
 class ImagesDetectionMLflowModelWrapper(mlflow.pyfunc.PythonModel):
     """MLflow model wrapper for Images Detection models."""
 
@@ -205,19 +215,21 @@ class ImagesDetectionMLflowModelWrapper(mlflow.pyfunc.PythonModel):
             cur_image_preds = {ISLiterals.BOXES: []}
             for bbox, label, mask in zip(bboxes, labels, masks):
                 polygon, _ = bitmap_to_polygon(mask)
-                cur_image_preds[ISLiterals.BOXES].append(
-                    {
-                        ISLiterals.BOX: {
-                            ISLiterals.TOP_X: float(bbox[0]) / image_size[0],
-                            ISLiterals.TOP_Y: float(bbox[1]) / image_size[1],
-                            ISLiterals.BOTTOM_X: float(bbox[2]) / image_size[0],
-                            ISLiterals.BOTTOM_Y: float(bbox[3]) / image_size[1],
-                        },
-                        ISLiterals.LABEL: self._model.CLASSES[label],
-                        ISLiterals.SCORE: float(bbox[4]),
-                        ISLiterals.POLYGON: _normalize_polygon(polygon, image_size),
-                    }
-                )
+                polygon = _remove_invalid_patches(polygon)
+                if len(polygon) > 0:
+                    cur_image_preds[ISLiterals.BOXES].append(
+                        {
+                            ISLiterals.BOX: {
+                                ISLiterals.TOP_X: float(bbox[0]) / image_size[0],
+                                ISLiterals.TOP_Y: float(bbox[1]) / image_size[1],
+                                ISLiterals.BOTTOM_X: float(bbox[2]) / image_size[0],
+                                ISLiterals.BOTTOM_Y: float(bbox[3]) / image_size[1],
+                            },
+                            ISLiterals.LABEL: self._model.CLASSES[label],
+                            ISLiterals.SCORE: float(bbox[4]),
+                            ISLiterals.POLYGON: _normalize_polygon(polygon, image_size),
+                        }
+                    )
             predictions.append(cur_image_preds)
         return predictions
 


### PR DESCRIPTION
Base model is predicting the polygons with mutiple segments/ patches. Some patches are having less than 6 points which form invalid polygon. So filtering them out.

It also causing compute metrics component fails because converting these invalid patches to RLE encoding is throwing errors.

Mlflow conversion:
https://ml.azure.com/experiments/id/58d56a32-4154-4b12-a7e2-6cb61814b36e/runs/ac5b4dbf-5934-4f9e-95dc-7c5afa9b8d62?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/grajguru-resource-group/providers/Microsoft.MachineLearningServices/workspaces/grajguru-workspace&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#

batch job:
https://ml.azure.com/experiments/id/0e8ba3e8-44c2-42e7-86c1-d581c322ca44/runs/batchjob-acaaf203-7993-4ff0-98b9-c302f0d09d15?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/grajguru-resource-group/providers/Microsoft.MachineLearningServices/workspaces/grajguru-workspace&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#

