### PR TITLE
passing the tokenizer settings from finetune to eval

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -203,6 +203,14 @@ ACFT_CONFIG = {
         "load_tokenizer_kwargs": {
             "add_eos_token": True,
             "padding_side": "right"
+        },
+        "mlflow_ft_conf": {
+            "mlflow_hftransformers_misc_conf": {
+                "tokenizer_hf_load_kwargs": {
+                    "add_eos_token": True,
+                    "padding_side": "right",
+                },
+            }
         }
     }
 }


### PR DESCRIPTION
The finetune uses the _eos_token_ and _padding_side_ parameters while loading the tokenizer. Setting the mlflow model file with same params to be used in evaluation