### PR TITLE
Update model monitor common command components

### DIFF
--- a/assets/model_monitoring/amlcompute_components/data_drift/data_drift_signal_monitor_command/spec.yaml
+++ b/assets/model_monitoring/amlcompute_components/data_drift/data_drift_signal_monitor_command/spec.yaml
@@ -46,7 +46,6 @@ inputs:
 outputs:
   signal_output:
     type: uri_folder
-    mode: direct
 jobs:
   compute_feature_importances:
     type: command
@@ -155,7 +154,6 @@ jobs:
       signal_output:
         type: uri_folder
         path: ${{parent.outputs.signal_output}}
-        mode: direct
   evaluate_metric_thresholds:
     type: command
     component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold_command/versions/0.0.2

--- a/assets/model_monitoring/amlcompute_components/model_monitor/model_data_collector_preprocessor_command/spec.yaml
+++ b/assets/model_monitoring/amlcompute_components/model_monitor/model_data_collector_preprocessor_command/spec.yaml
@@ -1,15 +1,14 @@
 $schema: http://azureml/sdk-2-0/SparkComponent.json
-type: spark
+type: command
 
 name: model_data_collector_preprocessor_command
 display_name: Model Data Collector - Preprocessor
 description: Filters the data based on the window provided.
-version: 0.0.1
+version: 0.0.2
 is_deterministic: true
 
 code: ../../src
-entry:
-  file: ./model_data_collector_preprocessor/run.py
+environment: azureml:model_monitor_spark_standalone:1
 
 inputs:
   data_window_end:
@@ -18,38 +17,14 @@ inputs:
     type: string
   input_data:
     type: uri_folder
-    mode: direct
   extract_correlation_id:
     type: string
     default: "False"
 outputs:
   preprocessed_input_data:
     type: mltable
-    mode: direct
-conf:
-  spark.driver.cores: 1
-  spark.driver.memory: 2g
-  spark.executor.cores: 2
-  spark.executor.memory: 2g
-  spark.executor.instances: 1
-  spark.dynamicAllocation.enabled: True
-  spark.dynamicAllocation.minExecutors: 1
-  spark.dynamicAllocation.maxExecutors: 4
-  spark.synapse.library.python.env: |
-    channels:
-      - conda-forge
-    dependencies:
-      - python=3.8
-      - pip:
-        - scipy~=1.10.0
-        - numpy~=1.21.0
-        - pandas~=1.4.3
-        - azureml-mlflow~=1.49.0
-        - mltable~=1.3.0
-        - azureml-fsspec
-        - fsspec~=2023.4.0
-    name: momo-base-spark
-args: >-
+command: >-
+  python -m model_data_collector_preprocessor.run
   --data_window_end ${{inputs.data_window_end}}
   --data_window_start ${{inputs.data_window_start}}
   --input_data ${{inputs.input_data}}

--- a/assets/model_monitoring/amlcompute_components/model_monitor/model_monitor_create_manifest_command/spec.yaml
+++ b/assets/model_monitoring/amlcompute_components/model_monitor/model_monitor_create_manifest_command/spec.yaml
@@ -1,82 +1,58 @@
 $schema: http://azureml/sdk-2-0/SparkComponent.json
-type: spark
+type: command
 
 name: model_monitor_create_manifest_command
 display_name: Model Monitor - Create Manifest
 description: Creates the model monitor metric manifest.
-version: 0.0.1
+version: 0.0.2
 is_deterministic: true
 
 code: ../../src/
-entry:
-  file: ./model_monitor_create_manifest/run.py
+environment: azureml:model_monitor_spark_standalone:1
 
 inputs:
   signal_outputs_1:
     type: uri_folder
-    mode: direct
   signal_outputs_2:
     type: uri_folder
-    mode: direct
     optional: true
   signal_outputs_3:
     type: uri_folder
-    mode: direct
     optional: true
   signal_outputs_4:
     type: uri_folder
-    mode: direct
     optional: true
   signal_outputs_5:
     type: uri_folder
-    mode: direct
     optional: true
   signal_outputs_6:
     type: uri_folder
-    mode: direct
     optional: true
   signal_outputs_7:
     type: uri_folder
-    mode: direct
     optional: true
   signal_outputs_8:
     type: uri_folder
-    mode: direct
     optional: true
   signal_outputs_9:
     type: uri_folder
-    mode: direct
     optional: true
   signal_outputs_10:
     type: uri_folder
-    mode: direct
     optional: true
 outputs:
   model_monitor_metrics_output:
     type: uri_folder
