### PR TITLE
Added mmd-3x models

### DIFF
--- a/assets/models/system/mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco/asset.yaml
+++ b/assets/models/system/mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Models"]

--- a/assets/models/system/mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco/description.md
+++ b/assets/models/system/mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco/description.md
@@ -1,0 +1,83 @@
+`deformable-detr_refine_twostage_r50_16xb2-50e_coco` model is from <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0" target="_blank">OpenMMLab's MMDetection library</a>. This model is reported to obtain <a href="https://github.com/open-mmlab/mmdetection/blob/3.x/configs/deformable_detr/metafile.yml#L46" target="_blank">box AP of 46.8 for object-detection task on COCO dataset</a>. To understand the naming style used, please refer to <a href="https://mmdetection.readthedocs.io/en/v3.1.0/user_guides/config.html#config-name-style" target="_blank">MMDetection's Config Name Style</a>.
+
+DETR has been recently proposed to eliminate the need for many hand-designed components in object detection while demonstrating good performance. However, it suffers from slow convergence and limited feature spatial resolution, due to the limitation of Transformer attention modules in processing image feature maps. To mitigate these issues, we proposed Deformable DETR, whose attention modules only attend to a small set of key sampling points around a reference. Deformable DETR can achieve better performance than DETR (especially on small objects) with 10 times less training epochs. Extensive experiments on the COCO benchmark demonstrate the effectiveness of our approach.
+
+> The above abstract is from MMDetection website. Review the <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0/configs/deformable_detr" target="_blank">original-model-card</a> to understand the data used to train the model, evaluation metrics, license, intended uses, limitations and bias before using the model.
+
+### Inference samples
+
+Inference type|Python sample (Notebook)|CLI with YAML
+|--|--|--|
+Real time|<a href="https://aka.ms/azureml-infer-sdk-image-object-detection" target="_blank">image-object-detection-online-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-cli-image-object-detection" target="_blank">image-object-detection-online-endpoint.sh</a>
+Batch |<a href="https://aka.ms/azureml-infer-batch-sdk-image-object-detection" target="_blank">image-object-detection-batch-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-batch-cli-image-object-detection" target="_blank">image-object-detection-batch-endpoint.sh</a>
+
+### Finetuning samples
+
+Task|Use case|Dataset|Python sample (Notebook)|CLI with YAML
+|---|--|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-ft-sdk-image-object-detection" target="_blank">fridgeobjects-object-detection.ipynb</a>|<a href="https://aka.ms/azureml-ft-cli-image-object-detection" target="_blank">fridgeobjects-object-detection.sh</a>
+
+### Model Evaluation
+
+|Task|Use case|Dataset|Python sample (Notebook)|
+|---|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-evaluation-sdk-image-object-detection" target="_blank">image-object-detection.ipynb</a>|
+
+### Sample inputs and outputs (for real-time inference)
+
+#### Sample input
+
+```json
+{
+  "input_data": {
+    "columns": [
+      "image"
+    ],
+    "index": [0, 1],
+    "data": ["image1", "image2"]
+  }
+}
+```
+
+Note: "image1" and "image2" string should be in base64 format or publicly accessible urls.
+
+#### Sample output
+
+```json
+[
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.1,
+                    "topY": 0.2,
+                    "bottomX": 0.8,
+                    "bottomY": 0.7
+                },
+                "label": "carton",
+                "score": 0.98
+            }
+        ]
+    },
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.2,
+                    "topY": 0.3,
+                    "bottomX": 0.6,
+                    "bottomY": 0.5
+                },
+                "label": "can",
+                "score": 0.97
+            }
+        ]
+    }
+]
+```
+
+Note: Please refer to object detection output <a href="https://learn.microsoft.com/en-us/azure/machine-learning/reference-automl-images-schema?view=azureml-api-2#object-detection-1" target="_blank">data schema</a> for more detail.
+
+#### Model inference - visualization for a sample image
+
+<img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/plot_deformable_detr_twostage_refine_r50_16x2_50e_coco_OD.png" alt="od visualization">

--- a/assets/models/system/mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco/model.yaml
+++ b/assets/models/system/mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: finetuning-image-models
+  container_path: mmdetection-3.x-mlflow/deformable-detr_refine_twostage_r50_16xb2-50e_coco/1699897768/mlflow_model_folder
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: mlflow_model

--- a/assets/models/system/mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco/spec.yaml
+++ b/assets/models/system/mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco/spec.yaml
@@ -1,0 +1,32 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco
+path: ./
+properties:
+  SHA: 4c111175692fb607b153282bf15c81c8e7f8edcc
+  datasets: COCO
+  evaluation-min-sku-spec: 4|1|28|176
+  evaluation-recommended-sku: Standard_NC6s_v3
+  finetune-min-sku-spec: 4|1|28|176
+  finetune-recommended-sku: Standard_NC6s_v3
+  finetuning-tasks: image-object-detection
+  inference-min-sku-spec: 4|0|14|28
+  inference-recommended-sku: Standard_DS3_v2, Standard_D4a_v4, Standard_D4as_v4, Standard_DS4_v2,
+    Standard_D8a_v4, Standard_D8as_v4, Standard_DS5_v2, Standard_D16a_v4, Standard_D16as_v4,
+    Standard_D32a_v4, Standard_D32as_v4, Standard_D48a_v4, Standard_D48as_v4, Standard_D64a_v4,
+    Standard_D64as_v4, Standard_D96a_v4, Standard_D96as_v4, Standard_FX4mds, Standard_F8s_v2,
+    Standard_FX12mds, Standard_F16s_v2, Standard_F32s_v2, Standard_F48s_v2, Standard_F64s_v2,
+    Standard_F72s_v2, Standard_FX24mds, Standard_FX36mds, Standard_FX48mds, Standard_E4s_v3,
+    Standard_E8s_v3, Standard_E16s_v3, Standard_E32s_v3, Standard_E48s_v3, Standard_E64s_v3,
+    Standard_NC4as_T4_v3, Standard_NC6s_v3, Standard_NC8as_T4_v3, Standard_NC12s_v3,
+    Standard_NC16as_T4_v3, Standard_NC24s_v3, Standard_NC64as_T4_v3, Standard_NC24ads_A100_v4,
+    Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4,
+    Standard_ND40rs_v2
+  model_id: mmd-3x-deformable-detr_refine_twostage_r50_16xb2-50e_coco
+tags:
+  Preview: ''
+  license: apache-2.0
+  model_specific_defaults:
+    apply_deepspeed: 'false'
+    apply_ort: 'false'
+  task: object-detection
+version: 8

