### PR TITLE
Pass validated model dir as Path

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.16.14
+### 🐛 Bugs Fixed
+- [#1574](https://github.com/Azure/azureml-assets/pull/1574) Fix fetching validated model assets
+
 ## 1.16.13
 ### 🚀 New Features
 - [#1569](https://github.com/Azure/azureml-assets/pull/1569) Add model validations

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -481,7 +481,8 @@ def validate_assets(input_dirs: List[Path],
         # Populate dictionary of asset names to asset config paths
         asset_dirs[f"{asset_config.type.value} {asset_config.name}"].append(asset_config_path)
 
-        if asset_config.type == assets.AssetType.MODEL:
+        # validated_model_map would be ampty for non-drop scenario
+        if validated_model_map and asset_config.type == assets.AssetType.MODEL:
             error_count += validate_model_assets(asset_config, validated_model_map.get(asset_config.name, None))
 
         # Populate dictionary of image names to asset config paths

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -408,8 +408,8 @@ def get_validated_models_assets_map(model_validation_results_dir: str):
     """Return model assets map."""
     try:
         if not model_validation_results_dir:
-            logger.log_error(
-                "Unexpected. model_validation_results_dir is None. All models assets will fail in validation"
+            logger.log_warning(
+                "Unexpected !!! model_validation_results_dir is None. Model assets might fail in validation."
             )
             return {}
 

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -414,7 +414,7 @@ def get_validated_models_assets_map(model_validation_results_dir: str):
             return {}
 
         validated_model_assets: List[assets.AssetConfig] = util.find_assets(
-            input_dirs=[model_validation_results_dir],
+            input_dirs=[Path(model_validation_results_dir)],
             asset_config_filename=assets.DEFAULT_ASSET_FILENAME,
             types=[assets.config.AssetType.MODEL]
         )

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.13",
+   version="1.16.14",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
1. Path needs to be passed instead of str for `util.find_assets` call 
2. Let model spec validation happen in case model_validation_results_dir is not provided