### PR TITLE
Fixing issue in new llm-rag* environment

### DIFF
--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.57
+version: 0.0.58
 name: llm_ingest_dataset_to_acs_basic
 display_name: LLM - Dataset to ACS Pipeline
 is_deterministic: false
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.47'
+    component: 'azureml:llm_rag_validate_deployments:0.0.48'
     identity:
       type: user_identity
     inputs:
@@ -136,7 +136,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.45'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.46'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -159,7 +159,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.54'
+    component: 'azureml:llm_rag_create_promptflow:0.0.55'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -176,7 +176,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.38'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.39'
     inputs:
       chunks_source:
         type: uri_folder
@@ -226,7 +226,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.42'
+    component: 'azureml:llm_rag_update_acs_index:0.0.43'
     inputs:
       embeddings:
         type: uri_folder
@@ -246,7 +246,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.42'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.43'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_user_id/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_user_id/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.55
+version: 0.0.56
 name: llm_ingest_dataset_to_acs_user_id
 display_name: LLM - Dataset to ACS Pipeline
 is_deterministic: false
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.47'
+    component: 'azureml:llm_rag_validate_deployments:0.0.48'
     identity:
       type: user_identity
     inputs:
@@ -136,7 +136,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.45'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.46'
     identity:
       type: user_identity
     inputs:
@@ -161,7 +161,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.54'
+    component: 'azureml:llm_rag_create_promptflow:0.0.55'
     identity:
       type: user_identity
     inputs:
@@ -180,7 +180,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.38'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.39'
     identity:
       type: user_identity
     inputs:
@@ -234,7 +234,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.42'
+    component: 'azureml:llm_rag_update_acs_index:0.0.43'
     identity:
       type: user_identity
     inputs:
@@ -256,7 +256,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.42'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.43'
     identity:
       type: user_identity
     inputs:

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.56
+version: 0.0.57
 name: llm_ingest_dataset_to_faiss_basic
 display_name: LLM - Dataset to FAISS Pipeline
 is_deterministic: false
@@ -102,7 +102,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.47'
+    component: 'azureml:llm_rag_validate_deployments:0.0.48'
     identity:
       type: user_identity
     inputs:
@@ -125,7 +125,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.45'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.46'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -148,7 +148,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.54'
+    component: 'azureml:llm_rag_create_promptflow:0.0.55'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -165,7 +165,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.38'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.39'
     inputs:
       chunks_source:
         type: uri_folder
@@ -215,7 +215,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.43'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.44'
     inputs:
       embeddings:
         type: uri_folder
@@ -233,7 +233,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.42'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.43'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_user_id/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_user_id/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.55
+version: 0.0.56
 name: llm_ingest_dataset_to_faiss_user_id
 display_name: LLM - Dataset to FAISS Pipeline
 is_deterministic: false
@@ -102,7 +102,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.47'
+    component: 'azureml:llm_rag_validate_deployments:0.0.48'
     identity:
       type: user_identity
     inputs:
@@ -125,7 +125,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.45'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.46'
     identity:
       type: user_identity
     inputs:
@@ -150,7 +150,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.54'
+    component: 'azureml:llm_rag_create_promptflow:0.0.55'
     identity:
       type: user_identity
     inputs:
@@ -169,7 +169,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.38'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.39'
     identity:
       type: user_identity
     inputs:
@@ -223,7 +223,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.43'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.44'
     identity:
       type: user_identity
     inputs:
@@ -243,7 +243,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.42'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.43'
     identity:
       type: user_identity
     inputs:

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
@@ -4,7 +4,7 @@ tags:
   Preview: ""
 name: llm_ingest_db_to_acs
 display_name: LLM - SQL Datastore to ACS Pipeline
-version: 0.0.50
+version: 0.0.51
 description: Single job pipeline to chunk data from AzureML sql data store, and create ACS embeddings index
 settings:
   default_compute: serverless
