### PR TITLE
Allow python version customization

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.16.21 (2023-12-12)
+### 🐛 Bugs Fixed
+ - [#]() 
+
 ## 1.16.20 (2023-12-5)
 ### 🐛 Bugs Fixed
 - [#1871](https://github.com/Azure/azureml-assets/pull/1871) Update model validations criteria

--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## 1.16.21 (2023-12-12)
 ### 🐛 Bugs Fixed
- - [#]() 
+ - [#1928](https://github.com/Azure/azureml-assets/pull/1928) Allow python version customization
 
 ## 1.16.20 (2023-12-5)
 ### 🐛 Bugs Fixed

--- a/scripts/azureml-assets/azureml/assets/__init__.py
+++ b/scripts/azureml-assets/azureml/assets/__init__.py
@@ -7,6 +7,7 @@ from .config import (
     ComponentType,
     Config,
     DEFAULT_ASSET_FILENAME,
+    DEFAULT_PYTHON_VERSION,
     ModelConfig,
     ModelFlavor,
     ModelTaskName,

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -139,6 +139,7 @@ PUBLISH_LOCATION_HOSTNAMES = {PublishLocation.MCR: 'mcr.microsoft.com'}
 STANDARD_ASSET_TYPES = [AssetType.COMPONENT, AssetType.DATA, AssetType.ENVIRONMENT, AssetType.MODEL]
 TEMPLATE_CHECK = re.compile(r"\{\{.*\}\}")
 VERSION_AUTO = "auto"
+DEFAULT_PYTHON_VERSION = "3.11"
 
 
 class Config:

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.20",
+   version="1.16.21",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),

--- a/scripts/test/test_assets.py
+++ b/scripts/test/test_assets.py
@@ -77,6 +77,7 @@ def test_assets(input_dirs: List[Path],
                 asset_config_filename: str,
                 package_versions: Path,
                 changed_files: List[Path],
+                python_version: str,
                 reports_dir: Path = None) -> bool:
     """Test assets.
 
@@ -85,6 +86,7 @@ def test_assets(input_dirs: List[Path],
         asset_config_filename (str): Asset config filename to search input_dirs for.
         package_versions (Path): File containing packages to install in base conda environment.
         changed_files (List[Path]): List of changed files used to select only assets.
+        python_version (str): the version of python to be used.
         reports_dir (Path, optional): Directory to receive a JUnit report. Defaults to None.
 
     Returns:
@@ -101,7 +103,10 @@ def test_assets(input_dirs: List[Path],
         if not base_created:
             # Create base environment, which must succeed
             logger.start_group("Create base environment")
-            run(["conda", "create", "-n", BASE_ENVIRONMENT, "-y", "-q", "--file", package_versions], check=True)
+            run([
+                "conda", "create", "-n", BASE_ENVIRONMENT,
+                "-y", "-q", "--file", package_versions,
+                f"python={python_version}"], check=True)
             base_created = True
             logger.end_group()
 
@@ -149,6 +154,8 @@ if __name__ == '__main__':
                         help="File with package versions for the base conda environment")
     parser.add_argument("-c", "--changed-files", help="Comma-separated list of changed files, used to filter assets")
     parser.add_argument("-r", "--reports-dir", type=Path, help="Directory for pytest reports")
+    parser.add_argument("-v", "--python-version", help="The version of python to be used",
+                        default=assets.DEFAULT_PYTHON_VERSION)
     args = parser.parse_args()
 
     # Convert comma-separated values to lists
@@ -160,6 +167,7 @@ if __name__ == '__main__':
                           asset_config_filename=args.asset_config_filename,
                           package_versions=args.package_versions_file,
                           changed_files=changed_files,
+                          python_version=args.python_version,
                           reports_dir=args.reports_dir)
     if not success:
         sys.exit(1)


### PR DESCRIPTION
**Problem:** Currently our test system will take the default version of python, used by system, however, this version may not be supported by some packages.
**Solution:** Add new configuration variable to allow version other then the default system.