### PR TITLE
Rollback to LKG

### DIFF
--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.60
+version: 0.0.61
 name: llm_ingest_dataset_to_acs_basic
 display_name: LLM - Dataset to ACS Pipeline
 is_deterministic: false
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.50'
+    component: 'azureml:llm_rag_validate_deployments:0.0.51'
     identity:
       type: user_identity
     inputs:
@@ -136,7 +136,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.48'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.49'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -159,7 +159,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.57'
+    component: 'azureml:llm_rag_create_promptflow:0.0.58'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -176,7 +176,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.41'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.42'
     inputs:
       chunks_source:
         type: uri_folder
@@ -226,7 +226,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.45'
+    component: 'azureml:llm_rag_update_acs_index:0.0.46'
     inputs:
       embeddings:
         type: uri_folder
@@ -246,7 +246,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.45'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.46'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_user_id/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_user_id/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.58
+version: 0.0.59
 name: llm_ingest_dataset_to_acs_user_id
 display_name: LLM - Dataset to ACS Pipeline
 is_deterministic: false
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.50'
+    component: 'azureml:llm_rag_validate_deployments:0.0.51'
     identity:
       type: user_identity
     inputs:
@@ -136,7 +136,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.48'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.49'
     identity:
       type: user_identity
     inputs:
@@ -161,7 +161,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.57'
+    component: 'azureml:llm_rag_create_promptflow:0.0.58'
     identity:
       type: user_identity
     inputs:
@@ -180,7 +180,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.41'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.42'
     identity:
       type: user_identity
     inputs:
@@ -234,7 +234,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.45'
+    component: 'azureml:llm_rag_update_acs_index:0.0.46'
     identity:
       type: user_identity
     inputs:
@@ -256,7 +256,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.45'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.46'
     identity:
       type: user_identity
     inputs:

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.59
+version: 0.0.60
 name: llm_ingest_dataset_to_faiss_basic
 display_name: LLM - Dataset to FAISS Pipeline
 is_deterministic: false
@@ -102,7 +102,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.50'
+    component: 'azureml:llm_rag_validate_deployments:0.0.51'
     identity:
       type: user_identity
     inputs:
@@ -125,7 +125,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.48'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.49'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -148,7 +148,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.57'
+    component: 'azureml:llm_rag_create_promptflow:0.0.58'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
@@ -165,7 +165,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.41'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.42'
     inputs:
       chunks_source:
         type: uri_folder
@@ -215,7 +215,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.46'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.47'
     inputs:
       embeddings:
         type: uri_folder
@@ -233,7 +233,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.45'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.46'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_user_id/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_user_id/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.58
+version: 0.0.59
 name: llm_ingest_dataset_to_faiss_user_id
 display_name: LLM - Dataset to FAISS Pipeline
 is_deterministic: false
@@ -102,7 +102,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.50'
+    component: 'azureml:llm_rag_validate_deployments:0.0.51'
     identity:
       type: user_identity
     inputs:
@@ -125,7 +125,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.48'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.49'
     identity:
       type: user_identity
     inputs:
@@ -150,7 +150,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_promptflow:0.0.57'
+    component: 'azureml:llm_rag_create_promptflow:0.0.58'
     identity:
       type: user_identity
     inputs:
@@ -169,7 +169,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.41'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.42'
     identity:
       type: user_identity
     inputs:
@@ -223,7 +223,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.46'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.47'
     identity:
       type: user_identity
     inputs:
@@ -243,7 +243,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.45'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.46'
     identity:
       type: user_identity
     inputs:

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_acs/spec.yaml
@@ -4,7 +4,7 @@ tags:
   Preview: ""
 name: llm_ingest_db_to_acs
 display_name: LLM - SQL Datastore to ACS Pipeline
-version: 0.0.54
+version: 0.0.55
 description: Single job pipeline to chunk data from AzureML sql data store, and create ACS embeddings index
 settings:
   default_compute: serverless
@@ -117,7 +117,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: "azureml:llm_rag_generate_embeddings:0.0.41"
+    component: "azureml:llm_rag_generate_embeddings:0.0.42"
     inputs:
       chunks_source:
         type: uri_folder
@@ -169,7 +169,7 @@ jobs:
         path: ${{parent.inputs.acs_config}}
     outputs:
       index: ${{parent.outputs.grounding_index}}
