### PR TITLE
add gptv prompts (videos part2)

### DIFF
--- a/assets/large_language_models/prompts/GPTV/insurance_report/asset.yaml
+++ b/assets/large_language_models/prompts/GPTV/insurance_report/asset.yaml
@@ -1,0 +1,4 @@
+type: prompt
+spec: spec.yaml
+extra_config: storage.yaml
+categories: ["GPTV"]

--- a/assets/large_language_models/prompts/GPTV/insurance_report/prompt/prompt.yaml
+++ b/assets/large_language_models/prompts/GPTV/insurance_report/prompt/prompt.yaml
@@ -1,0 +1,22 @@
+$schema: https://azuremlschemas.azureedge.net/latest/prompt.schema.json
+
+_type: chat
+
+messages:
+- role: system
+  content:
+    - You are a car insurance and accident expert. Extract detailed information about the car's make, model, damage extent, license plate, airbag deployment status, and any other observations. Output results as JSON.
+
+starter_messages:
+- role: user
+  content:
+    - type: text
+      text: Provide details from car damage in the video
+    - type: video
+      image_url: video1.mp4
+
+execution_settings:
+  gptv:
+    enhance: true
+
+template_format: handlebars

--- a/assets/large_language_models/prompts/GPTV/insurance_report/spec.yaml
+++ b/assets/large_language_models/prompts/GPTV/insurance_report/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/asset.prompt.schema.json
 
 type: prompt
-version: 0.0.5
+version: 0.0.6
 name: insurance_report 
 display_name: Insurance Report
 description: Car Insurance Damage report writing

--- a/assets/large_language_models/prompts/GPTV/insurance_report/spec.yaml
+++ b/assets/large_language_models/prompts/GPTV/insurance_report/spec.yaml
@@ -1,0 +1,14 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.prompt.schema.json
+
+type: prompt
+version: 0.0.5
+name: insurance_report 
+display_name: Insurance Report
+description: Car Insurance Damage report writing
+
+tags:
+  modality: video
+  task: summarization
+
+data_uri: ./prompt
+template_path: prompt.yaml

--- a/assets/large_language_models/prompts/GPTV/insurance_report/storage.yaml
+++ b/assets/large_language_models/prompts/GPTV/insurance_report/storage.yaml
@@ -1,0 +1,5 @@
+path:
+  container_name: prompts
+  container_path: gptv/insurance_report/v1
+  storage_name: automlcesdkdataresources
+  type: azureblob

--- a/assets/large_language_models/prompts/GPTV/insurance_report/storage.yaml
+++ b/assets/large_language_models/prompts/GPTV/insurance_report/storage.yaml
@@ -1,5 +1,5 @@
 path:
   container_name: prompts
   container_path: gptv/insurance_report/v1
-  storage_name: automlcesdkdataresources
+  storage_name: amlregistryassets
   type: azureblob


### PR DESCRIPTION
This is a change to define prompts for GPT.

**Changes**
Add assets for following gptv prompt (for video contents), under assets/large_language_models/prompts/GPTV folder.  
* insurance_report

This is moved from internal repo, with minor update in system message.