### PR TITLE
Fix endpoint deployment failure scenario and MLTable as read-only input

### DIFF
--- a/assets/aml-benchmark/README.md
+++ b/assets/aml-benchmark/README.md
@@ -22,15 +22,24 @@ Inside the `aml-benchmark` directory, there are two subdirectories:
     * `pipelines/`: contains the pipelines to test the components, each component has its corresponding pipeline file.
     * `test_component_name.py`- contains the tests for the component, each component has its corresponding test file.
 
-## Note
+# Guidelines
 - All custom exceptions must be defined in `components/src/utils/exceptions.py`.
 - All custom errors must be defined in `components/src/utils/error_definitions.py`.
 - All custom error strings which can be shared among components must be defined in `components/src/utils/error_strings.py`.
+- import statements must follow the following order:
+    - Standard library imports, followed by a newline.
+    - Third party imports, followed by a newline.
+    - Local application imports.
 - Entry function for every component must satisfy the following criteria:
     - Must be defined in a script named `main.py`.
     - Must be named `main`.
     - Must be decorated with `swallow_all_exceptions`.
     - Must state all the arguments that the function accepts instead of accepting a single argument `argparse.Namespace`.
+- Every test file for a component must have the following classes:
+    - `Test<component_name>Component`: **Required**, contains the e2e tests for the component that requires submission to AML workspace. Try to keep the number of tests to a minimum while making sure all of the inputs are tested once.
+        - All the tests inside this class must use a single experiment name i.e. `<component-name>-test` and each test can use the method name as the run's display name.
+    - `Test<component_name>Script`: **Required**, contains the remaining e2e tests for the component. Must test all possible input combinations and the exceptions that the component can raise.
+    - `Test<component_name>Unit`: **Optional**, contains the unit tests for the component.
 
 # Before creating a PR, please make sure to go through the following points:
 > These are not mandatory to run manually but recommended. Allows to detect issues early, which otherwise would be detected by failing workflows after PR creation.

--- a/assets/aml-benchmark/components/dataset-sampler/spec.yaml
+++ b/assets/aml-benchmark/components/dataset-sampler/spec.yaml
@@ -44,7 +44,7 @@ inputs:
 outputs:
   output_dataset:
     type: uri_file
-    description: Path to the output file.
+    description: Path to the jsonl file where the sampled dataset will be saved.
 
 code: ../src
 environment: azureml://registries/azureml/environments/model-evaluation/labels/latest

--- a/assets/aml-benchmark/components/src/utils/io.py
+++ b/assets/aml-benchmark/components/src/utils/io.py
@@ -99,7 +99,7 @@ def resolve_io_path(dataset: str) -> List[str]:
             "Received 'dataset' as MLTable. Trying to process."
         )
         df = mltable.load(dataset).to_pandas_dataframe()
-        file_path = os.path.join(dataset, f"{uuid.uuid4()}.jsonl")
+        file_path = os.path.join(os.getcwd(), f"{uuid.uuid4()}.jsonl")
         df.to_json(file_path, orient="records", lines=True)
         return [file_path]
 

--- a/assets/aml-benchmark/tests/test_batch_benchmark_inference.py
+++ b/assets/aml-benchmark/tests/test_batch_benchmark_inference.py
@@ -206,9 +206,9 @@ class TestBatchBenchmarkInferenceComponent:
             )
         output_dir = os.path.join(output_dir, "named-outputs")
         self._check_output_data(
-            os.path.join(output_dir, "prediction_data"), "prediction_data", ["prediction"])
+            os.path.join(output_dir, "prediction_data"), "prediction.jsonl", ["prediction"])
         self._check_output_data(
-            os.path.join(output_dir, "perf_data"), "perf_data", ["start", "end", "latency"])
+            os.path.join(output_dir, "perf_data"), "perf_data.jsonl", ["start", "end", "latency"])
         self._check_output_data(
             os.path.join(
-                output_dir, "ground_truth_data"), "ground_truth_data", ["ground_truth"])
+                output_dir, "ground_truth_data"), "ground_truth_data.jsonl", ["ground_truth"])

--- a/assets/aml-benchmark/tests/utils.py
+++ b/assets/aml-benchmark/tests/utils.py
@@ -297,7 +297,7 @@ def deploy_fake_test_endpoint_maybe(
     should_deploy = False
     should_wait = True
     if use_workspace_name:
-        endpoint_name = f"{endpoint_name}-{ml_client.workspace_name}"
+        endpoint_name = f"{endpoint_name}-{ml_client.workspace_name.split('-')[-1]}"
     try:
         while should_wait:
             endpoint = ml_client.online_endpoints.get(name=endpoint_name)

--- a/assets/aml-benchmark/tests/utils.py
+++ b/assets/aml-benchmark/tests/utils.py
@@ -268,6 +268,7 @@ def _deploy_endpoint(ml_client, endpoint_name):
             auth_mode="key"
         )
     ml_client.online_endpoints.begin_create_or_update(endpoint).wait()
+    endpoint = ml_client.online_endpoints.get(name=endpoint_name)
     return endpoint
 
 

--- a/assets/aml-benchmark/tests/utils.py
+++ b/assets/aml-benchmark/tests/utils.py
@@ -301,6 +301,10 @@ def deploy_fake_test_endpoint_maybe(
             if endpoint.provisioning_state.lower() in ["creating", "updating", 'deleting', 'provisioning']:
                 time.sleep(30)
                 continue
+            elif endpoint.provisioning_state.lower() == 'failed':
+                ml_client.online_endpoints.begin_delete(name=endpoint_name)
+                should_deploy = True
+                break
             deployment = ml_client.online_deployments.get(
                 endpoint_name=endpoint_name, name=deployment_name)
             if deployment.provisioning_state.lower() == 'failed':

--- a/assets/aml-benchmark/tests/utils.py
+++ b/assets/aml-benchmark/tests/utils.py
@@ -290,11 +290,13 @@ def _deploy_fake_model(ml_client, endpoint_name, deployment_name):
 
 
 def deploy_fake_test_endpoint_maybe(
-        ml_client, endpoint_name="aml-benchmark-test-bzvkqd", deployment_name="test-model"
+        ml_client, endpoint_name="benchmark", deployment_name="test-model", use_workspace_name=True
 ):
     """Deploy a fake test endpoint."""
     should_deploy = False
     should_wait = True
+    if use_workspace_name:
+        endpoint_name = f"{endpoint_name}-{ml_client.workspace_name}"
     try:
         while should_wait:
             endpoint = ml_client.online_endpoints.get(name=endpoint_name)


### PR DESCRIPTION
This PR fixes the following scenario:
- endpoint deployment failure scenario
- MLTable as read-only input
- update the readme to include more guidelines