### PR TITLE
Update checksum logic calculation using sha256

### DIFF
--- a/assets/aml-benchmark/components/src/aml_benchmark/utils/logging.py
+++ b/assets/aml-benchmark/components/src/aml_benchmark/utils/logging.py
@@ -27,11 +27,11 @@ def log_mlflow_params(**kwargs: Any) -> None:
     for key, value in kwargs.items():
         if isinstance(value, str) and os.path.isfile(value):
             # calculate checksum of input dataset
-            checksum = hashlib.md5(open(value, "rb").read()).hexdigest()
+            checksum = hashlib.sha256(open(value, "rb").read()).hexdigest()
             params[key] = checksum
         elif isinstance(value, list) and all(isinstance(item, str) and os.path.isfile(item) for item in value):
             # calculate checksum of input dataset
-            checksum = hashlib.md5(b"".join(open(item, "rb").read() for item in value)).hexdigest()
+            checksum = hashlib.sha256(b"".join(open(item, "rb").read() for item in value)).hexdigest()
             params[key] = checksum
         else:
             if value is not None:

--- a/assets/aml-benchmark/tests/test_utils.py
+++ b/assets/aml-benchmark/tests/test_utils.py
@@ -281,11 +281,11 @@ def assert_logged_params(job_name: str, exp_name: str, **expected_params: Any) -
     for key, value in expected_params.items():
         if isinstance(value, str) and os.path.isfile(value):
             # calculate checksum of input dataset
-            checksum = hashlib.md5(open(value, "rb").read()).hexdigest()
+            checksum = hashlib.sha256(open(value, "rb").read()).hexdigest()
             params[key] = checksum
         elif isinstance(value, list) and all(isinstance(item, str) and os.path.isfile(item) for item in value):
             # calculate checksum of input dataset
-            checksum = hashlib.md5(b"".join(open(item, "rb").read() for item in value)).hexdigest()
+            checksum = hashlib.sha256(b"".join(open(item, "rb").read() for item in value)).hexdigest()
             params[key] = checksum
         else:
             params[key] = value


### PR DESCRIPTION
For benchmarking components, the current checksum is calculated using md5. This PR updates the logic to use sha256 instead.