### PR TITLE
Fix unpickling of the scikit-learn models.

### DIFF
--- a/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.jso
 name: automl_forecasting_inference
 display_name: AutoML Forecasting Inference
 description: Inference component for AutoML Forecasting.
-version: 0.0.3
+version: 0.0.4
 type: command
 
 inputs:

--- a/assets/training/forecasting_demand/automl-single-model-inference/src/inference.py
+++ b/assets/training/forecasting_demand/automl-single-model-inference/src/inference.py
@@ -5,6 +5,7 @@
 import argparse
 import json
 import os
+import pickle
 
 import azureml.automl.core.shared.constants as automl_constants
 import numpy as np
@@ -13,7 +14,6 @@ from azureml._common._error_definition import AzureMLError, error_decorator
 from azureml._common._error_definition.user_error import BadArgument
 from azureml.automl.core.shared.forecasting_exception import ForecastingDataException
 from azureml.core import Run
-from sklearn.externals import joblib
 
 try:
     import torch  # noqa: F401
@@ -136,7 +136,8 @@ def _get_model(model_full_path):
             fitted_model = torch.load(fh, map_location=map_location)
     else:
         # Load the sklearn pipeline.
-        fitted_model = joblib.load(model_full_path)
+        with open(model_full_path, 'rb') as fp:
+            fitted_model = pickle.load(fp)
 
     print("Model loading succeeded.")
     return fitted_model


### PR DESCRIPTION
After we have upgraded scikit-learn, joblib cannot be imported as `from sklearn.externals import joblib` instead we will use the pickle mechanism, which does not require extra dependencies.
This is a part of Task 2805732