### PR TITLE
Update LLaVA model versions to 1.5

### DIFF
--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/conda.yaml
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/conda.yaml
@@ -23,6 +23,7 @@ dependencies:
   - xz=5.4.2=h5eee18b_0
   - zlib=1.2.13=h5eee18b_0
   - pip:
+      - mlflow==2.3.1
       - accelerate==0.21.0
       - aiofiles==23.2.1
       - aiohttp==3.8.6
@@ -67,7 +68,7 @@ dependencies:
       - kiwisolver==1.4.5
       - linkify-it-py==2.0.2
       - lit==17.0.2
-      - llava-torch==1.1.0
+      - llava-torch==1.1.1
       - markdown-it-py==2.2.0
       - markdown2==2.4.10
       - markupsafe==2.1.3

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/conda.yaml
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/conda.yaml
@@ -4,7 +4,7 @@ dependencies:
   - _libgcc_mutex=0.1=main
   - _openmp_mutex=5.1=1_gnu
   - bzip2=1.0.8=h7b6447c_0
-  - ca-certificates=2023.05.30=h06a4308_0
+  - ca-certificates=2023.08.22=h06a4308_0
   - ld_impl_linux-64=2.38=h1181459_1
   - libffi=3.4.4=h6a678d5_0
   - libgcc-ng=11.2.0=h1234567_1
@@ -12,74 +12,73 @@ dependencies:
   - libstdcxx-ng=11.2.0=h1234567_1
   - libuuid=1.41.5=h5eee18b_0
   - ncurses=6.4=h6a678d5_0
-  - openssl=3.0.10=h7f8727e_2
+  - openssl=3.0.11=h7f8727e_2
   - pip=23.2.1=py310h06a4308_0
-  - python=3.10.12=h955ad1f_0
+  - python=3.10.13=h955ad1f_0
   - readline=8.2=h5eee18b_0
   - setuptools=68.0.0=py310h06a4308_0
   - sqlite=3.41.2=h5eee18b_0
   - tk=8.6.12=h1ccaba5_0
-  - wheel=0.38.4=py310h06a4308_0
+  - wheel=0.41.2=py310h06a4308_0
   - xz=5.4.2=h5eee18b_0
   - zlib=1.2.13=h5eee18b_0
   - pip:
-      - mlflow==2.3.1
       - accelerate==0.21.0
       - aiofiles==23.2.1
-      - aiohttp==3.8.5
+      - aiohttp==3.8.6
       - aiosignal==1.3.1
-      - altair==5.1.1
+      - altair==5.1.2
       - anyio==3.7.1
       - appdirs==1.4.4
       - async-timeout==4.0.3
       - attrs==23.1.0
       - bitsandbytes==0.41.0
       - certifi==2023.7.22
-      - charset-normalizer==3.2.0
+      - charset-normalizer==3.3.0
       - click==8.1.7
-      - cmake==3.27.2
-      - contourpy==1.1.0
-      - cycler==0.11.0
+      - cmake==3.27.6
+      - contourpy==1.1.1
+      - cycler==0.12.1
       - deepspeed==0.9.5
       - docker-pycreds==0.4.0
       - einops==0.6.1
       - einops-exts==0.0.4
       - exceptiongroup==1.1.3
-      - fastapi==0.103.0
+      - fastapi==0.103.2
       - ffmpy==0.3.1
-      - filelock==3.12.3
-      - fonttools==4.42.1
+      - filelock==3.12.4
+      - fonttools==4.43.1
       - frozenlist==1.4.0
-      - fsspec==2023.6.0
+      - fsspec==2023.9.2
       - gitdb==4.0.10
-      - gitpython==3.1.32
+      - gitpython==3.1.37
       - gradio==3.35.2
       - gradio-client==0.2.9
       - h11==0.14.0
       - hjson==3.1.0
       - httpcore==0.17.3
       - httpx==0.24.0
-      - huggingface-hub==0.16.4
+      - huggingface-hub==0.18.0
       - idna==3.4
       - jinja2==3.1.2
       - joblib==1.3.2
-      - jsonschema==4.19.0
+      - jsonschema==4.19.1
       - jsonschema-specifications==2023.7.1
       - kiwisolver==1.4.5
-      - llava-torch==1.0.2
       - linkify-it-py==2.0.2
-      - lit==16.0.6
+      - lit==17.0.2
+      - llava-torch==1.1.0
       - markdown-it-py==2.2.0
       - markdown2==2.4.10
       - markupsafe==2.1.3