--- a/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/asset.yaml
+++ b/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Models"]

--- a/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/description.md
+++ b/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/description.md
@@ -1,0 +1,87 @@
+This paper presents a new vision Transformer, called Swin Transformer, that capably serves as a general-purpose backbone for computer vision. Challenges in adapting Transformer from language to vision arise from differences between the two domains, such as large variations in the scale of visual entities and the high resolution of pixels in images compared to words in text. To address these differences, we propose a hierarchical Transformer whose representation is computed with Shifted windows. The shifted windowing scheme brings greater efficiency by limiting self-attention computation to non-overlapping local windows while also allowing for cross-window connection. This hierarchical architecture has the flexibility to model at various scales and has linear computational complexity with respect to image size. These qualities of Swin Transformer make it compatible with a broad range of vision tasks, including image classification (87.3 top-1 accuracy on ImageNet-1K) and dense prediction tasks such as object detection (58.7 box AP and 51.1 mask AP on COCO test-dev) and semantic segmentation (53.5 mIoU on ADE20K val). Its performance surpasses the previous state-of-the-art by a large margin of +2.7 box AP and +2.6 mask AP on COCO, and +3.2 mIoU on ADE20K, demonstrating the potential of Transformer-based models as vision backbones. The hierarchical design and the shifted window approach also prove beneficial for all-MLP architectures.
+
+> The above abstract is from mmdetection website. Review the <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0/configs/swin" target="_blank">original-model-card</a> to understand the data used to train the model, evaluation metrics, license, intended uses, limitations and bias before using the model.
+
+### Inference samples
+
+Inference type|Python sample (Notebook)|CLI with YAML
+|--|--|--|
+Real time|<a href="https://aka.ms/azureml-infer-sdk-image-instance-segmentation" target="_blank">image-instance-segmentation-online-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-cli-image-instance-segmentation" target="_blank">image-instance-segmentation-online-endpoint.sh</a>
+Batch|<a href="https://aka.ms/azureml-infer-batch-sdk-image-instance-segmentation" target="_blank">image-instance-segmentation-batch-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-batch-cli-image-instance-segmentation" target="_blank">image-instance-segmentation-batch-endpoint.sh</a>
+
+### Finetuning samples
+
+Task|Use case|Dataset|Python sample (Notebook)|CLI with YAML
+|---|--|--|--|--|
+Image instance segmentation|Image instance segmentation|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjectsMask.zip)|<a href="https://aka.ms/azureml-ft-sdk-image-instance-segmentation" target="_blank">fridgeobjects-instance-segmentation.ipynb</a>|<a href="https://aka.ms/azureml-ft-cli-image-instance-segmentation" target="_blank">fridgeobjects-instance-segmentation.sh</a>
+
+### Model Evaluation
+
+|Task|Use case|Dataset|Python sample (Notebook)|
+|---|--|--|--|
+|Image instance segmentation|Image instance segmentation|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjectsMask.zip)|<a href="https://aka.ms/azureml-evaluation-sdk-image-instance-segmentation" target="_blank">image-instance-segmentation.ipynb</a>|
+
+### Sample inputs and outputs (for real-time inference)
+
+#### Sample input
+
+```json
+{
+  "input_data": {
+    "columns": [
+      "image"
+    ],
+    "index": [0, 1],
+    "data": ["image1", "image2"]
+  }
+}
+```
+
+Note: "image1" and "image2" string should be in base64 format or publicly accessible urls.
+
+#### Sample output
+
+```json
+[
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.1,
+                    "topY": 0.2,
+                    "bottomX": 0.8,
+                    "bottomY": 0.7
+                },
+                "label": "carton",
+                "score": 0.98,
+                "polygon": [
+                    [ 0.576, 0.680,  …]
+                ]
+            }
+        ]
+    },
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.2,
+                    "topY": 0.3,
+                    "bottomX": 0.6,
+                    "bottomY": 0.5
+                },
+                "label": "can",
+                "score": 0.97,
+                "polygon": [
+                    [ 0.58, 0.7,  …]
+                ]
+            }
+        ]
+    }
+]
+```
+
+Note: Please refer to instance segmentation output <a href="https://learn.microsoft.com/en-us/azure/machine-learning/reference-automl-images-schema?view=azureml-api-2#instance-segmentation-1" target="_blank">data schema</a> for more detail.
+
+#### Model inference - visualization for a sample image
+
+<img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/plot_mask_rcnn_swin-t-p4-w7_fpn_1x_coco_IS.png" alt="is visualization">

--- a/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/model.yaml
+++ b/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: finetuning-image-models
+  container_path: mmdetection-3.x-mlflow/mask-rcnn_swin-t-p4-w7_fpn_1x_coco/1699942663/mlflow_model_folder
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: mlflow_model

--- a/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/spec.yaml
+++ b/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/spec.yaml
@@ -1,0 +1,32 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco
+path: ./
+properties:
+  SHA: fff646d3dda72d8c794471bfaa75b4db0adb7610
+  datasets: COCO
+  evaluation-min-sku-spec: 4|1|28|176
+  evaluation-recommended-sku: Standard_NC6s_v3
+  finetune-min-sku-spec: 4|1|28|176
+  finetune-recommended-sku: Standard_NC6s_v3
+  finetuning-tasks: image-instance-segmentation
+  inference-min-sku-spec: 4|0|14|28
+  inference-recommended-sku: Standard_DS3_v2, Standard_D4a_v4, Standard_D4as_v4, Standard_DS4_v2,
+    Standard_D8a_v4, Standard_D8as_v4, Standard_DS5_v2, Standard_D16a_v4, Standard_D16as_v4,
+    Standard_D32a_v4, Standard_D32as_v4, Standard_D48a_v4, Standard_D48as_v4, Standard_D64a_v4,
+    Standard_D64as_v4, Standard_D96a_v4, Standard_D96as_v4, Standard_FX4mds, Standard_F8s_v2,
+    Standard_FX12mds, Standard_F16s_v2, Standard_F32s_v2, Standard_F48s_v2, Standard_F64s_v2,
+    Standard_F72s_v2, Standard_FX24mds, Standard_FX36mds, Standard_FX48mds, Standard_E4s_v3,
+    Standard_E8s_v3, Standard_E16s_v3, Standard_E32s_v3, Standard_E48s_v3, Standard_E64s_v3,
+    Standard_NC4as_T4_v3, Standard_NC6s_v3, Standard_NC8as_T4_v3, Standard_NC12s_v3,
+    Standard_NC16as_T4_v3, Standard_NC24s_v3, Standard_NC64as_T4_v3, Standard_NC24ads_A100_v4,
+    Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4,
+    Standard_ND40rs_v2
+  model_id: mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco
+tags:
+  Preview: ''
+  license: apache-2.0
+  model_specific_defaults:
+    apply_deepspeed: 'false'
+    apply_ort: 'false'
+  task: image-segmentation
+version: 8

