### PR TITLE
Add a new version for runtime components. Update sweep components

### DIFF
--- a/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
@@ -262,7 +262,7 @@ jobs:
 
   image_classification_runtime_component:
     type: command
-    component: azureml:train_image_classification_model:0.0.4
+    component: azureml:train_image_classification_model:0.0.5
     compute: ${{parent.inputs.compute_finetune}}
     resources:
       shm_size: '16g'

--- a/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
@@ -307,7 +307,7 @@ jobs:
 
   image_instance_segmentation_runtime_component:
     type: command
-    component: azureml:train_instance_segmentation_model:0.0.4
+    component: azureml:train_instance_segmentation_model:0.0.5
     compute: ${{parent.inputs.compute_finetune}}
     resources:
       shm_size: '16g'

--- a/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
@@ -332,7 +332,7 @@ jobs:
 
   image_object_detection_runtime_component:
     type: command
-    component:  azureml:train_object_detection_model:0.0.4
+    component:  azureml:train_object_detection_model:0.0.5
     compute: ${{parent.inputs.compute_finetune}}
     resources:
       shm_size: '16g'

--- a/assets/training/vision/components/image_classification/spec.yaml
+++ b/assets/training/vision/components/image_classification/spec.yaml
@@ -5,7 +5,7 @@ description: Component to finetune AutoML legacy models for image classification
 
 name: train_image_classification_model
 display_name: Image Classification AutoML Legacy Model Finetune
-version: 0.0.4
+version: 0.0.5
 
 is_deterministic: false
 

--- a/assets/training/vision/components/instance_segmentation/spec.yaml
+++ b/assets/training/vision/components/instance_segmentation/spec.yaml
@@ -5,7 +5,7 @@ description: Component to finetune AutoML legacy models for instance segmentatio
 
 name: train_instance_segmentation_model
 display_name: Image Instance Segmentation AutoML Legacy Model Finetune
-version: 0.0.4
+version: 0.0.5
 
 is_deterministic: false
 

--- a/assets/training/vision/components/object_detection/spec.yaml
+++ b/assets/training/vision/components/object_detection/spec.yaml
@@ -5,7 +5,7 @@ description: Component to finetune AutoML legacy models for object detection.
 
 name: train_object_detection_model
 display_name: Image Object Detection AutoML Legacy Model Finetune
-version: 0.0.4
+version: 0.0.5
 
 is_deterministic: false
 


### PR DESCRIPTION
Version 0.0.4 for runtime components was accidentally deleted from registries.
This would fail all AutoML runs that would go through pipeline component route. Example run : https://ml.azure.com/runs/happy_dolphin_6w9y64q5f2?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/automlimage_eastus2_rg/providers/Microsoft.MachineLearningServices/workspaces/madhumaddi-aml-demo&tid=72f988bf-86f1-41af-91ab-2d7cd011db47

Re-creating the same component with same version number 0.0.4 is not supported.
Hence, we are upgrading runtime components version while still pointing to previous runtime component environment.
With this change, the finetune components used in the sweep components will also get updated, there by fixing the issues with image classification notebooks.