### PR TITLE
Fix a typo in scoring logging

### DIFF
--- a/assets/batch_score/components/driver/batch_score_llm/spec.yaml
+++ b/assets/batch_score/components/driver/batch_score_llm/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/ParallelComponent.json
 type: parallel
 
 name: batch_score_llm
-version: 1.0.2
+version: 1.0.3
 display_name: Batch Score Large Language Models
 is_deterministic: False
 

--- a/assets/batch_score/components/driver/src/batch_score/common/telemetry/scoring_logging.py
+++ b/assets/batch_score/components/driver/src/batch_score/common/telemetry/scoring_logging.py
@@ -104,5 +104,5 @@ class ScoreSucceedLog(BaseLog):
 
     def log(self):
         """Log function."""
-        msg = "Score succeeded after {%.3f}s: internal_id={} x-ms-client-request-id=[{}]"
+        msg = "Score succeeded after {:.3f}s: internal_id={} x-ms-client-request-id=[{}]"
         get_logger().info(msg.format(self.duration, self.internal_id, self.x_ms_client_request_id))


### PR DESCRIPTION
Here is a test job on this fix: https://ml.azure.com/experiments/id/e7e78963-3e59-4957-b7e3-ce9f6e87e60d/runs/nifty_hamster_d7p30jx598?wsid=/subscriptions/c0afea91-faba-4d71-bcb6-b08134f69982/resourcegroups/batchscore-test-centralus/providers/Microsoft.MachineLearningServices/workspaces/ws-batchscore-centralus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#