### PR TITLE
update model inference section for blip models

### DIFF
--- a/assets/models/system/salesforce-blip-image-captioning-base/description.md
+++ b/assets/models/system/salesforce-blip-image-captioning-base/description.md
@@ -44,6 +44,6 @@ Note:
 ```
 
 #### Model inference - image to text
-For a sample image below, the output text is "a stream in the middle of a forest".
+For sample image below, the output text is "a stream in the middle of a forest".
 
 <img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/output_blip_image_captioning_base.png" alt="Salesforce-BLIP-image-captioning-base">

--- a/assets/models/system/salesforce-blip-image-captioning-base/description.md
+++ b/assets/models/system/salesforce-blip-image-captioning-base/description.md
@@ -43,6 +43,7 @@ Note:
 ]
 ```
 
-#### Model inference: Text for the sample image
+#### Model inference - image to text
+For a sample image below, the output text is "a stream in the middle of a forest".
 
 <img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/output_blip_image_captioning_base.png" alt="Salesforce-BLIP-image-captioning-base">

--- a/assets/models/system/salesforce-blip-vqa-base/description.md
+++ b/assets/models/system/salesforce-blip-vqa-base/description.md
@@ -45,6 +45,6 @@ Note:
 ```
 
 #### Model inference - visual question answering
-For a sample image and text prompt "What is in the picture?".
+For sample image below and text prompt "What is in the picture?", the output text is "sand".
 
 <img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/output_blip_vqa_base.png" alt="Salesforce-BLIP-vqa-base">

--- a/assets/models/system/salesforce-blip-vqa-base/description.md
+++ b/assets/models/system/salesforce-blip-vqa-base/description.md
@@ -44,6 +44,7 @@ Note:
 ]
 ```
 
-#### Model inference: Text for the sample image
+#### Model inference - visual question answering
+For a sample image and text prompt "What is in the picture?".
 
 <img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/output_blip_vqa_base.png" alt="Salesforce-BLIP-vqa-base">

--- a/assets/models/system/salesforce-blip2-opt-2-7b-image-to-text/description.md
+++ b/assets/models/system/salesforce-blip2-opt-2-7b-image-to-text/description.md
@@ -43,6 +43,7 @@ Note:
 ]
 ```
 
-#### Model inference: Text for the sample image
+#### Model inference - image to text
+For a sample image below, the output text is "a grassy hillside with trees and a sunset".
 
 <img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/output_blip2_opt_2-7b_image_to_text.png" alt="blip2-opt-2.7b image-to-text">

--- a/assets/models/system/salesforce-blip2-opt-2-7b-image-to-text/description.md
+++ b/assets/models/system/salesforce-blip2-opt-2-7b-image-to-text/description.md
@@ -44,6 +44,6 @@ Note:
 ```
 
 #### Model inference - image to text
-For a sample image below, the output text is "a grassy hillside with trees and a sunset".
+For sample image below, the output text is "a grassy hillside with trees and a sunset".
 
 <img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/output_blip2_opt_2-7b_image_to_text.png" alt="blip2-opt-2.7b image-to-text">

--- a/assets/models/system/salesforce-blip2-opt-2-7b-vqa/description.md
+++ b/assets/models/system/salesforce-blip2-opt-2-7b-vqa/description.md
@@ -45,6 +45,6 @@ Note:
 ```
 
 #### Model inference - visual question answering
-For a sample image and text prompt "what are people doing? Answer: ".
+For sample image below and text prompt "what are people doing? Answer: ", the output text is "they're buying coffee".
 
 <img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/output_blip2_vqa.png" alt="Salesforce-BLIP2-vqa">

--- a/assets/models/system/salesforce-blip2-opt-2-7b-vqa/description.md
+++ b/assets/models/system/salesforce-blip2-opt-2-7b-vqa/description.md
@@ -44,6 +44,7 @@ Note:
 ]
 ```
 
-#### Model inference: Text for the sample image
+#### Model inference - visual question answering
+For a sample image and text prompt "what are people doing? Answer: ".
 
 <img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/output_blip2_vqa.png" alt="Salesforce-BLIP2-vqa">


### PR DESCRIPTION
[Salesforce-BLIP-image-captioning-base](https://ml.azure.com/registries/automl-images-dev/models/Salesforce-BLIP-image-captioning-base/version/7?tid=72f988bf-86f1-41af-91ab-2d7cd011db47#overview)

[Salesforce-BLIP-vqa-base](https://ml.azure.com/registries/automl-images-dev/models/Salesforce-BLIP-vqa-base/version/4?tid=72f988bf-86f1-41af-91ab-2d7cd011db47#overview)

[Salesforce-BLIP-2-opt-2-7b-image-to-text](https://ml.azure.com/registries/automl-images-dev/models/Salesforce-BLIP-2-opt-2-7b-image-to-text/version/3?tid=72f988bf-86f1-41af-91ab-2d7cd011db47#overview)

[Salesforce-BLIP-2-opt-2-7b-vqa](https://ml.azure.com/registries/automl-images-dev/models/Salesforce-BLIP-2-opt-2-7b-vqa/version/3?tid=72f988bf-86f1-41af-91ab-2d7cd011db47#overview)