### PR TITLE
Benchmark result aggregator test failure fix

### DIFF
--- a/assets/aml-benchmark/tests/pipelines/benchmark_result_aggregator_pipeline.yaml
+++ b/assets/aml-benchmark/tests/pipelines/benchmark_result_aggregator_pipeline.yaml
@@ -51,6 +51,7 @@ jobs:
         type: uri_folder
         path: ${{parent.jobs.evaluation.outputs.predictions}}
       task: text-classification
+      ground_truth_column_name: ground_truth
     outputs:
       evaluation_result:
         type: uri_folder

--- a/assets/aml-benchmark/tests/pipelines/benchmark_result_aggregator_pipeline_no_perf.yaml
+++ b/assets/aml-benchmark/tests/pipelines/benchmark_result_aggregator_pipeline_no_perf.yaml
@@ -51,6 +51,7 @@ jobs:
         type: uri_folder
         path: ${{parent.jobs.evaluation.outputs.predictions}}
       task: text-classification
+      ground_truth_column_name: ground_truth
     outputs:
       evaluation_result:
         type: uri_folder


### PR DESCRIPTION
The test was failing because of a new bug in `compute_metrics` component. To make the test pass, an workaround has been used by explicitly passing the ground_truth column name.