### PR TITLE
Try to use proxy to validate AOAI deployment if first attempt hit auth error.

### DIFF
--- a/assets/large_language_models/rag/components/src/validate_deployments.py
+++ b/assets/large_language_models/rag/components/src/validate_deployments.py
@@ -77,8 +77,8 @@ def validate_and_create_default_aoai_resource(ws, model_params, activity_logger=
             api_version = '2023-10-01'
 
             activity_logger.warn(
-                f"[Validate Deployments]: Validating deployment {model_params['deployment_id']} hit authorization error."
-                + f"Try to use proxy url '{proxy_url}' with specific app version '{api_version}'.")
+                f"[Validate Deployments]: Validating deployment {model_params['deployment_id']} hit "
+                + f"authorization error. Try to use proxy url '{proxy_url}' with app version '{api_version}'.")
 
             client.deployments.get.metadata['url'] = proxy_url
             response = client.deployments.get(

--- a/assets/large_language_models/rag/components/src/validate_deployments.py
+++ b/assets/large_language_models/rag/components/src/validate_deployments.py
@@ -71,9 +71,9 @@ def validate_and_create_default_aoai_resource(ws, model_params, activity_logger=
     except HttpResponseError as ex:
         # Hack: Use proxy url to access AOAI deployment with speicific app version
         if ex.reason == 'Forbidden':
-            proxy_url = '/subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroupName}}' \
+            proxy_url = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' \
                 + f'/providers/Microsoft.MachineLearningServices/workspaces/{ws.name}' \
-                + f'/endpoints/Azure.OpenAI/deployments/{{deploymentName}}'
+                + '/endpoints/Azure.OpenAI/deployments/{deploymentName}'
             api_version = '2023-10-01'
 
             activity_logger.warn(

--- a/assets/large_language_models/rag/components/src/validate_deployments.py
+++ b/assets/large_language_models/rag/components/src/validate_deployments.py
@@ -78,7 +78,7 @@ def validate_and_create_default_aoai_resource(ws, model_params, activity_logger=
 
             activity_logger.warn(
                 f"[Validate Deployments]: Validating deployment {model_params['deployment_id']} hit "
-                + f"authorization error. Try to use proxy url '{proxy_url}' with app version '{api_version}'.")
+                + f"authorization error.\nTry to use proxy url '{proxy_url}' with app version '{api_version}'.")
 
             client.deployments.get.metadata['url'] = proxy_url
             response = client.deployments.get(
@@ -90,7 +90,7 @@ def validate_and_create_default_aoai_resource(ws, model_params, activity_logger=
 
     response_status = str.lower(response.properties.provisioning_state)
     if (response_status != "succeeded"):
-        # log this becauase we need to find out what the possible states are
+        # log this because we need to find out what the possible states are
         print(
             f"Deployment is not yet in status 'succeeded'. Current status is: {response_status}")
     if (response_status == "failed" or response_status == "deleting"):
@@ -588,4 +588,4 @@ if __name__ == "__main__":
     finally:
         if _logger_factory.appinsights:
             _logger_factory.appinsights.flush()
-            time.sleep(5)  # wait for appinsights to send telemetry
+            time.sleep(5)  # wait for AppInsights to send telemetry

--- a/assets/large_language_models/rag/components/src/validate_deployments.py
+++ b/assets/large_language_models/rag/components/src/validate_deployments.py
@@ -35,6 +35,7 @@ logger = get_logger('validate_deployments')
 MAX_RETRIES = 3
 SLEEP_DURATION = 2
 
+
 def get_cognitive_services_client(ws):
     """Get cognitive services client."""
     client_id = os.environ.get("DEFAULT_IDENTITY_CLIENT_ID", None)
@@ -70,14 +71,15 @@ def validate_and_create_default_aoai_resource(ws, model_params, activity_logger=
     except HttpResponseError as ex:
         # Hack: Use proxy url to access AOAI deployment with speicific app version
         if ex.reason == 'Forbidden':
-            proxy_url = f'/subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroupName}}' \
-                + f'/providers/Microsoft.MachineLearningServices/workspaces/{ws.name}/endpoints/Azure.OpenAI/deployments/{{deploymentName}}'
+            proxy_url = '/subscriptions/{{subscriptionId}}/resourceGroups/{{resourceGroupName}}' \
+                + f'/providers/Microsoft.MachineLearningServices/workspaces/{ws.name}' \
+                + f'/endpoints/Azure.OpenAI/deployments/{{deploymentName}}'
             api_version = '2023-10-01'
-            
+
             activity_logger.warn(
-                f"[Validate Deployments]: AOAI resource deployment {model_params['deployment_id']} validation hit authorization error."
+                f"[Validate Deployments]: Validating deployment {model_params['deployment_id']} hit authorization error."
                 + f"Try to use proxy url '{proxy_url}' with specific app version '{api_version}'.")
-            
+
             client.deployments.get.metadata['url'] = proxy_url
             response = client.deployments.get(
                 resource_group_name=resource_group_name,

--- a/assets/large_language_models/rag/components/src/validate_deployments.py
+++ b/assets/large_language_models/rag/components/src/validate_deployments.py
@@ -69,7 +69,7 @@ def validate_and_create_default_aoai_resource(ws, model_params, activity_logger=
             deployment_name=deployment_name,
         )
     except HttpResponseError as ex:
-        # Hack: Use proxy url to access AOAI deployment with speicific app version
+        # Hack: Use proxy url to access AOAI deployment with specific app version
         if ex.reason == 'Forbidden':
             proxy_url = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' \
                 + f'/providers/Microsoft.MachineLearningServices/workspaces/{ws.name}' \

--- a/assets/large_language_models/rag/components/src/validate_deployments.py
+++ b/assets/large_language_models/rag/components/src/validate_deployments.py
@@ -56,7 +56,6 @@ def get_cognitive_services_client(ws):
 
 def validate_and_create_default_aoai_resource(ws, model_params, activity_logger=None):
     """Validate default AOAI deployments and attempt creation if does not exist."""
-
     resource_group_name = model_params.get("resource_group", ws.resource_group)
     account_name = model_params["default_aoai_name"]
     deployment_name = model_params["deployment_id"]


### PR DESCRIPTION
When direct access to AOAI is denied, hack CognitiveServicesManagementClient  to use proxy service to validate the deployment (of embedding model)

 1. Client (user id) --> AOAI control plan
 2. If hit access failure then client (user id) --> proxy --> AOAI control plan
