### PR TITLE
remove UAI

### DIFF
--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_histogram
 display_name: Annotation - Compute Histogram
 description: Compute annotation histogram given a deployment's model data input.
-version: 0.4.2
+version: 0.4.3
 is_deterministic: false
 inputs:
   production_dataset: 
@@ -111,7 +111,7 @@ conf:
       - pip:
           - azure-cli-core~=2.45.0
           - azure-identity~=1.12.0
-          - azure-ai-ml~=1.8.0
+          - azure-ai-ml~=1.10.0
           - azure-keyvault-secrets==4.7.0
           - tiktoken==0.3.3
           - json5==0.9.11

--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_metrics
 display_name: Annotation - Compute Metrics
 description: Compute annotation metrics given a deployment's model data input.
-version: 0.4.0
+version: 0.4.1
 is_deterministic: True
 inputs:
   annotation_histogram: 
@@ -66,7 +66,7 @@ conf:
       - pip:
           - azure-cli-core~=2.45.0
           - azure-identity~=1.12.0
-          - azure-ai-ml~=1.8.0
+          - azure-ai-ml~=1.10.0
           - azure-keyvault-secrets==4.7.0
           - tiktoken==0.3.3
           - json5==0.9.11

--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -97,7 +97,7 @@ outputs:
 jobs:
   compute_histogram:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.2
+    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.3
     inputs:
       production_dataset:
         type: mltable
@@ -137,7 +137,7 @@ jobs:
       type: managed
   compute_metrics:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.0
+    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.1
     inputs:
       annotation_histogram:
         type: mltable

--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: generation_safety_quality_signal_monitor
 display_name: Generation Safety & Quality - Signal Monitor
 description: Computes the content generation safety metrics over LLM outputs.
-version: 0.4.2
+version: 0.4.3
 is_deterministic: true
 inputs:
   monitor_name:

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -771,7 +771,7 @@ class WorkspaceConnectionTokenManager(_APITokenManager):
 
             credential = AzureMLTokenAuthentication._initialize_aml_token_auth()
 
-            uri_match = re.match(r"/subscriptions/(.*)/resourceGroups/(.*)/providers/Microsoft.MachineLearningServices/workspaces/(.*)/connections/(.*)", connection_name) # noqa: E501
+            uri_match = re.match(r"/subscriptions/(.*)/resourceGroups/(.*)/providers/Microsoft.MachineLearningServices/workspaces/(.*)/connections/(.*)", connection_name)  # noqa: E501
 
             ml_client = MLClient(
                 credential=credential,
@@ -781,7 +781,7 @@ class WorkspaceConnectionTokenManager(_APITokenManager):
             )
 
             if os.environ.get("AZUREML_RUN_ID", None) is not None:
-                # In AzureML Run context, we need to use workspaces internal endpoint that will accept 
+                # In AzureML Run context, we need to use workspaces internal endpoint that will accept
                 # AzureMLToken auth.
                 ml_client.connections._operation._client._base_url = f"{os.environ.get('AZUREML_SERVICE_ENDPOINT')}/rp/workspaces"  # noqa: E501
             _logger.info(f"Using ml_client base_url: {ml_client.connections._operation._client._base_url}")

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -764,7 +764,7 @@ class WorkspaceConnectionTokenManager(_APITokenManager):
         **kwargs,
     ):
         super().__init__(auth_header=auth_header)
-        
+
         try:
             from azureml.dataprep.api._aml_auth._azureml_token_authentication import AzureMLTokenAuthentication
             from azure.ai.ml import MLClient
@@ -774,7 +774,7 @@ class WorkspaceConnectionTokenManager(_APITokenManager):
 
             uri_match = re.match(r"/subscriptions/(.*)/resourceGroups/(.*)/providers/Microsoft.MachineLearningServices/workspaces/(.*)/connections/(.*)",  # noqa: E501
                                  connection_name, flags=re.IGNORECASE)
-                
+
             ml_client = MLClient(
                 credential=credential,
                 subscription_id=uri_match.group(1),
@@ -1604,7 +1604,6 @@ def apply_annotation(
     except Exception as e:
         print(f"Unable to process request: {e}")
         return
-
 
     endpoint_domain_name = token_manager.get_endpoint_domain().replace("https://", "")
     api_version = token_manager.get_api_version()

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -755,7 +755,7 @@ class _APITokenManager(ABC):
         pass
 
 
-class WorkspaceConnectionTokenManager(_APITokenManager):
+class _WorkspaceConnectionTokenManager(_APITokenManager):
     def __init__(
         self,
         *,
@@ -1595,7 +1595,7 @@ def apply_annotation(
     }
     try:
         # Define authorization token manager
-        token_manager_class = WorkspaceConnectionTokenManager
+        token_manager_class = _WorkspaceConnectionTokenManager
 
         token_manager = token_manager_class(
             connection_name=workspace_connection_arm_id,

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -797,12 +797,9 @@ class WorkspaceConnectionTokenManager(_APITokenManager):
                 raise Exception(f"Received unexpected endpoint type {connection.type}"
                                     "only Azure Open AI endpoints are supported at this time")
                 
-            self.api_version = connection.metadata.ApiVersion
-            print(self.api_version)
+            self.api_version = connection.metadata["ApiVersion"]
             self.domain_name = connection.target
-            print(self.domain_name)
-            self.token = connection.credentials.key
-            print(self.token)
+            self.token = connection.credentials["key"]
         except Exception:
             raise Exception("Error encountered while attempting to authentication token")
             


### PR DESCRIPTION
remove UAI token manager from GSQ compute histogram component and use run token instead
pin to api version 12-01-2022

success run : https://ml.azure.com/experiments/id/1a0a9a51-a26e-44b3-92d2-dcfd2d1fe6aa/runs/cool_raisin_yvdgxt2tzk?wsid=/subscriptions/e0fd569c-e34a-4249-8c24-e8d723c7f054/resourceGroups/hawestra-rg/providers/Microsoft.MachineLearningServices/workspaces/hawestra-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#