### PR TITLE
Pmanoj/change llama defaults

### DIFF
--- a/assets/models/system/Llama-2-13b/model.yaml
+++ b/assets/models/system/Llama-2-13b/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: meta/llama-2-13b/1692168478/mlflow_model_folder
+  container_path: meta/llama-2-13b/1698059909/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/Llama-2-13b/spec.yaml
+++ b/assets/models/system/Llama-2-13b/spec.yaml
@@ -39,9 +39,10 @@ tags:
   license: custom
   author: meta
   model_specific_defaults:
-    apply_deepspeed: 'false'
+    apply_deepspeed: 'true'
+    deepspeed_stage: '3'
     apply_lora: 'true'
-    precision: '4'
+    precision: '16'
   task: text-generation
   inference_supported_envs:
   - vllm

--- a/assets/models/system/Llama-2-13b/spec.yaml
+++ b/assets/models/system/Llama-2-13b/spec.yaml
@@ -39,13 +39,12 @@ tags:
   license: custom
   author: meta
   model_specific_defaults:
-    apply_deepspeed: 'true'
-    deepspeed_stage: '3'
+    apply_deepspeed: 'false'
     apply_lora: 'true'
-    precision: '16'
+    precision: '4'
   task: text-generation
   inference_supported_envs:
   - vllm
   - ds_mii
   SharedComputeCapacityEnabled: ''
-version: 12
+version: 13

--- a/assets/models/system/Llama-2-13b/spec.yaml
+++ b/assets/models/system/Llama-2-13b/spec.yaml
@@ -42,6 +42,7 @@ tags:
     apply_deepspeed: 'false'
     apply_lora: 'true'
     precision: '4'
+    max_seq_length: 256
   task: text-generation
   inference_supported_envs:
   - vllm


### PR DESCRIPTION
Changes
---------
1. Removed the model max length limit of 256. The new model max length is updated to 4096. The artifacts are updated in a new timestamped sub-folder of existing Llama-2-13b folder. This is compensated by adding _max_seq_length_ parameter that defaults the length to 256
2. Version is upgraded for the release