-    component: "azureml:llm_rag_update_acs_index:0.0.45"
+    component: "azureml:llm_rag_update_acs_index:0.0.46"
     type: command
   register_mlindex_asset_job:
     resources:
@@ -186,7 +186,7 @@ jobs:
     outputs:
       asset_id:
         type: uri_file
-    component: "azureml:llm_rag_register_mlindex_asset:0.0.45"
+    component: "azureml:llm_rag_register_mlindex_asset:0.0.46"
     type: command
   create_prompt_flow:
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_db_to_faiss/spec.yaml
@@ -4,7 +4,7 @@ tags:
   Preview: ""
 name: llm_ingest_db_to_faiss
 display_name: LLM - SQL Datastore to FAISS Pipeline
-version: 0.0.54
+version: 0.0.55
 description: Single job pipeline to chunk data from AzureML sql data store, and create FAISS embeddings index
 settings:
   default_compute: serverless
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: "azureml:llm_rag_generate_embeddings:0.0.41"
+    component: "azureml:llm_rag_generate_embeddings:0.0.42"
     inputs:
       chunks_source:
         type: uri_folder
@@ -159,7 +159,7 @@ jobs:
         path: ${{parent.jobs.generate_meta_embeddings.outputs.embeddings}}
     outputs:
       index: ${{parent.outputs.grounding_index}}
-    component: "azureml:llm_rag_create_faiss_index:0.0.46"
+    component: "azureml:llm_rag_create_faiss_index:0.0.47"
     type: command
   register_mlindex_asset_job:
     resources:
@@ -176,7 +176,7 @@ jobs:
     outputs:
       asset_id:
         type: uri_file
-    component: "azureml:llm_rag_register_mlindex_asset:0.0.45"
+    component: "azureml:llm_rag_register_mlindex_asset:0.0.46"
     type: command
   create_prompt_flow:
     environment_variables:

--- a/assets/large_language_models/components_pipelines/data_ingestion_dbcopilot_acs_e2e/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dbcopilot_acs_e2e/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.js
 type: pipeline
 
 name: llm_ingest_dbcopilot_acs_e2e
-version: 0.0.25
+version: 0.0.26
 display_name: Data Ingestion for DB Data Output to ACS E2E Deployment
 description: Single job pipeline to chunk data from AzureML DB Datastore and create acs embeddings index
 
@@ -145,7 +145,7 @@ jobs:
   #########################################
   generate_meta_embeddings:
     type: command
-    component: "azureml:llm_rag_generate_embeddings:0.0.41"
+    component: "azureml:llm_rag_generate_embeddings:0.0.42"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -166,7 +166,7 @@ jobs:
   #########################################
   create_meta_acs_index_job:
     type: command
-    component: "azureml:llm_rag_update_acs_index:0.0.45"
+    component: "azureml:llm_rag_update_acs_index:0.0.46"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -208,7 +208,7 @@ jobs:
   #########################################
   generate_sample_embeddings:
     type: command
-    component: "azureml:llm_rag_generate_embeddings:0.0.41"
+    component: "azureml:llm_rag_generate_embeddings:0.0.42"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -229,7 +229,7 @@ jobs:
   #########################################
   create_sample_acs_index_job:
     type: command
-    component: "azureml:llm_rag_update_acs_index:0.0.45"
+    component: "azureml:llm_rag_update_acs_index:0.0.46"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dbcopilot_faiss_e2e/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dbcopilot_faiss_e2e/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.js
 type: pipeline
 
 name: llm_ingest_dbcopilot_faiss_e2e
-version: 0.0.25
+version: 0.0.26
 display_name: Data Ingestion for DB Data Output to FAISS E2E Deployment
 description: Single job pipeline to chunk data from AzureML DB Datastore and create faiss embeddings index
 
@@ -135,7 +135,7 @@ jobs:
   #########################################
   generate_meta_embeddings:
     type: command
-    component: "azureml:llm_rag_generate_embeddings:0.0.41"
+    component: "azureml:llm_rag_generate_embeddings:0.0.42"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -156,7 +156,7 @@ jobs:
   #########################################
   create_meta_faiss_index_job:
     type: command
-    component: "azureml:llm_rag_create_faiss_index:0.0.46"
+    component: "azureml:llm_rag_create_faiss_index:0.0.47"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -196,7 +196,7 @@ jobs:
   #########################################
   generate_sample_embeddings:
     type: command