@@ -117,7 +117,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: "azureml:llm_rag_generate_embeddings:0.0.38"
+    component: "azureml:llm_rag_generate_embeddings:0.0.39"
     inputs:
       chunks_source:
         type: uri_folder
@@ -169,7 +169,7 @@ jobs:
         path: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.grounding_index}}
-    component: "azureml:llm_rag_update_acs_index:0.0.42"
+    component: "azureml:llm_rag_update_acs_index:0.0.43"
     type: command
   register_mlindex_asset_job:
     resources:
@@ -186,7 +186,7 @@ jobs:
     outputs:
       asset_id:
         type: uri_file
-    component: "azureml:llm_rag_register_mlindex_asset:0.0.42"
+    component: "azureml:llm_rag_register_mlindex_asset:0.0.43"
     type: command
   create_prompt_flow:
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
@@ -4,7 +4,7 @@ tags:
   Preview: ""
 name: llm_ingest_db_to_faiss
 display_name: LLM - SQL Datastore to FAISS Pipeline
-version: 0.0.50
+version: 0.0.51
 description: Single job pipeline to chunk data from AzureML sql data store, and create FAISS embeddings index
 settings:
   default_compute: serverless
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: "azureml:llm_rag_generate_embeddings:0.0.38"
+    component: "azureml:llm_rag_generate_embeddings:0.0.39"
     inputs:
       chunks_source:
         type: uri_folder
@@ -159,7 +159,7 @@ jobs:
         path: ${{parent.jobs.generate_meta_embeddings.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.grounding_index}}
-    component: "azureml:llm_rag_create_faiss_index:0.0.43"
+    component: "azureml:llm_rag_create_faiss_index:0.0.44"
     type: command
   register_mlindex_asset_job:
     resources:
@@ -176,7 +176,7 @@ jobs:
     outputs:
       asset_id:
         type: uri_file
-    component: "azureml:llm_rag_register_mlindex_asset:0.0.42"
+    component: "azureml:llm_rag_register_mlindex_asset:0.0.43"
     type: command
   create_prompt_flow:
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_dbcopilot_acs_e2e/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dbcopilot_acs_e2e/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.js
 type: pipeline
 
 name: llm_ingest_dbcopilot_acs_e2e
-version: 0.0.21
+version: 0.0.22
 display_name: Data Ingestion for DB Data Output to ACS E2E Deployment
 description: Single job pipeline to chunk data from AzureML DB Datastore and create acs embeddings index
 
@@ -145,7 +145,7 @@ jobs:
   #########################################
   generate_meta_embeddings:
     type: command
-    component: "azureml:llm_rag_generate_embeddings:0.0.38"
+    component: "azureml:llm_rag_generate_embeddings:0.0.39"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -166,7 +166,7 @@ jobs:
   #########################################
   create_meta_acs_index_job:
     type: command
-    component: "azureml:llm_rag_update_acs_index:0.0.42"
+    component: "azureml:llm_rag_update_acs_index:0.0.43"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -208,7 +208,7 @@ jobs:
   #########################################
   generate_sample_embeddings:
     type: command
-    component: "azureml:llm_rag_generate_embeddings:0.0.38"
+    component: "azureml:llm_rag_generate_embeddings:0.0.39"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -229,7 +229,7 @@ jobs:
   #########################################
   create_sample_acs_index_job:
     type: command
-    component: "azureml:llm_rag_update_acs_index:0.0.42"
+    component: "azureml:llm_rag_update_acs_index:0.0.43"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dbcopilot_faiss_e2e/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dbcopilot_faiss_e2e/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.js
 type: pipeline
 
 name: llm_ingest_dbcopilot_faiss_e2e
-version: 0.0.21
+version: 0.0.22
 display_name: Data Ingestion for DB Data Output to FAISS E2E Deployment
 description: Single job pipeline to chunk data from AzureML DB Datastore and create faiss embeddings index
 
@@ -135,7 +135,7 @@ jobs:
   #########################################
   generate_meta_embeddings:
     type: command
