### PR TITLE
Env & Component versions for component releases for PL workspace support

### DIFF
--- a/assets/responsibleai/tabular/components/causal/spec.yaml
+++ b/assets/responsibleai/tabular/components/causal/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_causal
 display_name: Add Causal to RAI Insights Dashboard
 description: Add Causal to RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.9.0
+version: 0.10.0
 type: command
 
 inputs:

--- a/assets/responsibleai/tabular/components/counterfactual/spec.yaml
+++ b/assets/responsibleai/tabular/components/counterfactual/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_counterfactual
 display_name: Add Counterfactuals to RAI Insights Dashboard
 description: Add Counterfactuals to RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.9.0
+version: 0.10.0
 type: command
 
 inputs:

--- a/assets/responsibleai/tabular/components/error_analysis/spec.yaml
+++ b/assets/responsibleai/tabular/components/error_analysis/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_erroranalysis
 display_name: Add Error Analysis to RAI Insights Dashboard
 description: Add Error Analysis to RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.9.0
+version: 0.10.0
 type: command
 
 inputs:

--- a/assets/responsibleai/tabular/components/explanation/spec.yaml
+++ b/assets/responsibleai/tabular/components/explanation/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_explanation
 display_name: Add Explanation to RAI Insights Dashboard
 description: Add Explanation to RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.9.0
+version: 0.10.0
 type: command
 
 inputs:

--- a/assets/responsibleai/tabular/components/insight_create/spec.yaml
+++ b/assets/responsibleai/tabular/components/insight_create/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_insight_constructor
 display_name: RAI Insights Dashboard Constructor
 description: RAI Insights Dashboard Constructor [Learn More](https://aka.ms/RAIComponents)
-version: 0.9.0
+version: 0.10.0
 type: command
 inputs:
   title:

--- a/assets/responsibleai/tabular/components/insight_gather/spec.yaml
+++ b/assets/responsibleai/tabular/components/insight_gather/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_insight_gather
 display_name: Gather RAI Insights Dashboard
 description: Gather RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.9.0
+version: 0.10.0
 type: command
 
 inputs:

--- a/assets/responsibleai/tabular/components/score_card/spec.yaml
+++ b/assets/responsibleai/tabular/components/score_card/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_score_card
 display_name: Generate rai insight score card (Public preview)
 description: Generate rai insight score card [Learn More](https://aka.ms/RAIComponents)
-version: 0.9.0
+version: 0.10.0
 type: command
 
 inputs:

--- a/assets/responsibleai/text/components/rai_text_insights/spec.yaml
+++ b/assets/responsibleai/text/components/rai_text_insights/spec.yaml
@@ -69,7 +69,7 @@ outputs:
     type: path
     description: Json file to which UX is serialized to for viewing in static AzureML Studio UI
 code: ../src
-environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/33
+environment: azureml://registries/azureml/environments/responsibleai-text-ubuntu20.04-py38-cpu/versions/36
 command: >-
   python ./rai_text_insights.py
   --task_type ${{inputs.task_type}}

--- a/assets/responsibleai/text/components/rai_text_insights/spec.yaml
+++ b/assets/responsibleai/text/components/rai_text_insights/spec.yaml
@@ -1,7 +1,7 @@
 $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: rai_text_insights
 display_name: RAI Text Insights
-version: 0.0.11
+version: 0.0.12
 tags:
   Preview: ""
 type: command

--- a/assets/responsibleai/vision/components/rai_vision_insights/spec.yaml
+++ b/assets/responsibleai/vision/components/rai_vision_insights/spec.yaml
@@ -1,7 +1,7 @@
 $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: rai_vision_insights
 display_name: RAI Vision Insights
-version: 0.0.11
+version: 0.0.12
 tags:
   Preview: ""
 type: command

--- a/assets/responsibleai/vision/components/rai_vision_insights/spec.yaml
+++ b/assets/responsibleai/vision/components/rai_vision_insights/spec.yaml
@@ -116,7 +116,7 @@ outputs:
     type: path
     description: Json file to which UX is serialized to for viewing in static AzureML Studio UI
 code: ../src
-environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/37
+environment: azureml://registries/azureml/environments/responsibleai-vision-ubuntu20.04-py38-cpu/versions/41
 command: >-
   python ./rai_vision_insights.py
   --task_type ${{inputs.task_type}}


### PR DESCRIPTION
This pull request includes changes to the `rai_text_insights` and `rai_vision_insights` components, which now require a different version of the environment. These changes are specified in the `spec.yaml` files for each component.

Main component changes:

* <a href="diffhunk://#diff-5b8ec26ae975a47611a5b2c64513e59a7de490552d6f4fde467f34d14c3586cbL72-R72">`assets/responsibleai/text/components/rai_text_insights/spec.yaml`</a>: The `rai_text_insights` component now requires a different version of the environment.
* <a href="diffhunk://#diff-e511095a83cf981bc262d49de127ff4195376522e536a04027056bd9d037394aL119-R119">`assets/responsibleai/vision/components/rai_vision_insights/spec.yaml`</a>: The `rai_vision_insights` component now requires a different version of the environment.