### PR TITLE
Save tika-server to docker image

### DIFF
--- a/assets/large_language_models/autoprompt/components/qna/spec.yaml
+++ b/assets/large_language_models/autoprompt/components/qna/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.16
+version: 0.0.17
 name: llm_autoprompt_qna
 display_name: LLM - Auto Prompt for QnA
 is_deterministic: true

--- a/assets/large_language_models/autoprompt/components/register_autoprompt_data_asset/spec.yaml
+++ b/assets/large_language_models/autoprompt/components/register_autoprompt_data_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.11
+version: 0.0.12
 name: llm_rag_register_autoprompt_data_asset
 display_name: LLM - Register AutoPrompt Data Asset
 is_deterministic: true

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.39
+version: 0.0.40
 name: llm_ingest_dataset_to_acs
 display_name: LLM - Dataset to ACS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -204,7 +204,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -230,7 +230,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -253,7 +253,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -274,7 +274,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -288,7 +288,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: azureml:llm_autoprompt_qna:0.0.16
+    component: azureml:llm_autoprompt_qna:0.0.17
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -319,7 +319,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -333,7 +333,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -351,7 +351,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -401,7 +401,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.18'
+    component: 'azureml:llm_rag_update_acs_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -421,7 +421,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.27
+version: 0.0.28
 name: llm_ingest_dataset_to_acs_basic
 display_name: LLM - Dataset to ACS Pipeline
 is_deterministic: false
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -136,7 +136,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -159,7 +159,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -176,7 +176,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -226,7 +226,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.18'
+    component: 'azureml:llm_rag_update_acs_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -246,7 +246,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.27
+version: 0.0.28
 name: llm_ingest_dataset_to_acs_qa_only
 display_name: LLM - Dataset to ACS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -134,7 +134,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -160,7 +160,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -183,7 +183,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -204,7 +204,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -218,7 +218,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -235,7 +235,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -285,7 +285,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.18'
+    component: 'azureml:llm_rag_update_acs_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -305,7 +305,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.39
+version: 0.0.40
 name: llm_ingest_dataset_to_faiss
 display_name: LLM - Dataset to FAISS Pipeline (With Test Data Generation and Auto Prompt
 is_deterministic: false
@@ -195,7 +195,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -218,7 +218,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -241,7 +241,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -262,7 +262,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -276,7 +276,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: azureml:llm_autoprompt_qna:0.0.16
+    component: azureml:llm_autoprompt_qna:0.0.17
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -310,7 +310,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -324,7 +324,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -342,7 +342,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -392,7 +392,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.18'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -410,7 +410,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.27
+version: 0.0.28
 name: llm_ingest_dataset_to_faiss_basic
 display_name: LLM - Dataset to FAISS Pipeline
 is_deterministic: false
@@ -102,7 +102,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -125,7 +125,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -148,7 +148,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -165,7 +165,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -215,7 +215,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.18'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -233,7 +233,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.27
+version: 0.0.28
 name: llm_ingest_dataset_to_faiss_qa_only
 display_name: LLM - Dataset to FAISS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -126,7 +126,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -149,7 +149,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -172,7 +172,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -193,7 +193,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -207,7 +207,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -224,7 +224,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -274,7 +274,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.18'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -292,7 +292,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
@@ -4,7 +4,7 @@ tags:
     Preview: ''
 name: llm_ingest_db_to_acs
 display_name: LLM - SQL Datastore to ACS Pipeline
-version: 0.0.22
+version: 0.0.23
 description: Single job pipeline to chunk data from AzureML sql data store, and create ACS embeddings index
 settings:
   default_compute: serverless
@@ -107,7 +107,7 @@ jobs:
       output_chunk_file:
         type: uri_folder
       output_grounding_context_file: ${{parent.outputs.db_context}}
-    component: azureml:llm_dbcopilot_grounding:0.0.19
+    component: azureml:llm_dbcopilot_grounding:0.0.20
     type: command
   generate_meta_embeddings:
     type: command
@@ -117,7 +117,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -169,7 +169,7 @@ jobs:
         path: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.grounding_index}}
