### PR TITLE
fixing env vuln for pyarrow

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -9,5 +9,7 @@ RUN pip install --upgrade pip
 COPY requirements.txt .
 
 RUN pip install "azureml-evaluate-mlflow=={{latest-pypi-version}}"
+# pyarrow-hotfix is installed to fix the vulnerability CVE-2023-47248
+# This can be removed once datasets is upgraded to >= 2.14.7
 RUN pip install -r requirements.txt --no-cache-dir
 RUN python -m nltk.downloader punkt

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -20,3 +20,4 @@ certifi==2023.07.22
 numpy==1.22
 peft==0.4.0
 deepspeed==0.9.5
+pyarrow-hotfix


### PR DESCRIPTION
Installing pyarrow-hotfix package to fix the vuln for the time being. The hotfix pkg can be removed once the datasets is upgraded to version>=2.14.7