-      - matplotlib==3.7.2
+      - matplotlib==3.8.0
       - mdit-py-plugins==0.3.3
       - mdurl==0.1.2
       - mpmath==1.3.0
       - multidict==6.0.4
       - networkx==3.1
-      - ninja==1.11.1
-      - numpy==1.25.2
+      - ninja==1.11.1.1
+      - numpy==1.26.0
       - nvidia-cublas-cu11==11.10.3.66
       - nvidia-cuda-cupti-cu11==11.7.101
       - nvidia-cuda-nvrtc-cu11==11.7.99
@@ -91,37 +90,37 @@ dependencies:
       - nvidia-cusparse-cu11==11.7.4.91
       - nvidia-nccl-cu11==2.14.3
       - nvidia-nvtx-cu11==11.7.91
-      - orjson==3.9.5
-      - packaging==23.1
-      - pandas==2.1.0
+      - orjson==3.9.8
+      - packaging==23.2
+      - pandas==2.1.1
       - pathtools==0.1.2
       - peft==0.4.0
-      - pillow==10.0.0
-      - protobuf==4.24.2
+      - pillow==10.0.1
+      - protobuf==4.24.4
       - psutil==5.9.5
       - py-cpuinfo==9.0.0
-      - pydantic==1.10.12
+      - pydantic==1.10.13
       - pydub==0.25.1
       - pygments==2.16.1
-      - pyparsing==3.0.9
+      - pyparsing==3.1.1
       - python-dateutil==2.8.2
       - python-multipart==0.0.6
-      - pytz==2023.3
+      - pytz==2023.3.post1
       - pyyaml==6.0.1
       - referencing==0.30.2
-      - regex==2023.8.8
+      - regex==2023.10.3
       - requests==2.31.0
-      - rpds-py==0.10.0
-      - safetensors==0.3.3
+      - rpds-py==0.10.4
+      - safetensors==0.4.0
       - scikit-learn==1.2.2
-      - scipy==1.11.2
+      - scipy==1.11.3
       - semantic-version==2.10.0
       - sentencepiece==0.1.99
-      - sentry-sdk==1.30.0
-      - setproctitle==1.3.2
+      - sentry-sdk==1.31.0
+      - setproctitle==1.3.3
       - shortuuid==1.0.11
       - six==1.16.0
-      - smmap==5.0.0
+      - smmap==5.0.1
       - sniffio==1.3.0
       - starlette==0.27.0
       - svgwrite==1.4.3
@@ -135,12 +134,12 @@ dependencies:
       - tqdm==4.66.1
       - transformers==4.31.0
       - triton==2.0.0
-      - typing-extensions==4.7.1
+      - typing-extensions==4.8.0
       - tzdata==2023.3
       - uc-micro-py==1.0.2
-      - urllib3==2.0.4
+      - urllib3==2.0.6
       - uvicorn==0.23.2
-      - wandb==0.15.9
+      - wandb==0.15.12
       - wavedrom==2.0.3.post3
       - websockets==11.0.3
       - yarl==1.9.2

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/llava_mlflow_wrapper.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/llava_mlflow_wrapper.py
@@ -24,7 +24,7 @@ class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
     LLAVA_13B = "13b"
     LLAVA_13B2 = "13b2"
     LLAVA_13B_15 = "13b_15"
-    MODEL_VERSIONS = [LLAVA_MPT, LLAVA_7B, LLAVA_13B, LLAVA_13B2, LLAVA_13B_15]
+    MODEL_VERSIONS = [LLAVA_MPT, LLAVA_7B, LLAVA_7B_15, LLAVA_13B, LLAVA_13B2, LLAVA_13B_15]
 
     def __init__(self, task_type: str) -> None:
         """Construct LLaVA MLflow wrapper object.
@@ -187,7 +187,7 @@ class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
             # For small models on V100 machines, long prompts cause a GPU OOMs which the server does not recover from.
             # To prevent this, we are using a length threshold that allows for a small number of question-answer pairs
             # (e.g. 5-10) in each prompt.
-            if self._model_version in [self.LLAVA_MPT, self.LLAVA_7B, self.LLAVA_7B_15B]:
+            if self._model_version in [self.LLAVA_MPT, self.LLAVA_7B, self.LLAVA_7B_15]:
                 prompt_length = max([len(i) for i in input_ids])
                 if prompt_length > MAX_PROMPT_LENGTH:
                     raise ValueError(

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/llava_mlflow_wrapper.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/llava/llava_mlflow_wrapper.py
@@ -20,9 +20,11 @@ class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
 
     LLAVA_MPT = "mpt"
     LLAVA_7B = "7b"
+    LLAVA_7B_15 = "7b_15"
     LLAVA_13B = "13b"
     LLAVA_13B2 = "13b2"
-    MODEL_VERSIONS = [LLAVA_MPT, LLAVA_7B, LLAVA_13B, LLAVA_13B2]
+    LLAVA_13B_15 = "13b_15"
+    MODEL_VERSIONS = [LLAVA_MPT, LLAVA_7B, LLAVA_13B, LLAVA_13B2, LLAVA_13B_15]
 
     def __init__(self, task_type: str) -> None:
         """Construct LLaVA MLflow wrapper object.