-    component: azureml:llm_rag_update_acs_index:0.0.18
+    component: azureml:llm_rag_update_acs_index:0.0.19
     type: command
   register_mlindex_asset_job:
     resources:
@@ -186,7 +186,7 @@ jobs:
     outputs:
       asset_id:
         type: uri_file
-    component: azureml:llm_rag_register_mlindex_asset:0.0.18
+    component: azureml:llm_rag_register_mlindex_asset:0.0.19
     type: command
   create_prompt_flow:
     environment_variables:
@@ -213,5 +213,5 @@ jobs:
         path: ${{parent.inputs.chat_aoai_deployment_name}}
       llm_config:
         path: ${{parent.inputs.llm_config}}
-    component: azureml:llm_dbcopilot_create_promptflow:0.0.18
+    component: azureml:llm_dbcopilot_create_promptflow:0.0.19
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
@@ -4,7 +4,7 @@ tags:
     Preview: ''
 name: llm_ingest_db_to_faiss
 display_name: LLM - SQL Datastore to FAISS Pipeline
-version: 0.0.22
+version: 0.0.23
 description: Single job pipeline to chunk data from AzureML sql data store, and create FAISS embeddings index
 settings:
   default_compute: serverless
@@ -100,7 +100,7 @@ jobs:
       output_chunk_file:
         type: uri_folder
       output_grounding_context_file: ${{parent.outputs.db_context}}
-    component: azureml:llm_dbcopilot_grounding:0.0.19
+    component: azureml:llm_dbcopilot_grounding:0.0.20
     type: command
   generate_meta_embeddings:
     type: command
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -159,7 +159,7 @@ jobs:
         path: ${{parent.jobs.generate_meta_embeddings.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.grounding_index}}
-    component: azureml:llm_rag_create_faiss_index:0.0.18
+    component: azureml:llm_rag_create_faiss_index:0.0.19
     type: command
   register_mlindex_asset_job:
     resources:
@@ -176,7 +176,7 @@ jobs:
     outputs:
       asset_id:
         type: uri_file
-    component: azureml:llm_rag_register_mlindex_asset:0.0.18
+    component: azureml:llm_rag_register_mlindex_asset:0.0.19
     type: command
   create_prompt_flow:
     environment_variables:
@@ -203,5 +203,5 @@ jobs:
         path: ${{parent.inputs.chat_aoai_deployment_name}}
       llm_config:
         path: ${{parent.inputs.llm_config}}
-    component: azureml:llm_dbcopilot_create_promptflow:0.0.18
+    component: azureml:llm_dbcopilot_create_promptflow:0.0.19
     type: command

--- a/assets/large_language_models/components_pipelines/data_ingestion_existing_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_existing_acs/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.37
+version: 0.0.38
 name: llm_ingest_existing_acs
 display_name: LLM - Existing ACS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -193,7 +193,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -215,7 +215,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: azureml:llm_rag_data_import_acs:0.0.17
+    component: azureml:llm_rag_data_import_acs:0.0.18
     inputs:
       num_docs: ${{parent.inputs.num_docs_to_import}}
       acs_config: ${{parent.inputs.acs_import_config}}
@@ -237,7 +237,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.jobs.data_import_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -258,7 +258,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -279,7 +279,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -293,7 +293,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: azureml:llm_autoprompt_qna:0.0.16
+    component: azureml:llm_autoprompt_qna:0.0.17
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -324,7 +324,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -338,7 +338,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -354,7 +354,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.data_import_job.outputs.ml_index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.21
+version: 0.0.22
 name: llm_ingest_existing_acs_basic
 display_name: LLM - Existing ACS Pipeline
 is_deterministic: false
@@ -97,7 +97,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: azureml:llm_rag_data_import_acs:0.0.17
+    component: azureml:llm_rag_data_import_acs:0.0.18
     inputs:
       num_docs: ${{parent.inputs.num_docs_to_import}}
       acs_config: ${{parent.inputs.acs_import_config}}
