### PR TITLE
Adding document intelligence connection id to components

### DIFF
--- a/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
@@ -13,7 +13,7 @@ description: |
   Creates chunks no larger than `chunk_size` from `input_data`, extracted document titles are prepended to each chunk
 
   LLM models have token limits for the prompts passed to them, this is a limiting factor at embedding time and even more limiting at prompt completion time as only so much context can be passed along with instructions to the LLM and user queries.
-  Chunking allows splitting source data of various formats into small but coherent snippets of information which can be 'packed' into LLM prompts when asking for answers to user querys related to the sorce documents.
+  Chunking allows splitting source data of various formats into small but coherent snippets of information which can be 'packed' into LLM prompts when asking for answers to user query related to the source documents.
 
   Supported formats: md, txt, html/htm, pdf, ppt(x), doc(x), xls(x), py
 
@@ -41,6 +41,10 @@ inputs:
     type: integer
     default: 0
     description: "Number of tokens to overlap between chunks."
+  doc_intel_connection_id:
+    type: string
+    optional: true
+    description: "Connection id for Document Intelligence service. If provided, will be used to extract content from .pdf document."
   data_source_url:
     type: string
     optional: true

--- a/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
@@ -13,7 +13,7 @@ description: |
   Creates chunks no larger than `chunk_size` from `input_data`, extracted document titles are prepended to each chunk
 
   LLM models have token limits for the prompts passed to them, this is a limiting factor at embedding time and even more limiting at prompt completion time as only so much context can be passed along with instructions to the LLM and user queries.
-  Chunking allows splitting source data of various formats into small but coherent snippets of information which can be 'packed' into LLM prompts when asking for answers to user querys related to the sorce documents.
+  Chunking allows splitting source data of various formats into small but coherent snippets of information which can be 'packed' into LLM prompts when asking for answers to user query related to the source documents.
 
   Supported formats: md, txt, html/htm, pdf, ppt(x), doc(x), xls(x), py
 
@@ -41,6 +41,10 @@ inputs:
     type: integer
     default: 0
     description: "Number of tokens to overlap between chunks."
+  doc_intel_connection_id:
+    type: string
+    optional: true
+    description: "Connection id for Document Intelligence service. If provided, will be used to extract content from .pdf document."
   citation_url:
     type: string
     optional: true


### PR DESCRIPTION
Adding document intelligence connection id to
- crack_and_chunk
- crack_and_chunk_and_embed