### PR TITLE
Add sample prompts, clean up old reference

### DIFF
--- a/assets/large_language_models/prompts/chat_hiking_chatbot/asset.yaml
+++ b/assets/large_language_models/prompts/chat_hiking_chatbot/asset.yaml
@@ -1,0 +1,3 @@
+type: prompt
+spec: spec.yaml
+categories: ["Sample Prompts"]

--- a/assets/large_language_models/prompts/chat_hiking_chatbot/prompt/prompt.yaml
+++ b/assets/large_language_models/prompts/chat_hiking_chatbot/prompt/prompt.yaml
@@ -1,0 +1,34 @@
+$schema: https://azuremlschemas.azureedge.net/latest/prompt.schema.json
+
+_type: chat
+
+messages: 
+- role: system
+  content: |
+    I am a hiking enthusiast named Forest who helps people discover fun hikes in their area. I am upbeat and friendly. I introduce myself when first saying hello. When helping people out, I always ask them for this information to inform the hiking recommendation I provide:
+      1. Where they are located
+      2. What hiking intensity they are looking for
+    I will then provide three suggestions for nearby hikes that vary in length after I get this information. I will also share an interesting fact about the local nature on the hikes when making a recommendation
+- role: user
+  content: |
+    Can you recommend some medium intensity hikes in the Seattle area?
+- role: assistant
+  content: |
+    I would love to do that!  Here are some popular hikes in the Seattle area that are medium intensity:
+      1. Rattlesnake Ledge
+      2. Little Si
+      3. Mt Pilchuck
+- role: user
+  content: |
+    Location: {{User_Location}}
+    Intensity: {{Hike_Intensity}}
+      
+input_variables:
+  - name: User_Location
+    description: Location that the user is looking to hike
+    defaultValue: United States
+  - name: Hike_Intensity
+    description: Desired hiking intensity from the user
+    defaultValue: Relaxed
+
+template_format: handlebars

--- a/assets/large_language_models/prompts/chat_hiking_chatbot/spec.yaml
+++ b/assets/large_language_models/prompts/chat_hiking_chatbot/spec.yaml
@@ -1,0 +1,14 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.prompt.schema.json
+
+type: prompt
+name: chat_hiking_chatbot
+version: 0.0.3
+display_name: Hiking recommendations chatbot
+
+tags:
+  modality: chat
+  task: chatbot
+  industry: sustainability
+
+data_uri: ./prompt
+template_path: prompt.yaml

--- a/assets/large_language_models/prompts/completion_news_headline/asset.yaml
+++ b/assets/large_language_models/prompts/completion_news_headline/asset.yaml
@@ -1,0 +1,3 @@
+type: prompt
+spec: spec.yaml
+categories: ["Sample Prompts"]

--- a/assets/large_language_models/prompts/completion_news_headline/prompt/prompt.yaml
+++ b/assets/large_language_models/prompts/completion_news_headline/prompt/prompt.yaml
@@ -1,0 +1,12 @@
+$schema: https://azuremlschemas.azureedge.net/latest/prompt.schema.json
+
+template: | 
+    Classify the following news headline into 1 of the following categories: Business, Tech, Politics, Sport, Entertainment
+    {{headline_text}}
+
+input_variables:
+  - name: headline_text
+    description: Headline Text
+    defaultValue: Chancellor on brink of second bailout for banks
+
+template_format: handlebars

--- a/assets/large_language_models/prompts/completion_news_headline/spec.yaml
+++ b/assets/large_language_models/prompts/completion_news_headline/spec.yaml
@@ -1,0 +1,15 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.prompt.schema.json
+
+type: prompt  
+version: 0.0.1
+name: completion_news_headline
+display_name: Classify News Headline
+description: Classify news headline for different categories
+
+tags:
+  modality: completion
+  industry: financial-services
+  task: classification
+
+data_uri: ./prompt
+template_path: prompt.yaml

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -25,8 +25,6 @@ class ValidationException(Exception):
 class AssetType(Enum):
     """Asset type."""
 
-    # TODO: Remove BENCHMARKRESULT after other scripts are updated to switch to EVALUATIONRESULT
-    BENCHMARKRESULT = 'benchmarkresult'
     COMPONENT = 'component'
     DATA = 'data'
     ENVIRONMENT = 'environment'


### PR DESCRIPTION
Add two more sample prompts to demonstrate 'completion' and 'chat' type prompts.

Also, remove the old reference to 'benchmarkresult' since the publishing scripts have been switched to use 'evaluationresult'