@@ -119,7 +119,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -134,7 +134,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.data_import_job.outputs.ml_index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_existing_acs_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.24
+version: 0.0.25
 name: llm_ingest_existing_acs_qa_only
 display_name: LLM - Existing ACS Pipeline (Only Test Data)
 is_deterministic: false
@@ -124,7 +124,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -146,7 +146,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: azureml:llm_rag_data_import_acs:0.0.17
+    component: azureml:llm_rag_data_import_acs:0.0.18
     inputs:
       num_docs: ${{parent.inputs.num_docs_to_import}}
       acs_config: ${{parent.inputs.acs_import_config}}
@@ -168,7 +168,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.jobs.data_import_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -189,7 +189,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -210,7 +210,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -224,7 +224,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -239,7 +239,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.data_import_job.outputs.ml_index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.39
+version: 0.0.40
 name: llm_ingest_git_to_acs
 display_name: LLM - Git to ACS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -215,7 +215,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -241,7 +241,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.18'
+    component: 'azureml:llm_rag_git_clone:0.0.19'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -261,7 +261,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -284,7 +284,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -305,7 +305,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -319,7 +319,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: azureml:llm_autoprompt_qna:0.0.16
+    component: azureml:llm_autoprompt_qna:0.0.17
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -350,7 +350,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -364,7 +364,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -382,7 +382,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -432,7 +432,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.18'
+    component: 'azureml:llm_rag_update_acs_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -452,7 +452,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.27
+version: 0.0.28
 name: llm_ingest_git_to_acs_basic
 display_name: LLM - Git to ACS Pipeline
 is_deterministic: false
@@ -121,7 +121,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -147,7 +147,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.18'
+    component: 'azureml:llm_rag_git_clone:0.0.19'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -167,7 +167,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -190,7 +190,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -207,7 +207,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -257,7 +257,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.18'
+    component: 'azureml:llm_rag_update_acs_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -277,7 +277,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_acs_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.27
+version: 0.0.28
 name: llm_ingest_git_to_acs_qa_only
 display_name: LLM - Git to ACS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -146,7 +146,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -172,7 +172,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.18'
+    component: 'azureml:llm_rag_git_clone:0.0.19'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -192,7 +192,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -215,7 +215,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -236,7 +236,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -250,7 +250,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -267,7 +267,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -317,7 +317,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.18'
+    component: 'azureml:llm_rag_update_acs_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -337,7 +337,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.40
+version: 0.0.41
 name: llm_ingest_git_to_faiss
 display_name: LLM - Git to FAISS Pipeline (With Test Data Generation and Auto Prompt)
 is_deterministic: false
@@ -210,7 +210,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -233,7 +233,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.18'
+    component: 'azureml:llm_rag_git_clone:0.0.19'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -253,7 +253,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -276,7 +276,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -297,7 +297,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -311,7 +311,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: azureml:llm_autoprompt_qna:0.0.16
+    component: azureml:llm_autoprompt_qna:0.0.17
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -345,7 +345,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_autoprompt_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -359,7 +359,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       best_prompts: ${{parent.jobs.hard_prompt_sweep_job.outputs.best_prompt}}
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
@@ -377,7 +377,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -427,7 +427,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.18'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -445,7 +445,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.27
+version: 0.0.28
 name: llm_ingest_git_to_faiss_basic
 display_name: LLM - Git to FAISS Pipeline
 is_deterministic: false
@@ -114,7 +114,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -137,7 +137,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.18'
+    component: 'azureml:llm_rag_git_clone:0.0.19'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -157,7 +157,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -180,7 +180,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -197,7 +197,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -247,7 +247,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.18'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -265,7 +265,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_qa_only/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_git_to_faiss_qa_only/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.27
+version: 0.0.28
 name: llm_ingest_git_to_faiss_qa_only
 display_name: LLM - Git to FAISS Pipeline (Only Test Data Generation)
 is_deterministic: false
@@ -140,7 +140,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.21'
+    component: 'azureml:llm_rag_validate_deployments:0.0.22'
     identity:
       type: user_identity
     inputs:
