### PR TITLE
fix libopenexr24 vulnerability alerts in responsibleai-vision docker image in azureml-assets

### DIFF
--- a/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
 # Install OpenCV native dependencies
 RUN apt-get update
 RUN apt-get install -y python3-opencv
-RUN apt-get remove -y libavutil56 libswresample3 libavformat58 libavcodec58 libswscale5
+RUN apt-get remove -y libavutil56 libswresample3 libavformat58 libavcodec58 libswscale5 libopenexr24
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-vision
 


### PR DESCRIPTION
link to vulnerability page:
https://ubuntu.com/security/notices/USN-5620-1 
link to icm:
https://portal.microsofticm.com/imp/v3/incidents/details/423236995/home 
