### PR TITLE
add validation for unique columns

### DIFF
--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_histogram
 display_name: Annotation - Compute Histogram
 description: Compute annotation histogram given a deployment's model data input.
-version: 0.4.8
+version: 0.4.9
 is_deterministic: false
 inputs:
   production_dataset: 

--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: generation_safety_quality_signal_monitor
 display_name: Generation Safety & Quality - Signal Monitor
 description: Computes the content generation safety metrics over LLM outputs.
-version: 0.4.10
+version: 0.4.11
 is_deterministic: true
 inputs:
   monitor_name:
@@ -97,7 +97,7 @@ outputs:
 jobs:
   compute_histogram:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.8
+    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.9
     inputs:
       production_dataset:
         type: mltable

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -1559,6 +1559,12 @@ def apply_annotation(
     if SIMILARITY in metric_names and ground_truth_column_name not in production_df.columns:
         raise ValueError(f"production_dataset must have column: {ground_truth_column_name}")
 
+    column_names = [prompt_column_name, completion_column_name, context_column_name, ground_truth_column_name]
+    if len(column_names) != len(set(column_names)):
+        raise ValueError("Detected duplicate specified columns. Column name input cannot be the same. Please ensure that"
+                         " the column input specified for prompt_column_name, completion_column_name, context_column_name,"
+                         " and ground_truth_column_name is unique.")
+        
     # rename columns to prompt, completion, context, ground truth to match metaprompt data
     production_df = (production_df.withColumnRenamed(prompt_column_name, PROMPT)
                      .withColumnRenamed(completion_column_name, COMPLETION)

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -1562,9 +1562,10 @@ def apply_annotation(
     column_names = [prompt_column_name, completion_column_name, context_column_name, ground_truth_column_name]
     if len(column_names) != len(set(column_names)):
         raise ValueError("Detected duplicate specified columns. Column name input cannot be the same. Please ensure "
-                        f"that the column input specified is unique. Received prompt_column_name: {prompt_column_name}"
-                        f"\ncompletion_column_name: {completion_column_name}\ncontext_column_name: "
-                        f"{context_column_name}\nground_truth_column_name: {ground_truth_column_name}")
+                         f"that the column input specified is unique.\nReceived prompt_column_name: "
+                         f"{prompt_column_name}\ncompletion_column_name: {completion_column_name}\n"
+                         f"context_column_name: {context_column_name}\nground_truth_column_name: "
+                         f"{ground_truth_column_name}")
 
     # rename columns to prompt, completion, context, ground truth to match metaprompt data
     production_df = (production_df.withColumnRenamed(prompt_column_name, PROMPT)

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -1561,10 +1561,11 @@ def apply_annotation(
 
     column_names = [prompt_column_name, completion_column_name, context_column_name, ground_truth_column_name]
     if len(column_names) != len(set(column_names)):
-        raise ValueError("Detected duplicate specified columns. Column name input cannot be the same. Please ensure that"
-                         " the column input specified for prompt_column_name, completion_column_name, context_column_name,"
-                         " and ground_truth_column_name is unique.")
-        
+        raise ValueError("Detected duplicate specified columns. Column name input cannot be the same. Please ensure "
+                        f"that the column input specified is unique. Received prompt_column_name: {prompt_column_name}"
+                        f"\ncompletion_column_name: {completion_column_name}\ncontext_column_name: "
+                        f"{context_column_name}\nground_truth_column_name: {ground_truth_column_name}")
+
     # rename columns to prompt, completion, context, ground truth to match metaprompt data
     production_df = (production_df.withColumnRenamed(prompt_column_name, PROMPT)
                      .withColumnRenamed(completion_column_name, COMPLETION)


### PR DESCRIPTION
Raise exception if the user specifies the same column for mulitple inputs. Example failure: 
<img width="366" alt="image" src="https://github.com/Azure/azureml-assets/assets/42190563/e5473c25-a091-4da0-963f-35ba9e832008">

example failure with 2 context columns: https://ml.azure.com/experiments/id/1a0a9a51-a26e-44b3-92d2-dcfd2d1fe6aa/runs/icy_fly_h39vvjgb8b?wsid=/subscriptions/e0fd569c-e34a-4249-8c24-e8d723c7f054/resourcegroups/hawestra-rg/providers/Microsoft.MachineLearningServices/workspaces/hawestra-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
