### PR TITLE
Adding dependency of applicationinsghits for UT gate pass

### DIFF
--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -18,6 +18,7 @@ setup(
       "marshmallow>=3.19",
       "tenacity>=8.2.2",
       "azure-ai-ml>=1.9.0",
+      "applicationinsights~=0.11.10",
    ],
    python_requires=">=3.8,<4.0",
    license="MIT",


### PR DESCRIPTION
The [AzureML-Assets-Unit-Tests](https://msdata.visualstudio.com/Vienna/_build?definitionId=23407&_a=summary) gate is failing due to dependency error of applicationinsights. Adding it in setup.py.

https://msdata.visualstudio.com/Vienna/_build/results?buildId=103668584&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=35f53584-79fc-539f-463c-6471d0663a3a