-    mode: direct
-conf:
-  spark.driver.cores: 1
-  spark.driver.memory: 2g
-  spark.executor.cores: 2
-  spark.executor.memory: 2g
-  spark.executor.instances: 1
-  spark.dynamicAllocation.enabled: True
-  spark.dynamicAllocation.minExecutors: 1
-  spark.dynamicAllocation.maxExecutors: 4
-  spark.synapse.library.python.env: |
-    channels:
-      - conda-forge
-    dependencies:
-      - python=3.8
-      - pip:
-        - scipy~=1.10.0
-        - numpy~=1.21.0
-        - pandas~=1.4.3
-        - azureml-mlflow~=1.49.0
-        - mltable~=1.3.0
-        - azureml-fsspec
-        - fsspec~=2023.4.0
-    name: momo-base-spark
-args: >-
-  --signal_outputs_1 ${{inputs.signal_outputs_1}} $[[--signal_outputs_2 ${{inputs.signal_outputs_2}}]] $[[--signal_outputs_3 ${{inputs.signal_outputs_3}}]] $[[--signal_outputs_4 ${{inputs.signal_outputs_4}}]] $[[--signal_outputs_5 ${{inputs.signal_outputs_5}}]] $[[--signal_outputs_6 ${{inputs.signal_outputs_6}}]] $[[--signal_outputs_7 ${{inputs.signal_outputs_7}}]] $[[--signal_outputs_8 ${{inputs.signal_outputs_8}}]] $[[--signal_outputs_9 ${{inputs.signal_outputs_9}}]] $[[--signal_outputs_10 ${{inputs.signal_outputs_10}}]] --model_monitor_metrics_output ${{outputs.model_monitor_metrics_output}}
+command: >-
+  python -m model_monitor_create_manifest.run
+  --signal_outputs_1 ${{inputs.signal_outputs_1}}
+  $[[--signal_outputs_2 ${{inputs.signal_outputs_2}}]]
+  $[[--signal_outputs_3 ${{inputs.signal_outputs_3}}]]
+  $[[--signal_outputs_4 ${{inputs.signal_outputs_4}}]]
+  $[[--signal_outputs_5 ${{inputs.signal_outputs_5}}]]
+  $[[--signal_outputs_6 ${{inputs.signal_outputs_6}}]]
+  $[[--signal_outputs_7 ${{inputs.signal_outputs_7}}]]
+  $[[--signal_outputs_8 ${{inputs.signal_outputs_8}}]]
+  $[[--signal_outputs_9 ${{inputs.signal_outputs_9}}]]
+  $[[--signal_outputs_10 ${{inputs.signal_outputs_10}}]]
+  --model_monitor_metrics_output ${{outputs.model_monitor_metrics_output}}

--- a/assets/model_monitoring/amlcompute_components/model_monitor/model_monitor_data_joiner_command/spec.yaml
+++ b/assets/model_monitoring/amlcompute_components/model_monitor/model_monitor_data_joiner_command/spec.yaml
@@ -1,55 +1,29 @@
 $schema: http://azureml/sdk-2-0/SparkComponent.json
-type: spark
+type: command
 
 name: model_monitor_data_joiner_command
 display_name: Model Monitor - Data Joiner
 description: Joins two data assets on the given columns for model monitor.
-version: 0.0.1
+version: 0.0.2
 is_deterministic: true
 
 code: ../../src/
-entry:
-  file: ./model_monitor_data_joiner/run.py
+environment: azureml:model_monitor_spark_standalone:1
 
 inputs:
   left_input_data:
     type: mltable
-    mode: direct
   left_join_column:
     type: string
   right_input_data:
     type: mltable
-    mode: direct
   right_join_column:
     type: string
 outputs:
   joined_data:
     type: mltable
-    mode: direct
-conf:
-  spark.driver.cores: 1
-  spark.driver.memory: 2g
-  spark.executor.cores: 2
-  spark.executor.memory: 2g
-  spark.executor.instances: 1
-  spark.dynamicAllocation.enabled: True
-  spark.dynamicAllocation.minExecutors: 1
-  spark.dynamicAllocation.maxExecutors: 4
-  spark.synapse.library.python.env: |
-    channels:
-      - conda-forge
-    dependencies:
-      - python=3.8
-      - pip:
-        - scipy~=1.10.0
-        - numpy~=1.21.0
-        - pandas~=1.4.3
-        - azureml-mlflow~=1.49.0
-        - mltable~=1.3.0
-        - azureml-fsspec
-        - fsspec~=2023.4.0
-    name: momo-base-spark
-args: >-
+command: >-
+  python -m model_monitor_data_joiner.run
   --left_input_data ${{inputs.left_input_data}}
   --left_join_column ${{inputs.left_join_column}}
   --right_input_data ${{inputs.right_input_data}}

