### PR TITLE
Improve sovereign cloud support by removing direct reference to Azure Public Cloud 

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## 1.16.3 (2023-09-26)
 ### 🐛 Bugs Fixed
 - [#1317](https://github.com/Azure/azureml-assets/pull/1317) Improve sovereign cloud support by removing direct reference to Azure Public Cloud
-- 
+
 ## 1.16.2 (2023-09-23)
 ### 🐛 Bugs Fixed
 - [#1288](https://github.com/Azure/azureml-assets/pull/1288) Add arg for no-op model updates

--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.16.3 (2023-09-26)
+### 🐛 Bugs Fixed
+- [#1317](https://github.com/Azure/azureml-assets/pull/1317) Improve sovereign cloud support by removing direct reference to Azure Public Cloud
+- 
 ## 1.16.2 (2023-09-23)
 ### 🐛 Bugs Fixed
 - [#1288](https://github.com/Azure/azureml-assets/pull/1288) Add arg for no-op model updates

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from ruamel.yaml import YAML
 from packaging import version
 from typing import Dict, List, Set, Tuple, Union
+from azure.ai.ml._azure_environments import _get_storage_endpoint_from_metadata
 
 
 class ValidationException(Exception):
@@ -446,8 +447,6 @@ class LocalAssetPath(AssetPath):
 class AzureBlobstoreAssetPath(AssetPath):
     """Azure Blobstore asset path."""
 
-    BLOBSTORE_URI = "https://{}.blob.core.windows.net/{}/{}"
-
     def __init__(self, storage_name: str, container_name: str, container_path: str):
         """Create a Blobstore path.
 
@@ -461,7 +460,8 @@ class AzureBlobstoreAssetPath(AssetPath):
         self._storage_name = storage_name
         self._container_name = container_name
         self._container_path = container_path
-        uri = AzureBlobstoreAssetPath.BLOBSTORE_URI.format(storage_name, container_name, container_path)
+
+        uri = f"https://{storage_name}.blob.{_get_storage_endpoint_from_metadata()}/{container_name}/{container_path}"
         super().__init__(PathType.AZUREBLOB, uri)
 
 

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.2",
+   version="1.16.3",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
The class `AzureBlobstoreAssetPath` has a hard coded reference to the storage account URL associated with Azure Public Cloud. This PR modifies the implementation to use the multi cloud support embedded with the Azure Machine Learning SDK to use the correct, cloud specific storage account URL.