### PR TITLE
add more supported dataType

### DIFF
--- a/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
@@ -387,7 +387,7 @@ def impute_categorical_with_mode(df: pyspark.sql.DataFrame) -> pyspark.sql.DataF
 
 
 def modify_dataType(data_stats_table) -> pyspark.sql.DataFrame:
-    """Cast DataType() to DataType"""
+    """Cast DataType() to DataType."""
     data_stats_table_mod = data_stats_table.withColumn(
         "dataType",
         when(col("dataType") == "DoubleType()", "double")

--- a/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
@@ -2,8 +2,10 @@
 # Licensed under the MIT License.
 
 """This file contains the core logic for data quality metrics component."""
-from typing import Tuple
+
 import pyspark
+import pyspark.pandas as ps
+import warnings
 from pyspark.context import SparkContext
 from pyspark.sql.session import SparkSession
 from pyspark.sql.types import (
@@ -29,13 +31,13 @@ from pyspark.sql.functions import (
     concat,
 )
 from pyspark.ml.feature import Imputer
-import pyspark.pandas as ps
+from typing import Tuple
 
 
 # Init spark session
 sc = SparkContext.getOrCreate()
 spark = SparkSession(sc)
-
+supported_datatypes = ['timestamp', 'boolean', 'double', 'binary', 'date', 'decimal', 'float', 'integer', 'long', 'short', 'string', 'char(30)', 'varchar(30)', 'byte']
 
 def get_df_schema(df: pyspark.sql.DataFrame) -> pyspark.sql.DataFrame:
     """
@@ -298,12 +300,17 @@ def compute_dtype_violation_count_modify_dataset(
 
         dtype_baseline = dtype_baseline[0][0]
 
-        # Cast the column to datatype from baseline reference column and count the number of errors
-        num_errors = (
-            df.select(column)
-            .where(~col(column).cast(dtype_baseline).isNotNull())
-            .count()
-        )
+        if dtype_baseline not in supported_datatypes:
+            # we set the default num of error as we do not support this type validation
+            warnings.warn("we set the default num of error to 0 as we do not support this datatype {} validation".format(dtype_baseline))
+            num_errors = 0
+        else:
+            # Cast the column to datatype from baseline reference column and count the number of errors
+            num_errors = (
+                df.select(column)
+                .where(~col(column).cast(dtype_baseline).isNotNull())
+                .count()
+            )
         # Add the conversion error count to the new DataFrame
         df_conversion_errors = df_conversion_errors.union(
             spark.createDataFrame([(column, num_errors)], schema=mySchema)
@@ -376,6 +383,29 @@ def impute_categorical_with_mode(df: pyspark.sql.DataFrame) -> pyspark.sql.DataF
     return df
 
 
+def modify_dataType(data_stats_table) -> pyspark.sql.DataFrame:
+    """Cast DataType() to DataType"""
+    data_stats_table_mod = data_stats_table.withColumn(
+        "dataType",
+        when(col("dataType") == "DoubleType()", "double")
+        .when(col("dataType") == "StringType()", "string")
+        .when(col("dataType") == "IntegerType()", "integer")
+        .when(col("dataType") == "LongType()", "long")
+        .when(col("dataType") == "TimestampType()", "timestamp")
+        .when(col("dataType") == "BooleanType()", "boolean")
+        .when(col("dataType") == "BinaryType()", "binary")
+        .when(col("dataType") == "DateType()", "date")
+        .when(col("dataType") == "DecimalType()", "decimal")
+        .when(col("dataType") == "FloatType()", "float")
+        .when(col("dataType") == "ShortType()", "short")
+        .when(col("dataType") == "CharType()", "char(30)")
+        .when(col("dataType") == "VarcharType()", "varchar(30)")
+        .when(col("dataType") == "ByteType()", "byte")
+        .otherwise(col("dataType")),
+    )
+    return data_stats_table_mod
+
+
 def compute_data_quality_metrics(df, data_stats_table):
     """Compute data quality metrics."""
     #########################
@@ -385,14 +415,7 @@ def compute_data_quality_metrics(df, data_stats_table):
     df.cache()
     data_stats_table.cache()
 
-    data_stats_table_mod = data_stats_table.withColumn(
-        "dataType",
-        when(col("dataType") == "DoubleType()", "double")
-        .when(col("dataType") == "StringType()", "string")
-        .when(col("dataType") == "IntegerType()", "integer")
-        .when(col("dataType") == "LongType()", "long")
-        .otherwise(col("dataType")),
-    )
+    data_stats_table_mod = modify_dataType(data_stats_table)
 
     #########################
     # COMPUTE VIOLATIONS
@@ -538,3 +561,4 @@ def compute_data_quality_metrics(df, data_stats_table):
     )
 
     return violation_df_remapped
+

--- a/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/src/data_quality_compute_metrics/compute_data_quality_metrics.py
@@ -37,7 +37,9 @@ from typing import Tuple
 # Init spark session
 sc = SparkContext.getOrCreate()
 spark = SparkSession(sc)
-supported_datatypes = ['timestamp', 'boolean', 'double', 'binary', 'date', 'decimal', 'float', 'integer', 'long', 'short', 'string', 'char(30)', 'varchar(30)', 'byte']
+supported_datatypes = ['timestamp', 'boolean', 'double', 'binary', 'date', 'decimal', 'float', 'integer',
+                       'long', 'short', 'string', 'char(30)', 'varchar(30)', 'byte']
+
 
 def get_df_schema(df: pyspark.sql.DataFrame) -> pyspark.sql.DataFrame:
     """
@@ -302,7 +304,8 @@ def compute_dtype_violation_count_modify_dataset(
 
         if dtype_baseline not in supported_datatypes:
             # we set the default num of error as we do not support this type validation
-            warnings.warn("we set the default num of error to 0 as we do not support this datatype {} validation".format(dtype_baseline))
+            warnings.warn("we set the default num of error to 0 as we do not support \
+                           this datatype {} validation".format(dtype_baseline))
             num_errors = 0
         else:
             # Cast the column to datatype from baseline reference column and count the number of errors
@@ -561,4 +564,3 @@ def compute_data_quality_metrics(df, data_stats_table):
     )
 
     return violation_df_remapped
-

--- a/assets/model_monitoring/components/tests/unit/test_compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_compute_data_quality_metrics.py
@@ -66,7 +66,8 @@ class TestModelMonitorDataQuality:
             data_stats_table_mod
     ):
         """Test datatype with no vialation"""
-        _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_without_datatype_violation, data_stats_table_mod)
+        _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_without_datatype_violation,
+                                                                               data_stats_table_mod)
         for rows in df_conversion_errors.select("violationCount").collect():
             assert rows[0] == 0
 
