### PR TITLE
fix libpmix2 security vulnerability in RAI vision docker image

### DIFF
--- a/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -2,7 +2,8 @@ FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
 # Install OpenCV native dependencies
 RUN apt-get update
 RUN apt-get install -y python3-opencv
-RUN apt-get remove -y libavutil56 libswresample3 libavformat58 libavcodec58 libswscale5 libopenexr24
+RUN apt-get remove -y libavutil56 libswresample3 libavformat58
+RUN apt-get remove -y libavcodec58 libswscale5 libopenexr24 libpmix2
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-vision
 


### PR DESCRIPTION
fix libpmix2 security vulnerability in RAI vision docker image

Alert:
ResponsibleAI public/azureml/curated/responsibleai-vision-ubuntu20.04-py38-cpu 37 199836 OOSLA 2023-11-04 Ubuntu Security Notification for PMIx Vulnerability (USN-6434-1)

Link to vulnerability:
https://ubuntu.com/security/notices/USN-6434-1