### PR TITLE
Docker Image Updated for Python 3.10 upgrade

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -1,5 +1,5 @@
 #PTCA image
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu117-py38-torch201:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
+FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu118-py310-torch201
 
 USER root
 


### PR DESCRIPTION
Docker Image Upgraded to python 3.10 version

FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu118-py310-torch201