--- a/assets/model_monitoring/amlcompute_components/model_monitor/model_monitor_metric_outputter_command/spec.yaml
+++ b/assets/model_monitoring/amlcompute_components/model_monitor/model_monitor_metric_outputter_command/spec.yaml
@@ -1,15 +1,14 @@
 $schema: http://azureml/sdk-2-0/SparkComponent.json
-type: spark
+type: command
 
 name: model_monitor_metric_outputter_command
 display_name: Model Monitor - Metric Outputter
 description: Output the computed model monitor metrics.
-version: 0.0.1
+version: 0.0.2
 is_deterministic: true
 
 code: ../../src/
-entry:
-  file: ./model_monitor_metric_outputter/run.py
+environment: azureml:model_monitor_spark_standalone:1
 
 inputs:
   monitor_name:
@@ -18,10 +17,8 @@ inputs:
     type: string
   signal_metrics: 
     type: mltable
-    mode: direct
   samples_index: 
     type: mltable
-    mode: direct
     optional: true
   signal_type: 
     type: string
@@ -30,29 +27,12 @@ inputs:
 outputs:
   signal_output:
     type: uri_folder
-    mode: direct
-conf:
-  spark.driver.cores: 1
-  spark.driver.memory: 2g
-  spark.executor.cores: 2
-  spark.executor.memory: 2g
-  spark.executor.instances: 1
-  spark.dynamicAllocation.enabled: True
-  spark.dynamicAllocation.minExecutors: 1
-  spark.dynamicAllocation.maxExecutors: 4
-  spark.synapse.library.python.env: |
-    channels:
-      - conda-forge
-    dependencies:
-      - python=3.8
-      - pip:
-        - scipy~=1.10.0
-        - numpy~=1.21.0
-        - pandas~=1.4.3
-        - azureml-mlflow~=1.49.0
-        - mltable~=1.3.0
-        - azureml-fsspec
-        - fsspec~=2023.4.0
-    name: momo-base-spark
-args: >-
-  --monitor_name ${{inputs.monitor_name}} --signal_name ${{inputs.signal_name}} --signal_type ${{inputs.signal_type}} --signal_metrics ${{inputs.signal_metrics}} --metric_timestamp ${{inputs.metric_timestamp}} --signal_output ${{outputs.signal_output}} $[[--samples_index ${{inputs.samples_index}}]]
+command: >-
+  python -m model_monitor_metric_outputter.run
+  --monitor_name ${{inputs.monitor_name}}
+  --signal_name ${{inputs.signal_name}}
+  --signal_type ${{inputs.signal_type}}
+  --signal_metrics ${{inputs.signal_metrics}}
+  --metric_timestamp ${{inputs.metric_timestamp}}
+  --signal_output ${{outputs.signal_output}}
+  $[[--samples_index ${{inputs.samples_index}}]]

