### PR TITLE
Support for custom data loaders and duplicate sampling style

### DIFF
--- a/assets/aml-benchmark/components/dataset-sampler/spec.yaml
+++ b/assets/aml-benchmark/components/dataset-sampler/spec.yaml
@@ -15,17 +15,23 @@ inputs:
     type: string
     optional: False
     default: head
-    description: The sampling method to use. Use `head` to sample from beginning of the file, `tail` to sample from the end of the file and `random` to sample randomly.
+    description: >-
+      The sampling method to use. Use `head` to sample from beginning of the file, `tail` to sample from the end 
+      of the file, `random` to sample randomly and `duplicate` to append the input file to itself until the correct 
+      output size is reached.
     enum:
     - random
     - head
     - tail
+    - duplicate
   sampling_ratio:
     type: number
     min: 0
-    max: 1
     optional: True
-    description: Portion of the dataset to be sampled; must be a float in (0,1]; must be null if `n_samples` is specified.
+    description: >-
+      Portion of the dataset to be sampled. If `sampling style` is not `duplicate`, must be a float in (0,1]; must be null if 
+      `n_samples` is specified. NOTE: If the `sampling_style` is `duplicate`, the component will duplicate the data in a "round robin" 
+      fashion, going over the input several times. This operation is very slow! So be cautious when using for large datasets.
   n_samples:
     type: integer
     optional: True

