### PR TITLE
relax the common column criteria

### DIFF
--- a/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_drift_compute_metrics
 display_name: Data Drift - Compute Metrics
 description: Compute data drift metrics given a baseline and a deployment's model data input.
-version: 0.3.7
+version: 0.3.8
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_drift_signal_monitor
 display_name: Data Drift - Signal Monitor
 description: Computes the data drift between a baseline and production data assets.
-version: 0.3.14
+version: 0.3.15
 is_deterministic: true
 
 inputs:
@@ -87,7 +87,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.7
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.8
     inputs:
       production_dataset:
         type: mltable
@@ -112,7 +112,7 @@ jobs:
       type: aml_token
   compute_histogram_buckets:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.2
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.3
     inputs:
       input_data_1:
         type: mltable

--- a/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram_buckets/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram_buckets/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_compute_histogram_buckets
 display_name: Model Monitor - Compute Histogram Buckets
 description: Compute histogram buckets given up to two datasets.
-version: 0.3.2
+version: 0.3.3
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: prediction_drift_signal_monitor
 display_name: Prediction Drift - Signal Monitor
 description: Computes the prediction drift between a baseline and a target data assets.
-version: 0.3.10
+version: 0.3.11
 is_deterministic: true
 
 inputs:
@@ -67,7 +67,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.6
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.8
     inputs:
       production_dataset:
         type: mltable

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
@@ -47,7 +47,8 @@ def compute_data_drift_measures_tests(
        len(categorical_columns_names) == 0:
         print("No common columns found between production data and baseline"
               "data. We dont support this scenario.")
-        return
+        raise ValueError("No common columns found between production data and baseline"
+              "data. We dont support this scenario.")
 
     if len(numerical_columns_names) != 0:
         numerical_df = compute_numerical_data_drift_measures_tests(

--- a/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
+++ b/assets/model_monitoring/components/src/data_drift_compute_metrics/compute_data_drift.py
@@ -45,8 +45,6 @@ def compute_data_drift_measures_tests(
 
     if len(numerical_columns_names) == 0 and \
        len(categorical_columns_names) == 0:
-        print("No common columns found between production data and baseline"
-              "data. We dont support this scenario.")
         raise ValueError("No common columns found between production data and baseline"
               "data. We dont support this scenario.")
 

--- a/assets/model_monitoring/components/src/shared_utilities/df_utils.py
+++ b/assets/model_monitoring/components/src/shared_utilities/df_utils.py
@@ -100,13 +100,13 @@ def get_common_columns(
             # and both of them are in [double, float],
             # We consider them to be double
             if production_df_dtypes.get(column_name) in data_type_double_group \
-                and baseline_df_dtypes.get(column_name) in data_type_double_group:
+                    and baseline_df_dtypes.get(column_name) in data_type_double_group:
                 common_columns[column_name] = 'double'
             # if baseline and target are of different type
             # and both of them are in [int, long, short]
             # We consider them to be long
             elif production_df_dtypes.get(column_name) in data_type_long_group\
-                and baseline_df_dtypes.get(column_name) in data_type_long_group:
+                    and baseline_df_dtypes.get(column_name) in data_type_long_group:
                 common_columns[column_name] = 'long'
 
     return common_columns

--- a/assets/model_monitoring/components/src/shared_utilities/df_utils.py
+++ b/assets/model_monitoring/components/src/shared_utilities/df_utils.py
@@ -4,6 +4,8 @@
 """This file contains additional utilities that are applicable to dataframe."""
 import pyspark.sql as pyspark_sql
 
+data_type_double_group = ["float", "double"]
+data_type_long_group = ["long", "int", "bigint", "short"]
 
 def get_numerical_columns(column_dtype_map: dict) -> list:
     """Get numerical columns from all columns."""
@@ -84,15 +86,28 @@ def is_categorical(column):
 
 def get_common_columns(
     baseline_df: pyspark_sql.DataFrame, production_df: pyspark_sql.DataFrame
-) -> list:
+) -> dict:
     """Get common columns from baseline and production dataframes."""
     baseline_df_dtypes = dict(baseline_df.dtypes)
     production_df_dtypes = dict(production_df.dtypes)
-
     common_columns = {}
     for (column_name, data_type) in baseline_df_dtypes.items():
         if production_df_dtypes.get(column_name) == data_type:
             common_columns[column_name] = data_type
+        else:
+            # if baseline and target are of different type
+            # and both of them are in [double, float],
+            # We consider them to be double
+            if production_df_dtypes.get(column_name) in data_type_double_group \
+            and baseline_df_dtypes.get(column_name) in data_type_double_group:
+                common_columns[column_name] = 'double'
+            # if baseline and target are of different type
+            # and both of them are in [int, long, short]
+            # We consider them to be long
+            elif production_df_dtypes.get(column_name) in data_type_long_group\
+            and baseline_df_dtypes.get(column_name) in data_type_long_group:
+                common_columns[column_name] = 'long'
+
     return common_columns
 
 

--- a/assets/model_monitoring/components/src/shared_utilities/df_utils.py
+++ b/assets/model_monitoring/components/src/shared_utilities/df_utils.py
@@ -7,6 +7,7 @@ import pyspark.sql as pyspark_sql
 data_type_double_group = ["float", "double"]
 data_type_long_group = ["long", "int", "bigint", "short"]
 
+
 def get_numerical_columns(column_dtype_map: dict) -> list:
     """Get numerical columns from all columns."""
     # NOTE: byte, short, long are not included in the list because they
@@ -99,13 +100,13 @@ def get_common_columns(
             # and both of them are in [double, float],
             # We consider them to be double
             if production_df_dtypes.get(column_name) in data_type_double_group \
-            and baseline_df_dtypes.get(column_name) in data_type_double_group:
+                and baseline_df_dtypes.get(column_name) in data_type_double_group:
                 common_columns[column_name] = 'double'
             # if baseline and target are of different type
             # and both of them are in [int, long, short]
             # We consider them to be long
             elif production_df_dtypes.get(column_name) in data_type_long_group\
-            and baseline_df_dtypes.get(column_name) in data_type_long_group:
+                and baseline_df_dtypes.get(column_name) in data_type_long_group:
                 common_columns[column_name] = 'long'
 
     return common_columns

--- a/assets/model_monitoring/components/tests/unit/test_df_utils.py
+++ b/assets/model_monitoring/components/tests/unit/test_df_utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 """This file contains unit tests for the df utilities."""
-from decimal import Decimal
+
 from pyspark.sql.types import (
     DoubleType,
     FloatType,
@@ -142,49 +142,49 @@ class TestDFUtils:
         emp_RDD = spark.sparkContext.emptyRDD()
         # Create empty schema
         columns = StructType([])
- 
+
         # Create an empty RDD with empty schema
         baseline_df = create_pyspark_dataframe(emp_RDD, columns)
         production_df = create_pyspark_dataframe(emp_RDD, columns)
         assert get_common_columns(baseline_df, production_df) == {}
 
         # Test with two dataframes that have common columns but datatype is not in the same type
-        float_data = [ (3.55,), (6.88,), (7.99,)]
+        float_data = [(3.55,), (6.88,), (7.99,)]
         schema = StructType([
-        StructField("target", FloatType(), True)])
+            StructField("target", FloatType(), True)])
         baseline_df = create_pyspark_dataframe(float_data, schema)
-        double_data = [ (3.55,), (6.88,), (7.99,)]
+        double_data = [(3.55,), (6.88,), (7.99,)]
         schema = StructType([
-        StructField("target", DoubleType(), True)])
-        production_df = create_pyspark_dataframe(double_data, schema)        
+            StructField("target", DoubleType(), True)])
+        production_df = create_pyspark_dataframe(double_data, schema)
         assert get_common_columns(baseline_df, production_df) == {'target': 'double'}
 
         # Test with two dataframes that have no common columns
         baseline_df = create_pyspark_dataframe([(1, "a"), (2, "b")],
-                                   ["id", "name"])
+                                               ["id", "name"])
         production_df = create_pyspark_dataframe([(3, "c"), (4, "d")],
-                                   ["age", "gender"])
+                                                 ["age", "gender"])
         assert get_common_columns(baseline_df, production_df) == {}
 
         # Test with two dataframes that have one common column
         baseline_df = create_pyspark_dataframe([(1, "a"), (2, "b")],
                                                ["id", "name"])