--- a/assets/models/system/mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco/asset.yaml
+++ b/assets/models/system/mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Models"]

--- a/assets/models/system/mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco/description.md
+++ b/assets/models/system/mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco/description.md
@@ -1,0 +1,83 @@
+`sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco` model is from <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0" target="_blank">OpenMMLab's MMDetection library</a>. This model is reported to obtain <a href="https://github.com/open-mmlab/mmdetection/blob/3.x/configs/sparse_rcnn/metafile.yml#L70" target="_blank">box AP of 46.2 for object-detection task on COCO dataset</a>. To understand the naming style used, please refer to <a href="https://mmdetection.readthedocs.io/en/v3.1.0/user_guides/config.html#config-name-style" target="_blank">MMDetection's Config Name Style</a>.
+
+We present Sparse R-CNN, a purely sparse method for object detection in images. Existing works on object detection heavily rely on dense object candidates, such as k anchor boxes pre-defined on all grids of image feature map of size H×W. In our method, however, a fixed sparse set of learned object proposals, total length of N, are provided to object recognition head to perform classification and location. By eliminating HWk (up to hundreds of thousands) hand-designed object candidates to N (e.g. 100) learnable proposals, Sparse R-CNN completely avoids all efforts related to object candidates design and many-to-one label assignment. More importantly, final predictions are directly output without non-maximum suppression post-procedure. Sparse R-CNN demonstrates accuracy, run-time and training convergence performance on par with the well-established detector baselines on the challenging COCO dataset, e.g., achieving 45.0 AP in standard 3× training schedule and running at 22 fps using ResNet-50 FPN model. We hope our work could inspire re-thinking the convention of dense prior in object detectors.
+
+> The above abstract is from MMDetection website. Review the <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0/configs/sparse_rcnn" target="_blank">original-model-card</a> to understand the data used to train the model, evaluation metrics, license, intended uses, limitations and bias before using the model.
+
+### Inference samples
+
+Inference type|Python sample (Notebook)|CLI with YAML
+|--|--|--|
+Real time|<a href="https://aka.ms/azureml-infer-sdk-image-object-detection" target="_blank">image-object-detection-online-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-cli-image-object-detection" target="_blank">image-object-detection-online-endpoint.sh</a>
+Batch |<a href="https://aka.ms/azureml-infer-batch-sdk-image-object-detection" target="_blank">image-object-detection-batch-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-batch-cli-image-object-detection" target="_blank">image-object-detection-batch-endpoint.sh</a>
+
+### Finetuning samples
+
+Task|Use case|Dataset|Python sample (Notebook)|CLI with YAML
+|---|--|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-ft-sdk-image-object-detection" target="_blank">fridgeobjects-object-detection.ipynb</a>|<a href="https://aka.ms/azureml-ft-cli-image-object-detection" target="_blank">fridgeobjects-object-detection.sh</a>
+
+### Model Evaluation
+
+|Task|Use case|Dataset|Python sample (Notebook)|
+|---|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-evaluation-sdk-image-object-detection" target="_blank">image-object-detection.ipynb</a>|
+
+### Sample inputs and outputs (for real-time inference)
+
+#### Sample input
+
+```json
+{
+  "input_data": {
+    "columns": [
+      "image"
+    ],
+    "index": [0, 1],
+    "data": ["image1", "image2"]
+  }
+}
+```
+
+Note: "image1" and "image2" string should be in base64 format or publicly accessible urls.
+
+#### Sample output
+
+```json
+[
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.1,
+                    "topY": 0.2,
+                    "bottomX": 0.8,
+                    "bottomY": 0.7
+                },
+                "label": "carton",
+                "score": 0.98
+            }
+        ]
+    },
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.2,
+                    "topY": 0.3,
+                    "bottomX": 0.6,
+                    "bottomY": 0.5
+                },
+                "label": "can",
+                "score": 0.97
+            }
+        ]
+    }
+]
+```
+
+Note: Please refer to object detection output <a href="https://learn.microsoft.com/en-us/azure/machine-learning/reference-automl-images-schema?view=azureml-api-2#object-detection-1" target="_blank">data schema</a> for more detail.
+
+#### Model inference - visualization for a sample image
+
+<img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/plot_sparse_rcnn_r101_fpn_300_proposals_crop_mstrain_480-800_3x_coco_OD.png" alt="od visualization">

--- a/assets/models/system/mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco/model.yaml
+++ b/assets/models/system/mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: finetuning-image-models
+  container_path: mmdetection-3.x-mlflow/sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco/1699809626/mlflow_model_folder
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: mlflow_model

--- a/assets/models/system/mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco/spec.yaml
+++ b/assets/models/system/mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco/spec.yaml
@@ -1,0 +1,32 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco
+path: ./
+properties:
+  SHA: fff646d3dda72d8c794471bfaa75b4db0adb7610
+  datasets: COCO
+  evaluation-min-sku-spec: 4|1|28|176
+  evaluation-recommended-sku: Standard_NC6s_v3
+  finetune-min-sku-spec: 4|1|28|176
+  finetune-recommended-sku: Standard_NC6s_v3
+  finetuning-tasks: image-object-detection
+  inference-min-sku-spec: 4|0|14|28
+  inference-recommended-sku: Standard_DS3_v2, Standard_D4a_v4, Standard_D4as_v4, Standard_DS4_v2,
+    Standard_D8a_v4, Standard_D8as_v4, Standard_DS5_v2, Standard_D16a_v4, Standard_D16as_v4,
+    Standard_D32a_v4, Standard_D32as_v4, Standard_D48a_v4, Standard_D48as_v4, Standard_D64a_v4,
+    Standard_D64as_v4, Standard_D96a_v4, Standard_D96as_v4, Standard_FX4mds, Standard_F8s_v2,
+    Standard_FX12mds, Standard_F16s_v2, Standard_F32s_v2, Standard_F48s_v2, Standard_F64s_v2,
+    Standard_F72s_v2, Standard_FX24mds, Standard_FX36mds, Standard_FX48mds, Standard_E4s_v3,
+    Standard_E8s_v3, Standard_E16s_v3, Standard_E32s_v3, Standard_E48s_v3, Standard_E64s_v3,
+    Standard_NC4as_T4_v3, Standard_NC6s_v3, Standard_NC8as_T4_v3, Standard_NC12s_v3,
+    Standard_NC16as_T4_v3, Standard_NC24s_v3, Standard_NC64as_T4_v3, Standard_NC24ads_A100_v4,
+    Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4,
+    Standard_ND40rs_v2
+  model_id: mmd-3x-sparse-rcnn_r101_fpn_300-proposals_crop-ms-480-800-3x_coco
+tags:
+  Preview: ''
+  license: apache-2.0
+  model_specific_defaults:
+    apply_deepspeed: 'false'
+    apply_ort: 'false'
+  task: object-detection
+version: 8

