### PR TITLE
Generate SAS tokens for prompts in addition to models

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.16.19 (2023-12-04)
+### 🐛 Bugs Fixed
+- [#1875](https://github.com/Azure/azureml-assets/pull/1875) Generate SAS tokens for prompts in addition to models
+
 ## 1.16.18 (2023-11-20)
 ### 🐛 Bugs Fixed
 - [#1760](https://github.com/Azure/azureml-assets/pull/1760) Generate SAS tokens for multiple models and output in JSON

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -1018,7 +1018,7 @@ class GenericAssetConfig(Config):
 
     @property
     def path(self) -> AssetPath:
-        """Remote storage path (Azure Blob is the only supported type)."""
+        """Remote Storage Path (Azure Blob is the only supported type)."""
         if self._path:
             return self._path
         path = self._yaml.get('path', {})

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -692,7 +692,11 @@ class ModelConfig(Config):
     """
 
     def __init__(self, file_name: Path):
-        """Initialize object for the Model Properties extracted from extra_config model.yaml."""
+        """Initialize object for the Model Properties extracted from extra_config model.yaml.
+        
+        Args:
+            file_name (Path): Model config file to load and validate.
+        """
         super().__init__(file_name)
         self._path = None
         self._description = ""
@@ -1000,10 +1004,10 @@ class GenericAssetConfig(Config):
     """
 
     def __init__(self, file_name: Path):
-        """Initialize object for the Generic Asset Properties extracted from extra_config prompt.yaml.
+        """Initialize object for the Generic Asset Properties extracted from storage.yaml.
         
         Args:
-            file_name (Path): Prompt config file to load and validate.
+            file_name (Path): Storage config file to load and validate.
         """
         super().__init__(file_name)
         self._path = None

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -1036,7 +1036,6 @@ class GenericAssetConfig(Config):
             return None
         return self._path
 
-
     @property
     def local_path(self) -> str:
         """Remote storage path (Azure Blob is the only supported type)."""

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -993,13 +993,14 @@ class GenericAssetConfig(Config):
     """
     Example:
 
-    path: 
-
-        ## Azure Blobstore example
+    # Remote storage path for asset data
+    remote_path:
         type: azureblob
         storage_name: my_storage
         container_name: my_container
         container_path: foo/bar
+    # Local folder path to copy remote files into
+    local_path: ./prompt
 
     """
 
@@ -1014,11 +1015,11 @@ class GenericAssetConfig(Config):
         pass
 
     @property
-    def path(self) -> AssetPath:
-        """Model Path."""
+    def remote_path(self) -> AssetPath:
+        """Remote storage path (Azure Blob is the only supported type)."""
         if self._path:
             return self._path
-        path = self._yaml.get('path', {})
+        path = self._yaml.get('remote_path', {})
         if path and path.get('type'):
             path_type = path.get('type')
             if path_type == PathType.AZUREBLOB.value:
@@ -1032,6 +1033,12 @@ class GenericAssetConfig(Config):
         else:
             return None
         return self._path
+
+
+    @property
+    def local_path(self) -> str:
+        """Remote storage path (Azure Blob is the only supported type)."""
+        return self._yaml.get('local_path')
 
 
 @total_ordering

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -1001,7 +1001,6 @@ class GenericAssetConfig(Config):
         container_path: foo/bar
     # Local folder path to copy remote files into
     local_path: ./prompt
-
     """
 
     def __init__(self, file_name: Path):

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -1041,7 +1041,7 @@ class GenericAssetConfig(Config):
 
     @property
     def local_path(self) -> str:
-        """Remote storage path (Azure Blob is the only supported type)."""
+        """Local file path to copy remote files into."""
         return self._yaml.get('local_path')
 
 

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -1000,7 +1000,11 @@ class GenericAssetConfig(Config):
     """
 
     def __init__(self, file_name: Path):
-        """Initialize object for the Generic Asset Properties extracted from extra_config."""
+        """Initialize object for the Generic Asset Properties extracted from extra_config prompt.yaml.
+        
+        Args:
+            file_name (Path): Prompt config file to load and validate.
+        """
         super().__init__(file_name)
         self._path = None
         self._validate()

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -988,10 +988,10 @@ class EnvironmentConfig(Config):
 
 
 class GenericAssetConfig(Config):
-    """Generic Asset Config class."""
+    """Generic Asset Config class.
 
-    """
     Example:
+
 
     # Remote storage path for asset data
     remote_path:

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -1012,7 +1012,9 @@ class GenericAssetConfig(Config):
 
     def _validate(self):
         """Validate the yaml file."""
-        pass
+        Config._validate_exists('generic_asset.path', self.remote_path)
+        Config._validate_enum('generic_asset.path.type', self.remote_path.type.value, PathType, True)
+        Config._validate_exists('generic_asset.local_path', self.local_path)
 
     @property
     def remote_path(self) -> AssetPath:

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -693,7 +693,7 @@ class ModelConfig(Config):
 
     def __init__(self, file_name: Path):
         """Initialize object for the Model Properties extracted from extra_config model.yaml.
-        
+
         Args:
             file_name (Path): Model config file to load and validate.
         """
@@ -1005,7 +1005,7 @@ class GenericAssetConfig(Config):
 
     def __init__(self, file_name: Path):
         """Initialize object for the Generic Asset Properties extracted from storage.yaml.
-        
+
         Args:
             file_name (Path): Storage config file to load and validate.
         """

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -994,13 +994,11 @@ class GenericAssetConfig(Config):
 
     Example:
         # Remote storage path for asset data
-        remote_path:
+        path:
             type: azureblob
             storage_name: my_storage
             container_name: my_container
             container_path: foo/bar
-        # Local folder path to copy remote files into
-        local_path: ./prompt
     """
 
     def __init__(self, file_name: Path):
@@ -1015,16 +1013,15 @@ class GenericAssetConfig(Config):
 
     def _validate(self):
         """Validate the yaml file."""
-        Config._validate_exists('generic_asset.path', self.remote_path)
-        Config._validate_enum('generic_asset.path.type', self.remote_path.type.value, PathType, True)
-        Config._validate_exists('generic_asset.local_path', self.local_path)
+        Config._validate_exists('generic_asset.path', self.path)
+        Config._validate_enum('generic_asset.path.type', self.path.type.value, PathType, True)
 
     @property
-    def remote_path(self) -> AssetPath:
+    def path(self) -> AssetPath:
         """Remote storage path (Azure Blob is the only supported type)."""
         if self._path:
             return self._path
-        path = self._yaml.get('remote_path', {})
+        path = self._yaml.get('path', {})
         if path and path.get('type'):
             path_type = path.get('type')
             if path_type == PathType.AZUREBLOB.value:
@@ -1038,11 +1035,6 @@ class GenericAssetConfig(Config):
         else:
             return None
         return self._path
-
-    @property
-    def local_path(self) -> str:
-        """Local file path to copy remote files into."""
-        return self._yaml.get('local_path')
 
 
 @total_ordering

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -991,7 +991,6 @@ class GenericAssetConfig(Config):
 
     Example:
 
-
     # Remote storage path for asset data
     remote_path:
         type: azureblob

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -671,25 +671,24 @@ class ModelConfig(Config):
     """Model Config class.
 
     Example:
+        path: # should contain local_path or should contain package object
+            ##Local path example
+            type: local
+            uri: "../models/bert-base-uncased" # the local path to the model
 
-    path: # should contain local_path or should contain package object
-        ##Local path example
-        type: local
-        uri: "../models/bert-base-uncased" # the local path to the model
+            ## GIT path example
+            type: git
+            uri: https://huggingface.co/bert-base-uncased
+            branch: main
 
-        ## GIT path example
-        type: git
-        uri: https://huggingface.co/bert-base-uncased
-        branch: main
-
-        ## Azure Blobstore example
-        type: azureblob
-        storage_name: my_storage
-        container_name: my_container
-        container_path: foo/bar
-    publish:
-        description: model_card.md
-        type: mlflow_model
+            ## Azure Blobstore example
+            type: azureblob
+            storage_name: my_storage
+            container_name: my_container
+            container_path: foo/bar
+        publish:
+            description: model_card.md
+            type: mlflow_model
     """
 
     def __init__(self, file_name: Path):
@@ -990,15 +989,14 @@ class GenericAssetConfig(Config):
     """Generic Asset Config class.
 
     Example:
-
-    # Remote storage path for asset data
-    remote_path:
-        type: azureblob
-        storage_name: my_storage
-        container_name: my_container
-        container_path: foo/bar
-    # Local folder path to copy remote files into
-    local_path: ./prompt
+        # Remote storage path for asset data
+        remote_path:
+            type: azureblob
+            storage_name: my_storage
+            container_name: my_container
+            container_path: foo/bar
+        # Local folder path to copy remote files into
+        local_path: ./prompt
     """
 
     def __init__(self, file_name: Path):

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -668,9 +668,8 @@ class GitAssetPath(AssetPath):
 
 
 class ModelConfig(Config):
-    """Model Config class."""
+    """Model Config class.
 
-    """
     Example:
 
     path: # should contain local_path or should contain package object

--- a/scripts/azureml-assets/azureml/assets/get_tokens.py
+++ b/scripts/azureml-assets/azureml/assets/get_tokens.py
@@ -10,7 +10,7 @@ from typing import List
 
 import azureml.assets as assets
 import azureml.assets.util as util
-from azureml.assets.config import AssetType, AzureBlobstoreAssetPath
+from azureml.assets.config import AssetType, AzureBlobstoreAssetPath, GENERIC_ASSET_TYPES
 
 from collections import defaultdict
 from datetime import timedelta
@@ -21,7 +21,7 @@ def get_tokens(input_dirs: List[Path],
                asset_config_filename: str,
                json_output_path: str,
                pattern: re.Pattern = None):
-    """Generate SAS tokens for models and prompts to JSON output file.
+    """Generate SAS tokens for models and generic assets to JSON output file.
 
     Args:
         input_dirs (List[Path]): List of directories to search for assets.
@@ -31,13 +31,13 @@ def get_tokens(input_dirs: List[Path],
     """
     json_info = defaultdict(dict)
 
-    # Generate SAS tokens for prompt assets
+    # Generate SAS tokens for generic assets
     for asset_config in util.find_assets(
-            input_dirs, asset_config_filename, types=[AssetType.PROMPT], pattern=pattern):
+            input_dirs, asset_config_filename, types=GENERIC_ASSET_TYPES, pattern=pattern):
 
-        prompt_config: assets.GenericAssetConfig = asset_config.extra_config_as_object()
-        if (prompt_config and isinstance(prompt_config.remote_path, AzureBlobstoreAssetPath)):
-            add_token_info(prompt_config.remote_path, json_info)
+        generic_config: assets.GenericAssetConfig = asset_config.extra_config_as_object()
+        if (generic_config and isinstance(generic_config.remote_path, AzureBlobstoreAssetPath)):
+            add_token_info(generic_config.remote_path, json_info)
 
     # Generate SAS tokens for models
     for asset_config in util.find_assets(

--- a/scripts/azureml-assets/azureml/assets/get_tokens.py
+++ b/scripts/azureml-assets/azureml/assets/get_tokens.py
@@ -30,6 +30,10 @@ def get_tokens(input_dirs: List[Path],
         pattern (re.Pattern, optional): Regex pattern for assets to copy. Defaults to None.
     """
     json_info = defaultdict(dict)
+    
+    # placeholder test
+    print('In updated get_tokens')
+    json_info['abc'] = 'def'
 
     # Filter to only models
     for asset_config in util.find_assets(

--- a/scripts/azureml-assets/azureml/assets/get_tokens.py
+++ b/scripts/azureml-assets/azureml/assets/get_tokens.py
@@ -30,7 +30,6 @@ def get_tokens(input_dirs: List[Path],
         pattern (re.Pattern, optional): Regex pattern for assets to copy. Defaults to None.
     """
     json_info = defaultdict(dict)
-    
 
     # Generate SAS tokens for prompt assets
     for asset_config in util.find_assets(
@@ -49,7 +48,7 @@ def get_tokens(input_dirs: List[Path],
 
         if not isinstance(path, AzureBlobstoreAssetPath):
             continue
-            
+
         add_token_info(path, json_info)
 
     with open(json_output_path, 'w') as json_token_file:

--- a/scripts/azureml-assets/azureml/assets/get_tokens.py
+++ b/scripts/azureml-assets/azureml/assets/get_tokens.py
@@ -43,7 +43,7 @@ def get_tokens(input_dirs: List[Path],
 
         elif asset_config.type in GENERIC_ASSET_TYPES:
             generic_config: assets.GenericAssetConfig = asset_config.extra_config_as_object()
-            if (generic_config and isinstance(generic_config.path, AzureBlobstoreAssetPath)):
+            if generic_config and isinstance(generic_config.path, AzureBlobstoreAssetPath):
                 add_token_info(generic_config.path, json_info)
 
     with open(json_output_path, 'w') as json_token_file:

--- a/scripts/azureml-assets/azureml/assets/get_tokens.py
+++ b/scripts/azureml-assets/azureml/assets/get_tokens.py
@@ -43,8 +43,8 @@ def get_tokens(input_dirs: List[Path],
 
         elif asset_config.type in GENERIC_ASSET_TYPES:
             generic_config: assets.GenericAssetConfig = asset_config.extra_config_as_object()
-            if (generic_config and isinstance(generic_config.remote_path, AzureBlobstoreAssetPath)):
-                add_token_info(generic_config.remote_path, json_info)
+            if (generic_config and isinstance(generic_config.path, AzureBlobstoreAssetPath)):
+                add_token_info(generic_config.path, json_info)
 
     with open(json_output_path, 'w') as json_token_file:
         json.dump(json_info, json_token_file)

--- a/scripts/azureml-assets/azureml/assets/get_tokens.py
+++ b/scripts/azureml-assets/azureml/assets/get_tokens.py
@@ -33,7 +33,20 @@ def get_tokens(input_dirs: List[Path],
     
     # placeholder test
     print('In updated get_tokens')
-    json_info['abc'] = 'def'
+
+    # Check prompt asssets
+    for asset_config in util.find_assets(
+            input_dirs, asset_config_filename, types=[AssetType.PROMPT], pattern=pattern):
+        print('found asset', asset_config)
+        prompt_config: assets.GenericAssetConfig = asset_config.extra_config_as_object()
+        path = prompt_config.path
+        print('found path:', path)
+        account_name = prompt_config.path.storage_name
+        container_name = prompt_config.path.container_name
+        print('found account', account_name, 'container', container_name)
+        _ = path.get_uri(token_expiration=timedelta(days=1))
+        token = path.token
+        json_info[account_name][container_name] = token
 
     # Filter to only models
     for asset_config in util.find_assets(

--- a/scripts/azureml-assets/azureml/assets/get_tokens.py
+++ b/scripts/azureml-assets/azureml/assets/get_tokens.py
@@ -55,7 +55,7 @@ def get_tokens(input_dirs: List[Path],
         json.dump(json_info, json_token_file)
 
 
-def add_token_info(path: AzureBlobstoreAssetPath, json_info: dict):
+def add_token_info(path: AzureBlobstoreAssetPath, json_info: defaultdict(dict)):
     """Generate a SAS token and add it to the json info token dictionary.
 
     Args:

--- a/scripts/azureml-assets/azureml/assets/get_tokens.py
+++ b/scripts/azureml-assets/azureml/assets/get_tokens.py
@@ -60,7 +60,7 @@ def add_token_info(path: AzureBlobstoreAssetPath, json_info: defaultdict(dict)):
 
     Args:
         storage_path (AzureBlobstoreAssetPath): Blob storage path to update.
-        json_info (dict): Dictionary used to generate the JSON token file.
+        json_info (defaultdict(dict)): Dictionary used to generate the JSON token file.
     """
     account_name = path.storage_name
     container_name = path.container_name

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.18",
+   version="1.16.19",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
Add support to have prompt files stored in remote storage.  On the config side, add an extra config object for generic assets to point to a remote storage path.  Then in the get_tokens step, check for prompt/generic assets in addition to model assets when generating tokens.