### PR TITLE
Set access for large_language_models directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 /assets/models/ @azure/aml-training @azure/azureml-inference-idc
 /assets/common/ @azure/aml-training
 /assets/model_monitoring/ @Azure/aml-model-monitoring
-/assets/large_language_models/ @azure/aml-training
+/assets/large_language_models/ @azure/aml-training @azure/aml-llm


### PR DESCRIPTION
Set up a team 'aml-llm' to have access to check in prompts to the large_language_models directory.

https://github.com/orgs/Azure/teams/aml-llm/members