### PR TITLE
[Model Monitor] - Fix histogram generation with no numerical features

### DIFF
--- a/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_drift_signal_monitor
 display_name: Data Drift - Signal Monitor
 description: Computes the data drift between a baseline and production data assets.
-version: 0.3.6
+version: 0.3.7
 is_deterministic: true
 
 inputs:
@@ -130,7 +130,7 @@ jobs:
       type: aml_token
   compute_baseline_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.0
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.1
     inputs:
       input_data:
         type: mltable
@@ -148,7 +148,7 @@ jobs:
       type: aml_token
   compute_target_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.0
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.1
     inputs:
       input_data:
         type: mltable

--- a/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_compute_histogram
 display_name: Model Monitor - Compute Histogram
 description: Compute a histogram given an input data and associated histogram buckets.
-version: 0.3.0
+version: 0.3.1
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/src/model_monitor_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/model_monitor_compute_histogram/run.py
@@ -5,7 +5,25 @@
 
 import argparse
 from histogram import compute_histograms
-from shared_utilities.io_utils import read_mltable_in_spark, save_spark_df_as_mltable
+from pyspark.sql.types import (
+    StructType,
+    StructField,
+    StringType,
+    DoubleType,
+)
+from shared_utilities.io_utils import init_spark, read_mltable_in_spark, save_spark_df_as_mltable
+
+
+def _create_empty_histogram_buckets_df():
+    spark = init_spark()
+    schema = StructType(
+        [
+            StructField("feature_name", StringType(), True),
+            StructField("data_type", StringType(), True),
+            StructField("bucket", DoubleType(), True),
+        ]
+    )
+    return spark.createDataFrame(data=[], schema=schema)
 
 
 def run():
@@ -18,7 +36,13 @@ def run():
     args = parser.parse_args()
 
     df = read_mltable_in_spark(args.input_data)
-    histogram_buckets = read_mltable_in_spark(args.histogram_buckets)
+    
+    histogram_buckets = None
+    try:
+        histogram_buckets = read_mltable_in_spark(args.histogram_buckets)
+    except Exception:
+        print("No histogram buckets detected.")
+        histogram_buckets = _create_empty_histogram_buckets_df()
 
     histogram_df = compute_histograms(df, histogram_buckets)
 

--- a/assets/model_monitoring/components/src/model_monitor_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/model_monitor_compute_histogram/run.py
@@ -36,7 +36,7 @@ def run():
     args = parser.parse_args()
 
     df = read_mltable_in_spark(args.input_data)
-    
+
     histogram_buckets = None
     try:
         histogram_buckets = read_mltable_in_spark(args.histogram_buckets)


### PR DESCRIPTION
Given the compute_histogram_buckets job currently only computes buckets for numerical features, the resulting bucket MLTable is sometimes empty. This crashes the compute_histogram job.

## Fix
- Handle empty bucket inputs. 