### PR TITLE
force upgrade pyarrow to 14.0.1 to fix pyarrow vulnerabilities for vision envs

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -11,3 +11,4 @@ RUN pip install -r requirements.txt --no-cache-dir
 # Vulnerability fixes
 RUN pip install pydash==6.0.0
 RUN pip install urllib3==2.0.7
+RUN pip install pyarrow==14.0.1

--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -11,4 +11,4 @@ RUN pip install -r requirements.txt --no-cache-dir
 # Vulnerability fixes
 RUN pip install pydash==6.0.0
 RUN pip install urllib3==2.0.7
-RUN pip install pyarrow==14.0.1
+RUN pip install pyarrow>=14.0.1


### PR DESCRIPTION
Runs: https://ml.azure.com/environments/acft-transformers-image-gpu/version/25?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/nilesh-new-rg/providers/Microsoft.MachineLearningServices/workspaces/nilesh-ws-new&tid=72f988bf-86f1-41af-91ab-2d7cd011db47