### PR TITLE
Fix the environment

### DIFF
--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_collect/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_collect/spec.yaml
@@ -32,7 +32,7 @@ outputs:
     description: 'jsonl used for evaluation component.'
 
 code: ../../src/collect
-environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+environment: azureml://registries/azureml/environments/automl-gpu/versions/3
 
 command: >-
   python collect.py 

--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_setup/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_setup/spec.yaml
@@ -67,7 +67,7 @@ outputs:
 
 
 code: ../../src/setup
-environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+environment: azureml://registries/azureml/environments/automl-gpu/versions/3
 
 command: >-
   python setup.py 

--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_prs_inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_prs_inference/spec.yaml
@@ -58,7 +58,7 @@ task:
   type: run_function
   code: ../../src/inference
   entry_script: inference.py
-  environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+  environment: azureml://registries/azureml/environments/automl-gpu/versions/3
   program_arguments: >-
     --setup-metadata ${{inputs.metadata}}
     --error_threshold -1

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_data_agg/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_data_agg/spec.yaml
@@ -58,7 +58,7 @@ task:
   type: run_function
   code: ../../src/data_agg
   entry_script: data_agg.py
-  environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+  environment: azureml://registries/azureml/environments/automl-gpu/versions/3
   program_arguments: >-
     --input-metadata ${{inputs.metadata}}
     --error_threshold -1

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_prs_train/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_prs_train/spec.yaml
@@ -58,7 +58,7 @@ task:
   type: run_function
   code: ../../src/train
   entry_script: train.py
-  environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+  environment: azureml://registries/azureml/environments/automl-gpu/versions/3
   program_arguments: >-
     --input-metadata ${{inputs.metadata}}
     --error_threshold -1

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_collect/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_collect/spec.yaml
@@ -23,7 +23,7 @@ outputs:
     description: 'Output metadata that contains train status.'
 
 code: ../../src/collect
-environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+environment: azureml://registries/azureml/environments/automl-gpu/versions/3
 
 command: >-
   python collect.py 

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_setup/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_setup/spec.yaml
@@ -37,7 +37,7 @@ outputs:
 
 
 code: ../../src/setup
-environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+environment: azureml://registries/azureml/environments/automl-gpu/versions/3
 
 command: >-
   python setup.py 

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_prs_train/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_prs_train/spec.yaml
@@ -57,7 +57,7 @@ task:
   type: run_function
   code: ../../src/train
   entry_script: train.py
-  environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+  environment: azureml://registries/azureml/environments/automl-gpu/versions/3
   program_arguments: >-
     --input-metadata ${{inputs.metadata}}
     --error_threshold -1

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_collect/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_collect/spec.yaml
@@ -25,7 +25,7 @@ outputs:
 
 
 code: ../../src/collect
-environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+environment: azureml://registries/azureml/environments/automl-gpu/versions/3
 
 command: >-
   python collect.py 

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_setup/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_setup/spec.yaml
@@ -45,7 +45,7 @@ outputs:
     description: 'The processed data from train setup run.'
 
 code: ../../src/setup
-environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+environment: azureml://registries/azureml/environments/automl-gpu/versions/3
 
 command: >-
   python setup.py 

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_collect_inf/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_collect_inf/spec.yaml
@@ -33,7 +33,7 @@ outputs:
     description: 'jsonl used for evaluation components.'
 
 code: ../src/collect
-environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+environment: azureml://registries/azureml/environments/automl-gpu/versions/3
 
 command: >-
   python collect.py 

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_prs_inferencing/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_prs_inferencing/spec.yaml
@@ -59,7 +59,7 @@ task:
   type: run_function
   code: ../src/inference
   entry_script: inference.py
-  environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+  environment: azureml://registries/azureml/environments/automl-gpu/versions/3
   program_arguments: >-
     --setup-metadata ${{inputs.metadata}}
     --error_threshold -1

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_setup_inf/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_setup_inf/spec.yaml
@@ -87,7 +87,7 @@ outputs:
     description: 'The processed data after setup step.'
 
 code: ../src/setup
-environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+environment: azureml://registries/azureml/environments/automl-gpu/versions/3
 
 command: >-
   python setup.py 

--- a/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
@@ -41,7 +41,7 @@ outputs:
     description: "The evaluation config file which can be consumed by the compute metrics component."
 
 code: ../../src
-environment: azureml://registries/azureml/environments/automl-gpu/versions/2
+environment: azureml://registries/azureml/environments/automl-gpu/versions/3
 
 command: >-
   python inference.py

--- a/assets/training/forecasting_demand/environments/automl-gpu/asset.yaml
+++ b/assets/training/forecasting_demand/environments/automl-gpu/asset.yaml
@@ -1,5 +1,5 @@
 name: automl-gpu
-version: 2
+version: 3
 type: environment
 spec: spec.yaml
 extra_config: environment.yaml

--- a/assets/training/forecasting_demand/environments/automl-gpu/context/conda_dependencies.yaml
+++ b/assets/training/forecasting_demand/environments/automl-gpu/context/conda_dependencies.yaml
@@ -14,7 +14,6 @@ dependencies:
 - pyopenssl=23.2.0
 - psutil>=5.2.2,<6.0.0
 - GitPython=3.1.32
-- scipy~=1.7.0
 - tqdm
 - setuptools=65.5.1
 - wheel=0.38.1

--- a/assets/training/forecasting_demand/environments/automl-gpu/context/conda_dependencies.yaml
+++ b/assets/training/forecasting_demand/environments/automl-gpu/context/conda_dependencies.yaml
@@ -6,7 +6,6 @@ dependencies:
 - python=3.8
 - pip=22.1.2
 - numpy~=1.22.3
-- scikit-learn=1.1.3
 - pandas~=1.3.5
 - py-xgboost=1.3.3
 - holidays=0.10.3
@@ -35,6 +34,8 @@ dependencies:
   - azureml-train-automl=={{latest-pypi-version}}
   - azureml-contrib-automl-dnn-forecasting=={{latest-pypi-version}}
   - https://aka.ms/automl-resources/packages/en_core_web_sm-2.1.0.tar.gz
+  - cryptography>=41.0.2
+  - scipy==1.11.0
   - spacy==2.1.8
   - prophet==1.1.4
   - py-cpuinfo==5.0.0

--- a/assets/training/forecasting_demand/environments/automl-gpu/context/conda_dependencies.yaml
+++ b/assets/training/forecasting_demand/environments/automl-gpu/context/conda_dependencies.yaml
@@ -35,7 +35,7 @@ dependencies:
   - azureml-contrib-automl-dnn-forecasting=={{latest-pypi-version}}
   - https://aka.ms/automl-resources/packages/en_core_web_sm-2.1.0.tar.gz
   - cryptography>=41.0.2
-  - scipy==1.11.0
+  - scipy==1.10.1
   - spacy==2.1.8
   - prophet==1.1.4
   - py-cpuinfo==5.0.0


### PR DESCRIPTION
In the previous version of environment, conda used to build and install the old version of cryptography and scipy. In this fix we are  pinning the versions to avoid this issue.