### PR TITLE
changing the type of validation file path from str -> default missing_type

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/preprocess/preprocess.py
+++ b/assets/training/finetune_acft_hf_nlp/src/preprocess/preprocess.py
@@ -7,7 +7,8 @@ import json
 import argparse
 from pathlib import Path
 from argparse import Namespace
-
+from typing import Any
+from functools import partial
 
 from azureml.acft.contrib.hf.nlp.task_factory import get_task_runner
 from azureml.acft.contrib.hf.nlp.constants.constants import (
@@ -50,6 +51,13 @@ def str2bool(arg):
         raise ValueError(f"Invalid argument {arg} to while converting string to boolean")
 
 
+def default_missing_path(arg_str: str, default: Any = None):
+    """If path of the arg is missing, reset the value to default. Use this type with paths."""
+    if isinstance(arg_str, str) and not Path(arg_str).is_file():
+        return default
+    return arg_str
+
+
 def get_parser():
     """
     Add arguments and returns the parser. Here we add all the arguments for all the tasks.
@@ -65,9 +73,11 @@ def get_parser():
         default=None,
         help="Train data path",
     )
+    # NOTE that the default is present in both :param `type` and `default`. In case of change, we need to update
+    # in both places
     parser.add_argument(
         "--validation_file_path",
-        type=str,
+        type=partial(default_missing_path, default=None),
         required=False,
         default=None,
         help="Validation data path",

--- a/assets/training/finetune_acft_hf_nlp/src/preprocess/preprocess.py
+++ b/assets/training/finetune_acft_hf_nlp/src/preprocess/preprocess.py
@@ -66,9 +66,11 @@ def get_parser():
     """
     parser = argparse.ArgumentParser(description="Model Preprocessing", allow_abbrev=False)
 
+    # NOTE that the default is present in both :param `type` and `default`. In case of change, we need to update
+    # in both places
     parser.add_argument(
         "--train_file_path",
-        type=str,
+        type=partial(default_missing_path, default=None),
         required=False,
         default=None,
         help="Train data path",
@@ -82,9 +84,11 @@ def get_parser():
         default=None,
         help="Validation data path",
     )
+    # NOTE that the default is present in both :param `type` and `default`. In case of change, we need to update
+    # in both places
     parser.add_argument(
         "--test_file_path",
-        type=str,
+        type=partial(default_missing_path, default=None),
         required=False,
         default=None,
         help="Test data path",


### PR DESCRIPTION
defaulting the file path to _argparser_ default value for train, validation and test file paths.