-    component: "azureml:llm_rag_generate_embeddings:0.0.38"
+    component: "azureml:llm_rag_generate_embeddings:0.0.39"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -156,7 +156,7 @@ jobs:
   #########################################
   create_meta_faiss_index_job:
     type: command
-    component: "azureml:llm_rag_create_faiss_index:0.0.43"
+    component: "azureml:llm_rag_create_faiss_index:0.0.44"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -196,7 +196,7 @@ jobs:
   #########################################
   generate_sample_embeddings:
     type: command
-    component: "azureml:llm_rag_generate_embeddings:0.0.38"
+    component: "azureml:llm_rag_generate_embeddings:0.0.39"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -217,7 +217,7 @@ jobs:
   #########################################
   create_sample_faiss_index_job:
     type: command
-    component: "azureml:llm_rag_create_faiss_index:0.0.43"
+    component: "azureml:llm_rag_create_faiss_index:0.0.44"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}

--- a/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.45
+version: 0.0.46
 name: llm_rag_crack_and_chunk
 display_name: LLM - Crack and Chunk Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.16
+version: 0.0.17
 name: llm_rag_crack_and_chunk_and_embed
 display_name: LLM - Crack, Chunk and Embed Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/crack_chunk_embed_index_and_register/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_chunk_embed_index_and_register/spec.yaml
@@ -1,5 +1,5 @@
 name: llm_rag_crack_chunk_embed_index_and_register
-version: 0.0.4
+version: 0.0.5
 tags:
     Preview: ""
 

--- a/assets/large_language_models/rag/components/crawl_url/spec.yaml
+++ b/assets/large_language_models/rag/components/crawl_url/spec.yaml
@@ -60,12 +60,12 @@ code: '../src/'
 
 command: >-
   python -m azureml.rag.tasks.crawl_url
-          --url ${{inputs.url}}        
-          --output_path ${{outputs.output_path}}        
-          $[[--max_crawl_depth ${{inputs.max_crawl_depth}}]]        
-          $[[--max_crawl_time ${{inputs.max_crawl_time}}]]        
-          $[[--max_download_time ${{inputs.max_download_time}}]]        
-          $[[--max_file_size ${{inputs.max_file_size}}]]        
-          $[[--max_redirects ${{inputs.max_redirects}}]]        
-          $[[--max_files ${{inputs.max_files}}]]        
-          $[[--support_http ${{inputs.support_http}}]]
+  --url ${{inputs.url}}        
+  --output_path ${{outputs.output_path}}        
+  $[[--max_crawl_depth ${{inputs.max_crawl_depth}}]]        
+  $[[--max_crawl_time ${{inputs.max_crawl_time}}]]        
+  $[[--max_download_time ${{inputs.max_download_time}}]]        
+  $[[--max_file_size ${{inputs.max_file_size}}]]        
+  $[[--max_redirects ${{inputs.max_redirects}}]]        
+  $[[--max_files ${{inputs.max_files}}]]        
+  $[[--support_http ${{inputs.support_http}}]]

--- a/assets/large_language_models/rag/components/crawl_url/spec.yaml
+++ b/assets/large_language_models/rag/components/crawl_url/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.4
+version: 0.0.3
 name: llm_rag_crawl_url
 display_name: LLM - Crawl URL to Retrieve Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/crawl_url/spec.yaml
+++ b/assets/large_language_models/rag/components/crawl_url/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.3
+version: 0.0.4
 name: llm_rag_crawl_url
 display_name: LLM - Crawl URL to Retrieve Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
+++ b/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.43
+version: 0.0.44
 name: llm_rag_create_faiss_index
 display_name: LLM - Create FAISS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_promptflow/spec.yaml
+++ b/assets/large_language_models/rag/components/create_promptflow/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.54
+version: 0.0.55
 name: llm_rag_create_promptflow
 display_name: LLM - Create Prompt Flow
 is_deterministic: true

