### PR TITLE
mark metric as failure if no output

### DIFF
--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_metrics
 display_name: Annotation - Compute Metrics
 description: Compute annotation metrics given a deployment's model data input.
-version: 0.4.2
+version: 0.4.3
 is_deterministic: True
 inputs:
   annotation_histogram: 

--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -137,7 +137,7 @@ jobs:
       type: aml_token
   compute_metrics:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.2
+    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.3
     inputs:
       annotation_histogram:
         type: mltable

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py
@@ -66,7 +66,7 @@ def _calculate_passrate(df, metric_name):
     # if there are no metric value, we should mark as fail since there was probably a
     # parsing error or request error that resulted in no metrics
     if total == 0:
-        return "0"
+        return "NaN"
     passrate = passing / total
     return str(passrate)
 

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py
@@ -63,8 +63,10 @@ def _calculate_passrate(df, metric_name):
         .head()[0]
     )
     total = df_with_buckets.select(sum(METRIC_VALUE_COLUMN)).head()[0]
+    # if there are no metric value, we should mark as fail since there was probably a
+    # parsing error or request error that resulted in no metrics
     if total == 0:
-        return "1"
+        return "0"
     passrate = passing / total
     return str(passrate)
 


### PR DESCRIPTION
If the GSQ compute histogram component outputs no metrics for a given metric, we currently mark the passrate as 1 which shows as green / passing in the UI. Instead, we should mark the passrate as NaN since there are no metrics which probably resulted from a parsing error or error when making the request to aoai. 

example output: https://ml.azure.com/data/azureml_40b81b8b-f769-49f1-8818-086ca580654c_output_data_signal_output/1/details?wsid=/subscriptions/e0fd569c-e34a-4249-8c24-e8d723c7f054/resourcegroups/hawestra-rg/providers/Microsoft.MachineLearningServices/workspaces/hawestra-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47
