### PR TITLE
Allow downloading a subset of configurations

### DIFF
--- a/assets/aml-benchmark/components/dataset-downloader/spec.yaml
+++ b/assets/aml-benchmark/components/dataset-downloader/spec.yaml
@@ -13,7 +13,9 @@ inputs:
     optional: True
   configuration:
     type: string
-    description: If a specific sub-dataset of the dataset to download, specify the configuration name; specify 'all' to download all configurations. Else, leave it null.
+    description: >-
+      If a specific sub-dataset of the dataset to download, specify the configuration name; specify 'all' to download all 
+      configurations; specify comma-separated values to download multiple configurations (Ex: config1,config2). Else, leave it null.
     optional: True
   split:
     type: string

--- a/assets/aml-benchmark/components/src/dataset_downloader/main.py
+++ b/assets/aml-benchmark/components/src/dataset_downloader/main.py
@@ -38,7 +38,10 @@ def parse_args() -> argparse.Namespace:
         "--configuration",
         type=str,
         default=None,
-        help="Sub-part of the dataset to download; specify 'all' to download all sub-parts."
+        help=(
+            "Sub-part of the dataset to download; specify 'all' to download all sub-parts; specify "
+            "comma-separated values to download multiple sub-parts (Ex: config1,config2)."
+        )
     )
     parser.add_argument(
         "--split",
@@ -92,12 +95,14 @@ def resolve_configuration(
     if configuration == ALL:
         return available_configs
 
-    if configuration not in available_configs:
-        mssg = f"Configuration '{configuration}' not available for dataset '{dataset_name}'."
-        raise BenchmarkValidationException._with_error(
-            AzureMLError.create(BenchmarkValidationError, error_details=mssg)
-        )
-    return [configuration]
+    configuration_arr = configuration.split(",")
+    for configuration in configuration_arr:
+        if configuration not in available_configs:
+            mssg = f"Configuration '{configuration}' not available for dataset '{dataset_name}'."
+            raise BenchmarkValidationException._with_error(
+                AzureMLError.create(BenchmarkValidationError, error_details=mssg)
+            )
+    return configuration_arr
 
 
 def resolve_split(
@@ -268,10 +273,10 @@ def main(
         )
 
     log_mlflow_params(
-        dataset_name=args.dataset_name,
-        configuration=args.configuration,
-        split=args.split,
-        script=args.script,
+        dataset_name=dataset_name if script is None else None,
+        configuration=configuration,
+        split=split,
+        script=script,
     )
 
 

--- a/assets/aml-benchmark/components/src/dataset_sampler/main.py
+++ b/assets/aml-benchmark/components/src/dataset_sampler/main.py
@@ -259,7 +259,6 @@ def main(
         f"Sampling {n_samples}/{line_counts} lines using sampling_style {sampling_style}."
     )
 
-    random_seed = args.random_seed
     if (
         sampling_style == SamplingStyle.head.value
         or sampling_style == SamplingStyle.tail.value

--- a/assets/aml-benchmark/tests/test_dataset_downloader.py
+++ b/assets/aml-benchmark/tests/test_dataset_downloader.py
@@ -33,7 +33,7 @@ class TestDatasetDownloaderComponent:
         "dataset_name, configuration, split, script",
         [
             ("xquad", "xquad.en", "validation", None),
-            ("xquad", "xquad.en", "all", None),
+            ("xquad", "xquad.en,xquad.hi", "all", None),
             ("xquad", "all", "all", None),
             (None, "all", "test", Constants.MATH_DATASET_LOADER_SCRIPT),
         ],
@@ -69,7 +69,8 @@ class TestDatasetDownloaderComponent:
         if configuration == "all":
             file_count = len(get_dataset_config_names(path))
         elif split == "all":
-            file_count = len(get_dataset_split_names(path, configuration))
+            configs = configuration.split(",")
+            file_count = sum(len(get_dataset_split_names(path, config)) for config in configs)
         self._verify_output(pipeline_job, temp_dir, file_count)
         assert_logged_params(
             pipeline_job.name,


### PR DESCRIPTION
This PR has the following changes:
- Allow downloading a subset of dataset configurations by allowing users to provide a comma-separated values.
- Modify existing test to test this new change
- Remove unnecessary `random_seed` assignment in sampler's main script 