--- a/assets/large_language_models/rag/components/data_import_acs/spec.yaml
+++ b/assets/large_language_models/rag/components/data_import_acs/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.39
+version: 0.0.40
 name: llm_rag_data_import_acs
 display_name: LLM - Import Data from ACS
 is_deterministic: false

--- a/assets/large_language_models/rag/components/data_import_acs/spec.yaml
+++ b/assets/large_language_models/rag/components/data_import_acs/spec.yaml
@@ -43,8 +43,8 @@ code: '../src/embeddings/'
 
 command: >-
   python data_import_acs.py
-    --num_docs ${{inputs.num_docs}}
-    --output_data ${{outputs.output_data}}
-    --ml_index ${{outputs.ml_index}}
-    --acs_config '${{inputs.acs_config}}'
-    --use_existing '${{inputs.use_existing}}'
+  --num_docs ${{inputs.num_docs}}
+  --output_data ${{outputs.output_data}}
+  --ml_index ${{outputs.ml_index}}
+  --acs_config '${{inputs.acs_config}}'
+  --use_existing '${{inputs.use_existing}}'

--- a/assets/large_language_models/rag/components/data_import_acs/spec.yaml
+++ b/assets/large_language_models/rag/components/data_import_acs/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.40
+version: 0.0.39
 name: llm_rag_data_import_acs
 display_name: LLM - Import Data from ACS
 is_deterministic: false

--- a/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.38
+version: 0.0.39
 name: llm_rag_generate_embeddings
 display_name: LLM - Generate Embeddings
 is_deterministic: true

--- a/assets/large_language_models/rag/components/generate_embeddings_parallel/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings_parallel/spec.yaml
@@ -4,7 +4,7 @@ type: parallel
 tags:
     Preview: ""
 
-version: 0.0.44
+version: 0.0.45
 name: llm_rag_generate_embeddings_parallel
 display_name: LLM - Generate Embeddings Parallel
 is_deterministic: true

--- a/assets/large_language_models/rag/components/git_clone/spec.yaml
+++ b/assets/large_language_models/rag/components/git_clone/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.42
+version: 0.0.43
 name: llm_rag_git_clone
 display_name: LLM - Clone Git Repo
 is_deterministic: true

--- a/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
+++ b/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.42
+version: 0.0.43
 name: llm_rag_qa_data_generation
 display_name: LLM - Generate QnA Test Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
+++ b/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.42
+version: 0.0.43
 name: llm_rag_register_mlindex_asset
 display_name: LLM - Register Vector Index Asset
 is_deterministic: true

--- a/assets/large_language_models/rag/components/register_qa_data_asset/spec.yaml
+++ b/assets/large_language_models/rag/components/register_qa_data_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.35
+version: 0.0.36
 name: llm_rag_register_qa_data_asset
 display_name: LLM - Register QA Generation Data Asset
 is_deterministic: true

--- a/assets/large_language_models/rag/components/src/validate_deployments.py
+++ b/assets/large_language_models/rag/components/src/validate_deployments.py
@@ -202,7 +202,7 @@ def check_deployment_status(model_params, model_type, activity_logger=None):
                     'question': "Did you receive the question?"
                 })
             except BadRequestError as ex:
-                activity_logger.info("ValidationFailed: completion model deployment validation failed due to the " 
+                activity_logger.info("ValidationFailed: completion model deployment validation failed due to the "
                                      + "following exception: {}.".format(traceback.format_exc()))
                 activity_logger.exception(
                     "ValidationFailed with exception: completion model deployment validation failed due to the "

--- a/assets/large_language_models/rag/components/src/validate_deployments.py
+++ b/assets/large_language_models/rag/components/src/validate_deployments.py
@@ -133,7 +133,7 @@ def check_deployment_status(model_params, model_type, activity_logger=None):
 
     openai.api_type = model_params["openai_api_type"]
     openai.api_version = model_params["openai_api_version"]
-    openai.api_base = model_params["openai_api_base"]
+    openai.base_url = model_params["openai_api_base"]
     openai.api_key = model_params["openai_api_key"]
     if (model_params["openai_api_type"].lower() != "azure" or not model_params["deployment_id"]):
         # If OAI (not-azure), just pass through validation
@@ -202,7 +202,7 @@ def check_deployment_status(model_params, model_type, activity_logger=None):
                     'question': "Did you receive the question?"
                 })
             except BadRequestError as ex:
