### PR TITLE
Adding trusted suffix azcopy flag for non-standard clouds

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.16.11 (2023-10-09)
+### 🐛 Bugs Fixed
+- [#1428](https://github.com/Azure/azureml-assets/pull/1428) Azcopy fixes to support additional clouds
+
 ## 1.16.10 (2023-10-06)
 ### 🐛 Bugs Fixed
 - [#1411](https://github.com/Azure/azureml-assets/pull/1411) Prevent Config._expand_path from returning directories

--- a/scripts/azureml-assets/azureml/assets/model/download_utils.py
+++ b/scripts/azureml-assets/azureml/assets/model/download_utils.py
@@ -79,7 +79,10 @@ def copy_azure_artifacts(src_uri: str, dstn_uri: str) -> bool:
         if _get_default_cloud_name() not in [AzureEnvironments.ENV_DEFAULT,
                                              AzureEnvironments.ENV_US_GOVERNMENT,
                                              AzureEnvironments.ENV_CHINA]:
-            download_cmd += f" --trusted-microsoft-suffixes {_get_storage_endpoint_from_metadata()}"
+            suffix = _get_storage_endpoint_from_metadata()
+            if not suffix.startswith("."):
+                suffix = "." + suffix
+            download_cmd += f" --trusted-microsoft-suffixes {suffix}"
 
         result = run_cmd(download_cmd)
         logger.print(f"azcopy result {result}")

--- a/scripts/azureml-assets/azureml/assets/model/download_utils.py
+++ b/scripts/azureml-assets/azureml/assets/model/download_utils.py
@@ -35,7 +35,7 @@ def run_cmd(cmd, cwd: Path = "./") -> int:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         encoding=sys.stdout.encoding,
-        errors="ignore"
+        errors="ignore",
     )
     if result.returncode != 0:
         logger.log_error(f"Failed with error {result.stdout}.")

--- a/scripts/azureml-assets/azureml/assets/model/download_utils.py
+++ b/scripts/azureml-assets/azureml/assets/model/download_utils.py
@@ -9,6 +9,11 @@ import stat
 import sys
 from pathlib import Path
 from azureml.assets.util import logger
+from azure.ai.ml._azure_environments import (
+    AzureEnvironments,
+    _get_default_cloud_name,
+    _get_storage_endpoint_from_metadata
+)
 
 
 def _onerror(func, path, exc_info):
@@ -30,7 +35,7 @@ def run_cmd(cmd, cwd: Path = "./") -> int:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         encoding=sys.stdout.encoding,
-        errors="ignore",
+        errors="ignore"
     )
     if result.returncode != 0:
         logger.log_error(f"Failed with error {result.stdout}.")
@@ -67,6 +72,15 @@ def copy_azure_artifacts(src_uri: str, dstn_uri: str) -> bool:
     try:
         download_cmd = f"azcopy copy '{src_uri}' '{dstn_uri}' " \
                        "--recursive --skip-version-check --output-level essential"
+
+        # AzureCloud, USGov, and China clouds should all the trusted Microsoft
+        # suffixes built into azcop by default. If the cloud is not one of these,
+        # then we need to add the appropriate cloud-specific suffix ourselves.
+        if _get_default_cloud_name() not in [AzureEnvironments.ENV_DEFAULT,
+                                             AzureEnvironments.ENV_US_GOVERNMENT,
+                                             AzureEnvironments.ENV_CHINA]:
+            download_cmd += f" --trusted-microsoft-suffixes {_get_storage_endpoint_from_metadata()}"
+
         result = run_cmd(download_cmd)
         logger.print(f"azcopy result {result}")
         # TODO: Handle error case correctly, since azcopy exits with 0 exit code, even in case of error.

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.10",
+   version="1.16.11",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
azcopy has built in trust support for standard clouds. If we are operating in a non-standard cloud, the we need additional azcopy command line args.