@@ -78,7 +79,8 @@ class TestModelMonitorDataQuality:
             data_stats_table_mod
     ):
         """Test datatype while there are vialation"""
-        _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_with_datatype_violation, data_stats_table_mod)
+        _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_with_datatype_violation,
+                                                                               data_stats_table_mod)
         for rows in df_conversion_errors.select("violationCount").collect():
             assert rows[0] >= 1
 
@@ -87,7 +89,8 @@ class TestModelMonitorDataQuality:
         data = [(1, 2), (2, 3)]
         columns = ["feature_unsupported_1", "feature_unsupported_2"]
         df = create_pyspark_dataframe(data, columns)
-        data_stats_tabel_mod_with_unsupported_type = [("feature_unsupported_1", "UnsupportedType()"), ("feature_unsupported_2", "UnsupportedType()")]
+        data_stats_tabel_mod_with_unsupported_type = [("feature_unsupported_1", "UnsupportedType()"),
+                                                      ("feature_unsupported_2", "UnsupportedType()")]
         columns = ['featureName',  'dataType']
         data_stats_table_mod = create_pyspark_dataframe(data_stats_tabel_mod_with_unsupported_type, columns)
         _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df, data_stats_table_mod)
@@ -97,10 +100,12 @@ class TestModelMonitorDataQuality:
     @pytest.mark.local
     def test_modify_type(self):
         """Test modify datatype from Datatype() to datatype"""