-    component: "azureml:llm_rag_generate_embeddings:0.0.41"
+    component: "azureml:llm_rag_generate_embeddings:0.0.42"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}
@@ -217,7 +217,7 @@ jobs:
   #########################################
   create_sample_faiss_index_job:
     type: command
-    component: "azureml:llm_rag_create_faiss_index:0.0.46"
+    component: "azureml:llm_rag_create_faiss_index:0.0.47"
     resources:
       instance_count: ${{parent.inputs.serverless_instance_count}}
       instance_type: ${{parent.inputs.serverless_instance_type}}

--- a/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.48
+version: 0.0.49
 name: llm_rag_crack_and_chunk
 display_name: LLM - Crack and Chunk Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.19
+version: 0.0.20
 name: llm_rag_crack_and_chunk_and_embed
 display_name: LLM - Crack, Chunk and Embed Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/crack_chunk_embed_index_and_register/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_chunk_embed_index_and_register/spec.yaml
@@ -1,5 +1,5 @@
 name: llm_rag_crack_chunk_embed_index_and_register
-version: 0.0.7
+version: 0.0.8
 tags:
     Preview: ""
 

--- a/assets/large_language_models/rag/components/crawl_url/spec.yaml
+++ b/assets/large_language_models/rag/components/crawl_url/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.6
+version: 0.0.7
 name: llm_rag_crawl_url
 display_name: LLM - Crawl URL to Retrieve Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
+++ b/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.46
+version: 0.0.47
 name: llm_rag_create_faiss_index
 display_name: LLM - Create FAISS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_promptflow/spec.yaml
+++ b/assets/large_language_models/rag/components/create_promptflow/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.57
+version: 0.0.58
 name: llm_rag_create_promptflow
 display_name: LLM - Create Prompt Flow
 is_deterministic: true

--- a/assets/large_language_models/rag/components/data_import_acs/spec.yaml
+++ b/assets/large_language_models/rag/components/data_import_acs/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.42
+version: 0.0.43
 name: llm_rag_data_import_acs
 display_name: LLM - Import Data from ACS
 is_deterministic: false

--- a/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.41
+version: 0.0.42
 name: llm_rag_generate_embeddings
 display_name: LLM - Generate Embeddings
 is_deterministic: true

--- a/assets/large_language_models/rag/components/generate_embeddings_parallel/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings_parallel/spec.yaml
@@ -4,7 +4,7 @@ type: parallel
 tags:
     Preview: ""
 
-version: 0.0.47
+version: 0.0.48
 name: llm_rag_generate_embeddings_parallel
 display_name: LLM - Generate Embeddings Parallel
 is_deterministic: true

--- a/assets/large_language_models/rag/components/git_clone/spec.yaml
+++ b/assets/large_language_models/rag/components/git_clone/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.45
+version: 0.0.46
 name: llm_rag_git_clone
 display_name: LLM - Clone Git Repo
 is_deterministic: true

--- a/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
+++ b/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.45
+version: 0.0.46
 name: llm_rag_qa_data_generation
 display_name: LLM - Generate QnA Test Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
+++ b/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.45
+version: 0.0.46
 name: llm_rag_register_mlindex_asset
 display_name: LLM - Register Vector Index Asset
 is_deterministic: true

--- a/assets/large_language_models/rag/components/register_qa_data_asset/spec.yaml
+++ b/assets/large_language_models/rag/components/register_qa_data_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.38
+version: 0.0.39
 name: llm_rag_register_qa_data_asset
 display_name: LLM - Register QA Generation Data Asset
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_acs_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_acs_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.45
+version: 0.0.46
 name: llm_rag_update_acs_index
 display_name: LLM - Update ACS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_azure_cosmos_mongo_vcore_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_azure_cosmos_mongo_vcore_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.2
+version: 0.0.3
 name: llm_rag_update_cosmos_mongo_vcore_index
 display_name: LLM - Update Azure Cosmos Mongo vCore Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_milvus_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_milvus_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.2
+version: 0.0.3
 name: llm_rag_update_milvus_index
 display_name: LLM - Update Milvus Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_pinecone_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_pinecone_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.13
+version: 0.0.14
 name: llm_rag_update_pinecone_index
 display_name: LLM - Update Pinecone Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/validate_deployments/spec.yaml
