### PR TITLE
Azure OpenAI v2 pipeline component update

### DIFF
--- a/assets/large_language_models/components_pipelines/oai_v2_1p/openai_completions_finetune_pipeline/spec.yaml
+++ b/assets/large_language_models/components_pipelines/oai_v2_1p/openai_completions_finetune_pipeline/spec.yaml
@@ -1,6 +1,6 @@
 $schema: http://azureml/sdk-2-0/PipelineComponent.json
 type: pipeline
-version: 0.0.8
+version: 0.0.9
 name: openai_completions_finetune_pipeline
 display_name: OpenAI Completions Finetune Pipeline
 description: Finetune your own OAI model. Visit https://learn.microsoft.com/en-us/azure/cognitive-services/openai/ for more info.


### PR DESCRIPTION
1. Exposing `learning_rate_multiplier` and `batch_size` parameters in oai v2 finetune pipeline component
2. Upgrading `openai_completions_finetune` component version from 0.3.5 to 0.3.10
3. Renamed `epochs` parameter to `n_epochs` to align with OpenAI