### PR TITLE
Tabular Component Version Bump

### DIFF
--- a/assets/responsibleai/tabular/components/insight_create/spec.yaml
+++ b/assets/responsibleai/tabular/components/insight_create/spec.yaml
@@ -44,7 +44,7 @@ outputs:
   rai_insights_dashboard:
     type: path
 code: ../src/
-environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/25
+environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/37
 command: >-
   python create_rai_insights.py
   --title '${{inputs.title}}'


### PR DESCRIPTION
Bumping component version as per https://github.com/Azure/azureml-assets/blob/a03add226a269bd5543b7810899eae6a697dfb4d/assets/responsibleai/vision/components/rai_vision_insights/spec.yaml#L119 for component release to work with PL workspaces

Copilot:
This pull request includes a single change to update the `environment` property in the `rai_insights_dashboard` section of `spec.yaml` from version 25 to version 37. This update ensures correct environment usage in the `create_rai_insights.py` script.

Main change:

* <a href="diffhunk://#diff-e8ebdaeb0fa842150a9fabc37eb84b2f2fd8de943658392fda3f67ed5fc6356cL47-R47">`assets/responsibleai/tabular/components/insight_create/spec.yaml`</a>: Updated the `environment` property in the `rai_insights_dashboard` section of `spec.yaml` from version 25 to version 37.