### PR TITLE
resolve for mlflow, aiohttp vulnerability for mmtracking

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/asset.yaml
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/asset.yaml
@@ -1,5 +1,5 @@
 name: acft-mmtracking-video-gpu
-version: "6"
+version: "7"
 type: environment
 spec: spec.yaml
 extra_config: environment.yaml

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -22,3 +22,4 @@ RUN pip install pydash==6.0.0
 RUN pip install urllib3==2.0.7
 RUN pip install scipy==1.10.1
 RUN pip install pyarrow==14.0.1
+RUN pip install aiohttp==3.9.1


### PR DESCRIPTION
resolve vulnerability, pin aiohttp==3.9.1, mlflow==2.8.1 for [acft-mmtracking-video-gpu](https://ml.azure.com/environments/acft-mmtracking-video-gpu/version/2?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rupaljain-rs/providers/Microsoft.MachineLearningServices/workspaces/rupaljain-workspace&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)