### PR TITLE
[Model Monitor] - Add support for LongType for Data Quality data type violations

### DIFF
--- a/assets/model_monitoring/components/data_quality/data_quality_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_quality_compute_metrics
 display_name:  Data Quality - Compute Metrics
 description: Compute data quality metrics leveraged by the data quality monitor.
-version: 0.3.2
+version: 0.3.3
 is_deterministic: true
 
 inputs:

--- a/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_quality_signal_monitor
 display_name: Data Quality - Signal Monitor
 description: Computes the data quality of a target dataset with reference to a baseline.
-version: 0.3.6
+version: 0.3.7
 is_deterministic: true
 
 inputs:
@@ -102,7 +102,7 @@ jobs:
       type: aml_token
   compute_baseline_data_quality:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.2
+    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.3
     inputs:
       input_data:
         type: mltable
@@ -125,7 +125,7 @@ jobs:
       type: aml_token
   compute_target_data_quality:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.2
+    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.3
     inputs:
       input_data:
         type: mltable

--- a/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
@@ -10,8 +10,13 @@ from pyspark.sql.types import (
     StructType,
     StructField,
     StringType,
-    DoubleType,
+    ByteType,
+    ShortType,
     IntegerType,
+    LongType,
+    FloatType,
+    DoubleType,
+    DecimalType,
 )
 from pyspark.sql.functions import (
     col,
@@ -329,7 +334,7 @@ def impute_numericals_with_median(df: pyspark.sql.DataFrame) -> pyspark.sql.Data
     Returns:
     df (pyspark.sql.DataFrame): The input DataFrame with missing values in numerical columns imputed with median
     """
-    dbl_cols = [f.name for f in df.schema.fields if isinstance(f.dataType, DoubleType)]
+    dbl_cols = [f.name for f in df.schema.fields if isinstance(f.dataType, (ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType, DecimalType))] #noqa
     imputer = Imputer(inputCols=dbl_cols, outputCols=[c for c in dbl_cols]).setStrategy(
         "median"
     )

--- a/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
@@ -334,7 +334,7 @@ def impute_numericals_with_median(df: pyspark.sql.DataFrame) -> pyspark.sql.Data
     Returns:
     df (pyspark.sql.DataFrame): The input DataFrame with missing values in numerical columns imputed with median
     """
-    dbl_cols = [f.name for f in df.schema.fields if isinstance(f.dataType, (ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType, DecimalType))] #noqa
+    dbl_cols = [f.name for f in df.schema.fields if isinstance(f.dataType, (ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType, DecimalType))] # noqa
     imputer = Imputer(inputCols=dbl_cols, outputCols=[c for c in dbl_cols]).setStrategy(
         "median"
     )

--- a/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
@@ -335,11 +335,13 @@ def impute_numericals_with_median(df: pyspark.sql.DataFrame) -> pyspark.sql.Data
     df (pyspark.sql.DataFrame): The input DataFrame with missing values in numerical columns imputed with median
     """
     dbl_cols = [f.name for f in df.schema.fields if isinstance(f.dataType, (ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType, DecimalType))] # noqa
-    imputer = Imputer(inputCols=dbl_cols, outputCols=[c for c in dbl_cols]).setStrategy(
-        "median"
-    )
-    # Fit imputer on Data Frame and Transform it
-    df = imputer.fit(df).transform(df)
+    
+    if len(dbl_cols) > 0:
+        imputer = Imputer(inputCols=dbl_cols, outputCols=[c for c in dbl_cols]).setStrategy(
+            "median"
+        )
+        # Fit imputer on Data Frame and Transform it
+        df = imputer.fit(df).transform(df)
     return df
 
 

--- a/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
@@ -335,7 +335,7 @@ def impute_numericals_with_median(df: pyspark.sql.DataFrame) -> pyspark.sql.Data
     df (pyspark.sql.DataFrame): The input DataFrame with missing values in numerical columns imputed with median
     """
     dbl_cols = [f.name for f in df.schema.fields if isinstance(f.dataType, (ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType, DecimalType))] # noqa
-    
+
     if len(dbl_cols) > 0:
         imputer = Imputer(inputCols=dbl_cols, outputCols=[c for c in dbl_cols]).setStrategy(
             "median"


### PR DESCRIPTION
Spark 3.3 saw the addition of LongTypes which broke the data type violation imputer.

## Fi
- Add numerical types as valid numerical types for imputing missing values on data type violations