### PR TITLE
fix overriding of sys prompts

### DIFF
--- a/assets/training/model_management/environments/foundation-model-inference/context/score.py
+++ b/assets/training/model_management/environments/foundation-model-inference/context/score.py
@@ -603,7 +603,7 @@ def build_chat_completion_prompt(data: List[str]) -> dict:
     assert len(conv_arr) > 0
     assert conv_arr[-1]["role"] == "user"
     next_turn = "system" if conv_arr[0]["role"] == "system" else "user"
-    system_message=""
+    system_message = ""
     # Build conversation
     if next_turn == "system":
         content = conv_arr[0]["content"].strip()

--- a/assets/training/model_management/environments/foundation-model-inference/context/score.py
+++ b/assets/training/model_management/environments/foundation-model-inference/context/score.py
@@ -603,16 +603,16 @@ def build_chat_completion_prompt(data: List[str]) -> dict:
     assert len(conv_arr) > 0
     assert conv_arr[-1]["role"] == "user"
     next_turn = "system" if conv_arr[0]["role"] == "system" else "user"
+    system_message=""
     # Build conversation
+    if next_turn == "system":
+        content = conv_arr[0]["content"].strip()
+        _check_unsafe_content(content)
+        system_message = B_SYS + content + E_SYS
+        conv_arr = conv_arr[1:]
+        next_turn = "user"
     conversation = Conversation()
     for i, conv in enumerate(conv_arr):
-        if conv["role"] == "system":
-            assert next_turn == "system", "System prompts can only be set at the start of the conversation"
-            next_turn = "user"
-            content = conv_arr[0]["content"].strip()
-            _check_unsafe_content(content)
-            conversation.add_user_input(B_SYS + content + E_SYS)
-            conversation.mark_processed()
         if conv["role"] == "assistant":
             assert next_turn == "assistant", "Invalid Turn. Expected user input"
             next_turn = "user"
@@ -624,7 +624,11 @@ def build_chat_completion_prompt(data: List[str]) -> dict:
             next_turn = "assistant"
             content = conv["content"].strip()
             _check_unsafe_content(content)
-            conversation.add_user_input(content)
+            if system_message:
+                conversation.add_user_input(system_message + content)
+                system_message = ""
+            else:
+                conversation.add_user_input(content)
             if i != len(conv_arr[0:]) - 1:
                 conversation.mark_processed()
     conv_dict = conversation.__dict__


### PR DESCRIPTION
Fixes issues with overriding of sys prompt from the User. When there is only one user prompt.

```
data2 = {
    "inp": [
            { 
        "role": "system", 
        "content": "Only answer with emojis and nothing else" 
      }, 
      { 
        "role": "user", 
        "content": "I am going to Paris, what should I see?" 
      }
        ],
    "parameters": {
      "max_length": 2048,
      "temperature": 0.8,
      "top_p": 0.7,
      "do_sample": True,
      "max_new_tokens": 256
    }
}

```


![image](https://github.com/Azure/azureml-assets/assets/41802116/f0e432f2-05fd-4a27-b669-bdbc44eefe13)