-        production_df = create_pyspark_dataframe([(1, "c"), (2, "d")], 
+        production_df = create_pyspark_dataframe([(1, "c"), (2, "d")],
                                                  ["id", "age"])
         assert get_common_columns(baseline_df, production_df) == {"id": "bigint"}
 
         # Test with two dataframes that have multiple common columns
         baseline_df = create_pyspark_dataframe([(1, "a", 10), (2, "b", 20)],
-                                   ["id", "name", "age"])
+                                               ["id", "name", "age"])
         production_df = create_pyspark_dataframe([(1, "c", 30), (2, "d", 40)],
-                                    ["id", "name", "age"])
+                                                 ["id", "name", "age"])
         assert get_common_columns(baseline_df, production_df) == {"id": "bigint", "name": "string", "age": "bigint"}
 
         # Test with two dataframes that have different Types in common columns
         baseline_df = create_pyspark_dataframe([(1.0, "a", 10), (2.0, "b", 20)],
-                                   ["id", "name", "age"])
+                                               ["id", "name", "age"])
         production_df = create_pyspark_dataframe([(1, "c", 30), (2, "d", 40)],
-                                     ["id", "name", "age"])
+                                                 ["id", "name", "age"])
         assert get_common_columns(baseline_df, production_df) == {"name": "string", "age": "bigint"}
 
     def init_spark(self):


### PR DESCRIPTION
1. If no common column, we raise valueerror exception. Otherwise, the none or empty dataframe cannot be written in the mltable, we will have none type error.
2. If baseline and production data column (of the same name) both in [float, double] group or [int, bigint, long, short] group, we consider them to be the same column