### PR TITLE
Fix mlflow param logging error in benchmarking result aggregator component.

### DIFF
--- a/assets/aml-benchmark/components/benchmark-result-aggregator/spec.yaml
+++ b/assets/aml-benchmark/components/benchmark-result-aggregator/spec.yaml
@@ -4,7 +4,7 @@ type: command
 name: benchmark_result_aggregator
 display_name: Benchmark result aggregator
 description: Aggregate quality metrics, performance metrics and all of the metadata from the pipeline. Also add them to the root run.
-version: 0.0.2
+version: 0.0.3
 is_deterministic: false
 
 inputs:

--- a/assets/aml-benchmark/components/compute-performance-metrics/spec.yaml
+++ b/assets/aml-benchmark/components/compute-performance-metrics/spec.yaml
@@ -5,6 +5,7 @@ name: compute_performance_metrics
 display_name: Compute Performance Metrics
 description: Performs performance metric post processing using data from a model inference run.
 version: 0.0.1
+is_deterministic: true
 
 inputs:
   performance_data: 

--- a/assets/aml-benchmark/components/src/aml_benchmark/result_aggregator/main.py
+++ b/assets/aml-benchmark/components/src/aml_benchmark/result_aggregator/main.py
@@ -213,6 +213,9 @@ def _log_params_and_metrics(parameters: Dict[str, Any], metrics: Dict[str, Any])
         elif isinstance(metrics[key], (int, float)):
             filtered_metrics[key] = metrics[key]
     # Log to current run
+    logger.info(
+        f"Attempting to log {len(parameters)} parameters and {len(filtered_metrics)} metrics."
+    )
     try:
         log_mlflow_params(**parameters)
     except Exception as ex:

--- a/assets/aml-benchmark/components/src/aml_benchmark/result_aggregator/main.py
+++ b/assets/aml-benchmark/components/src/aml_benchmark/result_aggregator/main.py
@@ -155,10 +155,8 @@ def _get_pipeline_params() -> Tuple[
         run_v1 = Run(experiment=current_run.experiment, run_id=run_id)
         step_name = get_step_name(run)
         run_details = cast(Dict[str, Any], run_v1.get_details())
-        logger.info(f"Run details for {run_id}: {run_details}")
         run_definition = run_details.get('runDefinition', {})
         run_v1_properties = run_details.get('properties', {})
-        logger.info(f"Run definition for {run_id}: {run_definition}")
 
         # Get run parameters, input assets and compute_information.
         run_params = _get_run_params(run_definition)
@@ -181,7 +179,6 @@ def _get_pipeline_params() -> Tuple[
             **_get_run_reused_properties(run_v1_properties),
             **_get_run_environment_properties(run_definition),
         }
-        logger.info(f"Pipeline params for {step_name}: {pipeline_params[step_name]}")
 
         # Update loggable parameters.
         loggable_params[f"{step_name}.node_count"] = run_definition.get('nodeCount', None)

--- a/assets/aml-benchmark/tests/pipelines/prompt_crafter_pipeline.yaml
+++ b/assets/aml-benchmark/tests/pipelines/prompt_crafter_pipeline.yaml
@@ -19,7 +19,7 @@ inputs:
   prompt_type: "completions"
   system_message: "Answer truthfully. "
   ground_truth_column_name: "answerKey"  
-
+  few_shot_pattern: ""
 outputs:
   output_file:
     type: uri_file

--- a/assets/aml-benchmark/tests/pipelines/prompt_crafter_pipeline_with_few_shot.yaml
+++ b/assets/aml-benchmark/tests/pipelines/prompt_crafter_pipeline_with_few_shot.yaml
@@ -19,6 +19,7 @@ inputs:
   prompt_type: "completions"
   system_message: "Answer truthfully. "
   ground_truth_column_name: "answerKey"  
+  few_shot_pattern: ""
 
 outputs:
   output_file:
@@ -36,6 +37,7 @@ jobs:
       few_shot_data: ${{parent.inputs.few_shot_data}}
       n_shots: ${{parent.inputs.n_shots}}
       prompt_pattern: ${{parent.inputs.prompt_pattern}}
+      few_shot_pattern: ${{parent.inputs.few_shot_pattern}}
       output_pattern: ${{parent.inputs.output_pattern}}
       prompt_type: ${{parent.inputs.prompt_type}}
       system_message: ${{parent.inputs.system_message}}

--- a/assets/aml-benchmark/tests/test_prompt_crafter.py
+++ b/assets/aml-benchmark/tests/test_prompt_crafter.py
@@ -161,8 +161,10 @@ class TestPromptCrafterComponent:
 
         :return: The pipeline job.
         """
-        pipeline_job = load_yaml_pipeline("prompt_crafter_pipeline.yaml")
-
+        if few_shot_pattern:
+            pipeline_job = load_yaml_pipeline("prompt_crafter_pipeline_with_few_shot.yaml")
+        else:
+            pipeline_job = load_yaml_pipeline("prompt_crafter_pipeline.yaml")
         # set the pipeline inputs
         pipeline_job.inputs.test_data = Input(type=AssetTypes.URI_FILE, path=test_data)
         pipeline_job.inputs.prompt_type = prompt_type

--- a/assets/aml-benchmark/tests/test_prompt_crafter.py
+++ b/assets/aml-benchmark/tests/test_prompt_crafter.py
@@ -120,6 +120,7 @@ class TestPromptCrafterComponent:
             prompt_pattern,
             output_pattern,
             self.test_prompt_crafter_component.__name__,
+            few_shot_pattern,
         )
 
         # submit the pipeline job

--- a/assets/aml-benchmark/tests/test_prompt_crafter.py
+++ b/assets/aml-benchmark/tests/test_prompt_crafter.py
@@ -163,13 +163,13 @@ class TestPromptCrafterComponent:
         """
         if few_shot_pattern:
             pipeline_job = load_yaml_pipeline("prompt_crafter_pipeline_with_few_shot.yaml")
+            pipeline_job.inputs.few_shot_pattern = few_shot_pattern
         else:
             pipeline_job = load_yaml_pipeline("prompt_crafter_pipeline.yaml")
         # set the pipeline inputs
         pipeline_job.inputs.test_data = Input(type=AssetTypes.URI_FILE, path=test_data)
         pipeline_job.inputs.prompt_type = prompt_type
         pipeline_job.inputs.prompt_pattern = prompt_pattern
-        pipeline_job.inputs.few_shot_pattern = few_shot_pattern
         pipeline_job.inputs.few_shot_data = Input(type=AssetTypes.URI_FILE, path=few_shot_data)
         pipeline_job.inputs.n_shots = n_shots
         pipeline_job.inputs.output_pattern = output_pattern


### PR DESCRIPTION
Logging mlflow params is an optional functionality. Errors in it will now be caught and warning logged instead of failing the runs.