### PR TITLE
Prompt Crafter json loads fix for numbers

### DIFF
--- a/assets/aml-benchmark/components/prompt_crafter/spec.yaml
+++ b/assets/aml-benchmark/components/prompt_crafter/spec.yaml
@@ -6,7 +6,7 @@ display_name: Prompt Crafter
 description: This component is used to create prompts from a given dataset. From a 
   given jinja prompt template, it will generate prompts. It can also create 
   few-shot prompts given a few-shot dataset and the number of shots.
-version: 0.0.1.0
+version: 0.0.2.0
 is_deterministic: true
 
 inputs:

--- a/assets/aml-benchmark/components/src/prompt_crafter/main.py
+++ b/assets/aml-benchmark/components/src/prompt_crafter/main.py
@@ -142,7 +142,8 @@ def main(
         system_message=system_message,
         random_seed=random_seed,
         test_dataset_checksum=resolve_io_path(test_data),
-        few_shot_dataset_checksum=resolve_io_path(few_shot_data),
+        few_shot_dataset_checksum=resolve_io_path(few_shot_data)
+        if few_shot_data else None,
         output_dataset_checksum=resolve_io_path(output_file))
 
 

--- a/assets/aml-benchmark/components/src/prompt_crafter/package/prompt_crafter.py
+++ b/assets/aml-benchmark/components/src/prompt_crafter/package/prompt_crafter.py
@@ -156,7 +156,7 @@ transformations:
             if len(few_shot_paths) == 1:
                 few_shot_pool = read_jsonl_files(few_shot_paths)
             else:
-                mssg = f"Multiple or No input files found for {few_shot_paths}"
+                mssg = f"Multiple or No input files found for {few_shot_file}"
                 raise BenchmarkValidationException._with_error(
                     AzureMLError.create(BenchmarkValidationError, error_details=mssg)
                 )

--- a/assets/aml-benchmark/components/src/prompt_crafter/package/prompt_factory.py
+++ b/assets/aml-benchmark/components/src/prompt_crafter/package/prompt_factory.py
@@ -330,6 +330,11 @@ class ChatPromptFactory(PromptFactory):
             # NOTE: user role is currently prefered over system role
             # though this may change in the future as models are updated
             messages = [{"role": role, "content": affix}]
+
+        # Handling the case where Json.loads load a string with only number as intger.
+        if isinstance(messages, int):
+            messages = [{"role": role, "content": affix}]
+
         messages = self._make_list(messages)
         self._validate_messages(messages)
         return messages

--- a/assets/aml-benchmark/components/src/prompt_crafter/package/prompt_factory.py
+++ b/assets/aml-benchmark/components/src/prompt_crafter/package/prompt_factory.py
@@ -324,7 +324,17 @@ class ChatPromptFactory(PromptFactory):
 
     def _parse_affix(self, affix: str, role="user") -> OpenAICreateChatPrompt:
         """Convert affix string to messages format."""
-        messages = [{"role": role, "content": affix}]
+        try:
+            messages = json.loads(affix)
+        except json.decoder.JSONDecodeError:
+            # NOTE: user role is currently prefered over system role
+            # though this may change in the future as models are updated
+            messages = [{"role": role, "content": affix}]
+
+        # Handling the case where Json.loads load a string with only number as intger.
+        if isinstance(messages, int):
+            messages = [{"role": role, "content": affix}]
+
         messages = self._make_list(messages)
         self._validate_messages(messages)
         return messages

--- a/assets/aml-benchmark/components/src/prompt_crafter/package/prompt_factory.py
+++ b/assets/aml-benchmark/components/src/prompt_crafter/package/prompt_factory.py
@@ -324,17 +324,7 @@ class ChatPromptFactory(PromptFactory):
 
     def _parse_affix(self, affix: str, role="user") -> OpenAICreateChatPrompt:
         """Convert affix string to messages format."""
-        try:
-            messages = json.loads(affix)
-        except json.decoder.JSONDecodeError:
-            # NOTE: user role is currently prefered over system role
-            # though this may change in the future as models are updated
-            messages = [{"role": role, "content": affix}]
-
-        # Handling the case where Json.loads load a string with only number as intger.
-        if isinstance(messages, int):
-            messages = [{"role": role, "content": affix}]
-
+        messages = [{"role": role, "content": affix}]
         messages = self._make_list(messages)
         self._validate_messages(messages)
         return messages

