### PR TITLE
Updated oai ft pipeline component to 0.0.7

### DIFF
--- a/assets/large_language_models/components_pipelines/oai_v2_1p/openai_completions_finetune_pipeline/spec.yaml
+++ b/assets/large_language_models/components_pipelines/oai_v2_1p/openai_completions_finetune_pipeline/spec.yaml
@@ -1,6 +1,6 @@
 $schema: http://azureml/sdk-2-0/PipelineComponent.json
 type: pipeline
-version: 0.0.6
+version: 0.0.7
 name: openai_completions_finetune_pipeline
 display_name: OpenAI Completions Finetune Pipeline
 description: Finetune your own OAI model. Visit https://learn.microsoft.com/en-us/azure/cognitive-services/openai/ for more info.
@@ -48,6 +48,10 @@ outputs:
     type: uri_folder
     description: Dataset with the output model weights (LoRA weights)
     mode: mount
+  output_merged_model:
+    type: uri_folder
+    description: Dataset with the output (merged) model weights
+    mode: mount
 
 jobs:
   openai_data_import:
@@ -59,7 +63,7 @@ jobs:
       model: ${{parent.inputs.model}}
   openai_completions_finetune:
     type: command
-    component: azureml://registries/azure-openai-v2/components/openai_completions_finetune/versions/0.3.0
+    component: azureml://registries/azure-openai-v2/components/openai_completions_finetune/versions/0.3.1
     inputs:
       input_dataset: ${{parent.jobs.openai_data_import.outputs.out_dataset}}
       model: ${{parent.inputs.model}}

--- a/assets/large_language_models/components_pipelines/oai_v2_1p/openai_completions_finetune_pipeline/spec.yaml
+++ b/assets/large_language_models/components_pipelines/oai_v2_1p/openai_completions_finetune_pipeline/spec.yaml
@@ -72,3 +72,4 @@ jobs:
       epochs: ${{parent.inputs.epochs}}
     outputs:
       output_model: ${{parent.outputs.output_model}}
+      output_merged_model: ${{parent.outputs.output_merged_model}}


### PR DESCRIPTION
Updated oai ft pipeline component to 0.0.7, this only support Turbo output merged model but will fail for babbage-002 and davinci-002 model (debugging is in progress)