+++ b/assets/large_language_models/rag/components/validate_deployments/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.50
+version: 0.0.51
 name: llm_rag_validate_deployments
 display_name: LLM - Validate Deployments
 is_deterministic: false

--- a/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
@@ -7,21 +7,21 @@ dependencies:
 - pip=23.3.1
 - scikit-learn==0.24.2
 - pip:
-  - azureml-rag[cognitive_search,data_generation,pinecone,milvus,azure_cosmos_mongo_vcore]==0.2.23.3
+  - azureml-rag[cognitive_search,data_generation,pinecone]==0.2.22
   - azure-search-documents==11.4.0b8
-  - langchain==0.0.348
+  - langchain==0.0.317
   - tiktoken~=0.3.0
-  - azure-ai-ml=={{latest-pypi-version}}
+  - azure-ai-ml==1.12.1
   - azure-identity==1.12.0
   - azure-keyvault-secrets==4.6.0
   - azure-mgmt-cognitiveservices~=13.4.0
   - azureml-contrib-services
-  - azureml-core=={{latest-pypi-version}}
-  - azureml-telemetry=={{latest-pypi-version}}
+  - azureml-core==1.54.0
+  - azureml-telemetry==1.54.0
   - azureml-dataprep>=4.12.7 # Change back to latest version once azureml-fsspec is compatible
   - azureml-fsspec
   - azureml-inference-server-http==0.7.6
-  - azureml-mlflow=={{latest-pypi-version}}
+  - azureml-mlflow==1.54.0
   - beautifulsoup4~=4.11.2
   - datasets~=2.10.1
   - faiss-cpu~=1.7.3
@@ -33,8 +33,8 @@ dependencies:
   - mlflow>=2.6.0
   - msal~=1.22.0
   - nltk==3.8.1
-  - openai>=0.27.4
-  - pandas>=1
+  - openai~=0.27.4
+  - pandas~=1.1.5
   - polling2~=0.5.0
   - psutil~=5.8.0
   - pymssql==2.2.7

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
@@ -7,10 +7,10 @@ dependencies:
 - pip=23.3.1
 - pip:
     # RAG package
-  - azureml-rag[azure,faiss,cognitive_search,document_parsing,data_generation,pinecone,milvus,azure_cosmos_mongo_vcore]==0.2.23.3
+  - azureml-rag[azure,faiss,cognitive_search,document_parsing,data_generation,pinecone]==0.2.22
     # Azure AI
   - azure-ai-formrecognizer==3.3.1
-  - azure-ai-ml=={{latest-pypi-version}}
+  - azure-ai-ml==1.12.1
     # Azure
   - azure-core<2.0.0,>=1.8.0,!=1.22.0
   - azure-identity==1.12.0
@@ -20,18 +20,18 @@ dependencies:
   - azure-search-documents==11.4.0b8
     # Azure ML
   - azureml-contrib-services
-  - azureml-core=={{latest-pypi-version}}
+  - azureml-core==1.54.0
   - azureml-dataprep>=4.12.7 # Change back to latest version once azureml-fsspec is compatible
   - azureml-inference-server-http==0.7.6
-  - azureml-mlflow=={{latest-pypi-version}}
-  - azureml-telemetry=={{latest-pypi-version}}
+  - azureml-mlflow==1.54.0
+  - azureml-telemetry==1.54.0
     # Other public packages
   - beautifulsoup4~=4.11.2
   - datasets~=2.10.1
   - faiss-cpu~=1.7.3
   - GitPython>=3.1
   - inference-schema==1.4
-  - langchain==0.0.348
+  - langchain==0.0.317
   - lxml
   - markdown
   - mlflow>=2.6.0
@@ -39,8 +39,8 @@ dependencies:
   - msal~=1.22.0
   - msrest>=0.6.18
   - nltk==3.8.1
-  - openai>=0.27.4
-  - pandas>=1
+  - openai~=0.27.4
+  - pandas~=1.1.5
   - polling2~=0.5.0
   - psutil~=5.8.0
   - pymssql==2.2.7


### PR DESCRIPTION
RAG components in environment v.34 broke main pipeline step (embedding)

This PR will
- Override conda_dependency  files with the ones in v.31. The version is pined to specific version, to make sure the roll back
- Bump up RAG component version.

As a result, this PR will roll back to LKG components. 