### PR TITLE
Update environments-ci.yaml

### DIFF
--- a/.github/workflows/environments-ci.yaml
+++ b/.github/workflows/environments-ci.yaml
@@ -70,8 +70,9 @@ jobs:
       
       - name: Use Python 3.8 or newer
         uses: actions/setup-python@v4
+        # azureml-dataprep and/or azureml-dataprep-native doesn't support python 3.12 yet.
         with:
-          python-version: '>=3.8'
+          python-version: '>=3.8, <3.12'
     
       - name: Install dependencies
         run: pip install -e $scripts_azureml_assets_dir


### PR DESCRIPTION
Adding python version constrain in environment build.
"SDK seems to support up to 3.10 as a whole... so not sure when we will get to 3.12"
python 3.12 cannot build package contains azureml-dataprep and azureml-dataprep-native


BTW.  this workflow doesn't seem right - it should honor the python version specified in conda_dependences.