--- a/assets/models/system/mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco/asset.yaml
+++ b/assets/models/system/mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Models"]

--- a/assets/models/system/mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco/description.md
+++ b/assets/models/system/mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco/description.md
@@ -1,0 +1,83 @@
+`sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco` model is from <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0" target="_blank">OpenMMLab's MMDetection library</a>. This model is reported to obtain <a href="https://github.com/open-mmlab/mmdetection/blob/3.x/configs/sparse_rcnn/metafile.yml#L46" target="_blank">box AP of 45.0 for object-detection task on COCO dataset</a>. To understand the naming style used, please refer to <a href="https://mmdetection.readthedocs.io/en/v3.1.0/user_guides/config.html#config-name-style" target="_blank">MMDetection's Config Name Style</a>.
+
+We present Sparse R-CNN, a purely sparse method for object detection in images. Existing works on object detection heavily rely on dense object candidates, such as k anchor boxes pre-defined on all grids of image feature map of size H×W. In our method, however, a fixed sparse set of learned object proposals, total length of N, are provided to object recognition head to perform classification and location. By eliminating HWk (up to hundreds of thousands) hand-designed object candidates to N (e.g. 100) learnable proposals, Sparse R-CNN completely avoids all efforts related to object candidates design and many-to-one label assignment. More importantly, final predictions are directly output without non-maximum suppression post-procedure. Sparse R-CNN demonstrates accuracy, run-time and training convergence performance on par with the well-established detector baselines on the challenging COCO dataset, e.g., achieving 45.0 AP in standard 3× training schedule and running at 22 fps using ResNet-50 FPN model. We hope our work could inspire re-thinking the convention of dense prior in object detectors.
+
+> The above abstract is from MMDetection website. Review the <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0/configs/sparse_rcnn" target="_blank">original-model-card</a> to understand the data used to train the model, evaluation metrics, license, intended uses, limitations and bias before using the model.
+
+### Inference samples
+
+Inference type|Python sample (Notebook)|CLI with YAML
+|--|--|--|
+Real time|<a href="https://aka.ms/azureml-infer-sdk-image-object-detection" target="_blank">image-object-detection-online-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-cli-image-object-detection" target="_blank">image-object-detection-online-endpoint.sh</a>
+Batch |<a href="https://aka.ms/azureml-infer-batch-sdk-image-object-detection" target="_blank">image-object-detection-batch-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-batch-cli-image-object-detection" target="_blank">image-object-detection-batch-endpoint.sh</a>
+
+### Finetuning samples
+
+Task|Use case|Dataset|Python sample (Notebook)|CLI with YAML
+|---|--|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-ft-sdk-image-object-detection" target="_blank">fridgeobjects-object-detection.ipynb</a>|<a href="https://aka.ms/azureml-ft-cli-image-object-detection" target="_blank">fridgeobjects-object-detection.sh</a>
+
+### Model Evaluation
+
+|Task|Use case|Dataset|Python sample (Notebook)|
+|---|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-evaluation-sdk-image-object-detection" target="_blank">image-object-detection.ipynb</a>|
+
+### Sample inputs and outputs (for real-time inference)
+
+#### Sample input
+
+```json
+{
+  "input_data": {
+    "columns": [
+      "image"
+    ],
+    "index": [0, 1],
+    "data": ["image1", "image2"]
+  }
+}
+```
+
+Note: "image1" and "image2" string should be in base64 format or publicly accessible urls.
+
+#### Sample output
+
+```json
+[
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.1,
+                    "topY": 0.2,
+                    "bottomX": 0.8,
+                    "bottomY": 0.7
+                },
+                "label": "carton",
+                "score": 0.98
+            }
+        ]
+    },
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.2,
+                    "topY": 0.3,
+                    "bottomX": 0.6,
+                    "bottomY": 0.5
+                },
+                "label": "can",
+                "score": 0.97
+            }
+        ]
+    }
+]
+```
+
+Note: Please refer to object detection output <a href="https://learn.microsoft.com/en-us/azure/machine-learning/reference-automl-images-schema?view=azureml-api-2#object-detection-1" target="_blank">data schema</a> for more detail.
+
+#### Model inference - visualization for a sample image
+
+<img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/plot_sparse_rcnn_r50_fpn_300_proposals_crop_mstrain_480-800_3x_coco_OD.png" alt="od visualization">

--- a/assets/models/system/mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco/model.yaml
+++ b/assets/models/system/mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: finetuning-image-models
+  container_path: mmdetection-3.x-mlflow/sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco/1699641882/mlflow_model_folder
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: mlflow_model

