### PR TITLE
Adding Document Intelligence support to crack and chunk components

### DIFF
--- a/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
@@ -87,6 +87,7 @@ command: >-
   --output_chunks ${{outputs.output_chunks}}
   --chunk_size ${{inputs.chunk_size}}
   --chunk_overlap ${{inputs.chunk_overlap}}
+  $[[--doc_intel_connection_id ${{inputs.doc_intel_connection_id}}]]
   $[[--data_source_url ${{inputs.data_source_url}}]]
   $[[--document_path_replacement_regex '${{inputs.document_path_replacement_regex}}']]
   --max_sample_files ${{inputs.max_sample_files}}

--- a/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
@@ -91,6 +91,7 @@ command: >-
   --use_rcts '${{inputs.use_rcts}}'
   $[[--citation_url ${{inputs.citation_url}}]]
   $[[--citation_replacement_regex '${{inputs.citation_replacement_regex}}']]
+  $[[--doc_intel_connection_id ${{inputs.doc_intel_connection_id}}]]
   --embeddings_model ${{inputs.embeddings_model}}
   $[[--embeddings_connection_id ${{inputs.embeddings_connection_id}}]]
   $[[--embeddings_container ${{inputs.embeddings_container}}]]


### PR DESCRIPTION
Adding optional parameters - doc_intel_connection_id to both crack_and_chunk and crack_and_chunk_and_embed components.