@@ -163,7 +163,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_git_clone:0.0.18'
+    component: 'azureml:llm_rag_git_clone:0.0.19'
     inputs:
       git_repository: ${{parent.inputs.git_repository}}
       branch_name: ${{parent.inputs.branch_name}}
@@ -183,7 +183,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.19'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.20'
     inputs:
       input_data: ${{parent.jobs.git_clone_job.outputs.output_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -206,7 +206,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_qa_data_generation:0.0.20'
+    component: 'azureml:llm_rag_qa_data_generation:0.0.21'
     inputs:
       openai_api_version: ${{parent.inputs.openai_api_version}}
       openai_api_type: ${{parent.inputs.openai_api_type}}
@@ -227,7 +227,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_qa_data_asset:0.0.11'
+    component: 'azureml:llm_rag_register_qa_data_asset:0.0.12'
     inputs:
       storage_uri: ${{parent.jobs.data_generation_job.outputs.output_data}}
       register_output: ${{parent.inputs.register_outputs}}
@@ -241,7 +241,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.30'
+    component: 'azureml:llm_rag_create_promptflow:0.0.31'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -258,7 +258,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.13'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.14'
     inputs:
       chunks_source:
         type: uri_folder
@@ -308,7 +308,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.18'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.19'
     inputs:
       embeddings:
         type: uri_folder
@@ -326,7 +326,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.18'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.19'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/dbcopilot/components/llm_dbcopilot_create_promptflow/spec.yaml
+++ b/assets/large_language_models/dbcopilot/components/llm_dbcopilot_create_promptflow/spec.yaml
@@ -4,7 +4,7 @@ tags:
     Preview: ''
 name: llm_dbcopilot_create_promptflow
 display_name: LLM - Create DBCopilot Prompt Flow
-version: 0.0.18
+version: 0.0.19
 inputs:
   index_name:
     type: string

--- a/assets/large_language_models/dbcopilot/components/llm_dbcopilot_grounding/spec.yaml
+++ b/assets/large_language_models/dbcopilot/components/llm_dbcopilot_grounding/spec.yaml
@@ -4,7 +4,7 @@ tags:
     Preview: ''
 name: llm_dbcopilot_grounding
 display_name: LLM - DBCopilot Grounding DB
-version: 0.0.19
+version: 0.0.20
 inputs:
   asset_uri:
     type: string

--- a/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
@@ -87,3 +87,4 @@ command: >-
   $[[--document_path_replacement_regex '${{inputs.document_path_replacement_regex}}']]
   --max_sample_files ${{inputs.max_sample_files}}
   --use_rcts '${{inputs.use_rcts}}'
+  --output_format ${{inputs.output_format}}

--- a/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
@@ -60,6 +60,13 @@ inputs:
     - "True"
     - "False"
     description:  "Whether to use RecursiveCharacterTextSplitter to split documents into chunks"
+  output_format:
+    type: string
+    default: "csv"
+    enum:
+    - "csv"
+    - "jsonl"
+    description: "Format of the output chunk file"
 
 outputs:
    output_chunks:

--- a/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_rag_crack_and_chunk
 display_name: LLM - Crack and Chunk Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
+++ b/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.18
+version: 0.0.19
 name: llm_rag_create_faiss_index
 display_name: LLM - Create FAISS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_promptflow/spec.yaml
+++ b/assets/large_language_models/rag/components/create_promptflow/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.30
+version: 0.0.31
 name: llm_rag_create_promptflow
 display_name: LLM - Create Prompt Flow
 is_deterministic: true

--- a/assets/large_language_models/rag/components/data_import_acs/spec.yaml
+++ b/assets/large_language_models/rag/components/data_import_acs/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.17
+version: 0.0.18
 name: llm_rag_data_import_acs
 display_name: LLM - Import Data from ACS
 is_deterministic: false

--- a/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.13
+version: 0.0.14
 name: llm_rag_generate_embeddings
 display_name: LLM - Generate Embeddings
 is_deterministic: true

--- a/assets/large_language_models/rag/components/generate_embeddings_parallel/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings_parallel/spec.yaml
@@ -4,7 +4,7 @@ type: parallel
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_rag_generate_embeddings_parallel
 display_name: LLM - Generate Embeddings Parallel
 is_deterministic: true

--- a/assets/large_language_models/rag/components/git_clone/spec.yaml
+++ b/assets/large_language_models/rag/components/git_clone/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.18
+version: 0.0.19
 name: llm_rag_git_clone
 display_name: LLM - Clone Git Repo
 is_deterministic: true

--- a/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
+++ b/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.20
+version: 0.0.21
 name: llm_rag_qa_data_generation
 display_name: LLM - Generate QnA Test Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
+++ b/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.18
+version: 0.0.19
 name: llm_rag_register_mlindex_asset
 display_name: LLM - Register Vector Index Asset
 is_deterministic: true

--- a/assets/large_language_models/rag/components/register_qa_data_asset/spec.yaml
+++ b/assets/large_language_models/rag/components/register_qa_data_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.11
+version: 0.0.12
 name: llm_rag_register_qa_data_asset
 display_name: LLM - Register QA Generation Data Asset
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_acs_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_acs_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.18
+version: 0.0.19
 name: llm_rag_update_acs_index
 display_name: LLM - Update ACS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/validate_deployments/spec.yaml
+++ b/assets/large_language_models/rag/components/validate_deployments/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.21
+version: 0.0.22
 name: llm_rag_validate_deployments
 display_name: LLM – Validate Deployments
 is_deterministic: false

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/Dockerfile
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/Dockerfile
@@ -95,3 +95,13 @@ RUN set -eux; \
     fileEncoding="$(echo 'System.out.println(System.getProperty("file.encoding"))' | jshell -s -)"; [ "$fileEncoding" = 'UTF-8' ]; rm -rf ~/.java; \
     javac --version; \
     java --version
+
+ENV TIKA_SERVER_JAR file:///tika-server.jar
+
+RUN downloadUrl='http://search.maven.org/remotecontent?filepath=org/apache/tika/tika-server-standard/2.6.0/tika-server-standard-2.6.0.jar'; \
+	downloadMd5='45241a0fa165cb0ac4848bbc0999c1bc'; \
+    wget --progress=dot:giga -O tika-server.jar "$downloadUrl"; \
+    # tika-python looks for tika-server.jar.md5 file along with TIKA_SERVER_JAR
+    echo -n "$downloadMd5" > tika-server.jar.md5; \
+    # basic smoke test
+    python -c 'from tika import parser; parser.from_file("/root/.bashrc")'

--- a/assets/large_language_models/utils/ComponentVersionUpdator.py
+++ b/assets/large_language_models/utils/ComponentVersionUpdator.py
@@ -181,12 +181,19 @@ validate_fields = {
     'environment': validate_environment
 }
 
+skip_dirs = [
+    "oai_v2_1p"
+]
+
 
 def generate_assets(folder_path: List[str]) -> Tuple[Dict[str, Component], Dict[str, Pipeline]]:
     """Walk the file tree and pull out all the components and component pipelines."""
     comp_assets_all = {}
     pipe_assets_all = {}
     for root, _, files in os.walk(folder_path):
+        if [d for d in skip_dirs if d in root]:
+            print(f"Skipping {root}")
+            continue
         comp = parse_asset_yamls(files, root)
         if comp is not None:
             if isinstance(comp, Pipeline):

--- a/assets/large_language_models/utils/ComponentVersionUpdator.py
+++ b/assets/large_language_models/utils/ComponentVersionUpdator.py
@@ -182,7 +182,7 @@ validate_fields = {
 }
 
 skip_dirs = [
-    "oai_v2_1p"
+    "oai_v2_1p",  # owned by oai team
 ]
 
 


### PR DESCRIPTION
Currently tika-server is downloaded at runtime. This PR packages it in the docker image to avoid this download.

Meant to fix issues where tika server is not properly downloaded like: 

> RuntimeError: Unable to start Tika server.