--- a/assets/models/system/mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco/spec.yaml
+++ b/assets/models/system/mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco/spec.yaml
@@ -1,0 +1,32 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco
+path: ./
+properties:
+  SHA: 621b8c8dc1bed2d6116eed8b741d8d356e3f372a
+  datasets: COCO
+  evaluation-min-sku-spec: 4|1|28|176
+  evaluation-recommended-sku: Standard_NC6s_v3
+  finetune-min-sku-spec: 4|1|28|176
+  finetune-recommended-sku: Standard_NC6s_v3
+  finetuning-tasks: image-object-detection
+  inference-min-sku-spec: 4|0|14|28
+  inference-recommended-sku: Standard_DS3_v2, Standard_D4a_v4, Standard_D4as_v4, Standard_DS4_v2,
+    Standard_D8a_v4, Standard_D8as_v4, Standard_DS5_v2, Standard_D16a_v4, Standard_D16as_v4,
+    Standard_D32a_v4, Standard_D32as_v4, Standard_D48a_v4, Standard_D48as_v4, Standard_D64a_v4,
+    Standard_D64as_v4, Standard_D96a_v4, Standard_D96as_v4, Standard_FX4mds, Standard_F8s_v2,
+    Standard_FX12mds, Standard_F16s_v2, Standard_F32s_v2, Standard_F48s_v2, Standard_F64s_v2,
+    Standard_F72s_v2, Standard_FX24mds, Standard_FX36mds, Standard_FX48mds, Standard_E4s_v3,
+    Standard_E8s_v3, Standard_E16s_v3, Standard_E32s_v3, Standard_E48s_v3, Standard_E64s_v3,
+    Standard_NC4as_T4_v3, Standard_NC6s_v3, Standard_NC8as_T4_v3, Standard_NC12s_v3,
+    Standard_NC16as_T4_v3, Standard_NC24s_v3, Standard_NC64as_T4_v3, Standard_NC24ads_A100_v4,
+    Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4,
+    Standard_ND40rs_v2
+  model_id: mmd-3x-sparse-rcnn_r50_fpn_300-proposals_crop-ms-480-800-3x_coco
+tags:
+  Preview: ''
+  license: apache-2.0
+  model_specific_defaults:
+    apply_deepspeed: 'false'
+    apply_ort: 'false'
+  task: object-detection
+version: 8

--- a/assets/models/system/mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco/asset.yaml
+++ b/assets/models/system/mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Models"]

--- a/assets/models/system/mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco/description.md
+++ b/assets/models/system/mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco/description.md
@@ -1,0 +1,83 @@
+`vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco` model is from <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0" target="_blank">OpenMMLab's MMDetection library</a>. This model is reported to obtain <a href="https://github.com/open-mmlab/mmdetection/blob/3.x/configs/vfnet/metafile.yml#L46" target="_blank">box AP of 48.0 for object-detection task on COCO dataset</a>. To understand the naming style used, please refer to <a href="https://mmdetection.readthedocs.io/en/v3.1.0/user_guides/config.html#config-name-style" target="_blank">MMDetection's Config Name Style</a>.
+
+Accurately ranking the vast number of candidate detections is crucial for dense object detectors to achieve high performance. Prior work uses the classification score or a combination of classification and predicted localization scores to rank candidates. However, neither option results in a reliable ranking, thus degrading detection performance. In this paper, we propose to learn an Iou-aware Classification Score (IACS) as a joint representation of object presence confidence and localization accuracy. We show that dense object detectors can achieve a more accurate ranking of candidate detections based on the IACS. We design a new loss function, named Varifocal Loss, to train a dense object detector to predict the IACS, and propose a new star-shaped bounding box feature representation for IACS prediction and bounding box refinement. Combining these two new components and a bounding box refinement branch, we build an IoU-aware dense object detector based on the FCOS+ATSS architecture, that we call VarifocalNet or VFNet for short. Extensive experiments on MS COCO show that our VFNet consistently surpasses the strong baseline by ∼2.0 AP with different backbones. Our best model VFNet-X-1200 with Res2Net-101-DCN achieves a single-model single-scale AP of 55.1 on COCO test-dev, which is state-of-the-art among various object detectors.
+
+> The above abstract is from MMDetection website. Review the <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0/configs/vfnet" target="_blank">original-model-card</a> to understand the data used to train the model, evaluation metrics, license, intended uses, limitations and bias before using the model.
+
+### Inference samples
+
+Inference type|Python sample (Notebook)|CLI with YAML
+|--|--|--|
+Real time|<a href="https://aka.ms/azureml-infer-sdk-image-object-detection" target="_blank">image-object-detection-online-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-cli-image-object-detection" target="_blank">image-object-detection-online-endpoint.sh</a>
+Batch |<a href="https://aka.ms/azureml-infer-batch-sdk-image-object-detection" target="_blank">image-object-detection-batch-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-batch-cli-image-object-detection" target="_blank">image-object-detection-batch-endpoint.sh</a>
+
+### Finetuning samples
+
+Task|Use case|Dataset|Python sample (Notebook)|CLI with YAML
+|---|--|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-ft-sdk-image-object-detection" target="_blank">fridgeobjects-object-detection.ipynb</a>|<a href="https://aka.ms/azureml-ft-cli-image-object-detection" target="_blank">fridgeobjects-object-detection.sh</a>
+
+### Model Evaluation
+
+|Task|Use case|Dataset|Python sample (Notebook)|
+|---|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-evaluation-sdk-image-object-detection" target="_blank">image-object-detection.ipynb</a>|
+
+### Sample inputs and outputs (for real-time inference)
+
+#### Sample input
+
+```json
+{
+  "input_data": {
+    "columns": [
+      "image"
+    ],
+    "index": [0, 1],
+    "data": ["image1", "image2"]
+  }
+}
+```
+
+Note: "image1" and "image2" string should be in base64 format or publicly accessible urls.
+
+#### Sample output
+
+```json
+[
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.1,
+                    "topY": 0.2,
+                    "bottomX": 0.8,
+                    "bottomY": 0.7
+                },
+                "label": "carton",
+                "score": 0.98
+            }
+        ]
+    },
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.2,
+                    "topY": 0.3,
+                    "bottomX": 0.6,
+                    "bottomY": 0.5
+                },
+                "label": "can",
+                "score": 0.97
+            }
+        ]
+    }
+]
+```
+
+Note: Please refer to object detection output <a href="https://learn.microsoft.com/en-us/azure/machine-learning/reference-automl-images-schema?view=azureml-api-2#object-detection-1" target="_blank">data schema</a> for more detail.
+
+#### Model inference - visualization for a sample image
+
+<img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/plot_vfnet_r50_fpn_mdconv_c3-c5_mstrain_2x_coco_OD.png" alt="od visualization">

--- a/assets/models/system/mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco/model.yaml
+++ b/assets/models/system/mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: finetuning-image-models
+  container_path: mmdetection-3.x-mlflow/vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco/1699860028/mlflow_model_folder
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: mlflow_model

