### PR TITLE
Updated openai whisper large to version 11

### DIFF
--- a/assets/models/system/openai-whisper-large/model.yaml
+++ b/assets/models/system/openai-whisper-large/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: openai-whisper-large-lft-v2
-  container_path: openai-whisper-large-v7/mlflow_model_folder
+  container_path: openai-whisper-large-v11/mlflow_model_folder
   storage_name: tanmaywhisper23457829905
   type: azureblob
 publish:

--- a/assets/models/system/openai-whisper-large/spec.yaml
+++ b/assets/models/system/openai-whisper-large/spec.yaml
@@ -16,4 +16,4 @@ tags:
   Preview: ''
   license: mit
   task: automatic-speech-recognition
-version: 10
+version: 11

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/whisper/conda.yaml
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/whisper/conda.yaml
@@ -19,6 +19,5 @@ dependencies:
   - more-itertools==9.1.0
   - ffmpeg-python==0.2.0
   - decord==0.6.0
-  - azureml-inference-server-http
   - wget==3.2
 name: mlflow-env

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/whisper/conda.yaml
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/whisper/conda.yaml
@@ -3,32 +3,22 @@ channels:
 - pytorch
 - conda-forge
 dependencies:
-- python=3.8.16
-- pip<=23.0.1
+- pip<=22.2.2
+- python=3.8.13
 - ffmpeg=4.2.2
 - pip:
-  - mlflow==2.3.1
-  - cloudpickle==2.2.1
-  - jsonpickle==3.0.1
-  - mlflow-skinny==2.3.1
-  - azureml-core==1.51.0.post1
-  - azureml-mlflow==1.51.0
-  - azureml-metrics==0.0.14.post1
-  - scikit-learn==0.24.2
-  - cryptography==41.0.1
-  - python-dateutil==2.8.2
+  - azureml-evaluate-mlflow==0.0.23
   - datasets==2.11.0
-  - soundfile==0.12.1
-  - librosa==0.10.0.post2
-  - diffusers==0.14.0
-  - sentencepiece==0.1.97
-  - transformers==4.30.2
-  - torch==2.0.1
+  - requests==2.31.0
+  - torch>=1.9,!=1.12.0
   - torchaudio
-  - accelerate==0.20.3
-  - Pillow==9.4.0
-  - azureml-evaluate-mlflow==0.0.14.post1
-  - wget==3.2
+  - sentencepiece==0.1.97
+  - protobuf==3.20.2
+  - pyctcdecode==0.5.0
+  - phonemizer==3.2.1
   - more-itertools==9.1.0
   - ffmpeg-python==0.2.0
+  - decord==0.6.0
+  - azureml-inference-server-http
+  - wget==3.2
 name: mlflow-env

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/whisper/predict.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/whisper/predict.py
@@ -17,7 +17,7 @@ from tempfile import TemporaryDirectory
 from transformers import WhisperProcessor, WhisperForConditionalGeneration, pipeline
 from urllib.parse import urlparse
 
-logging.basicConfig(format="%(asctime)s %(levelname)s %(message)s", level=logging.WARNING)
+logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s', level=logging.WARNING)
 
 supported_languages = [
     "en",
@@ -195,11 +195,12 @@ def predict(
     chunk_length_s = min(chunk_length_s, 30)
     stride_length_s = kwargs.get("stride_length_s", chunk_length_s/6)
 
-    if device == -1 and torch.cuda.is_available():
-        logging.warning('CUDA available. To switch to GPU device pass `"parameters": {"device" : 0}` in the input.')
-    if device == 0 and not torch.cuda.is_available():
+    if torch.cuda.is_available():
+        device = 0
+        logging.warning('CUDA available. Mounting Model to GPU')
+    if not torch.cuda.is_available():
         device = -1
-        logging.warning("CUDA unavailable. Defaulting to CPU device.")
+        logging.warning("CUDA unavailable. Defaulting to CPU.")
 
     device = "cuda:0" if device == 0 else "cpu"
 
@@ -214,8 +215,8 @@ def predict(
         feature_extractor=tokenizer.feature_extractor,
         chunk_length_s=chunk_length_s,
         stride_length_s=stride_length_s,
-        device=device,
-        )
+        device = device
+    )
 
     for row in model_input.itertuples():
         # Parse inputs.

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/whisper/predict.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/whisper/predict.py
@@ -215,7 +215,7 @@ def predict(
         feature_extractor=tokenizer.feature_extractor,
         chunk_length_s=chunk_length_s,
         stride_length_s=stride_length_s,
-        device = device
+        device=device
     )
 
     for row in model_input.itertuples():


### PR DESCRIPTION
Updated the conda.yaml file: Fixes Azure/azureml-examples#2602.
Updated the model and spec file to create a version 11 release for openai-whisper-large model.

Successful online endpoint deployment on CPU - [Link](https://ml.azure.com/endpoints/realtime/tanmay-whisper2-sbyri/detail?wsid=/subscriptions/a7772904-6f89-406e-a2d2-e3aef319fa70/resourceGroups/tanmay-rg/providers/Microsoft.MachineLearningServices/workspaces/tanmay-whisper2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)

Successful online endpoint deployment on GPU - [Link](https://ml.azure.com/endpoints/realtime/gpu-image-testing-vuyeo/detail?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourcegroups/hbendapudi/providers/Microsoft.MachineLearningServices/workspaces/gpu-image-testing&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)

Successful batch endpoint deployment on CPU - [Link](https://ml.azure.com/endpoints/batch/whisper-largecli08311414292693/detail?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourcegroups/hbendapudi/providers/Microsoft.MachineLearningServices/workspaces/gpu-image-testing&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)