### PR TITLE
roberta large mnli with hftransformersv2

### DIFF
--- a/assets/models/system/roberta-large-mnli/model.yaml
+++ b/assets/models/system/roberta-large-mnli/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/roberta-large-mnli/1694148890/mlflow_model_folder
+  container_path: huggingface/roberta-large-mnli/1698935096/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/roberta-large-mnli/spec.yaml
+++ b/assets/models/system/roberta-large-mnli/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: roberta-large-mnli
 path: ./
 properties:
-  SHA: 0dcbcf20673c006ac2d1e324954491b96f0c0015
+  SHA: df0f743a40fd2c7a260dfae33c1991f72ca9d472
   datasets: multi_nli, wikipedia, bookcorpus
   evaluation-min-sku-spec: 8|0|28|56
   evaluation-recommended-sku: Standard_DS4_v2
@@ -53,4 +53,4 @@ tags:
     apply_lora: 'true'
     apply_ort: 'true'
   task: text-classification
-version: 10
+version: 11


### PR DESCRIPTION
Job Link:- https://ml.azure.com/runs/great_plum_cl9kcdndts?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourcegroups/shared-finetuning-rg/workspaces/suvrat&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#

Blob storage:
https://ml.azure.com/runs/loving_balloon_g837v12wlb?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourcegroups/shared-finetuning-rg/workspaces/suvrat&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#

default enpoint:-
https://ml.azure.com/endpoints/realtime/roberta-large-mnli-2023-11-2/detail?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourcegroups/shared-finetuning-rg/workspaces/suvrat&tid=72f988bf-86f1-41af-91ab-2d7cd011db47

<img width="960" alt="roberta-large-mnli" src="https://github.com/Azure/azureml-assets/assets/142586261/3caf074d-20b4-435c-951f-f6f671d2c180">


**conda.yaml**

```
channels:
- conda-forge
dependencies:
- python=3.8.17
- pip<=23.2.1
- pip:
  - mlflow==2.6.0
  - cloudpickle==2.2.1
  - jsonpickle==3.0.2
  - mlflow-skinny==2.6.0
  - azureml-core==1.53.0
  - azureml-mlflow==1.53.0
  - azureml-metrics[all]==0.0.26
  - scikit-learn==1.1.0
  - cryptography==41.0.3
  - python-dateutil==2.8.2
  - datasets==2.14.5
  - soundfile==0.12.1
  - librosa==0.10.1
  - diffusers==0.21.1
  - sentencepiece==0.1.99
  - transformers==4.33.1
  - torch==1.13.1
  - accelerate==0.23.0
  - Pillow==9.4.0
  - azureml-evaluate-mlflow==0.0.26
- pycocotools=2.0.4
name: mlflow-env
```

**MLmodel**

```
flavors:
  hftransformersv2:
    code: null
    hf_config_class: AutoConfig
    hf_pretrained_class: AutoModelForSequenceClassification
    hf_tokenizer_class: AutoTokenizer
    huggingface_id: roberta-large-mnli
    model_data: data
    pytorch_version: 1.13.1
    task_type: text-classification
    transformers_version: 4.33.1
  python_function:
    data: data
    env: conda.yaml
    loader_module: azureml.evaluate.mlflow.hftransformers
    python_version: 3.8.17
mlflow_version: 2.6.0
model_uuid: 67b70f528f5c40ff9ad1662bde6fd8f3
utc_time_created: '2023-11-02 05:11:01.298851'
```