--- a/assets/models/system/mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco/spec.yaml
+++ b/assets/models/system/mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco/spec.yaml
@@ -1,0 +1,32 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco
+path: ./
+properties:
+  SHA: fff646d3dda72d8c794471bfaa75b4db0adb7610
+  datasets: COCO
+  evaluation-min-sku-spec: 4|1|28|176
+  evaluation-recommended-sku: Standard_NC6s_v3
+  finetune-min-sku-spec: 4|1|28|176
+  finetune-recommended-sku: Standard_NC6s_v3
+  finetuning-tasks: image-object-detection
+  inference-min-sku-spec: 4|0|14|28
+  inference-recommended-sku: Standard_DS3_v2, Standard_D4a_v4, Standard_D4as_v4, Standard_DS4_v2,
+    Standard_D8a_v4, Standard_D8as_v4, Standard_DS5_v2, Standard_D16a_v4, Standard_D16as_v4,
+    Standard_D32a_v4, Standard_D32as_v4, Standard_D48a_v4, Standard_D48as_v4, Standard_D64a_v4,
+    Standard_D64as_v4, Standard_D96a_v4, Standard_D96as_v4, Standard_FX4mds, Standard_F8s_v2,
+    Standard_FX12mds, Standard_F16s_v2, Standard_F32s_v2, Standard_F48s_v2, Standard_F64s_v2,
+    Standard_F72s_v2, Standard_FX24mds, Standard_FX36mds, Standard_FX48mds, Standard_E4s_v3,
+    Standard_E8s_v3, Standard_E16s_v3, Standard_E32s_v3, Standard_E48s_v3, Standard_E64s_v3,
+    Standard_NC4as_T4_v3, Standard_NC6s_v3, Standard_NC8as_T4_v3, Standard_NC12s_v3,
+    Standard_NC16as_T4_v3, Standard_NC24s_v3, Standard_NC64as_T4_v3, Standard_NC24ads_A100_v4,
+    Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4,
+    Standard_ND40rs_v2
+  model_id: mmd-3x-vfnet_r50-mdconv-c3-c5_fpn_ms-2x_coco
+tags:
+  Preview: ''
+  license: apache-2.0
+  model_specific_defaults:
+    apply_deepspeed: 'false'
+    apply_ort: 'false'
+  task: object-detection
+version: 8

--- a/assets/models/system/mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco/asset.yaml
+++ b/assets/models/system/mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Models"]

--- a/assets/models/system/mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco/description.md
+++ b/assets/models/system/mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco/description.md
@@ -1,0 +1,83 @@
+`vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco` model is from <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0" target="_blank">OpenMMLab's MMDetection library</a>. This model is reported to obtain <a href="https://github.com/open-mmlab/mmdetection/blob/3.x/configs/vfnet/metafile.yml#L106" target="_blank">box AP of 50.8 for object-detection task on COCO dataset</a>. To understand the naming style used, please refer to <a href="https://mmdetection.readthedocs.io/en/v3.1.0/user_guides/config.html#config-name-style" target="_blank">MMDetection's Config Name Style</a>.
+
+Accurately ranking the vast number of candidate detections is crucial for dense object detectors to achieve high performance. Prior work uses the classification score or a combination of classification and predicted localization scores to rank candidates. However, neither option results in a reliable ranking, thus degrading detection performance. In this paper, we propose to learn an Iou-aware Classification Score (IACS) as a joint representation of object presence confidence and localization accuracy. We show that dense object detectors can achieve a more accurate ranking of candidate detections based on the IACS. We design a new loss function, named Varifocal Loss, to train a dense object detector to predict the IACS, and propose a new star-shaped bounding box feature representation for IACS prediction and bounding box refinement. Combining these two new components and a bounding box refinement branch, we build an IoU-aware dense object detector based on the FCOS+ATSS architecture, that we call VarifocalNet or VFNet for short. Extensive experiments on MS COCO show that our VFNet consistently surpasses the strong baseline by ∼2.0 AP with different backbones. Our best model VFNet-X-1200 with Res2Net-101-DCN achieves a single-model single-scale AP of 55.1 on COCO test-dev, which is state-of-the-art among various object detectors.
+
+> The above abstract is from MMDetection website. Review the <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0/configs/vfnet" target="_blank">original-model-card</a> to understand the data used to train the model, evaluation metrics, license, intended uses, limitations and bias before using the model.
+
+### Inference samples
+
+Inference type|Python sample (Notebook)|CLI with YAML
+|--|--|--|
+Real time|<a href="https://aka.ms/azureml-infer-sdk-image-object-detection" target="_blank">image-object-detection-online-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-cli-image-object-detection" target="_blank">image-object-detection-online-endpoint.sh</a>
+Batch |<a href="https://aka.ms/azureml-infer-batch-sdk-image-object-detection" target="_blank">image-object-detection-batch-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-batch-cli-image-object-detection" target="_blank">image-object-detection-batch-endpoint.sh</a>
+
+### Finetuning samples
+
+Task|Use case|Dataset|Python sample (Notebook)|CLI with YAML
+|---|--|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-ft-sdk-image-object-detection" target="_blank">fridgeobjects-object-detection.ipynb</a>|<a href="https://aka.ms/azureml-ft-cli-image-object-detection" target="_blank">fridgeobjects-object-detection.sh</a>
+
+### Model Evaluation
+
+|Task|Use case|Dataset|Python sample (Notebook)|
+|---|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-evaluation-sdk-image-object-detection" target="_blank">image-object-detection.ipynb</a>|
+
+### Sample inputs and outputs (for real-time inference)
+
+#### Sample input
+
+```json
+{
+  "input_data": {
+    "columns": [
+      "image"
+    ],
+    "index": [0, 1],
+    "data": ["image1", "image2"]
+  }
+}
+```
+
+Note: "image1" and "image2" string should be in base64 format or publicly accessible urls.
+
+#### Sample output
+
+```json
+[
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.1,
+                    "topY": 0.2,
+                    "bottomX": 0.8,
+                    "bottomY": 0.7
+                },
+                "label": "carton",
+                "score": 0.98
+            }
+        ]
+    },
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.2,
+                    "topY": 0.3,
+                    "bottomX": 0.6,
+                    "bottomY": 0.5
+                },
+                "label": "can",
+                "score": 0.97
+            }
+        ]
+    }
+]
+```
+
+Note: Please refer to object detection output <a href="https://learn.microsoft.com/en-us/azure/machine-learning/reference-automl-images-schema?view=azureml-api-2#object-detection-1" target="_blank">data schema</a> for more detail.
+
+#### Model inference - visualization for a sample image
+
+<img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/plot_vfnet_x101_64x4d_fpn_mdconv_c3-c5_mstrain_2x_coco_OD.png" alt="od visualization">

--- a/assets/models/system/mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco/model.yaml
+++ b/assets/models/system/mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: finetuning-image-models
+  container_path: mmdetection-3.x-mlflow/vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco/1699897690/mlflow_model_folder
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: mlflow_model

