### PR TITLE
update codellama tags props

### DIFF
--- a/assets/models/system/CodeLlama-13b-Python-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-13b-Python-hf/spec.yaml
@@ -8,6 +8,7 @@ properties:
   evaluation-recommended-sku: Standard_NC24s_v3, Standard_NC24rs_v3, Standard_ND40rs_v2,
     Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   languages: EN
+  azureml.copyRegistryFilesToWorkspace: true
 tags:
   Featured: ''
   Preview: ''
@@ -23,7 +24,8 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
+  SharedComputeCapacityEnabled: ''
+  task: text-generation
   license: llama2
   author: meta
-  task: text-generation
-version: 2
+version: 3

--- a/assets/models/system/CodeLlama-13b-Python-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-13b-Python-hf/spec.yaml
@@ -28,4 +28,4 @@ tags:
   task: text-generation
   license: llama2
   author: meta
-version: 3
+version: 2

--- a/assets/models/system/CodeLlama-13b-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-13b-hf/spec.yaml
@@ -37,4 +37,4 @@ tags:
   task: text-generation
   license: llama2
   author: meta
-version: 3
+version: 2

--- a/assets/models/system/CodeLlama-13b-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-13b-hf/spec.yaml
@@ -9,6 +9,7 @@ properties:
     Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   finetune-recommended-sku: Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   languages: EN
+  azureml.copyRegistryFilesToWorkspace: true
 tags:
   Featured: ''
   Preview: ''
@@ -28,6 +29,12 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
+  model_specific_defaults:
+    apply_deepspeed: 'true'
+    apply_lora: 'true'
+    precision: '4'
+  SharedComputeCapacityEnabled: ''
+  task: text-generation
   license: llama2
   author: meta
-version: 2
+version: 3

--- a/assets/models/system/CodeLlama-34b-Python-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-34b-Python-hf/spec.yaml
@@ -6,6 +6,7 @@ properties:
   inference-recommended-sku: Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   evaluation-recommended-sku: Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   languages: EN
+  azureml.copyRegistryFilesToWorkspace: true
 tags:
   Featured: ''
   Preview: ''
@@ -17,6 +18,8 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
+  SharedComputeCapacityEnabled: ''
+  task: text-generation
   license: llama2
   author: meta
-version: 2
+version: 3

--- a/assets/models/system/CodeLlama-34b-Python-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-34b-Python-hf/spec.yaml
@@ -22,4 +22,4 @@ tags:
   task: text-generation
   license: llama2
   author: meta
-version: 3
+version: 2

--- a/assets/models/system/CodeLlama-34b-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-34b-hf/spec.yaml
@@ -25,4 +25,4 @@ tags:
   task: text-generation
   license: llama2
   author: meta
-version: 2
+version: 1

--- a/assets/models/system/CodeLlama-34b-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-34b-hf/spec.yaml
@@ -7,6 +7,7 @@ properties:
   evaluation-recommended-sku: Standard_NC24s_v3,
     Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   languages: EN
+  azureml.copyRegistryFilesToWorkspace: true
 tags:
   Featured: ''
   Preview: ''
@@ -20,6 +21,8 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
+  SharedComputeCapacityEnabled: ''
+  task: text-generation
   license: llama2
   author: meta
-version: 1
+version: 2

--- a/assets/models/system/CodeLlama-7b-Python-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-7b-Python-hf/spec.yaml
@@ -30,4 +30,4 @@ tags:
   task: text-generation
   license: llama2
   author: meta
-version: 3
+version: 2

--- a/assets/models/system/CodeLlama-7b-Python-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-7b-Python-hf/spec.yaml
@@ -8,6 +8,7 @@ properties:
   evaluation-recommended-sku: Standard_NC12s_v3, Standard_NC24s_v3, Standard_NC24rs_v3,
     Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   languages: EN
+  azureml.copyRegistryFilesToWorkspace: true
 tags:
   Featured: ''
   Preview: ''
@@ -25,8 +26,8 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
-
+  SharedComputeCapacityEnabled: ''
+  task: text-generation
   license: llama2
   author: meta
-  task: text-generation
-version: 2
+version: 3

--- a/assets/models/system/CodeLlama-7b-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-7b-hf/spec.yaml
@@ -43,4 +43,4 @@ tags:
   task: text-generation
   license: llama2
   author: meta
-version: 3
+version: 2

--- a/assets/models/system/CodeLlama-7b-hf/spec.yaml
+++ b/assets/models/system/CodeLlama-7b-hf/spec.yaml
@@ -11,6 +11,7 @@ properties:
     Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   finetuning-tasks: text-classification
   languages: EN
+  azureml.copyRegistryFilesToWorkspace: true
 tags:
   Featured: ''
   Preview: ''
@@ -34,11 +35,12 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
-  license: llama2
-  author: meta
-  task: text-generation
   model_specific_defaults:
     apply_deepspeed: 'true'
     apply_lora: 'true'
     precision: '16'
-version: 2
+  SharedComputeCapacityEnabled: ''
+  task: text-generation
+  license: llama2
+  author: meta
+version: 3

--- a/assets/models/system/codellama-13b-instruct-hf/spec.yaml
+++ b/assets/models/system/codellama-13b-instruct-hf/spec.yaml
@@ -24,8 +24,8 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
-  license: custom
-  author: meta
-  task: text-generation
   SharedComputeCapacityEnabled: ''
+  task: text-generation
+  license: llama2
+  author: meta
 version: 1

--- a/assets/models/system/codellama-34b-instruct-hf/spec.yaml
+++ b/assets/models/system/codellama-34b-instruct-hf/spec.yaml
@@ -20,9 +20,8 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
-  license: custom
-  author: meta
-  task: text-generation
   SharedComputeCapacityEnabled: ''
-  disable-batch: 'true'
+  task: text-generation
+  license: llama2
+  author: meta
 version: 2

--- a/assets/models/system/codellama-7b-instruct-hf/spec.yaml
+++ b/assets/models/system/codellama-7b-instruct-hf/spec.yaml
@@ -31,8 +31,8 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
   - Standard_ND96amsr_A100_v4
-  license: custom
-  author: meta
-  task: text-generation
   SharedComputeCapacityEnabled: ''
+  task: text-generation
+  license: llama2
+  author: meta
 version: 2


### PR DESCRIPTION
azureml-meta models need `azureml.copyRegistryFilesToWorkspace: true` property to copy model files to workspace and then perform deployment. Deployment has to be performed this way as azureml-meta doesnot have anon storage access 