-        data = [("BinaryType()", "featureName1"),  ("TimestampType()", "featureName1"), ("BooleanType()", "featureName1"),
-                ("DoubleType()", "featureName1"),  ("StringType()", "featureName1"),    ("DateType()", "featureName1"),
-                ("LongType()", "featureName1"),    ("ShortType()", "featureName1"),     ("CharType()", "featureName1"),
-                ("VarcharType()", "featureName1"), ("ByteType()", "featureName1"),      ("IntegerType()", "featureName1")]
+        data = [("BinaryType()", "featureName1"),  ("TimestampType()", "featureName1"),
+                ("BooleanType()", "featureName1"), ("DoubleType()", "featureName1"),
+                ("StringType()", "featureName1"),  ("DateType()", "featureName1"),
+                ("LongType()", "featureName1"),    ("ShortType()", "featureName1"),
+                ("CharType()", "featureName1"),    ("VarcharType()", "featureName1"),
+                ("ByteType()", "featureName1"),    ("IntegerType()", "featureName1")]
 
         columns = ["dataType", "featureName"]
         expected = ["binary",      "timestamp", "boolean",

--- a/assets/model_monitoring/components/tests/unit/test_compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_compute_data_quality_metrics.py
@@ -1,0 +1,113 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""This file contains unit tests for the Model Monitor Data Quality Compute Metric component."""
+
+import pytest
+from pyspark.sql.functions import current_timestamp
+from pyspark.sql.types import Row
+from src.data_quality_compute_metrics.compute_data_quality_metrics import (
+    compute_dtype_violation_count_modify_dataset,
+    modify_dataType)
+from tests.e2e.utils.io_utils import create_pyspark_dataframe
+
+
+df_without_violation = [
+        ( True, 41.2, 101001, "2021-03-11", 2.345, \
+          345.66, 234, 45634, 3877, "string", \
+          "a", "a")
+        ]
+columns = ["feature_boolean", "feature_double", "feature_binary", "feature_date", "feature_decimal", \
+           "feature_float", "feature_integer", "feature_long", "feature_short", "feature_string", \
+           "feature_char", "feature_varchar"]
+df = create_pyspark_dataframe(df_without_violation, columns)
+df_without_violation = df.withColumn("feature_timestamp", current_timestamp())
+
+data_with_violation = [
+        ( "*", "*", "*", "*", \
+          "*", "*", "*", "*", None, \
+          None, None ),
+        ( "*", "*", "*", "*", \
+          "*", "*", "*", "*", 1, \
+          1, 1 )
+        ]
+columns = ["feature_boolean", "feature_double",  "feature_date", "feature_decimal", \
+           "feature_float", "feature_integer", "feature_long", "feature_short", "feature_string", \
+           "feature_char", "feature_varchar"]
+df_with_violation = create_pyspark_dataframe(data_with_violation, columns)
+
+columns = ['featureName',  'dataType']
+data_stats = [
+            ('feature_timestamp', 'timestamp'),
+            ('feature_boolean', 'boolean'),
+            ('feature_double', 'double'),
+            ('feature_binary', 'binary'),
+            ('feature_date', 'date'),
+            ('feature_decimal', 'decimal'),
+            ('feature_float', 'float'),
+            ('feature_integer', 'integer'),
+            ('feature_long', 'long'),
+            ('feature_short', 'short'),
+            ('feature_string', 'string'),
+            ('feature_char', 'char(30)'),
+            ('feature_varchar', 'varchar(30)')
+        ]
+data_stats_table_mod = create_pyspark_dataframe(data_stats, columns)
+
+
+@pytest.mark.unit
+class TestModelMonitorDataQuality:
+    """Test class for model monitor data quality component."""
+
+    @pytest.mark.parametrize("df_without_datatype_violation, data_stats_table_mod", [(df_without_violation, data_stats_table_mod)])
+    def test_compute_dtype_violation_count_modify_dataset_without_violation(
+            self,
+            df_without_datatype_violation,
+            data_stats_table_mod
+    ):
+        """Test datatype with no vialation"""
+        _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_without_datatype_violation, data_stats_table_mod)
+        for rows in df_conversion_errors.select("violationCount").collect():
+            assert rows[0] == 0
+            
+    @pytest.mark.parametrize("df_with_datatype_violation, data_stats_table_mod", [(df_with_violation, data_stats_table_mod)])
+    def test_compute_dtype_violation_count_modify_dataset_with_violation(
+            self,
+            df_with_datatype_violation,
+            data_stats_table_mod
+    ):
+        """Test datatype while there are vialation"""
+        _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_with_datatype_violation, data_stats_table_mod)
+        for rows in df_conversion_errors.select("violationCount").collect():
+            assert rows[0] >= 1
+
+
+    def test_compute_dtype_violation_count_modify_dataset_with_unsupported_type(self):
+        """Test datatype while the datatype is unsupported"""
+        data = [(1, 2), (2, 3)]
+        columns = ["feature_unsupported_1", "feature_unsupported_2"]
+        df = create_pyspark_dataframe(data, columns)
+        data_stats_tabel_mod_with_unsupported_type = [("feature_unsupported_1", "UnsupportedType()"), ("feature_unsupported_2", "UnsupportedType()")]
+        columns = ['featureName',  'dataType']
+        data_stats_table_mod = create_pyspark_dataframe(data_stats_tabel_mod_with_unsupported_type, columns)
+        _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df, data_stats_table_mod)
+        for rows in df_conversion_errors.select("violationCount").collect():
+            assert rows[0] == 0
+
+    @pytest.mark.local
+    def test_modify_type(self):
+        """Test modify datatype from Datatype() to datatype"""
+        data = [("BinaryType()", "featureName1"), ("TimestampType()", "featureName1"), ("BooleanType()", "featureName1"),
+                ("DoubleType()", "featureName1"), ("StringType()", "featureName1"),    ("DateType()", "featureName1"),
+                ("LongType()", "featureName1"),   ("ShortType()", "featureName1"),     ("CharType()", "featureName1"),
+                ("VarcharType()", "featureName1"),("ByteType()", "featureName1"),      ("IntegerType()", "featureName1")]
+        
+        columns = ["dataType", "featureName"]
+        expected = ["binary", "timestamp", "boolean",
+                    "double", "string",    "date",
+                    "long",   "short",     "char(30)",
+                    "varchar(30)","byte", "integer"]
+        df = create_pyspark_dataframe(data, columns)
+        df_mod = modify_dataType(df)
+        dataType_array = [str(row.dataType) for row in df_mod.collect()]
+        assert dataType_array == expected

--- a/assets/model_monitoring/components/tests/unit/test_compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_compute_data_quality_metrics.py
@@ -5,7 +5,6 @@
 
 import pytest
 from pyspark.sql.functions import current_timestamp
-from pyspark.sql.types import Row
 from src.data_quality_compute_metrics.compute_data_quality_metrics import (
     compute_dtype_violation_count_modify_dataset,
     modify_dataType)
@@ -13,26 +12,26 @@ from tests.e2e.utils.io_utils import create_pyspark_dataframe
 
 
 df_without_violation = [
-        ( True, 41.2, 101001, "2021-03-11", 2.345, \
-          345.66, 234, 45634, 3877, "string", \
-          "a", "a")
+        (True, 41.2, 101001, "2021-03-11", 2.345,
+         345.66, 234, 45634, 3877, "string",
+         "a", "a")
         ]
-columns = ["feature_boolean", "feature_double", "feature_binary", "feature_date", "feature_decimal", \
-           "feature_float", "feature_integer", "feature_long", "feature_short", "feature_string", \
+columns = ["feature_boolean", "feature_double", "feature_binary", "feature_date", "feature_decimal",
+           "feature_float", "feature_integer", "feature_long", "feature_short", "feature_string",
            "feature_char", "feature_varchar"]
 df = create_pyspark_dataframe(df_without_violation, columns)
 df_without_violation = df.withColumn("feature_timestamp", current_timestamp())
 
 data_with_violation = [
-        ( "*", "*", "*", "*", \
-          "*", "*", "*", "*", None, \
-          None, None ),
-        ( "*", "*", "*", "*", \
-          "*", "*", "*", "*", 1, \
-          1, 1 )
+        ("*", "*", "*", "*",
+         "*", "*", "*", "*", None,
+         None, None),
+        ("*", "*", "*", "*",
+         "*", "*", "*", "*", 1,
+         1, 1)
         ]
-columns = ["feature_boolean", "feature_double",  "feature_date", "feature_decimal", \
-           "feature_float", "feature_integer", "feature_long", "feature_short", "feature_string", \
+columns = ["feature_boolean", "feature_double",  "feature_date", "feature_decimal",
+           "feature_float", "feature_integer", "feature_long", "feature_short", "feature_string",
            "feature_char", "feature_varchar"]
 df_with_violation = create_pyspark_dataframe(data_with_violation, columns)
 
@@ -59,7 +58,8 @@ data_stats_table_mod = create_pyspark_dataframe(data_stats, columns)
 class TestModelMonitorDataQuality:
     """Test class for model monitor data quality component."""
 
-    @pytest.mark.parametrize("df_without_datatype_violation, data_stats_table_mod", [(df_without_violation, data_stats_table_mod)])
+    @pytest.mark.parametrize("df_without_datatype_violation, data_stats_table_mod",
+                             [(df_without_violation, data_stats_table_mod)])
     def test_compute_dtype_violation_count_modify_dataset_without_violation(
             self,
             df_without_datatype_violation,
@@ -69,8 +69,9 @@ class TestModelMonitorDataQuality:
         _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_without_datatype_violation, data_stats_table_mod)
         for rows in df_conversion_errors.select("violationCount").collect():
             assert rows[0] == 0
-            
-    @pytest.mark.parametrize("df_with_datatype_violation, data_stats_table_mod", [(df_with_violation, data_stats_table_mod)])
+
+    @pytest.mark.parametrize("df_with_datatype_violation, data_stats_table_mod",
+                             [(df_with_violation, data_stats_table_mod)])
     def test_compute_dtype_violation_count_modify_dataset_with_violation(
             self,
             df_with_datatype_violation,
@@ -80,7 +81,6 @@ class TestModelMonitorDataQuality:
         _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_with_datatype_violation, data_stats_table_mod)
         for rows in df_conversion_errors.select("violationCount").collect():
             assert rows[0] >= 1
-
 
     def test_compute_dtype_violation_count_modify_dataset_with_unsupported_type(self):
         """Test datatype while the datatype is unsupported"""
@@ -97,16 +97,16 @@ class TestModelMonitorDataQuality:
     @pytest.mark.local
     def test_modify_type(self):
         """Test modify datatype from Datatype() to datatype"""
-        data = [("BinaryType()", "featureName1"), ("TimestampType()", "featureName1"), ("BooleanType()", "featureName1"),
-                ("DoubleType()", "featureName1"), ("StringType()", "featureName1"),    ("DateType()", "featureName1"),
-                ("LongType()", "featureName1"),   ("ShortType()", "featureName1"),     ("CharType()", "featureName1"),
-                ("VarcharType()", "featureName1"),("ByteType()", "featureName1"),      ("IntegerType()", "featureName1")]
-        
+        data = [("BinaryType()", "featureName1"),  ("TimestampType()", "featureName1"), ("BooleanType()", "featureName1"),
+                ("DoubleType()", "featureName1"),  ("StringType()", "featureName1"),    ("DateType()", "featureName1"),
+                ("LongType()", "featureName1"),    ("ShortType()", "featureName1"),     ("CharType()", "featureName1"),
+                ("VarcharType()", "featureName1"), ("ByteType()", "featureName1"),      ("IntegerType()", "featureName1")]
+
         columns = ["dataType", "featureName"]
-        expected = ["binary", "timestamp", "boolean",
-                    "double", "string",    "date",
-                    "long",   "short",     "char(30)",
-                    "varchar(30)","byte", "integer"]
+        expected = ["binary",      "timestamp", "boolean",
+                    "double",      "string",    "date",
+                    "long",        "short",     "char(30)",
+                    "varchar(30)", "byte",      "integer"]
         df = create_pyspark_dataframe(data, columns)
         df_mod = modify_dataType(df)
         dataType_array = [str(row.dataType) for row in df_mod.collect()]

--- a/assets/model_monitoring/components/tests/unit/test_compute_data_quality_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_compute_data_quality_metrics.py
@@ -65,7 +65,7 @@ class TestModelMonitorDataQuality:
             df_without_datatype_violation,
             data_stats_table_mod
     ):
-        """Test datatype with no vialation"""
+        """Test datatype with no violation."""
         _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_without_datatype_violation,
                                                                                data_stats_table_mod)
         for rows in df_conversion_errors.select("violationCount").collect():
@@ -78,14 +78,14 @@ class TestModelMonitorDataQuality:
             df_with_datatype_violation,
             data_stats_table_mod
     ):
-        """Test datatype while there are vialation"""
+        """Test datatype while there are violation."""
         _, df_conversion_errors = compute_dtype_violation_count_modify_dataset(df_with_datatype_violation,
                                                                                data_stats_table_mod)
         for rows in df_conversion_errors.select("violationCount").collect():
             assert rows[0] >= 1
 
     def test_compute_dtype_violation_count_modify_dataset_with_unsupported_type(self):
-        """Test datatype while the datatype is unsupported"""
+        """Test datatype while the datatype is unsupported."""
         data = [(1, 2), (2, 3)]
         columns = ["feature_unsupported_1", "feature_unsupported_2"]
         df = create_pyspark_dataframe(data, columns)
@@ -99,7 +99,7 @@ class TestModelMonitorDataQuality:
 
     @pytest.mark.local
     def test_modify_type(self):
-        """Test modify datatype from Datatype() to datatype"""
+        """Test modify datatype from Datatype() to datatype."""
         data = [("BinaryType()", "featureName1"),  ("TimestampType()", "featureName1"),
                 ("BooleanType()", "featureName1"), ("DoubleType()", "featureName1"),
                 ("StringType()", "featureName1"),  ("DateType()", "featureName1"),


### PR DESCRIPTION
1. Add more supported dataType when cast dataType
2. If the dataType is not supported, we do not throw runtime exception, instead we set the datatype violation number be the default value 0 and log a warning
3. added unit test for the changes.