--- a/assets/models/system/mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco/spec.yaml
+++ b/assets/models/system/mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco/spec.yaml
@@ -1,0 +1,32 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco
+path: ./
+properties:
+  SHA: fff646d3dda72d8c794471bfaa75b4db0adb7610
+  datasets: COCO
+  evaluation-min-sku-spec: 4|1|28|176
+  evaluation-recommended-sku: Standard_NC6s_v3
+  finetune-min-sku-spec: 4|1|28|176
+  finetune-recommended-sku: Standard_NC6s_v3
+  finetuning-tasks: image-object-detection
+  inference-min-sku-spec: 4|0|14|28
+  inference-recommended-sku: Standard_DS3_v2, Standard_D4a_v4, Standard_D4as_v4, Standard_DS4_v2,
+    Standard_D8a_v4, Standard_D8as_v4, Standard_DS5_v2, Standard_D16a_v4, Standard_D16as_v4,
+    Standard_D32a_v4, Standard_D32as_v4, Standard_D48a_v4, Standard_D48as_v4, Standard_D64a_v4,
+    Standard_D64as_v4, Standard_D96a_v4, Standard_D96as_v4, Standard_FX4mds, Standard_F8s_v2,
+    Standard_FX12mds, Standard_F16s_v2, Standard_F32s_v2, Standard_F48s_v2, Standard_F64s_v2,
+    Standard_F72s_v2, Standard_FX24mds, Standard_FX36mds, Standard_FX48mds, Standard_E4s_v3,
+    Standard_E8s_v3, Standard_E16s_v3, Standard_E32s_v3, Standard_E48s_v3, Standard_E64s_v3,
+    Standard_NC4as_T4_v3, Standard_NC6s_v3, Standard_NC8as_T4_v3, Standard_NC12s_v3,
+    Standard_NC16as_T4_v3, Standard_NC24s_v3, Standard_NC64as_T4_v3, Standard_NC24ads_A100_v4,
+    Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4,
+    Standard_ND40rs_v2
+  model_id: mmd-3x-vfnet_x101-64x4d-mdconv-c3-c5_fpn_ms-2x_coco
+tags:
+  Preview: ''
+  license: apache-2.0
+  model_specific_defaults:
+    apply_deepspeed: 'false'
+    apply_ort: 'false'
+  task: object-detection
+version: 8

--- a/assets/models/system/mmd-3x-yolof_r50_c5_8x8_1x_coco/asset.yaml
+++ b/assets/models/system/mmd-3x-yolof_r50_c5_8x8_1x_coco/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Models"]