@@ -64,6 +66,11 @@ class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
                     model_base = os.path.join(model_dir, "Llama-2-7b-chat")
                     stop_str = conv_templates["llava_llama_2"].sep
 
+                elif self._model_version == self.LLAVA_7B_15:
+                    model_name = "llava-v1.5-7b"
+                    model_base = None
+                    stop_str = conv_templates["llava_v1"].sep2
+
                 elif self._model_version == self.LLAVA_13B:
                     model_name = "llava-v1-0719-336px-lora-merge-vicuna-13b-v1.3"
                     model_base = None
@@ -73,6 +80,11 @@ class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
                     model_name = "llava-llama-2-13b-chat-lightning-preview"
                     model_base = None
                     stop_str = conv_templates["llava_llama_2"].sep
+
+                elif self._model_version == self.LLAVA_13B_15:
+                    model_name = "llava-v1.5-13b"
+                    model_base = None
+                    stop_str = conv_templates["llava_v1"].sep2
 
                 else:
                     raise NotImplementedError(f"Model name {self._model_version} not supported.")
@@ -134,9 +146,15 @@ class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
                         f"the visual content that the user provides, and assist the user with a variety of tasks "
                         f"using natural language.\n<</SYS>>\n\n<im_start><image><im_end>\n{direct_question} [/INST]"
                     )
+                elif self._model_version == self.LLAVA_7B_15:
+                    prompt = (
+                        f"A chat between a curious human and an artificial intelligence assistant. "
+                        f"The assistant gives helpful, detailed, and polite answers to the human's questions. USER: "
+                        f"<image>\n{direct_question} ASSISTANT:"
+                    )
                 elif self._model_version == self.LLAVA_13B:
                     prompt = (
-                        f"input to llava: A chat between a curious human and an artificial intelligence assistant. "
+                        f"A chat between a curious human and an artificial intelligence assistant. "
                         f"The assistant gives helpful, detailed, and polite answers to the human's questions. USER: "
                         f"<im_start><image><im_end>\n{direct_question} ASSISTANT:"
                     )
@@ -145,6 +163,12 @@ class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
                         f"[INST] <<SYS>>\nYou are a helpful language and vision assistant. You are able to understand "
                         f"the visual content that the user provides, and assist the user with a variety of tasks "
                         f"using natural language.\n<</SYS>>\n\n<image>\n{direct_question} [/INST]"
+                    )
+                elif self._model_version == self.LLAVA_13B_15:
+                    prompt = (
+                        f"A chat between a curious human and an artificial intelligence assistant. "
+                        f"The assistant gives helpful, detailed, and polite answers to the human's questions. USER: "
+                        f"<image>\n{direct_question} ASSISTANT:"
                     )
             else:
                 prompt_from_direct_question = False
@@ -163,7 +187,7 @@ class LLaVAMLflowWrapper(mlflow.pyfunc.PythonModel):
             # For small models on V100 machines, long prompts cause a GPU OOMs which the server does not recover from.
             # To prevent this, we are using a length threshold that allows for a small number of question-answer pairs
             # (e.g. 5-10) in each prompt.
-            if self._model_version in [self.LLAVA_MPT, self.LLAVA_7B]:
+            if self._model_version in [self.LLAVA_MPT, self.LLAVA_7B, self.LLAVA_7B_15B]:
                 prompt_length = max([len(i) for i in input_ids])
                 if prompt_length > MAX_PROMPT_LENGTH:
                     raise ValueError(


### PR DESCRIPTION
Add support for the latest LLaVA model versions, which bring a significant quality improvement. We still need approval for these versions, so this PR should not be merged yet, but it can be reviewed.
Successful model publish pipeline run: https://ml.azure.com/experiments/id/d1873606-5a43-4303-9053-6fb512612c9f/runs/blue_malanga_z7j9vdxs73?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/phmantri_eastus/providers/Microsoft.MachineLearningServices/workspaces/phmantri_eastus_2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47 .
