### PR TITLE
validating the file formats

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/data_import/data_import.py
+++ b/assets/training/finetune_acft_hf_nlp/src/data_import/data_import.py
@@ -93,11 +93,16 @@ def data_import(args: Namespace):
 
     # validate file formats
     _validate_file_paths_with_supported_formats([args.train_file_path, args.validation_file_path])
+    logger.info("File format validation successful.")
 
     # copy files
+    logger.info(f"Copy started for {args.train_file_path}")
     shutil.copyfile(args.train_file_path, args.output_dataset / TRAIN_FILE_NAME)
+    logger.info("Copy completed")
     if args.validation_file_path is not None:
+        logger.info(f"Copy started for {args.validation_file_path}")
         shutil.copyfile(args.validation_file_path, args.output_dataset / VALIDATION_FILE_NAME)
+        logger.info("Copy completed")
 
 
 @swallow_all_exceptions(time_delay=5)

--- a/assets/training/finetune_acft_hf_nlp/src/data_import/data_import.py
+++ b/assets/training/finetune_acft_hf_nlp/src/data_import/data_import.py
@@ -5,7 +5,7 @@
 
 import argparse
 from argparse import Namespace
-from typing import List
+from typing import List, Optional
 
 from pathlib import Path
 import shutil
@@ -69,12 +69,12 @@ def get_parser():
     return parser
 
 
-def _validate_file_paths_with_supported_formats(file_paths: List[str]):
+def _validate_file_paths_with_supported_formats(file_paths: List[Optional[str]]):
     """Check if the file path is in the list of supported formats."""
     global SUPPORTED_FILE_FORMATS
 
     for file_path in file_paths:
-        if not Path(file_path).suffix.lower() in SUPPORTED_FILE_FORMATS:
+        if file_path and not Path(file_path).suffix.lower() in SUPPORTED_FILE_FORMATS:
             raise ACFTValidationException._with_error(
                 AzureMLError.create(
                     ACFTUserError,


### PR DESCRIPTION
1. Validating the train and validation file paths with supported file formats
2. Changed the time delay from 60 -> 5sec for swallow all exceptions as the script has very few log lines
3. Skipping the copy of validation file path if not present