--- a/assets/aml-benchmark/tests/test_prompt_crafter.py
+++ b/assets/aml-benchmark/tests/test_prompt_crafter.py
@@ -190,9 +190,21 @@ class TestPromptCrafterScript:
         few_shot_data, prompt_pattern, output_pattern",
         [
             (Constants.PROMPTCRAFTER_SAMPLE_INPUT_FILE, "completions", 1,
-             Constants.PROMPTCRAFTER_SAMPLE_FEWSHOT_FILE, _prompt_pattern_test, _output_pattern_test),
+             Constants.PROMPTCRAFTER_SAMPLE_FEWSHOT_FILE, _prompt_pattern_test,
+                _output_pattern_test),
             (Constants.PROMPTCRAFTER_SAMPLE_INPUT_FILE, "chat", 1,
-             Constants.PROMPTCRAFTER_SAMPLE_FEWSHOT_FILE, _prompt_pattern_test, _output_pattern_test),
+             Constants.PROMPTCRAFTER_SAMPLE_FEWSHOT_FILE, _prompt_pattern_test,
+                _output_pattern_test),
+            (Constants.PROMPTCRAFTER_SAMPLE_INPUT_FILE, "completions", 0,
+             Constants.PROMPTCRAFTER_SAMPLE_FEWSHOT_FILE, _prompt_pattern_test,
+                _output_pattern_test),
+            (Constants.PROMPTCRAFTER_SAMPLE_INPUT_FILE, "chat", 0,
+             Constants.PROMPTCRAFTER_SAMPLE_FEWSHOT_FILE, _prompt_pattern_test,
+                _output_pattern_test),
+            (Constants.PROMPTCRAFTER_SAMPLE_INPUT_FILE, "completions", 0,
+                None, _prompt_pattern_test, _output_pattern_test),
+            (Constants.PROMPTCRAFTER_SAMPLE_INPUT_FILE, "chat", 0,
+                None, _prompt_pattern_test, _output_pattern_test),
         ]
     )
     def test_valid_prompt_crafter(
@@ -296,8 +308,6 @@ class TestPromptCrafterScript:
             "python -m prompt_crafter.main",
             "--system_message",
             f"{system_message}",
-            "--few_shot_data",
-            f"{few_shot_data}",
             "--random_seed",
             f"{random_seed}",
             "--output_file",
@@ -317,5 +327,7 @@ class TestPromptCrafterScript:
             args.extend(["--prompt_pattern", f'"{prompt_pattern}"'])
         if output_pattern is not None:
             args.extend(["--output_pattern", f'"{output_pattern}"'])
+        if few_shot_data is not None:
+            args.extend(["--few_shot_data", f'"{few_shot_data}"'])
 
         run_command(str(" ".join(args)))

--- a/assets/aml-benchmark/tests/test_prompts.py
+++ b/assets/aml-benchmark/tests/test_prompts.py
@@ -76,7 +76,6 @@ def test_chat_prompts(
 
 
 def test_chat_prompts_with_few_shot_pattern() -> None:
-
     """Test the functionality of the chat prompts with few_shot_pattern."""
     n_shots = 1
     prompt_pattern = "{{input}}?"

--- a/assets/aml-benchmark/tests/test_prompts.py
+++ b/assets/aml-benchmark/tests/test_prompts.py
@@ -4,6 +4,9 @@
 """Test the functionality of the prompt factory which powers the prompt crafter."""
 
 import sys
+import pytest
+
+from  typing import List, Dict
 from .test_utils import get_src_dir
 
 sys.path.append(get_src_dir())
@@ -13,26 +16,54 @@ except ImportError:
     raise ImportError("Please install the package 'prompt_crafter' to run this test.")
 
 
-def test_chat_prompts() -> None:
+# Without few_shot_pattern as inputs
+expected_op_str_response = [
+                    {"role": "system", "content": "You are an assistant."},
+                    {"role": "user", "content": "fs_in?"},
+                    {"role": "assistant", "content": "fs_out"},
+                    {"role": "user", "content": "in4?"}
+                ]
+
+expected_op_int_response = [
+            {"role": "user", "content": "fs_in?"},
+            {"role": "assistant", "content": "1"},
+            {"role": "user", "content": "in4?"}
+        ]
+
+system_message = "You are an assistant."
+
+
+@pytest.mark.parametrize(
+    "n_shots, few_shot_pool, row, expected_output, system_message",
+    [
+        (1, [{'input': 'fs_in', 'output': 'fs_out'}],
+         {'input': 'in4'},
+         expected_op_str_response, system_message),
+        (1, [{'input': 'fs_in', 'output': '1'}],
+         {'input': 'in4'},
+         expected_op_int_response, None),
+        (0, [{'input': 'fs_in', 'output': 'fs_out'}],
+         {'input': 'in4'},
+         [{"role": "user", "content": "in4?"}], None),
+    ]
+)
+def test_chat_prompts(
+    n_shots: int,
+    few_shot_pool: List[Dict[str, str]],
+    row: Dict[str, str],
+    expected_output: str,
+    system_message: str,
+) -> None:
     """Test the functionality of the chat prompts with various inputs.
 
     The role of the few shot prompts outputs should be correctly set to user/
     assistant roles. If few_shot_pattern is present, then assistant role is
     not added to the few_shot_prompts.
     """
-    n_shots = 1
     prompt_pattern = "{{input}}?"
     output_pattern = '{{output}}'
-    few_shot_pool = [{'input': 'fs_in', 'output': 'fs_out'}]
     few_shot_separator = "\n"
-    system_message = "You are an assistant."
-    row = {'input': 'in4'}
 
-    # Without few_shot_pattern as inputs
-    expected_output = [{"role": "system", "content": "You are an assistant."},
-                       {"role": "user", "content": "fs_in?"},
-                       {"role": "assistant", "content": "fs_out"},
-                       {"role": "user", "content": "in4?"}]
     prompt_factory = ChatPromptFactory(
         n_shots=n_shots,
         prompt_pattern=prompt_pattern,
@@ -43,12 +74,22 @@ def test_chat_prompts() -> None:
     prompt = prompt_factory.create_prompt(row=row)
     assert prompt.raw_prompt == expected_output
 
+
+def test_chat_prompts_with_few_shot_pattern() -> None:
+
+    """Test the functionality of the chat prompts with few_shot_pattern."""
+    n_shots = 1
+    prompt_pattern = "{{input}}?"
+    output_pattern = "{{output}}"
+    few_shot_separator = "\n"
+    few_shot_pool = [{'input': 'fs_in', 'output': 'fs_out'}]
+    row = {'input': 'in'}
     # When few_shot_prompt is present in input
     few_shot_pattern = '[{"role": "user", "content": "{{input}}?{{output}}"}]'
     expected_output_with_few_shot_pattern = [
         {"role": "system", "content": "You are an assistant."},
         {"role": "user", "content": "fs_in?fs_out"},
-        {"role": "user", "content": "in4?"}]
+        {"role": "user", "content": "in?"}]
     prompt_factory = ChatPromptFactory(
         n_shots=n_shots,
         prompt_pattern=prompt_pattern,
@@ -60,19 +101,52 @@ def test_chat_prompts() -> None:
     prompt = prompt_factory.create_prompt(row=row)
     assert prompt.raw_prompt == expected_output_with_few_shot_pattern
 
+    # Without system message test
+    expected_output_with_few_shot_pattern = [
+        {"role": "user", "content": "fs_in?fs_out"},
+        {"role": "user", "content": "in?"}]
+    prompt_factory = ChatPromptFactory(
+        n_shots=n_shots,
+        prompt_pattern=prompt_pattern,
+        few_shot_pool=few_shot_pool,
+        output_pattern=output_pattern,
+        few_shot_separator=few_shot_separator,
+        system_message=None,
+        few_shot_pattern=few_shot_pattern)
+    prompt = prompt_factory.create_prompt(row=row)
+    assert prompt.raw_prompt == expected_output_with_few_shot_pattern
 
-def test_completions_prompts() -> None:
+
+@pytest.mark.parametrize(
+    "n_shots, few_shot_pool, row, expected_output",
+    [
+        (1, [{'input': 'in', 'output': 'out'}],
+         {'input': 'in4', 'output': 'out4'},
+         'Input:in\nOutput:out\nInput:in4\nOutput:'),
+        (1, [{'input': 'in', 'output': '1'}],
+         {'input': 'in4', 'output': '2'},
+         'Input:in\nOutput:1\nInput:in4\nOutput:'),
+        (0, [{'input': 'in', 'output': 'out'}],
+         {'input': 'in4', 'output': 'out4'},
+         'Input:in4\nOutput:'),
+        (0, [{'input': 'in', 'output': '1'}],
+         {'input': 'in4', 'output': '2'},
+         'Input:in4\nOutput:')
+    ]
+)
+def test_completions_prompts(
+    n_shots: int,
+    few_shot_pool: List[Dict[str, str]],
+    row: Dict[str, str],
+    expected_output: str
+) -> None:
     """Test the functionality of the completions prompt factory."""
-    n_shots = 1
     prompt_pattern = 'Input:{{input}}\nOutput:'
+    output_pattern = '{{output}}'
     few_shot_pattern = 'Input:{{input}}\nOutput:{{output}}'
-    few_shot_pool = [{'input': 'in', 'output': 'out'}]
     few_shot_separator = "\n"
     prefix = None
-    row = {'input': 'in4', 'output': 'out4'}
     system_message = "You are an AI assistant."
-    expected_output = 'Input:in\nOutput:out\nInput:in4\nOutput:'
-    output_pattern = '{{output}}'
 
     # When few_shot_pattern is present
     prompt_factory = CompletionsPromptFactory(
@@ -89,7 +163,8 @@ def test_completions_prompts() -> None:
 
     assert prompt.raw_prompt == expected_output
 
-    # When few_shot_pattern is absent, it will be created from prompt_pattern and output_pattern
+    # When few_shot_pattern is absent, it will be created
+    # from prompt_pattern and output_pattern
     prompt_factory = CompletionsPromptFactory(
         n_shots=n_shots,
         prompt_pattern=prompt_pattern,

--- a/assets/aml-benchmark/tests/test_prompts.py
+++ b/assets/aml-benchmark/tests/test_prompts.py
@@ -5,8 +5,8 @@
 
 import sys
 import pytest
+from typing import List, Dict
 
-from  typing import List, Dict
 from .test_utils import get_src_dir
 
 sys.path.append(get_src_dir())


### PR DESCRIPTION
Fix the failure when output pattern has a number and the json loads fails. 
Removing the try/except logic for json loads as for chat models, we would always need the role to be added.