-                activity_logger.info("ValidationFailed: completion model deployment validation failed due to the "
+                activity_logger.info("ValidationFailed: completion model deployment validation failed due to the " 
                                      + "following exception: {}.".format(traceback.format_exc()))
                 activity_logger.exception(
                     "ValidationFailed with exception: completion model deployment validation failed due to the "

--- a/assets/large_language_models/rag/components/src/validate_deployments.py
+++ b/assets/large_language_models/rag/components/src/validate_deployments.py
@@ -19,7 +19,7 @@ from azureml.core.run import _OfflineRun
 from azure.identity import ManagedIdentityCredential, AzureCliCredential
 from azure.ai.ml.identity import AzureMLOnBehalfOfCredential
 from azure.mgmt.cognitiveservices import CognitiveServicesManagementClient
-from openai.error import InvalidRequestError
+from openai import BadRequestError
 from azureml.rag.utils.logging import (
     get_logger,
     enable_stdout_logging,
@@ -201,7 +201,7 @@ def check_deployment_status(model_params, model_type, activity_logger=None):
                     'context': "Say Yes if you received the the question",
                     'question': "Did you receive the question?"
                 })
-            except InvalidRequestError as ex:
+            except BadRequestError as ex:
                 activity_logger.info("ValidationFailed: completion model deployment validation failed due to the "
                                      + "following exception: {}.".format(traceback.format_exc()))
                 activity_logger.exception(
@@ -224,7 +224,7 @@ def check_deployment_status(model_params, model_type, activity_logger=None):
             try:
                 embeddings.embed_query(
                     "Embed this query to test if deployment exists")
-            except InvalidRequestError as ex:
+            except BadRequestError as ex:
                 activity_logger.info(
                     "ValidationFailed: embeddings deployment validation failed due to the following exception: {}."
                     .format(traceback.format_exc()))

--- a/assets/large_language_models/rag/components/update_acs_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_acs_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.42
+version: 0.0.43
 name: llm_rag_update_acs_index
 display_name: LLM - Update ACS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_acs_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_acs_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.43
+version: 0.0.42
 name: llm_rag_update_acs_index
 display_name: LLM - Update ACS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_acs_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_acs_index/spec.yaml
@@ -46,7 +46,7 @@ code: '../src/'
 
 command: >-
   python -m azureml.rag.tasks.update_acs
-    --embeddings ${{inputs.embeddings}}
-    --acs_config '${{inputs.acs_config}}'
-    --output ${{outputs.index}}
-    $[[--connection_id '${{inputs.index_connection_id}}']]
+  --embeddings ${{inputs.embeddings}}
+  --acs_config '${{inputs.acs_config}}'
+  --output ${{outputs.index}}
+  $[[--connection_id '${{inputs.index_connection_id}}']]

--- a/assets/large_language_models/rag/components/update_pinecone_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_pinecone_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.10
+version: 0.0.11
 name: llm_rag_update_pinecone_index
 display_name: LLM - Update Pinecone Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/validate_deployments/spec.yaml
+++ b/assets/large_language_models/rag/components/validate_deployments/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.47
+version: 0.0.48
 name: llm_rag_validate_deployments
 display_name: LLM - Validate Deployments
 is_deterministic: false


### PR DESCRIPTION
1. When openai upgraded to 1.v , the validate_deployments.py shipped with this version need to be changed.
2. To make the component definitions more consistent, RAG component spec.yaml files were updated (using 2-space indent). but there are bugs.