### PR TITLE
pin metrics package to 0.0.27

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -8,6 +8,7 @@ RUN pip install --upgrade pip
 
 COPY requirements.txt .
 
-RUN pip install "azureml-evaluate-mlflow=={{latest-pypi-version}}"
+RUN pip install "azureml-metrics[all]==0.0.27" && \
+    pip install "azureml-evaluate-mlflow"
 RUN pip install -r requirements.txt --no-cache-dir
 RUN python -m nltk.downloader punkt


### PR DESCRIPTION
PR to fix the error of downgrading torch to 1.13
env link with the proposed change: https://ml.azure.com/environments/acft-hf-nlp-gpu/version/0.ds3.release.13?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourceGroups/training_rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-workspace&flight=itpmerge&tid=72f988bf-86f1-41af-91ab-2d7cd011db47