### PR TITLE
Responsible AI: unwrap sklearn models when possible

### DIFF
--- a/assets/responsibleai/tabular/components/src/create_rai_insights.py
+++ b/assets/responsibleai/tabular/components/src/create_rai_insights.py
@@ -177,6 +177,10 @@ def main(args):
             model_path=args.model_input,
         )
 
+    # unwrap the model if it's an sklearn wrapper
+    if model_estimator.__class__.__name__ == "_SklearnModelWrapper":
+        model_estimator = model_estimator.sklearn_model
+
     constructor_args = create_constructor_arg_dict(args)
 
     # Make sure that it actually loads

--- a/assets/responsibleai/tabular/components/src/rai_component_utilities.py
+++ b/assets/responsibleai/tabular/components/src/rai_component_utilities.py
@@ -382,6 +382,10 @@ def create_rai_insights_from_port_path(my_run: Run, port_path: str) -> RAIInsigh
         model_id=model_id,
     )
 
+    # unwrap the model if it's an sklearn wrapper
+    if model_estimator.__class__.__name__ == "_SklearnModelWrapper":
+        model_estimator = model_estimator.sklearn_model
+
     _logger.info("Creating RAIInsights object")
     rai_i = RAIInsights(
         model=model_estimator, train=df_train, test=df_test, **constructor_args


### PR DESCRIPTION
Mirroring change from https://github.com/Azure/RAI-vNext-Preview/pull/201 to avoid having regression models that fail RAIInsights validation because `hasattr(model, 'predict_proba')` is True (because an object is returned) rather than False. 