### PR TITLE
Fix Promptflow CI multiple downloads, refine log.

### DIFF
--- a/assets/promptflow/.cspell.json
+++ b/assets/promptflow/.cspell.json
@@ -153,7 +153,10 @@
       "**.py",
       "**.jinja2",
       "**.txt",
-      "**.json"
+      "**.json",
+      "**/asset.yaml",
+      "**/description.md",
+      "**/model.yaml"
     ],
     "allowCompoundWords": true
   }

--- a/assets/promptflow/.cspell.json
+++ b/assets/promptflow/.cspell.json
@@ -143,7 +143,8 @@
       "ayod",
       "AYOD",
       "Featur",
-      "showno"
+      "showno",
+      "amlraipfmodels"
     ],
     "flagWords": [
       "Prompt Flow"

--- a/assets/promptflow/models/qna-with-your-own-data-using-faiss-index/description.md
+++ b/assets/promptflow/models/qna-with-your-own-data-using-faiss-index/description.md
@@ -14,7 +14,7 @@ Batch | N/A | N/A
 ```json
 {
     "inputs": {
-        "question": "What's AML SDK V2? Should I use V1 or V2? some typos fdsfadasf toadfase adfqfdasfzcvafwe qerfda"
+        "question": "What's AML SDK V2? Should I use V1 or V2?"
     }
 }
 ```

--- a/assets/promptflow/models/qna-with-your-own-data-using-faiss-index/description.md
+++ b/assets/promptflow/models/qna-with-your-own-data-using-faiss-index/description.md
@@ -14,7 +14,7 @@ Batch | N/A | N/A
 ```json
 {
     "inputs": {
-        "question": "What's AML SDK V2? Should I use V1 or V2?"
+        "question": "What's AML SDK V2? Should I use V1 or V2? some typos fdsfadasf toadfase adfqfdasfzcvafwe qerfda"
     }
 }
 ```

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -49,7 +49,7 @@ def download_blob_to_file(container_name, container_path, storage_name, target_d
     blob_service_client = BlobServiceClient(account_url, credential=cli_auth)
     container_client = blob_service_client.get_container_client(container_name)
 
-    log_debug(f"Downloading blobs under path {container_path} to {target_dir}")
+    log_debug(f"Downloading blobs under path {container_path} to {target_dir}.")
     blob_list = container_client.list_blobs(container_path)
     for blob in blob_list:
         relative_path = os.path.relpath(blob.name, container_path)
@@ -65,7 +65,7 @@ def download_blob_to_file(container_name, container_path, storage_name, target_d
 
 def get_changed_models(diff_files):
     """Get changed models dir."""
-    changed_models = []
+    changed_models = set()
     deleted_models_path = []
     for file_path in diff_files:
         file_path_list = file_path.split("\t")
@@ -75,17 +75,14 @@ def get_changed_models(diff_files):
                     or git_diff_file_path == " ":
                 deleted_models_path.append(file_path)
             else:
-                changed_models.append(os.path.join(
+                changed_models.add(os.path.join(
                     MODELS_ROOT, git_diff_file_path.split("/")[-2]))
-
-    changed_models = ('assets/promptflow/models/template-chat-flow',
-                      'assets/promptflow/models/template-eval-flow', 'assets/promptflow/models/template-standard-flow')
 
     log_debug(
         f"Find {len(deleted_models_path)} deleted models: {deleted_models_path}.")
     log_debug(f"Find {len(changed_models)} changed models: {changed_models}.")
 
-    return changed_models
+    return list(changed_models)
 
 
 def get_all_models():
@@ -168,7 +165,7 @@ if __name__ == "__main__":
     # Get changed models folder or all models folder
     diff_files = get_diff_files()
     diff_files_list = {path.split('/')[-1] for path in diff_files}
-    log_debug(f"Git diff files include:{diff_files_list}")
+    log_debug(f"Git diff files include:{diff_files}.")
 
     if "promptflow_ci.py" in diff_files_list or "promptflow-ci.yml" in diff_files_list:
         log_debug("promptflow_ci.py or promptflow_ci.yml changed, test all models.")
@@ -182,10 +179,11 @@ if __name__ == "__main__":
     if args.skipped_flows != "":
         skipped_flows = args.skipped_flows.split(",")
         skipped_flows = [flow.replace("_", "-") for flow in skipped_flows]
-        log_debug(f"Skipped flows: {skipped_flows}")
+        log_debug(f"Skipped flows: {skipped_flows}.")
         flows_dirs = [flow_dir for flow_dir in changed_models if Path(
             flow_dir).name not in skipped_flows]
     # Check download models
+    log_debug(f"Flows to validate: {changed_models}.")
     errors = []
     for model_dir in flows_dirs:
         try:
@@ -194,7 +192,7 @@ if __name__ == "__main__":
             errors.append(e)
 
     if len(errors) > 0:
-        log_error(f"Found {len(errors)} errors when downloading models")
+        log_error(f"Found {len(errors)} errors when downloading models.")
         for error in errors:
             log_error(error)
         exit(1)
@@ -205,7 +203,7 @@ if __name__ == "__main__":
     flows_dirs = [Path(os.path.join(dir, TEST_FOLDER))
                   for dir in flows_dirs]
 
-    log_debug(flows_dirs)
+    log_debug(f"Flows to test: {flows_dirs}.")
     if len(flows_dirs) == 0:
         log_debug("No flow code change, skip flow testing.")
         exit(0)
@@ -218,7 +216,7 @@ if __name__ == "__main__":
         flows_dirs = flow_utils._assign_flow_values(flows_dirs)
         flow_utils._create_run_yamls(flows_dirs)
     except Exception as e:
-        log_error("Error when creating flow")
+        log_error("Error when creating flow.")
         raise e
     # endregion
 
@@ -245,7 +243,7 @@ if __name__ == "__main__":
     failed_evaluation_runs = {}  # run key : evaluation_run_link
     if flow_runs_count == 0:
         log_debug(
-            "\nNo bulk test run or bulk test evaluation run need to check status")
+            "\nNo bulk test run or bulk test evaluation run need to check status.")
 
     run_workspace = Workspace.get(
         name=args.workspace_name,
@@ -287,7 +285,7 @@ if __name__ == "__main__":
                   "to https://msdata.visualstudio.com/Vienna/_git/PromptFlow?path=/docs/"
                   "sharing-your-flows-in-prompt-flow-gallery.md&_a=preview&anchor=2.-how-to-debug-a-failed"
                   "-run-in--%60validate-prompt-flows%60-step-of-%5Bpromptflow-ci"
-                  "%5D(https%3A//github.com/azure/azureml-assets/actions/workflows/promptflow-ci.yml)")
+                  "%5D(https%3A//github.com/azure/azureml-assets/actions/workflows/promptflow-ci.yml).")
     elif len(submitted_flow_run_ids) == 0:
         log_debug(
             f"\nRun status checking completed. {flow_runs_count} flow runs completed.")


### PR DESCRIPTION
1. Fix validate flow step download models multiple times.
2. Refine logs.
3. Update cspell check to ignore words "amlraipfmodels".
4. Spell check only check spec.yaml, dag.yaml, readme.md.