### PR TITLE
Update code owners for assets/models/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 /assets/training/ @azure/aml-training
 /assets/sample/ @Azure/aml-assets
 /assets/data/ @Azure/azureml-data
-/assets/models/ @azure/aml-training @azure/azureml-inference-idc
+/assets/models/ @azure/aml-training
 /assets/common/ @azure/aml-training
 /assets/model_monitoring/ @Azure/aml-model-monitoring
 /assets/large_language_models/ @azure/aml-training @azure/aml-llm


### PR DESCRIPTION
Update code owners for assets/models/

Considering that the models utilizing the inference image are no longer receiving updates and the latest models do not use huggingface inferencing image, inferencing team's approval seems unnecessary.