--- a/assets/model_monitoring/amlcompute_components/src/model_data_collector_preprocessor/run.py
+++ b/assets/model_monitoring/amlcompute_components/src/model_data_collector_preprocessor/run.py
@@ -79,7 +79,7 @@ def mdc_preprocessor(
 
     # Save preprocessed_data MLTable to temp location
     des_path = preprocessed_input_data + "/temp"
-    shutil.copytree(save_path, des_path)
+    shutil.copytree(save_path, des_path, dirs_exist_ok=True)
 
     # Read mltable from preprocessed_data
     df = read_mltable_in_spark(mltable_path=des_path)

--- a/assets/model_monitoring/amlcompute_components/src/model_data_collector_preprocessor/run.py
+++ b/assets/model_monitoring/amlcompute_components/src/model_data_collector_preprocessor/run.py
@@ -10,19 +10,20 @@ import tempfile
 from azureml.fsspec import AzureMachineLearningFileSystem
 from datetime import datetime
 from pyspark.sql.functions import col, lit
-from shared_utilities.datetime_utils import parse_datetime_from_string
-from shared_utilities.io_utils import (
-    init_spark,
-    read_mltable_in_spark,
-    save_spark_df_as_mltable,
-)
 
 from shared_utilities.constants import (
     MDC_CHAT_HISTORY_COLUMN,
     MDC_CORRELATION_ID_COLUMN,
     MDC_DATA_COLUMN
 )
-
+from shared_utilities.datetime_utils import parse_datetime_from_string
+from shared_utilities.io_utils import (
+    init_spark,
+    read_mltable_in_spark,
+    save_spark_df_as_mltable,
+)
+from shared_utilities.patch_mltable import patch_all
+patch_all()
 
 def _convert_uri_folder_to_mltable(
     start_datetime: datetime,

--- a/assets/model_monitoring/amlcompute_components/src/model_data_collector_preprocessor/run.py
+++ b/assets/model_monitoring/amlcompute_components/src/model_data_collector_preprocessor/run.py
@@ -26,6 +26,7 @@ from shared_utilities.io_utils import (
 from shared_utilities.patch_mltable import patch_all
 patch_all()
 
+
 def _convert_uri_folder_to_mltable(
     start_datetime: datetime,
     end_datetime: datetime,

--- a/assets/model_monitoring/amlcompute_components/src/model_monitor_create_manifest/run.py
+++ b/assets/model_monitoring/amlcompute_components/src/model_monitor_create_manifest/run.py
@@ -7,9 +7,10 @@ import argparse
 import glob
 import json
 import os
+import shutil
 import uuid
 
-from shared_utilities.amlfs import amlfs_put_as_json, amlfs_download, amlfs_upload
+from shared_utilities.io_utils import save_dict_as_json
 from shared_utilities.patch_mltable import patch_all
 patch_all()
 
@@ -51,13 +52,12 @@ def run():
 
     temp_path = str(uuid.uuid4())
     for signal_output in signals_outputs:
-        amlfs_download(remote_path=signal_output, local_path=temp_path)
-    amlfs_upload(local_path=temp_path, remote_path=args.model_monitor_metrics_output)
-    amlfs_put_as_json(
-        _generate_manifest(temp_path),
-        args.model_monitor_metrics_output,
-        "manifest.json",
-    )
+        shutil.copytree(signal_output, temp_path, dirs_exist_ok=True)
+        shutil.copytree(temp_path, args.model_monitor_metrics_output, dirs_exist_ok=True)
+
+        manifest_dict = _generate_manifest(temp_path)
+        manifest_dest_path = os.path.join(args.model_monitor_metrics_output, "manifest.json")
+        save_dict_as_json(manifest_dict, manifest_dest_path)
 
     print("*************** output metrics ***************")
     print("Successfully executed the create manifest component.")

--- a/assets/model_monitoring/amlcompute_components/src/model_monitor_create_manifest/run.py
+++ b/assets/model_monitoring/amlcompute_components/src/model_monitor_create_manifest/run.py
@@ -8,9 +8,9 @@ import glob
 import json
 import os
 import uuid
-from shared_utilities.patch_mltable import patch_all
-from shared_utilities.amlfs import amlfs_put_as_json, amlfs_download, amlfs_upload
 
+from shared_utilities.amlfs import amlfs_put_as_json, amlfs_download, amlfs_upload
+from shared_utilities.patch_mltable import patch_all
 patch_all()
 
 

--- a/assets/model_monitoring/amlcompute_components/src/model_monitor_data_joiner/run.py
+++ b/assets/model_monitoring/amlcompute_components/src/model_monitor_data_joiner/run.py
@@ -14,6 +14,7 @@ from shared_utilities.io_utils import (
 from shared_utilities.patch_mltable import patch_all
 patch_all()
 
+
 def _validate_join_column_in_input_data(
     input_data_df: pyspark_sql.DataFrame,
     join_column: str,

--- a/assets/model_monitoring/amlcompute_components/src/model_monitor_data_joiner/run.py
+++ b/assets/model_monitoring/amlcompute_components/src/model_monitor_data_joiner/run.py
@@ -5,12 +5,14 @@
 
 import argparse
 import pyspark.sql as pyspark_sql
+
 from shared_utilities.event_utils import post_warning_event
 from shared_utilities.io_utils import (
     read_mltable_in_spark,
     save_spark_df_as_mltable,
 )
-
+from shared_utilities.patch_mltable import patch_all
+patch_all()
 
 def _validate_join_column_in_input_data(
     input_data_df: pyspark_sql.DataFrame,

--- a/assets/model_monitoring/amlcompute_components/src/model_monitor_metric_outputter/run.py
+++ b/assets/model_monitoring/amlcompute_components/src/model_monitor_metric_outputter/run.py
@@ -23,6 +23,8 @@ from shared_utilities.io_utils import (
     np_encoder,
     read_mltable_in_spark,
 )
+from shared_utilities.patch_mltable import patch_all
+patch_all()
 
 
 def run():

--- a/assets/model_monitoring/amlcompute_components/src/shared_utilities/io_utils.py
+++ b/assets/model_monitoring/amlcompute_components/src/shared_utilities/io_utils.py
@@ -15,6 +15,9 @@ def _get_datastore_id():
               + r"/microsoft.machinelearningservices/workspaces/(.+?)$"
 
     match = re.search(pattern, workspace_scope)
+    if not match:
+        raise ValueError(f"'{workspace_scope}' is not a valid workspace scope.")
+
     subscription_id = match.group(1)
     resource_group_name = match.group(2)
     workspace_name = match.group(3)
@@ -30,6 +33,9 @@ def _get_datastore_relative_data_path(data_path):
     pattern = r"^(.+?)/cap/data-capability/wd/(.+?)$"
 
     match = re.search(pattern, data_path)
+    if not match:
+        raise ValueError(f"'{data_path}' is not a valid data path.")
+
     output_folder = match.group(2)
 
     return f"paths/azureml/{job_id}/{output_folder}"

--- a/assets/model_monitoring/amlcompute_components/src/shared_utilities/io_utils.py
+++ b/assets/model_monitoring/amlcompute_components/src/shared_utilities/io_utils.py
@@ -4,11 +4,11 @@
 """This file contains utilities to read write data."""
 
 import numpy as np
+import os
 from pyspark.sql import SparkSession
 
 
 def _get_datastore_id():
-    import os
     import re
     workspace_scope = os.environ['AZUREML_WORKSPACE_SCOPE'].lower()
     pattern = r"^/subscriptions/(.+?)/resourcegroups/(.+?)/providers"\
@@ -27,7 +27,6 @@ def _get_datastore_id():
 
 
 def _get_datastore_relative_data_path(data_path):
-    import os
     import re
     job_id = os.environ['AZUREML_RUN_ID']
     pattern = r"^(.+?)/cap/data-capability/wd/(.+?)$"
@@ -43,7 +42,6 @@ def _get_datastore_relative_data_path(data_path):
 
 def convert_to_azureml_uri(data_path: str):
     """Convert the local data path to azureml data path uri."""
-    import os
     datastore_id = _get_datastore_id()
     relative_data_path = _get_datastore_relative_data_path(data_path)
 
@@ -60,6 +58,21 @@ def np_encoder(object):
     """Json encoder for numpy types."""
     if isinstance(object, np.generic):
         return object.item()
+
+
+def save_dict_as_json(payload: dict, dest_path: str):
+    """Save a dictionary object in json format to the destination path.
+
+    Args:
+        payload: The dictionary object to be uploaded.
+        dest_path: The destination path.
+    """
+    import json
+    content = json.dumps(payload, indent=4, default=np_encoder)
+
+    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+    with open(dest_path, "w") as fp:
+        fp.write(content)
 
 
 def read_mltable_in_spark(mltable_path: str):

--- a/assets/model_monitoring/amlcompute_components/tests/e2e/test_create_manifest_e2e.py
+++ b/assets/model_monitoring/amlcompute_components/tests/e2e/test_create_manifest_e2e.py
@@ -5,7 +5,7 @@
 
 import pytest
 from azure.ai.ml import MLClient, Output, Input
-from azure.ai.ml.entities import Spark, AmlTokenConfiguration
+from azure.ai.ml.entities import Command
 from azure.ai.ml.dsl import pipeline
 from tests.e2e.utils.constants import (
     COMPONENT_NAME_DATA_DRIFT_SIGNAL_MONITOR,
@@ -43,7 +43,7 @@ def _submit_data_drift_and_create_manifest_job(
             notification_emails="yeta@microsoft.com",
         )
 
-        create_manifest_output: Spark = create_manifest(
+        create_manifest_output: Command = create_manifest(
             signal_outputs_1=dd_model_monitor_metrics_output.outputs.signal_output,
         )
 


### PR DESCRIPTION
Changes:
- Update mdc preprocessor command component
- Update create manifest command compoent
- Fix a bug in data drift command component output spec
- Give better exception messages when conversion from local path to azureml path fails.

Test job: https://ml.azure.com/experiments/id/9fec6fb8-5992-4a91-a6d2-1b935493209b/runs/loyal_tiger_ghjly8s1cz?wsid=/subscriptions/ea4faa5b-5e44-4236-91f6-5483d5b17d14/resourcegroups/yeta-eastus-rg/providers/Microsoft.MachineLearningServices/workspaces/yeta-eastus-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#