### PR TITLE
rename columns if custom column input

### DIFF
--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_histogram
 display_name: Annotation - Compute Histogram
 description: Compute annotation histogram given a deployment's model data input.
-version: 0.4.5
+version: 0.4.7
 is_deterministic: false
 inputs:
   production_dataset: 

--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: generation_safety_quality_signal_monitor
 display_name: Generation Safety & Quality - Signal Monitor
 description: Computes the content generation safety metrics over LLM outputs.
-version: 0.4.7
+version: 0.4.9
 is_deterministic: true
 inputs:
   monitor_name:
@@ -97,7 +97,7 @@ outputs:
 jobs:
   compute_histogram:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.5
+    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.7
     inputs:
       production_dataset:
         type: mltable

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -1555,12 +1555,18 @@ def apply_annotation(
     if SIMILARITY in metric_names and ground_truth_column_name not in production_df.columns:
         raise ValueError(f"production_dataset must have column: {ground_truth_column_name}")
 
+    # rename columns to prompt, completion, context, ground truth to match metaprompt data
+    production_df = (production_df.withColumnRenamed(prompt_column_name, PROMPT)
+                     .withColumnRenamed(completion_column_name, COMPLETION)
+                     .withColumnRenamed(context_column_name, CONTEXT)
+                     .withColumnRenamed(ground_truth_column_name, GROUND_TRUTH))
+
     annotation_requirements = {
-        GROUNDEDNESS: [prompt_column_name, completion_column_name, context_column_name],
-        RELEVANCE: [prompt_column_name, completion_column_name, context_column_name],
-        FLUENCY: [prompt_column_name, completion_column_name],
-        COHERENCE: [prompt_column_name, completion_column_name],
-        SIMILARITY: [prompt_column_name, completion_column_name, ground_truth_column_name]
+        GROUNDEDNESS: [PROMPT, COMPLETION, CONTEXT],
+        RELEVANCE: [PROMPT, COMPLETION, CONTEXT],
+        FLUENCY: [PROMPT, COMPLETION],
+        COHERENCE: [PROMPT, COMPLETION],
+        SIMILARITY: [PROMPT, COMPLETION, GROUND_TRUTH]
     }
     # Sampling
     production_df_sampled = production_df.sample(withReplacement=False, fraction=sample_rate)


### PR DESCRIPTION
If the user has custom column input we need to make sure the schema is consistent with our metaprompt information; rename the columns to match prompt completion context ground_truth in this scenario: 

example:
input data is 
<img width="833" alt="image" src="https://github.com/Azure/azureml-assets/assets/42190563/47a34e9a-6273-4fb1-adb5-42086e44120a">
we rename the columns so instead of 
<img width="846" alt="image" src="https://github.com/Azure/azureml-assets/assets/42190563/8b0938a1-c5fe-41fe-aaaf-ec12fe85b8b5">

<img width="668" alt="image" src="https://github.com/Azure/azureml-assets/assets/42190563/3fda1541-2b7f-4ec9-ac29-8f77159724c8">
