### PR TITLE
Update ft tags for llama models 7b 13b 70b & ORT support enabled for 13b

### DIFF
--- a/assets/models/system/Llama-2-13b/spec.yaml
+++ b/assets/models/system/Llama-2-13b/spec.yaml
@@ -45,7 +45,7 @@ tags:
   model_specific_defaults:
     apply_deepspeed: 'true'
     apply_lora: 'true'
-    apply_lora: 'true'
+    apply_ort: 'true'
     precision: '16'
   task: text-generation
   inference_supported_envs:

--- a/assets/models/system/Llama-2-13b/spec.yaml
+++ b/assets/models/system/Llama-2-13b/spec.yaml
@@ -20,6 +20,9 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
+  - Standard_NC24ads_A100_v4
+  - Standard_NC48ads_A100_v4 
+  - Standard_NC96ads_A100_v4
   evaluation_compute_allow_list:
   - Standard_NC24s_v3
   - Standard_ND40rs_v2
@@ -30,6 +33,7 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
+  
   sku_to_num_replicas_map:
     Standard_NC24s_v3: 1
     Standard_ND40rs_v2: 4
@@ -39,9 +43,10 @@ tags:
   license: custom
   author: meta
   model_specific_defaults:
-    apply_deepspeed: 'false'
+    apply_deepspeed: 'true'
     apply_lora: 'true'
-    precision: '4'
+    apply_lora: 'true'
+    precision: '16'
   task: text-generation
   inference_supported_envs:
   - ds_mii

--- a/assets/models/system/Llama-2-70b/spec.yaml
+++ b/assets/models/system/Llama-2-70b/spec.yaml
@@ -23,6 +23,9 @@ tags:
   - Standard_NC96ads_A100_v4
   finetune_compute_allow_list:
   - Standard_ND96amsr_A100_v4
+  - Standard_NC24ads_A100_v4
+  - Standard_NC48ads_A100_v4 
+  - Standard_NC96ads_A100_v4
   license: custom
   author: meta
   model_specific_defaults:

--- a/assets/models/system/Llama-2-7b/spec.yaml
+++ b/assets/models/system/Llama-2-7b/spec.yaml
@@ -20,6 +20,9 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
+  - Standard_NC24ads_A100_v4
+  - Standard_NC48ads_A100_v4 
+  - Standard_NC96ads_A100_v4
   evaluation_compute_allow_list:
   - Standard_NC12s_v3
   - Standard_NC24s_v3


### PR DESCRIPTION
Please review this PR
Following Changes were made.
1 spec.yaml files for all 3 llama_models where updated for finetune compute allowed list by adding Standard_NC24ads_A100_v4, Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4 
2 for model 13b ORT support enabled in  model_specific_defaults.
@amangupta26 @novaturient95 