### PR TITLE
Decrease azcopy verbosity

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.15.2 (2023-09-08)
+### 🐛 Bugs Fixed
+- [#1188](https://github.com/Azure/azureml-assets/pull/1188) Decrease azcopy verbosity
+
 ## 1.15.1 (2023-09-07)
 ### 🐛 Bugs Fixed
 - [#1182](https://github.com/Azure/azureml-assets/pull/1182) Fix authentication when retrieving temporary data references during model upload

--- a/scripts/azureml-assets/azureml/assets/model/download_utils.py
+++ b/scripts/azureml-assets/azureml/assets/model/download_utils.py
@@ -65,7 +65,8 @@ def copy_azure_artifacts(src_uri: str, dstn_uri: str) -> bool:
     :type dstn_uri: str
     """
     try:
-        download_cmd = f"azcopy copy '{src_uri}' '{dstn_uri}' --recursive --skip-version-check --output-level essential"
+        download_cmd = f"azcopy copy '{src_uri}' '{dstn_uri}' " \
+                       "--recursive --skip-version-check --output-level essential"
         result = run_cmd(download_cmd)
         logger.print(f"azcopy result {result}")
         # TODO: Handle error case correctly, since azcopy exits with 0 exit code, even in case of error.

--- a/scripts/azureml-assets/azureml/assets/model/download_utils.py
+++ b/scripts/azureml-assets/azureml/assets/model/download_utils.py
@@ -65,7 +65,7 @@ def copy_azure_artifacts(src_uri: str, dstn_uri: str) -> bool:
     :type dstn_uri: str
     """
     try:
-        download_cmd = f"azcopy copy '{src_uri}' '{dstn_uri}' --recursive"
+        download_cmd = f"azcopy copy '{src_uri}' '{dstn_uri}' --recursive --skip-version-check --output-level essential"
         result = run_cmd(download_cmd)
         logger.print(f"azcopy result {result}")
         # TODO: Handle error case correctly, since azcopy exits with 0 exit code, even in case of error.

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.15.1",
+   version="1.15.2",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
azcopy's status info takes up a lot of space in logs. This is an attempt to quiet it down a bit.