### PR TITLE
Finetune config v2 support

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/components/finetune/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_finetune
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Question Answering Finetune
 description: Component to finetune Hugging Face pretrained models for extractive question answering task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/question_answering_finetune) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_finetune
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Summarization Finetune
 description: Component to finetune Hugging Face pretrained models for summarization task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/summarization_finetune) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_finetune
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: false
@@ -8,7 +8,7 @@ is_deterministic: false
 display_name: Text Classification Finetune
 description: Component to finetune Hugging Face pretrained models for text classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/text_classification_finetune) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_finetune
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Generation Finetune
 description: Component to finetune model for Text Generation task
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_finetune
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: false
@@ -8,7 +8,7 @@ is_deterministic: false
 display_name: Token Classification Finetune
 description: Component to finetune Hugging Face pretrained models for token classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/token_classification_finetune) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_finetune
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Translation Finetune
 description: Component to finetune Hugging Face pretrained models for translation task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/translation_finetune) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: ft_nlp_model_converter
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Common Model Converter
 description: Component to convert the finetune job output to pytorch and mlflow model
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/model_converter
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_model_import
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Question Answering Model Import
 description: Component to import PyTorch / MLFlow model. See [docs](https://aka.ms/azureml/components/question_answering_model_import) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_model_import
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Summarization Model Import
 description: Component to import PyTorch / MLFlow model. See [docs](https://aka.ms/azureml/components/summarization_model_import) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_model_import
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Classification Model Import
 description: Component to import PyTorch / MLFlow model. See [docs](https://aka.ms/azureml/components/text_classification_model_import) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_model_import
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Generation Model Import
 description: Import PyTorch / MLFlow model
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_model_import
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Token Classification Model Import
 description: Component to import PyTorch / MLFlow model. See [docs](https://aka.ms/azureml/components/token_classification_model_import) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_model_import
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Translation Model Import
 description: Component to import PyTorch / MLFlow model. See [docs](https://aka.ms/azureml/components/translation_model_import) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: question_answering_pipeline
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Question Answering Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for extractive question answering task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/question_answering_pipeline) to learn more.
@@ -541,7 +541,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -573,7 +573,7 @@ jobs:
 
   question_answering_model_import:
     type: command
-    component: azureml:question_answering_model_import:0.0.26
+    component: azureml:question_answering_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -584,7 +584,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   question_answering_datapreprocess:
     type: command
-    component: azureml:question_answering_datapreprocess:0.0.26
+    component: azureml:question_answering_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -609,7 +609,7 @@ jobs:
       model_selector_output: '${{parent.jobs.question_answering_model_import.outputs.output_dir}}'
   question_answering_finetune:
     type: command
-    component: azureml:question_answering_finetune:0.0.26
+    component: azureml:question_answering_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: summarization_pipeline
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Summarization Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for summarization task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/summarization_pipeline) to learn more.
@@ -512,7 +512,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -541,7 +541,7 @@ jobs:
       adam_epsilon: '${{parent.inputs.adam_epsilon}}'
   summarization_model_import:
     type: command
-    component: azureml:summarization_model_import:0.0.26
+    component: azureml:summarization_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -552,7 +552,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   summarization_datapreprocess:
     type: command
-    component: azureml:summarization_datapreprocess:0.0.26
+    component: azureml:summarization_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -572,7 +572,7 @@ jobs:
       model_selector_output: '${{parent.jobs.summarization_model_import.outputs.output_dir}}'
   summarization_finetune:
     type: command
-    component: azureml:summarization_finetune:0.0.26
+    component: azureml:summarization_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -630,7 +630,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
@@ -543,7 +543,7 @@ jobs:
       adam_epsilon: '${{parent.inputs.adam_epsilon}}'
   text_classification_model_import:
     type: command
-    component: azureml:text_classification_model_import:0.0.26
+    component: azureml:text_classification_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -554,7 +554,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   text_classification_datapreprocess:
     type: command
-    component: azureml:text_classification_datapreprocess:0.0.26
+    component: azureml:text_classification_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -575,7 +575,7 @@ jobs:
       model_selector_output: '${{parent.jobs.text_classification_model_import.outputs.output_dir}}'
   text_classification_finetune:
     type: command
-    component: azureml:text_classification_finetune:0.0.26
+    component: azureml:text_classification_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -633,7 +633,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline
 description: Pipeline component for text generation
@@ -528,7 +528,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -558,7 +558,7 @@ jobs:
       adam_epsilon: '${{parent.inputs.adam_epsilon}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -570,7 +570,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -590,7 +590,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -649,7 +649,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_high
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -564,7 +564,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -589,7 +589,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -652,7 +652,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_low
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -564,7 +564,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -589,7 +589,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -652,7 +652,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_medium
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -564,7 +564,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -589,7 +589,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -652,7 +652,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_high
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -564,7 +564,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -589,7 +589,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -652,7 +652,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_low
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -564,7 +564,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -589,7 +589,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -652,7 +652,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_medium
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -564,7 +564,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -589,7 +589,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -652,7 +652,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_high
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -564,7 +564,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -589,7 +589,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -652,7 +652,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_low
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -564,7 +564,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -589,7 +589,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -652,7 +652,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_medium
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.26
+    component: azureml:text_generation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -564,7 +564,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.26
+    component: azureml:text_generation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -589,7 +589,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.26
+    component: azureml:text_generation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -652,7 +652,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: token_classification_pipeline
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Token Classification Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for token classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/token_classification_pipeline) to learn more.
@@ -507,7 +507,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -536,7 +536,7 @@ jobs:
       adam_epsilon: '${{parent.inputs.adam_epsilon}}'
   token_classification_model_import:
     type: command
-    component: azureml:token_classification_model_import:0.0.26
+    component: azureml:token_classification_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -547,7 +547,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   token_classification_datapreprocess:
     type: command
-    component: azureml:token_classification_datapreprocess:0.0.26
+    component: azureml:token_classification_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -566,7 +566,7 @@ jobs:
       model_selector_output: '${{parent.jobs.token_classification_model_import.outputs.output_dir}}'
   token_classification_finetune:
     type: command
-    component: azureml:token_classification_finetune:0.0.26
+    component: azureml:token_classification_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -624,7 +624,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: translation_pipeline
-version: 0.0.28
+version: 0.0.29
 type: pipeline
 display_name: Translation Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for translation task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/translation_pipeline) to learn more.
@@ -504,7 +504,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.26
+    component: azureml:ft_nlp_common_validation:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -533,7 +533,7 @@ jobs:
       adam_epsilon: '${{parent.inputs.adam_epsilon}}'
   translation_model_import:
     type: command
-    component: azureml:translation_model_import:0.0.26
+    component: azureml:translation_model_import:0.0.27
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -544,7 +544,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   translation_datapreprocess:
     type: command
-    component: azureml:translation_datapreprocess:0.0.26
+    component: azureml:translation_datapreprocess:0.0.27
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -563,7 +563,7 @@ jobs:
       model_selector_output: '${{parent.jobs.translation_model_import.outputs.output_dir}}'
   translation_finetune:
     type: command
-    component: azureml:translation_finetune:0.0.26
+    component: azureml:translation_finetune:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -621,7 +621,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.26
+    component: azureml:ft_nlp_model_converter:0.0.27
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_datapreprocess
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Question Answering DataPreProcess
 description: Component to preprocess data for question answering task. See [docs](https://aka.ms/azureml/components/question_answering_datapreprocess) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_datapreprocess
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Summarization DataPreProcess
 description: Component to preprocess data for summarization task. See [docs](https://aka.ms/azureml/components/summarization_datapreprocess) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_datapreprocess
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Classification DataPreProcess
 description: Component to preprocess data for single label classification task. See [docs](https://aka.ms/azureml/components/text_classification_datapreprocess) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_datapreprocess
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Generation DataPreProcess
 description: Component to preprocess data for text generation task
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_datapreprocess
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Token Classification DataPreProcess
 description: Component to preprocess data for token classification task. See [docs](https://aka.ms/azureml/components/token_classification_datapreprocess) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_datapreprocess
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Translation DataPreProcess
 description: Component to preprocess data for translation task. See [docs](https://aka.ms/azureml/components/translation_datapreprocess) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: ft_nlp_common_validation
-version: 0.0.26
+version: 0.0.27
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Common Validation Component
 description: Component to validate the finetune job against Validation Service
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/31
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/33
 
 code: ../../../src/validation
 

--- a/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
+++ b/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
@@ -18,7 +18,7 @@ import re
 import torch
 
 # set up transformers cache
-from azureml.acft.common_components.utils import transformer_utils
+from azureml.acft.common_components.utils import transformer_utils  # noqa: F401
 from transformers.trainer_utils import set_seed, enable_full_determinism
 
 from azureml.acft.contrib.hf.nlp.constants.constants import (

--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/finetune_config.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/finetune_config.py
@@ -217,6 +217,8 @@ class FinetuneConfig:
         io_finetune_config_path: Optional[str] = None,
     ) -> None:
         """
+        Finetune config init.
+
         :param task_name - The finetune task
         :type str
         :param model_name - The huggingface model name
@@ -240,7 +242,7 @@ class FinetuneConfig:
     def _read_ft_config_json_file(
         self, json_file_path: Optional[str]
     ) -> Dict[str, Any]:
-        """Utility to read the finetune config json file.
+        """Read finetune config json file.
 
         :param json_file_path - Path to the finetune config json file
         :type Optional[str]
@@ -283,8 +285,9 @@ class FinetuneConfig:
         return finetune_config
 
     def _read_legacy_finetune_config(self) -> Dict[str, Any]:
-        """Read the finetune config from the legacy ACFT_CONFIG a.k.a FINETUNE_CONFIG_V0. If both model_name and
-        model_type are present, precedence is given to model_name over model_type.
+        """Read the finetune config from the legacy ACFT_CONFIG a.k.a FINETUNE_CONFIG_V0.
+
+        If both model_name and model_type are present, precedence is given to model_name over model_type.
         """
         finetune_config_v0 = {}
         if self.model_name is not None and self.model_name in FINETUNE_CONFIG_V0:

--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/finetune_config.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/finetune_config.py
@@ -1,0 +1,300 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""File containing utilities for loading finetune config."""
+
+import copy
+import json
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+from azureml.acft.contrib.hf.nlp.utils.common_utils import deep_update
+from azureml.acft.contrib.hf.nlp.constants.constants import HfModelTypes
+
+from azureml.acft.common_components import get_logger_app
+
+
+logger = get_logger_app(
+    "azureml.acft.contrib.hf.scripts.components.scripts.model_selector.finetune_config"
+)
+
+
+# TODO - Move REFINED_WEB to :dataclass HfModelTypes
+REFINED_WEB = "RefinedWeb"
+MIXFORMER_SEQUENTIAL = "mixformer-sequential"  # Phi models
+
+
+# user config passed along with model, will be prefered over default settings
+# NOTE Deleted `load_model_kwargs` for trust_remote_code=True as for falcon models
+# we are adding a hack and overriding :meth `from_pretrained` for Text, Token and
+# QnA auto classes in finetune.py.
+# Don't forget to add back the `load_model_kwargs` once the hack to override methods
+# is removed
+ACFT_CONFIG = {
+    "tiiuae/falcon-7b": {
+        "load_config_kwargs": {
+            "trust_remote_code": True,
+        },
+        "load_tokenizer_kwargs": {
+            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
+            "pad_token": "<|endoftext|>",
+            "trust_remote_code": True,
+        },
+        "finetune_args": {},
+        "mlflow_ft_conf": {
+            "mlflow_hftransformers_misc_conf": {
+                "config_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+                "tokenizer_hf_load_kwargs": {
+                    "model_input_names": ["input_ids", "attention_mask"],
+                    "return_token_type_ids": False,
+                },
+                "model_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+                "tokenizer_config": {
+                    "return_token_type_ids": False,
+                },
+            },
+            "mlflow_save_model_kwargs": {
+                "extra_pip_requirements": ["einops"],
+            },
+        },
+    },
+    "tiiuae/falcon-40b": {
+        "load_config_kwargs": {
+            "trust_remote_code": True,
+        },
+        "load_tokenizer_kwargs": {
+            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
+            "pad_token": "<|endoftext|>",
+            "trust_remote_code": True,
+        },
+        "finetune_args": {},
+        "mlflow_ft_conf": {
+            "mlflow_hftransformers_misc_conf": {
+                "config_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+                "tokenizer_hf_load_kwargs": {
+                    "model_input_names": ["input_ids", "attention_mask"],
+                    "return_token_type_ids": False,
+                },
+                "model_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+                "tokenizer_config": {
+                    "return_token_type_ids": False,
+                },
+            },
+            "mlflow_save_model_kwargs": {
+                "extra_pip_requirements": ["einops"],
+            },
+        },
+    },
+    HfModelTypes.REFINEDWEBMODEL: {
+        "load_config_kwargs": {
+            "trust_remote_code": True,
+        },
+        "load_tokenizer_kwargs": {
+            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
+            "pad_token": "<|endoftext|>",
+            "trust_remote_code": True,
+        },
+        "finetune_args": {},
+        "mlflow_ft_conf": {
+            "mlflow_hftransformers_misc_conf": {
+                "config_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+                "tokenizer_hf_load_kwargs": {
+                    "model_input_names": ["input_ids", "attention_mask"],
+                    "return_token_type_ids": False,
+                },
+                "model_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+                "tokenizer_config": {
+                    "return_token_type_ids": False,
+                },
+            },
+            "mlflow_save_model_kwargs": {
+                "extra_pip_requirements": ["einops"],
+            },
+        },
+    },
+    HfModelTypes.FALCON: {
+        "load_config_kwargs": {
+            "trust_remote_code": True,
+        },
+        "load_tokenizer_kwargs": {
+            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
+            "pad_token": "<|endoftext|>",
+            "trust_remote_code": True,
+        },
+        "finetune_args": {},
+        "mlflow_ft_conf": {
+            "mlflow_hftransformers_misc_conf": {
+                "config_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+                "tokenizer_hf_load_kwargs": {
+                    "model_input_names": ["input_ids", "attention_mask"],
+                    "return_token_type_ids": False,
+                },
+                "model_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+            },
+            "mlflow_save_model_kwargs": {
+                "extra_pip_requirements": ["einops"],
+            },
+        },
+    },
+    REFINED_WEB: {
+        "load_config_kwargs": {
+            "trust_remote_code": True,
+        },
+        "load_tokenizer_kwargs": {
+            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
+            "pad_token": "<|endoftext|>",
+            "trust_remote_code": True,
+        },
+        "finetune_args": {},
+        "mlflow_ft_conf": {
+            "mlflow_hftransformers_misc_conf": {
+                "config_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+                "tokenizer_hf_load_kwargs": {
+                    "model_input_names": ["input_ids", "attention_mask"],
+                    "return_token_type_ids": False,
+                },
+                "model_hf_load_kwargs": {
+                    "trust_remote_code": True,
+                },
+                "tokenizer_config": {
+                    "return_token_type_ids": False,
+                },
+            },
+            "mlflow_save_model_kwargs": {
+                "extra_pip_requirements": ["einops"],
+            },
+        },
+    },
+    HfModelTypes.LLAMA: {
+        "load_tokenizer_kwargs": {"add_eos_token": True, "padding_side": "right"},
+        "mlflow_ft_conf": {
+            "mlflow_hftransformers_misc_conf": {
+                "tokenizer_hf_load_kwargs": {
+                    "add_eos_token": True,
+                    "padding_side": "right",
+                },
+            }
+        },
+    },
+}
+
+
+# The constant dictionary is the legacy way of storing finetune config. The new versions of models
+# have the finetune config packaged with the mlflow model artifacts.
+FINETUNE_CONFIG_V0 = ACFT_CONFIG
+
+
+class FinetuneConfig:
+    """Class for finetune config utilities."""
+
+    # If version is not mentioned in the json, it falls under v1 config
+    _DEFAULT_VERSION = "1"
+
+    def __init__(
+        self,
+        task_name: str,
+        model_name: Optional[str] = None,
+        model_type: Optional[str] = None,
+        artifacts_finetune_config_path: Optional[str] = None,
+        io_finetune_config_path: Optional[str] = None,
+    ) -> None:
+        """
+        :param task_name - The finetune task
+        :type str
+        :param model_name - The huggingface model name
+        :type Optional[str]
+        :param model_type - The name of the model family. For instance, the model names llama-2-7b, llama-2-13b,
+        llama-2-70b belong to model_type llama
+        :type Optional[str]
+        :param artifacts_finetune_config_path - The path to finetune config packaged with model artifacts. The
+        finetune config comes with 2 versions. More details about this is defined in the respective methods
+        :type Optional[str]
+        :param io_finetune_config_path - The io path to the finetune config. This takes precedence over the config
+        passed with model artifacts.
+        :type Optional[str]
+        """
+        self.task_name = task_name
+        self.model_name = model_name
+        self.model_type = model_type
+        self.artifacts_finetune_config_path = artifacts_finetune_config_path
+        self.io_finetune_config_path = io_finetune_config_path
+
+    def _read_ft_config_json_file(
+        self, json_file_path: Optional[str]
+    ) -> Dict[str, Any]:
+        """Utility to read the finetune config json file.
+
+        :param json_file_path - Path to the finetune config json file
+        :type Optional[str]
+        :return finetune_config
+        :rtype Dict[str, Any]
+        """
+        if not json_file_path or not Path(json_file_path).is_file():
+            return {}
+
+        with open(json_file_path, "r", encoding="utf-8") as rptr:
+            json_data = json.load(rptr)
+        # filter the finetune config for version 2
+        if json_data.get("version", self._DEFAULT_VERSION) == "2":
+            json_data = json_data.get("task_specific_config", {}).get(
+                self.task_name, {}
+            )
+
+        return json_data
+
+    def get_finetune_config(self) -> Dict[str, Any]:
+        """Fetch the finetune config. Attempts to read the finetune config with v2 version."""
+        finetune_config_artifacts = self._read_ft_config_json_file(
+            self.artifacts_finetune_config_path
+        )
+        finetune_config_io = self._read_ft_config_json_file(
+            self.io_finetune_config_path
+        )
+        # combine artifacts and io finetune config.
+        finetune_config = deep_update(
+            finetune_config_artifacts,
+            finetune_config_io,  # finetune_config_io is given more precedence over finetune_config_artifacts
+        )
+
+        # read legacy config from FINETUNE_CONFIG_V0
+        if not finetune_config:
+            finetune_config = self._read_legacy_finetune_config()
+        logger.info(
+            f"Setting the following finetune config to this model: {finetune_config}"
+        )
+        return finetune_config
+
+    def _read_legacy_finetune_config(self) -> Dict[str, Any]:
+        """Read the finetune config from the legacy ACFT_CONFIG a.k.a FINETUNE_CONFIG_V0. If both model_name and
+        model_type are present, precedence is given to model_name over model_type.
+        """
+        finetune_config_v0 = {}
+        if self.model_name is not None and self.model_name in FINETUNE_CONFIG_V0:
+            finetune_config_v0 = copy.deepcopy(FINETUNE_CONFIG_V0[self.model_name])
+            logger.info(
+                f"Found model name in finetune config version v0 - {finetune_config_v0}"
+            )
+        elif self.model_type is not None and self.model_type in ACFT_CONFIG:
+            finetune_config_v0 = copy.deepcopy(FINETUNE_CONFIG_V0[self.model_type])
+            logger.info(
+                f"Found model type in finetune config version v0 - {finetune_config_v0}"
+            )
+        return finetune_config_v0

--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -2,23 +2,27 @@
 # Licensed under the MIT License.
 
 """File containing function for model selector component."""
+import shutil
 from pathlib import Path
 import argparse
 import json
 from argparse import Namespace
 import copy
 import yaml
+from typing import Optional, Dict, Any
 
 from azureml.acft.contrib.hf.nlp.task_factory import get_task_runner
 from azureml.acft.contrib.hf.nlp.utils.common_utils import deep_update
 from azureml.acft.contrib.hf.nlp.constants.constants import LOGS_TO_BE_FILTERED_IN_APPINSIGHTS
-from azureml.acft.contrib.hf.nlp.constants.constants import SaveFileConstants, HfModelTypes
+from azureml.acft.contrib.hf.nlp.constants.constants import SaveFileConstants, MLFlowHFFlavourConstants
 
 from azureml.acft.common_components.utils.error_handling.swallow_all_exceptions_decorator import (
     swallow_all_exceptions,
 )
 from azureml.acft.common_components import get_logger_app, set_logging_parameters, LoggingLiterals
 from azureml.acft.contrib.hf import VERSION, PROJECT_NAME
+
+from finetune_config import FinetuneConfig
 
 
 logger = get_logger_app("azureml.acft.contrib.hf.scripts.components.scripts.model_selector.model_selector")
@@ -36,215 +40,6 @@ class ModelSelectorConstants:
 
     ASSET_ID_NOT_FOUND = "ASSET_ID_NOT_FOUND",
     MODEL_NAME_NOT_FOUND = "MODEL_NAME_NOT_FOUND"
-
-
-# user config passed along with model, will be prefered over default settings
-# NOTE Deleted `load_model_kwargs` for trust_remote_code=True as for falcon models
-# we are adding a hack and overriding :meth `from_pretrained` for Text, Token and
-# QnA auto classes in finetune.py.
-# Don't forget to add back the `load_model_kwargs` once the hack to override methods
-# is removed
-ACFT_CONFIG = {
-    "tiiuae/falcon-7b": {
-        "load_config_kwargs": {
-            "trust_remote_code": True,
-        },
-        "load_tokenizer_kwargs": {
-            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
-            "pad_token": "<|endoftext|>",
-            "trust_remote_code": True,
-        },
-        "finetune_args": {},
-        "mlflow_ft_conf": {
-            "mlflow_hftransformers_misc_conf": {
-                "config_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_hf_load_kwargs": {
-                    "model_input_names": ["input_ids", "attention_mask"],
-                    "return_token_type_ids": False,
-                },
-                "model_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_config": {
-                    "return_token_type_ids": False,
-                },
-            },
-            "mlflow_save_model_kwargs": {
-                "extra_pip_requirements": ["einops"],
-            },
-        },
-    },
-    "tiiuae/falcon-40b": {
-        "load_config_kwargs": {
-            "trust_remote_code": True,
-        },
-        "load_tokenizer_kwargs": {
-            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
-            "pad_token": "<|endoftext|>",
-            "trust_remote_code": True,
-        },
-        "finetune_args": {},
-        "mlflow_ft_conf": {
-            "mlflow_hftransformers_misc_conf": {
-                "config_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_hf_load_kwargs": {
-                    "model_input_names": ["input_ids", "attention_mask"],
-                    "return_token_type_ids": False,
-                },
-                "model_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_config": {
-                    "return_token_type_ids": False,
-                },
-            },
-            "mlflow_save_model_kwargs": {
-                "extra_pip_requirements": ["einops"],
-            },
-        },
-    },
-    HfModelTypes.REFINEDWEBMODEL: {
-        "load_config_kwargs": {
-            "trust_remote_code": True,
-        },
-        "load_tokenizer_kwargs": {
-            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
-            "pad_token": "<|endoftext|>",
-            "trust_remote_code": True,
-        },
-        "finetune_args": {},
-        "mlflow_ft_conf": {
-            "mlflow_hftransformers_misc_conf": {
-                "config_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_hf_load_kwargs": {
-                    "model_input_names": ["input_ids", "attention_mask"],
-                    "return_token_type_ids": False,
-                },
-                "model_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_config": {
-                    "return_token_type_ids": False,
-                },
-            },
-            "mlflow_save_model_kwargs": {
-                "extra_pip_requirements": ["einops"],
-            },
-        },
-    },
-    HfModelTypes.FALCON: {
-        "load_config_kwargs": {
-            "trust_remote_code": True,
-        },
-        "load_tokenizer_kwargs": {
-            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
-            "pad_token": "<|endoftext|>",
-            "trust_remote_code": True,
-        },
-        "finetune_args": {},
-        "mlflow_ft_conf": {
-            "mlflow_hftransformers_misc_conf": {
-                "config_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_hf_load_kwargs": {
-                    "model_input_names": ["input_ids", "attention_mask"],
-                    "return_token_type_ids": False,
-                },
-                "model_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-            },
-            "mlflow_save_model_kwargs": {
-                "extra_pip_requirements": ["einops"],
-            },
-        },
-    },
-    REFINED_WEB: {
-        "load_config_kwargs": {
-            "trust_remote_code": True,
-        },
-        "load_tokenizer_kwargs": {
-            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
-            "pad_token": "<|endoftext|>",
-            "trust_remote_code": True,
-        },
-        "finetune_args": {},
-        "mlflow_ft_conf": {
-            "mlflow_hftransformers_misc_conf": {
-                "config_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_hf_load_kwargs": {
-                    "model_input_names": ["input_ids", "attention_mask"],
-                    "return_token_type_ids": False,
-                },
-                "model_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_config": {
-                    "return_token_type_ids": False,
-                },
-            },
-            "mlflow_save_model_kwargs": {
-                "extra_pip_requirements": ["einops"],
-            },
-        },
-    },
-    HfModelTypes.LLAMA: {
-        "load_tokenizer_kwargs": {
-            "add_eos_token": True,
-            "padding_side": "right"
-        },
-        "mlflow_ft_conf": {
-            "mlflow_hftransformers_misc_conf": {
-                "tokenizer_hf_load_kwargs": {
-                    "add_eos_token": True,
-                    "padding_side": "right",
-                },
-            }
-        }
-    },
-    MIXFORMER_SEQUENTIAL: {
-        "load_config_kwargs": {
-            "trust_remote_code": True,
-        },
-        "load_tokenizer_kwargs": {
-            # adding eos_token as pad_token. The value of eos_token is taken from tokenization_config.json file
-            "pad_token": "<|endoftext|>",
-            "trust_remote_code": True,
-        },
-        "finetune_args": {},
-        "mlflow_ft_conf": {
-            "mlflow_hftransformers_misc_conf": {
-                "config_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                },
-                "tokenizer_hf_load_kwargs": {
-                    # "model_input_names": ["input_ids", "attention_mask"],
-                    "return_token_type_ids": False,
-                },
-                "model_hf_load_kwargs": {
-                    "trust_remote_code": True,
-                    "ignore_mismatched_sizes": True,
-                },
-                "hf_predict_module": "phi_predict"
-                # "tokenizer_config": {
-                #     "return_token_type_ids": False,
-                # },
-            },
-            "mlflow_save_model_kwargs": {
-                "extra_pip_requirements": ["einops"],
-            },
-        }
-    }
-}
 
 
 FLAVOR_MAP = {
@@ -348,8 +143,14 @@ def get_parser():
     return parser
 
 
-def model_selector(args: Namespace):
-    """Model selector."""
+def model_selector(args: Namespace) -> Dict[str, Any]:
+    """Model selector main.
+
+    :param args - component args
+    :type Namespace
+    :return Meta data saved by model selector component (model selector args)
+    :rtype Dict[str, Any]
+    """
     Path(args.output_dir).mkdir(parents=True, exist_ok=True)
 
     if args.huggingface_id is not None:
@@ -367,120 +168,90 @@ def model_selector(args: Namespace):
     task_runner = get_task_runner(task_name=args.task_name)()
     task_runner.run_modelselector(**vars(args))
 
-    # load user provided finetune_config.json
-    ft_config_path = getattr(args, "finetune_config_path", None)
-    # if ft_config_path is not provided check inside pytorch/mlflow model folder
-    if ft_config_path is None:
-        model_path = getattr(args, "pytorch_model_path", None) \
-            if getattr(args, "pytorch_model_path", None) is not None else getattr(args, "mlflow_model_path", None)
-        if model_path is not None:
-            ft_model_config_path = Path(model_path, SaveFileConstants.ACFT_CONFIG_SAVE_PATH)
-            if ft_model_config_path.is_file():
-                ft_config_path = str(ft_model_config_path)
-    if ft_config_path is not None:
-        try:
-            with open(ft_config_path, "r") as rptr:
-                ft_config_data = json.load(rptr)
-        except Exception as e:
-            logger.info(f"Unable to load {SaveFileConstants.ACFT_CONFIG_SAVE_PATH} - {e}")
-            ft_config_data = {}
-    else:
-        logger.info(f"{SaveFileConstants.ACFT_CONFIG_SAVE_PATH} does not exist")
-        ft_config_data = {}
-
     # read model selector args
-    # fetch model details
     model_selector_args_save_path = Path(args.output_dir, SaveFileConstants.MODEL_SELECTOR_ARGS_SAVE_PATH)
     with open(model_selector_args_save_path, "r") as rptr:
         model_selector_args = json.load(rptr)
-    model_name = model_selector_args.get("model_name", ModelSelectorConstants.MODEL_NAME_NOT_FOUND)
-    logger.info(f"Model name - {model_name}")
 
-    # fetch model_type
+    return model_selector_args
+
+
+def fetch_model_type(model_path: str) -> Optional[str]:
+    """Fetch the model type.
+
+    :param model_path - path to the model artifacts
+    :type str
+    :return model type
+    :rtype Optional[str]
+    """
     model_type = None
     try:
         # fetch model_type
-        model_base_path = Path(args.output_dir, model_name)
-        model_config_path = Path(model_base_path, "config.json")
-        if model_base_path.is_dir() and model_config_path.is_file():
+        model_config_path = Path(model_path, "config.json")
+        if model_config_path.is_file():
             with open(model_config_path, "r") as fp:
                 model_config = json.load(fp)
                 model_type = model_config.get("model_type", None)
         else:
-            logger.info(f"Model config.json does not exist for {model_name}")
+            logger.info(f"Model config.json does not exist for {model_path}")
     except Exception:
-        logger.info(f"Unable to fetch model_type for {model_name}")
+        logger.info(f"Unable to fetch model_type for {model_path}")
 
-    if model_type is not None and model_type in ACFT_CONFIG:
-        model_ft_config = copy.deepcopy(ACFT_CONFIG[model_type])
-        model_ft_config.update(ft_config_data)
-        ft_config_data = copy.deepcopy(model_ft_config)
-        logger.info(f"Updated FT config from model_type data - {ft_config_data}")
-    elif model_name is not None and model_name in ACFT_CONFIG:
-        model_ft_config = copy.deepcopy(ACFT_CONFIG[model_name])
-        model_ft_config.update(ft_config_data)
-        ft_config_data = copy.deepcopy(model_ft_config)
-        logger.info(f"Updated FT config from model_name data - {ft_config_data}")
-    else:
-        logger.info(f"Not updating FT config data - {ft_config_data}")
+    return model_type
 
-    # for base curated models forward MLmodel info
-    if getattr(args, "mlflow_model_path", None) is not None:
-        import shutil
-        from azureml.acft.contrib.hf.nlp.constants.constants import MLFlowHFFlavourConstants
-        mlflow_config_file = Path(args.mlflow_model_path, MLFlowHFFlavourConstants.MISC_CONFIG_FILE)
-        if mlflow_config_file.is_file():
-            shutil.copy(str(mlflow_config_file), args.output_dir)
-            logger.info("Copied MLmodel file to output dir")
 
-            # pass mlflow data to ft config if available
-            mlflow_ftconf_data = {}
-            mlflow_data = None
-            try:
-                with open(str(mlflow_config_file), "r") as fp:
-                    mlflow_data = yaml.safe_load(fp)
-                if mlflow_data and "flavors" in mlflow_data:
-                    for key in mlflow_data["flavors"]:
-                        if key in FLAVOR_MAP.keys():
-                            for key2 in mlflow_data["flavors"][key]:
-                                if key2 == "generator_config" and args.task_name == "TextGeneration":
-                                    generator_config = mlflow_data["flavors"][key]["generator_config"]
-                                    mlflow_ftconf_data_temp = {
-                                            "load_config_kwargs": copy.deepcopy(generator_config),
-                                            "mlflow_ft_conf": {
-                                                "mlflow_hftransformers_misc_conf": {
-                                                    "generator_config": copy.deepcopy(generator_config),
-                                                },
+def read_base_model_finetune_config(mlflow_model_path: str, task_name: str) -> Dict[str, Any]:
+    """Read the finetune config from base model.
+
+    :param mlflow_model_path - Path to the mlflow model
+    :type str
+    :param task_name - Finetune task
+    :type str
+    :return base model finetune config
+    :type Optional[Dict[str, Any]]
+    """
+    if mlflow_model_path is None:
+        return {}
+
+    mlflow_config_file = Path(mlflow_model_path, MLFlowHFFlavourConstants.MISC_CONFIG_FILE)
+    mlflow_ftconf_data = {}
+    if mlflow_config_file.is_file():
+        # pass mlflow data to ft config if available
+        mlflow_data = None
+        try:
+            with open(str(mlflow_config_file), "r") as fp:
+                mlflow_data = yaml.safe_load(fp)
+            if mlflow_data and "flavors" in mlflow_data:
+                for key in mlflow_data["flavors"]:
+                    if key in FLAVOR_MAP:
+                        for key2 in mlflow_data["flavors"][key]:
+                            if key2 == "generator_config" and task_name == "TextGeneration":
+                                generator_config = mlflow_data["flavors"][key]["generator_config"]
+                                mlflow_ftconf_data_temp = {
+                                        "load_config_kwargs": copy.deepcopy(generator_config),
+                                        "mlflow_ft_conf": {
+                                            "mlflow_hftransformers_misc_conf": {
+                                                "generator_config": copy.deepcopy(generator_config),
                                             },
-                                        }
-                                    mlflow_ftconf_data = deep_update(mlflow_ftconf_data_temp, mlflow_ftconf_data)
-                                elif key2 == "model_hf_load_kwargs":
-                                    model_hf_load_kwargs = mlflow_data["flavors"][key]["model_hf_load_kwargs"]
-                                    mlflow_ftconf_data_temp = {
-                                            "mlflow_ft_conf": {
-                                                "mlflow_hftransformers_misc_conf": {
-                                                    "model_hf_load_kwargs": copy.deepcopy(model_hf_load_kwargs),
-                                                },
+                                        },
+                                    }
+                                mlflow_ftconf_data = deep_update(mlflow_ftconf_data_temp, mlflow_ftconf_data)
+                            elif key2 == "model_hf_load_kwargs":
+                                model_hf_load_kwargs = mlflow_data["flavors"][key]["model_hf_load_kwargs"]
+                                mlflow_ftconf_data_temp = {
+                                        "mlflow_ft_conf": {
+                                            "mlflow_hftransformers_misc_conf": {
+                                                "model_hf_load_kwargs": copy.deepcopy(model_hf_load_kwargs),
                                             },
-                                        }
-                                    mlflow_ftconf_data = deep_update(mlflow_ftconf_data_temp, mlflow_ftconf_data)
-                ft_config_data = deep_update(mlflow_ftconf_data, ft_config_data)
-                logger.info(f"Updated FT config data - {ft_config_data}")
-            except Exception:
-                logger.info("Unable to read MLModel file")
-        else:
-            logger.info("MLmodel file does not exist")
+                                        },
+                                    }
+                                mlflow_ftconf_data = deep_update(mlflow_ftconf_data_temp, mlflow_ftconf_data)
+        except Exception:
+            logger.info("Error while updating base model finetune config from MlModel file.")
     else:
-        logger.info("mlflow_model_path is empty")
+        logger.info("MLmodel file does not exist")
 
-    # saving FT config
-    with open(str(Path(args.output_dir, SaveFileConstants.ACFT_CONFIG_SAVE_PATH)), "w") as rptr:
-        json.dump(ft_config_data, rptr, indent=2)
-    logger.info(f"Saved {SaveFileConstants.ACFT_CONFIG_SAVE_PATH}")
-
-    # additional logging
-    logger.info(f"Model name: {getattr(args, 'model_name', None)}")
-    logger.info(f"Task name: {getattr(args, 'task_name', None)}")
+    return mlflow_ftconf_data
 
 
 @swallow_all_exceptions(time_delay=60)
@@ -503,7 +274,49 @@ def main():
     # Adding flavor map to args
     setattr(args, "flavor_map", FLAVOR_MAP)
 
-    model_selector(args)
+    # run model selector
+    model_selector_args = model_selector(args)
+    model_name = model_selector_args.get("model_name", ModelSelectorConstants.MODEL_NAME_NOT_FOUND)
+    logger.info(f"Model name - {model_name}")
+    logger.info(f"Task name: {getattr(args, 'task_name', None)}")
+
+    # load ft config and update ACFT config
+    # finetune_config_dict = load_finetune_config(args)
+    ft_config_obj = FinetuneConfig(
+        task_name=args.task_name,
+        model_name=model_name,
+        model_type=fetch_model_type(str(Path(args.output_dir, model_name))),
+        artifacts_finetune_config_path=str(
+            Path(
+                args.pytorch_model_path or args.mlflow_model_path,
+                SaveFileConstants.ACFT_CONFIG_SAVE_PATH
+            )
+        ),
+        io_finetune_config_path=args.finetune_config_path
+    )
+    finetune_config = ft_config_obj.get_finetune_config()
+
+    # read finetune config from base mlmodel file
+    # Priority order: io_finetune_config > artifacts_finetune_config > base_model_finetune_config
+    updated_finetune_config = deep_update(
+        read_base_model_finetune_config(
+            args.mlflow_model_path,
+            args.task_name
+        ),
+        finetune_config
+    )
+    logger.info(f"Updated finetune config with base model config: {updated_finetune_config}")
+    # save FT config
+    with open(str(Path(args.output_dir, SaveFileConstants.ACFT_CONFIG_SAVE_PATH)), "w") as rptr:
+        json.dump(updated_finetune_config, rptr, indent=2)
+    logger.info(f"Saved {SaveFileConstants.ACFT_CONFIG_SAVE_PATH}")
+
+    # copy the mlmodel file to output dir. This is only applicable for mlflow model
+    if args.mlflow_model_path is not None:
+        mlflow_config_file = Path(args.mlflow_model_path, MLFlowHFFlavourConstants.MISC_CONFIG_FILE)
+        if mlflow_config_file.is_file():
+            shutil.copy(str(mlflow_config_file), args.output_dir)
+            logger.info("Copied MLmodel file to output dir")
 
 
 if __name__ == "__main__":

--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -288,7 +288,7 @@ def main():
         model_type=fetch_model_type(str(Path(args.output_dir, model_name))),
         artifacts_finetune_config_path=str(
             Path(
-                args.pytorch_model_path or args.mlflow_model_path,
+                args.pytorch_model_path or args.mlflow_model_path or "",
                 SaveFileConstants.ACFT_CONFIG_SAVE_PATH
             )
         ),


### PR DESCRIPTION
Changes -
1. Finetune config v2 support
2. Pipeline components upgraded from 28 -> 29
3. Command components upgraded from 26 -> 27


Sanity Runs - [Link](https://ml.azure.com/experiments/id/88c501f6-9c43-4e6e-b473-4eb30c5abb22?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)
Two runs (same retried twice) are failing with min loss scale issue. Rerunning the issue fixed it. Rest of the runs are going through fine