### PR TITLE
Mitigate issue with long prompts for LLaVA 7B on V100

### DIFF
--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/config.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/config.py
@@ -6,6 +6,9 @@
 from enum import Enum
 
 
+MAX_PROMPT_LENGTH = 800
+
+
 class _CustomEnum(Enum):
     @classmethod
     def has_value(cls, value):

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/llava_mlflow_wrapper.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/llava_mlflow_wrapper.py
@@ -12,7 +12,7 @@ import pandas as pd
 from PIL import Image
 from transformers import TextStreamer
 
-from config import MLflowLiterals, MLflowSchemaLiterals, Tasks
+from config import MAX_PROMPT_LENGTH, MLflowLiterals, MLflowSchemaLiterals, Tasks
 
 
 class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
@@ -159,6 +159,12 @@ class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
                 prompt, self._tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
             ).unsqueeze(0).cuda()
             stopping_criteria = KeywordsStoppingCriteria([self._stop_str], self._tokenizer, input_ids)
+
+            # Long prompts cause a GPU OOMs which the server does not recover from. To prevent this, we are using a
+            # length threshold that allows for a small number of question-answer pairs (e.g. 5-10) in each prompt.
+            prompt_length = max([len(i) for i in input_ids])
+            if prompt_length > MAX_PROMPT_LENGTH:
+                raise ValueError(f"Prompt too long: {prompt_length} tokens. Maximum allowed is {MAX_PROMPT_LENGTH}.")
 
             # Call model.
             output_ids = self._model.generate(


### PR DESCRIPTION
On V100 machines, long LLaVA prompts may cause GPU OOM errors which the endpoint/server does not recover from. This PR imposes an upper bound on the number of prompt tokens and throws a `ValueError` exception for longer prompts instead of doing inference on them. This effectively upper bounds the number of questions in a dialog to 5-10 (actual number dependent on question and answer length), but ensures that dialogs do not break the server.
On A100 machines, the memory consumption is normally around 22GB for the 13B model, so no issues.

Tested by
1. Running an endpoint with modified code and sending it questions until it raises the `ValueError` exception. (V100, 7B)
2. Running the LLaVA cli client on an A100 machine.

Screenshots with details for the above are in private chat.
