### PR TITLE
Phi support

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -360,6 +360,10 @@ def model_selector(args: Namespace):
     except Exception:
         logger.info(f"Unable to fetch model_type for {model_name}")
 
+    if model_type is not None:
+        logger.info(f"Setting model_type in model_selector args - {model_type}")
+        model_selector_args["model_type"] = model_type
+
     if model_type is not None and model_type in ACFT_CONFIG:
         model_ft_config = copy.deepcopy(ACFT_CONFIG[model_type])
         model_ft_config.update(ft_config_data)
@@ -427,6 +431,9 @@ def model_selector(args: Namespace):
     # saving FT config
     with open(str(Path(args.output_dir, SaveFileConstants.ACFT_CONFIG_SAVE_PATH)), "w") as rptr:
         json.dump(ft_config_data, rptr, indent=2)
+    # updating model selector args
+    with open(str(Path(args.output_dir, SaveFileConstants.MODEL_SELECTOR_ARGS_SAVE_PATH)), "w") as rptr:
+        json.dump(model_selector_args, rptr, indent=2)
     logger.info(f"Saved {SaveFileConstants.ACFT_CONFIG_SAVE_PATH}")
 
     # additional logging


### PR DESCRIPTION
Added from_pretrained override function for AutoConfig, AutoTokenizer and Auto trainer class to support Phi model finetuning

The above logic will be moved as part of model specific config

Testing
===
Successful FT run: https://ml.azure.com/runs/d7c67cb6-a163-4337-b94d-8203cf5596a2?wsid=%2Fsubscriptions%2Fed2cab61-14cc-4fb3-ac23-d72609214cfd%2Fresourcegroups%2Ftraining_rg%2Fworkspaces%2Ftraining_ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47&reloadCount=1#

In discussion with eval team to understand eval component failure