### PR TITLE
Version up classification models

### DIFF
--- a/assets/models/system/facebook-deit-base-patch16-224/spec.yaml
+++ b/assets/models/system/facebook-deit-base-patch16-224/spec.yaml
@@ -29,4 +29,4 @@ tags:
     apply_deepspeed: 'true'
     apply_ort: 'true'
   task: image-classification
-version: 10
+version: 11

--- a/assets/models/system/google-vit-base-patch16-224/spec.yaml
+++ b/assets/models/system/google-vit-base-patch16-224/spec.yaml
@@ -29,4 +29,4 @@ tags:
     apply_deepspeed: 'true'
     apply_ort: 'true'
   task: image-classification
-version: 10
+version: 11

--- a/assets/models/system/microsoft-beit-base-patch16-224-pt22k-ft22k/spec.yaml
+++ b/assets/models/system/microsoft-beit-base-patch16-224-pt22k-ft22k/spec.yaml
@@ -29,4 +29,4 @@ tags:
     apply_deepspeed: 'true'
     apply_ort: 'true'
   task: image-classification
-version: 11
+version: 12

--- a/assets/models/system/microsoft-swinv2-base-patch4-window12-192-22k/spec.yaml
+++ b/assets/models/system/microsoft-swinv2-base-patch4-window12-192-22k/spec.yaml
@@ -29,4 +29,4 @@ tags:
     apply_deepspeed: 'true'
     apply_ort: 'true'
   task: image-classification
-version: 12
+version: 13


### PR DESCRIPTION
Version bump for HF classification models after datasets upgrade to 2.14.5
This is to fix the failing runners. 

Failing run: 
https://ml.azure.com/experiments/id/35630321-bef6-4e40-b985-d9c07814a5bb/runs/stoic_helmet_ngsw5fp9lx?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourcegroups/donotdelete-fm-runner-rg/workspaces/donotdelete-fm-runners-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#

https://ml.azure.com/experiments/id/25df2a22-5be6-46e5-8989-b8a32deaab09/runs/63192abd-3164-41a9-855d-564aff50bc15?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/nilesh-new-rg/providers/Microsoft.MachineLearningServices/workspaces/nilesh-ws-new&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#

Passing run:
https://ml.azure.com/experiments/id/25df2a22-5be6-46e5-8989-b8a32deaab09/runs/5c3bca80-4589-4748-87ed-c655c5a91eec?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/nilesh-new-rg/providers/Microsoft.MachineLearningServices/workspaces/nilesh-ws-new&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
