### PR TITLE
Fixed bug in Azure OpenAI v2 pipeline component yaml defininton

### DIFF
--- a/assets/large_language_models/components_pipelines/oai_v2_1p/openai_completions_finetune_pipeline/spec.yaml
+++ b/assets/large_language_models/components_pipelines/oai_v2_1p/openai_completions_finetune_pipeline/spec.yaml
@@ -70,7 +70,6 @@ jobs:
       model: ${{parent.inputs.model}}
   openai_completions_finetune:
     type: command
-    resources:
     component: azureml://registries/azure-openai-v2/components/openai_completions_finetune/versions/0.4.5
     inputs:
       input_dataset: ${{parent.jobs.openai_data_import.outputs.out_dataset}}


### PR DESCRIPTION
- Removed empty `resources` field in yaml defintion.