--- a/assets/models/system/mmd-3x-yolof_r50_c5_8x8_1x_coco/description.md
+++ b/assets/models/system/mmd-3x-yolof_r50_c5_8x8_1x_coco/description.md
@@ -1,0 +1,83 @@
+`yolof_r50_c5_8x8_1x_coco` model is from <a href="https://github.com/open-mmlab/mmdetection/tree/v2.28.2" target="_blank">OpenMMLab's MMDetection library</a>. This model is reported to obtain <a href="https://github.com/open-mmlab/mmdetection/blob/3.x/configs/yolof/metafile.yml#L21" target="_blank">box AP of 37.5 for object-detection task on COCO dataset</a>. To understand the naming style used, please refer to <a href="https://mmdetection.readthedocs.io/en/v3.1.0/user_guides/config.html#config-name-style" target="_blank">MMDetection's Config Name Style</a>.
+
+This paper revisits feature pyramids networks (FPN) for one-stage detectors and points out that the success of FPN is due to its divide-and-conquer solution to the optimization problem in object detection rather than multi-scale feature fusion. From the perspective of optimization, we introduce an alternative way to address the problem instead of adopting the complex feature pyramids - {\em utilizing only one-level feature for detection}. Based on the simple and efficient solution, we present You Only Look One-level Feature (YOLOF). In our method, two key components, Dilated Encoder and Uniform Matching, are proposed and bring considerable improvements. Extensive experiments on the COCO benchmark prove the effectiveness of the proposed model. Our YOLOF achieves comparable results with its feature pyramids counterpart RetinaNet while being 2.5× faster. Without transformer layers, YOLOF can match the performance of DETR in a single-level feature manner with 7× less training epochs. With an image size of 608×608, YOLOF achieves 44.3 mAP running at 60 fps on 2080Ti, which is 13% faster than YOLOv4.
+
+> The above abstract is from MMDetection website. Review the <a href="https://github.com/open-mmlab/mmdetection/tree/v3.1.0/configs/yolof" target="_blank">original-model-card</a> to understand the data used to train the model, evaluation metrics, license, intended uses, limitations and bias before using the model.
+
+### Inference samples
+
+Inference type|Python sample (Notebook)|CLI with YAML
+|--|--|--|
+Real time|<a href="https://aka.ms/azureml-infer-sdk-image-object-detection" target="_blank">image-object-detection-online-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-cli-image-object-detection" target="_blank">image-object-detection-online-endpoint.sh</a>
+Batch |<a href="https://aka.ms/azureml-infer-batch-sdk-image-object-detection" target="_blank">image-object-detection-batch-endpoint.ipynb</a>|<a href="https://aka.ms/azureml-infer-batch-cli-image-object-detection" target="_blank">image-object-detection-batch-endpoint.sh</a>
+
+### Finetuning samples
+
+Task|Use case|Dataset|Python sample (Notebook)|CLI with YAML
+|---|--|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-ft-sdk-image-object-detection" target="_blank">fridgeobjects-object-detection.ipynb</a>|<a href="https://aka.ms/azureml-ft-cli-image-object-detection" target="_blank">fridgeobjects-object-detection.sh</a>
+
+### Model Evaluation
+
+|Task|Use case|Dataset|Python sample (Notebook)|
+|---|--|--|--|
+Image object detection|Image object detection|[fridgeObjects](https://cvbp-secondary.z19.web.core.windows.net/datasets/object_detection/odFridgeObjects.zip)|<a href="https://aka.ms/azureml-evaluation-sdk-image-object-detection" target="_blank">image-object-detection.ipynb</a>|
+
+### Sample inputs and outputs (for real-time inference)
+
+#### Sample input
+
+```json
+{
+  "input_data": {
+    "columns": [
+      "image"
+    ],
+    "index": [0, 1],
+    "data": ["image1", "image2"]
+  }
+}
+```
+
+Note: "image1" and "image2" string should be in base64 format or publicly accessible urls.
+
+#### Sample output
+
+```json
+[
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.1,
+                    "topY": 0.2,
+                    "bottomX": 0.8,
+                    "bottomY": 0.7
+                },
+                "label": "carton",
+                "score": 0.98
+            }
+        ]
+    },
+    {
+        "boxes": [
+            {
+                "box": {
+                    "topX": 0.2,
+                    "topY": 0.3,
+                    "bottomX": 0.6,
+                    "bottomY": 0.5
+                },
+                "label": "can",
+                "score": 0.97
+            }
+        ]
+    }
+]
+```
+
+Note: Please refer to object detection output <a href="https://learn.microsoft.com/en-us/azure/machine-learning/reference-automl-images-schema?view=azureml-api-2#object-detection-1" target="_blank">data schema</a> for more detail.
+
+#### Model inference - visualization for a sample image
+
+<img src="https://automlcesdkdataresources.blob.core.windows.net/finetuning-image-models/images/Model_Result_Visualizations(Do_not_delete)/plot_yolof_r50_c5_8x8_1x_coco_OD.png" alt="od visualization">

--- a/assets/models/system/mmd-3x-yolof_r50_c5_8x8_1x_coco/model.yaml
+++ b/assets/models/system/mmd-3x-yolof_r50_c5_8x8_1x_coco/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: finetuning-image-models
+  container_path: mmdetection-3.x-mlflow/yolof_r50_c5_8x8_1x_coco/1699943805/mlflow_model_folder
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: mlflow_model

--- a/assets/models/system/mmd-3x-yolof_r50_c5_8x8_1x_coco/spec.yaml
+++ b/assets/models/system/mmd-3x-yolof_r50_c5_8x8_1x_coco/spec.yaml
@@ -1,0 +1,32 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: mmd-3x-yolof_r50_c5_8x8_1x_coco
+path: ./
+properties:
+  SHA: 621b8c8dc1bed2d6116eed8b741d8d356e3f372a
+  datasets: COCO
+  evaluation-min-sku-spec: 4|1|28|176
+  evaluation-recommended-sku: Standard_NC6s_v3
+  finetune-min-sku-spec: 4|1|28|176
+  finetune-recommended-sku: Standard_NC6s_v3
+  finetuning-tasks: image-object-detection
+  inference-min-sku-spec: 4|0|14|28
+  inference-recommended-sku: Standard_DS3_v2, Standard_D4a_v4, Standard_D4as_v4, Standard_DS4_v2,
+    Standard_D8a_v4, Standard_D8as_v4, Standard_DS5_v2, Standard_D16a_v4, Standard_D16as_v4,
+    Standard_D32a_v4, Standard_D32as_v4, Standard_D48a_v4, Standard_D48as_v4, Standard_D64a_v4,
+    Standard_D64as_v4, Standard_D96a_v4, Standard_D96as_v4, Standard_FX4mds, Standard_F8s_v2,
+    Standard_FX12mds, Standard_F16s_v2, Standard_F32s_v2, Standard_F48s_v2, Standard_F64s_v2,
+    Standard_F72s_v2, Standard_FX24mds, Standard_FX36mds, Standard_FX48mds, Standard_E4s_v3,
+    Standard_E8s_v3, Standard_E16s_v3, Standard_E32s_v3, Standard_E48s_v3, Standard_E64s_v3,
+    Standard_NC4as_T4_v3, Standard_NC6s_v3, Standard_NC8as_T4_v3, Standard_NC12s_v3,
+    Standard_NC16as_T4_v3, Standard_NC24s_v3, Standard_NC64as_T4_v3, Standard_NC24ads_A100_v4,
+    Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4,
+    Standard_ND40rs_v2
+  model_id: mmd-3x-yolof_r50_c5_8x8_1x_coco
+tags:
+  Preview: ''
+  license: apache-2.0
+  model_specific_defaults:
+    apply_deepspeed: 'false'
+    apply_ort: 'false'
+  task: object-detection
+version: 8

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/detection_predict.py
@@ -83,10 +83,10 @@ class ImagesDetectionMLflowModelWrapper(mlflow.pyfunc.PythonModel):
         for result in batch_results:
             image_height, image_width = result.ori_shape
             pred_instances = result.pred_instances
-            bboxes = pred_instances.bboxes.numpy()
-            labels = pred_instances.labels.numpy()
-            scores = pred_instances.scores.numpy()
-            masks = pred_instances.masks.numpy() if self._task_type == Tasks.MM_INSTANCE_SEGMENTATION.value else None
+            bboxes = pred_instances.bboxes.cpu().numpy()
+            labels = pred_instances.labels.cpu().numpy()
+            scores = pred_instances.scores.cpu().numpy()
+            masks = pred_instances.masks.cpu().numpy() if self._task_type == Tasks.MM_INSTANCE_SEGMENTATION.value else None
 
             cur_image_preds = {ODLiterals.BOXES: []}
             for i in range(len(labels)):
@@ -166,7 +166,7 @@ class ImagesDetectionMLflowModelWrapper(mlflow.pyfunc.PythonModel):
 
         with tempfile.TemporaryDirectory() as tmp_output_dir:
             image_path_list = (
-                processed_images.iloc[:, 0].map(lambda row: create_temp_file(row, tmp_output_dir)).tolist()
+                processed_images.iloc[:, 0].map(lambda row: create_temp_file(row, tmp_output_dir)[0]).tolist()
             )
 
             results = self._inference_detector(imgs=image_path_list, model=self._model)

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/mmdet-is-requirements.txt
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/mmdet-is-requirements.txt
@@ -1,4 +1,4 @@
-mlflow==2.6.2
+mlflow==2.6.0
 cloudpickle==2.2.1
 datasets==2.14.5
 openmim==0.3.9
@@ -6,6 +6,5 @@ torch==2.0.1
 torchvision==0.15.2
 transformers==4.34.0
 accelerate==0.23.0
-albumentations==1.3.0
 scikit-image==0.19.3
 simplification==0.5.7

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/mmdet-od-requirements.txt
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/vision/mmdet-od-requirements.txt
@@ -1,4 +1,4 @@
-mlflow==2.6.2
+mlflow==2.6.0
 cloudpickle==2.2.1
 datasets==2.14.5
 openmim==0.3.9
@@ -6,4 +6,3 @@ torch==2.0.1
 torchvision==0.15.2
 transformers==4.34.0
 accelerate==0.23.0
-albumentations==1.3.0


### PR DESCRIPTION
Adding MMDetection 3.x models which would be used by latest MMD component. To distiguish these models with MMD 2.x models, we are prefixing the model names in the registry with mmd-3x.