--- a/assets/aml-benchmark/components/src/dataset_downloader/main.py
+++ b/assets/aml-benchmark/components/src/dataset_downloader/main.py
@@ -146,7 +146,7 @@ def download_dataset_from_hf(
             raise DatasetDownloadException._with_error(
                 AzureMLError.create(DatasetDownloadError, error_details=mssg)
             )
-        out_dir = os.path.join(output_dir, configuration, split)
+        out_dir = os.path.join(output_dir, str(configuration), split)
         os.makedirs(out_dir, exist_ok=True)
         output_file_path = os.path.join(out_dir, "data.jsonl")
         dataset.to_json(output_file_path)

--- a/assets/aml-benchmark/components/src/utils/io.py
+++ b/assets/aml-benchmark/components/src/utils/io.py
@@ -67,7 +67,7 @@ def _get_file_paths_from_folder(dataset: str) -> List[str]:
 def get_output_file_path(input_file_path: str, output_path: str, counter: Optional[int] = None) -> str:
     """Get output file path.
 
-    Uses the file name and extension from input_file_path along with counter to create the output file name.
+    Uses the file name and extension from `input_file_path` along with counter to create the output file name.
 
     :param input_file_path: Path to input file
     :param output_path: Path to output directory

--- a/assets/aml-benchmark/scripts/data_loaders/math.py
+++ b/assets/aml-benchmark/scripts/data_loaders/math.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Data Loading Script for MATH dataset."""
+
+import json
+
+import datasets
+
+
+_CITATION = """\
+@article{hendrycksmath2021,
+  title={Measuring Mathematical Problem Solving With the MATH Dataset},
+  author={Dan Hendrycks and Collin Burns and Saurav Kadavath and Akul Arora and Steven Basart and Eric Tang \
+and Dawn Song and Jacob Steinhardt},
+  journal={NeurIPS},
+  year={2021}
+}
+"""
+
+_DESCRIPTION = """\
+The Mathematics Aptitude Test of Heuristics (MATH) dataset consists of problems \
+from mathematics competitions, covering 7 subjects including algebra, geometry, \
+precalculus, and more. Each problem in MATH has a full step-by-step solution, \
+which can be used to teach models to generate answer derivations and explanations.\
+"""
+
+_HOMEPAGE = "https://github.com/hendrycks/math/"
+_LICENSE = "MIT"
+_URL = "https://people.eecs.berkeley.edu/~hendrycks/MATH.tar"
+
+_SUBJECTS = [
+    "algebra",
+    "counting_and_probability",
+    "geometry",
+    "intermediate_algebra",
+    "number_theory",
+    "prealgebra",
+    "precalculus",
+]
+
+
+class MATH(datasets.GeneratorBasedBuilder):
+    """MATH dataset."""
+
+    BUILDER_CONFIGS = [
+        datasets.BuilderConfig(
+            name=sub,
+            version=datasets.Version("1.0.0"),
+            description=f"MATH - Subject: {sub}",
+        )
+        for sub in _SUBJECTS
+    ]
+
+    def _info(self):
+        features = datasets.Features(
+            {
+                "problem": datasets.Value("string"),
+                "level": datasets.Value("string"),
+                "type": datasets.Value("string"),
+                "solution": datasets.Value("string"),
+            }
+        )
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Return SplitGenerators."""
+        archive = dl_manager.download(_URL)
+        iter_archive = dl_manager.iter_archive(archive)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={
+                    "iter_archive": iter_archive,
+                    "split": "train"
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "iter_archive": iter_archive,
+                    "split": "test"
+                },
+            ),
+        ]
+
+    def _generate_examples(self, iter_archive, split):
+        """Yield examples as a tuple."""
+        for id_file, (path, file) in enumerate(iter_archive):
+            if f"{split}/{self.config.name}" in path:
+                content = file.read().decode('utf-8')
+                data = json.loads(content)
+                yield id_file, data

--- a/assets/aml-benchmark/scripts/data_loaders/mmlu.py
+++ b/assets/aml-benchmark/scripts/data_loaders/mmlu.py
@@ -1,0 +1,173 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Data Loading Script for MMLU."""
+
+import csv
+
+import datasets
+
+
+_CITATION = """\
+@article{hendryckstest2021,
+  title={Measuring Massive Multitask Language Understanding},
+  author={Dan Hendrycks and Collin Burns and Steven Basart and Andy Zou and Mantas Mazeika and Dawn Song and \
+Jacob Steinhardt},
+  journal={Proceedings of the International Conference on Learning Representations (ICLR)},
+  year={2021}
+}
+"""
+
+_DESCRIPTION = """\
+This is a massive multitask test consisting of multiple-choice questions from various \
+branches of knowledge, covering 57 subjects including elementary mathematics, US history, \
+computer science, law, and more.\
+"""
+
+_HOMEPAGE = "https://github.com/hendrycks/test"
+_LICENSE = "MIT"
+_URL = "https://people.eecs.berkeley.edu/~hendrycks/data.tar"
+
+_SUBJECTS = [
+    "abstract_algebra",
+    "anatomy",
+    "astronomy",
+    "business_ethics",
+    "clinical_knowledge",
+    "college_biology",
+    "college_chemistry",
+    "college_computer_science",
+    "college_mathematics",
+    "college_medicine",
+    "college_physics",
+    "computer_security",
+    "conceptual_physics",
+    "econometrics",
+    "electrical_engineering",
+    "elementary_mathematics",
+    "formal_logic",
+    "global_facts",
+    "high_school_biology",
+    "high_school_chemistry",
+    "high_school_computer_science",
+    "high_school_european_history",
+    "high_school_geography",
+    "high_school_government_and_politics",
+    "high_school_macroeconomics",
+    "high_school_mathematics",
+    "high_school_microeconomics",
+    "high_school_physics",
+    "high_school_psychology",
+    "high_school_statistics",
+    "high_school_us_history",
+    "high_school_world_history",
+    "human_aging",
+    "human_sexuality",
+    "international_law",
+    "jurisprudence",
+    "logical_fallacies",
+    "machine_learning",
+    "management",
+    "marketing",
+    "medical_genetics",
+    "miscellaneous",
+    "moral_disputes",
+    "moral_scenarios",
+    "nutrition",
+    "philosophy",
+    "prehistory",
+    "professional_accounting",
+    "professional_law",
+    "professional_medicine",
+    "professional_psychology",
+    "public_relations",
+    "security_studies",
+    "sociology",
+    "us_foreign_policy",
+    "virology",
+    "world_religions",
+]
+
+
+class MMLU(datasets.GeneratorBasedBuilder):
+    """MMLU dataset."""
+
+    BUILDER_CONFIGS = [
+        datasets.BuilderConfig(
+            name=sub,
+            version=datasets.Version("1.0.0"),
+            description=f"MMLU - Subject: {sub}",
+        )
+        for sub in _SUBJECTS
+    ]
+
+    def _info(self):
+        features = datasets.Features(
+            {
+                "question": datasets.Value("string"),
+                "subject": datasets.Value("string"),
+                "choices": datasets.features.Sequence(datasets.Value("string")),
+                "answer": datasets.features.ClassLabel(
+                    num_classes=4, names=["A", "B", "C", "D"]
+                ),
+            }
+        )
+        return datasets.DatasetInfo(
+            description=_DESCRIPTION,
+            features=features,
+            homepage=_HOMEPAGE,
+            license=_LICENSE,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Return SplitGenerators."""
+        archive = dl_manager.download(_URL)
+        iter_archive = dl_manager.iter_archive(archive)
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split("auxiliary_train"),
+                gen_kwargs={
+                    "iter_archive": iter_archive,
+                    "split": "auxiliary_train",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split.TEST,
+                gen_kwargs={
+                    "iter_archive": iter_archive,
+                    "split": "test",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split("val"),
+                gen_kwargs={
+                    "iter_archive": iter_archive,
+                    "split": "val",
+                },
+            ),
+            datasets.SplitGenerator(
+                name=datasets.Split("dev"),
+                gen_kwargs={
+                    "iter_archive": iter_archive,
+                    "split": "dev",
+                },
+            ),
+        ]
+
+    def _generate_examples(self, iter_archive, split):
+        """Yield examples as a tuple."""
+        for id_file, (path, file) in enumerate(iter_archive):
+            if f"data/{split}/" in path:
+                if split == "auxiliary_train" or f"{self.config.name}_{split}.csv" in path:
+                    subject = self.config.name if split != "auxiliary_train" else ""
+                    lines = (line.decode("utf-8") for line in file)
+                    reader = csv.reader(lines)
+                    for id_line, data in enumerate(reader):
+                        yield f"{id_file}_{id_line}", {
+                            "question": data[0],
+                            "choices": data[1:5],
+                            "answer": data[5],
+                            "subject": subject,
+                        }

--- a/assets/aml-benchmark/tests/test_dataset_downloader.py
+++ b/assets/aml-benchmark/tests/test_dataset_downloader.py
@@ -35,6 +35,7 @@ class TestDatasetDownloaderComponent:
             ("xquad", "xquad.en", "validation", None),
             ("xquad", "xquad.en", "all", None),
             ("xquad", "all", "all", None),
+            (None, "all", "test", Constants.MATH_DATASET_LOADER_SCRIPT),
         ],
     )
     def test_dataset_downloader_component(


### PR DESCRIPTION
This PR adds the support for:
- custom data loaders in dataset_downloader to be able to download data from any source by creating scripts that respect the HF data loader script template
- sampling style `duplicate` to allow duplicating the rows from files(s) while doing sampling.