### PR TITLE
add gptv prompts (videos part1)

### DIFF
--- a/assets/large_language_models/prompts/GPTV/advertising_summary/asset.yaml
+++ b/assets/large_language_models/prompts/GPTV/advertising_summary/asset.yaml
@@ -1,0 +1,4 @@
+type: prompt
+spec: spec.yaml
+extra_config: storage.yaml
+categories: ["GPTV"]

--- a/assets/large_language_models/prompts/GPTV/advertising_summary/prompt/prompt.yaml
+++ b/assets/large_language_models/prompts/GPTV/advertising_summary/prompt/prompt.yaml
@@ -1,0 +1,22 @@
+$schema: https://azuremlschemas.azureedge.net/latest/prompt.schema.json
+
+_type: chat
+
+messages:
+- role: system
+  content:
+    - Your task is to assist in analyzing and optimizing creative assets. You will be presented with advertisement videos for products. First describe the video in detail paying close attention to Product characteristics highlighted, Background images, Lighting, Color Palette and Human characteristics for persons in the video. Finally provide a summary of the video and talk about the main message the advertisement video tries to convey to the viewer.
+
+starter_messages:
+- role: user
+  content:
+    - type: text
+      text: Summarize the ad video
+    - type: video
+      image_url: video1.mp4
+
+execution_settings:
+  gptv:
+    enhance: true
+
+template_format: handlebars

--- a/assets/large_language_models/prompts/GPTV/advertising_summary/spec.yaml
+++ b/assets/large_language_models/prompts/GPTV/advertising_summary/spec.yaml
@@ -1,0 +1,14 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.prompt.schema.json
+
+type: prompt
+version: 0.0.3
+name: advertising_summary 
+display_name: Advertising Summary
+description: Summarize an advertisement and identify issues (i.e. not showing logo early, etc.)
+
+tags:
+  modality: video
+  task: summarization
+
+data_uri: ./prompt
+template_path: prompt.yaml

--- a/assets/large_language_models/prompts/GPTV/advertising_summary/storage.yaml
+++ b/assets/large_language_models/prompts/GPTV/advertising_summary/storage.yaml
@@ -1,0 +1,5 @@
+path:
+  container_name: prompts
+  container_path: gptv/advertising_summary/v1
+  storage_name: automlcesdkdataresources
+  type: azureblob

--- a/assets/large_language_models/prompts/GPTV/property_listing_video/asset.yaml
+++ b/assets/large_language_models/prompts/GPTV/property_listing_video/asset.yaml
@@ -1,0 +1,4 @@
+type: prompt
+spec: spec.yaml
+extra_config: storage.yaml
+categories: ["GPTV"]

--- a/assets/large_language_models/prompts/GPTV/property_listing_video/prompt/prompt.yaml
+++ b/assets/large_language_models/prompts/GPTV/property_listing_video/prompt/prompt.yaml
@@ -1,0 +1,22 @@
+$schema: https://azuremlschemas.azureedge.net/latest/prompt.schema.json
+
+_type: chat
+
+messages:
+- role: system
+  content:
+    - Given the following images of a residential property, create a compelling and professional real estate listing
+
+starter_messages:
+- role: user
+  content:
+    - type: text
+      text: Describe the property in the video
+    - type: video
+      image_url: video1.mp4
+
+execution_settings:
+  gptv:
+    enhance: true
+
+template_format: handlebars

--- a/assets/large_language_models/prompts/GPTV/property_listing_video/spec.yaml
+++ b/assets/large_language_models/prompts/GPTV/property_listing_video/spec.yaml
@@ -1,0 +1,14 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.prompt.schema.json
+
+type: prompt
+version: 0.0.3
+name: property_listing_video 
+display_name: Property Listing Video
+description: Provide a summary and highlights of the property
+
+tags:
+  modality: video
+  task: summarization
+
+data_uri: ./prompt
+template_path: prompt.yaml

--- a/assets/large_language_models/prompts/GPTV/property_listing_video/storage.yaml
+++ b/assets/large_language_models/prompts/GPTV/property_listing_video/storage.yaml
@@ -1,0 +1,5 @@
+path:
+  container_name: prompts
+  container_path: gptv/property_listing_video/v1
+  storage_name: automlcesdkdataresources
+  type: azureblob

--- a/assets/large_language_models/prompts/GPTV/social_media_post_analysis/asset.yaml
+++ b/assets/large_language_models/prompts/GPTV/social_media_post_analysis/asset.yaml
@@ -1,0 +1,4 @@
+type: prompt
+spec: spec.yaml
+extra_config: storage.yaml
+categories: ["GPTV"]

--- a/assets/large_language_models/prompts/GPTV/social_media_post_analysis/prompt/prompt.yaml
+++ b/assets/large_language_models/prompts/GPTV/social_media_post_analysis/prompt/prompt.yaml
@@ -1,0 +1,22 @@
+$schema: https://azuremlschemas.azureedge.net/latest/prompt.schema.json
+
+_type: chat
+
+messages:
+- role: system
+  content:
+    - You are a social media video expert. You are to extract key details about the main themes, brands visible, and potential promotional opportunities. Your goal is to generate a comprehensive summary that advertisers can utilize for targeted promotions.
+
+starter_messages:
+- role: user
+  content:
+    - type: text
+      text: Analyze the content, themes, brands, and notable elements of the social media video
+    - type: video
+      image_url: video1.mp4
+
+execution_settings:
+  gptv:
+    enhance: true
+
+template_format: handlebars

--- a/assets/large_language_models/prompts/GPTV/social_media_post_analysis/spec.yaml
+++ b/assets/large_language_models/prompts/GPTV/social_media_post_analysis/spec.yaml
@@ -1,0 +1,14 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.prompt.schema.json
+
+type: prompt
+version: 0.0.3
+name: social_media_post_analysis 
+display_name: Social Media Post Analysis
+description: Analyze short videos to generate tags, content summaries, and targeted promotions while ensuring better content moderation and risk management
+
+tags:
+  modality: video
+  task: summarization
+
+data_uri: ./prompt
+template_path: prompt.yaml

--- a/assets/large_language_models/prompts/GPTV/social_media_post_analysis/storage.yaml
+++ b/assets/large_language_models/prompts/GPTV/social_media_post_analysis/storage.yaml
@@ -1,0 +1,5 @@
+path:
+  container_name: prompts
+  container_path: gptv/social_media_post_analysis/v1
+  storage_name: automlcesdkdataresources
+  type: azureblob


### PR DESCRIPTION
This is a change to define prompts for GPT.

**Changes**
* Add assets for following gptv prompts (for video contents), under assets/large_language_models/prompts/GPTV folder

advertising_summary
property_listing_video
social_media_post_analysis