### PR TITLE
Add new asset type for benchmark results

### DIFF
--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -21,6 +21,7 @@ class ValidationException(Exception):
 class AssetType(Enum):
     """Asset type."""
 
+    BENCHMARKRESULT = 'benchmarkresult'
     COMPONENT = 'component'
     DATA = 'data'
     ENVIRONMENT = 'environment'


### PR DESCRIPTION
Adding another asset type for benchmark results.  This should be the last one for ignite, and then we will refactor this to be more generic.  (Ideally, we should be able to add new asset types without updating the enum every time.