### PR TITLE
fix missing azureml-rai-utils dependency on RAI tabular components

### DIFF
--- a/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -30,7 +30,8 @@ RUN pip install --no-deps 'charset-normalizer==2.0.12' \
 RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
                 'azureml-core=={{latest-pypi-version}}' \
                 'azureml-mlflow=={{latest-pypi-version}}' \
-                'azureml-telemetry=={{latest-pypi-version}}'
+                'azureml-telemetry=={{latest-pypi-version}}' \
+                'azureml-rai-utils==0.0.6'
 
 # azureml-dataset-runtime[fuse] upper bound for pyarrow is 11.0.0
 # so we install pyarrow in extra step to avoid conflict

--- a/assets/responsibleai/tabular/components/causal/spec.yaml
+++ b/assets/responsibleai/tabular/components/causal/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_causal
 display_name: Add Causal to RAI Insights Dashboard
 description: Add Causal to RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.11.0
+version: 0.12.0
 type: command
 
 inputs:
@@ -58,7 +58,7 @@ outputs:
 
 code: ../src/
 
-environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/37
+environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/39
 
 # For debugging
 environment_variables:

--- a/assets/responsibleai/tabular/components/counterfactual/spec.yaml
+++ b/assets/responsibleai/tabular/components/counterfactual/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_counterfactual
 display_name: Add Counterfactuals to RAI Insights Dashboard
 description: Add Counterfactuals to RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.11.0
+version: 0.12.0
 type: command
 
 inputs:
@@ -38,7 +38,7 @@ outputs:
 
 code: ../src/
 
-environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/37
+environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/39
 
 command: >-
   python create_counterfactual.py

--- a/assets/responsibleai/tabular/components/error_analysis/spec.yaml
+++ b/assets/responsibleai/tabular/components/error_analysis/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_erroranalysis
 display_name: Add Error Analysis to RAI Insights Dashboard
 description: Add Error Analysis to RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.11.0
+version: 0.12.0
 type: command
 
 inputs:
@@ -27,7 +27,7 @@ outputs:
 
 code: ../src/
 
-environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/37
+environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/39
 
 command: >-
   python create_error_analysis.py

--- a/assets/responsibleai/tabular/components/explanation/spec.yaml
+++ b/assets/responsibleai/tabular/components/explanation/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_explanation
 display_name: Add Explanation to RAI Insights Dashboard
 description: Add Explanation to RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.11.0
+version: 0.12.0
 type: command
 
 inputs:
@@ -17,7 +17,7 @@ outputs:
 
 code: ../src/
 
-environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/37
+environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/39
 
 command: >-
   python create_explanation.py

--- a/assets/responsibleai/tabular/components/insight_create/spec.yaml
+++ b/assets/responsibleai/tabular/components/insight_create/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_insight_constructor
 display_name: RAI Insights Dashboard Constructor
 description: RAI Insights Dashboard Constructor [Learn More](https://aka.ms/RAIComponents)
-version: 0.11.0
+version: 0.12.0
 type: command
 inputs:
   title:
@@ -44,7 +44,7 @@ outputs:
   rai_insights_dashboard:
     type: path
 code: ../src/
-environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/37
+environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/39
 command: >-
   python create_rai_insights.py
   --title '${{inputs.title}}'

--- a/assets/responsibleai/tabular/components/insight_gather/spec.yaml
+++ b/assets/responsibleai/tabular/components/insight_gather/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_insight_gather
 display_name: Gather RAI Insights Dashboard
 description: Gather RAI Insights Dashboard [Learn More](https://aka.ms/RAIComponents)
-version: 0.11.0
+version: 0.12.0
 type: command
 
 inputs:
@@ -27,7 +27,7 @@ outputs:
   ux_json:
     type: path
 
-environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/37
+environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/39
 
 code: ../src/
 

--- a/assets/responsibleai/tabular/components/score_card/spec.yaml
+++ b/assets/responsibleai/tabular/components/score_card/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/CommandComponent.json
 name: microsoft_azureml_rai_tabular_score_card
 display_name: Generate rai insight score card (Public preview)
 description: Generate rai insight score card [Learn More](https://aka.ms/RAIComponents)
-version: 0.11.0
+version: 0.12.0
 type: command
 
 inputs:
@@ -17,7 +17,7 @@ outputs:
   scorecard:
     type: path
 
-environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/37
+environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/39
 
 code: ../src/
 


### PR DESCRIPTION
fix missing azureml-rai-utils dependency on RAI tabular components

Seeing errors with the 0.11.0 components released yesterday:

```
Traceback (most recent call last):
  File "create_rai_insights.py", line 12, in <module>
    from azureml.rai.utils.telemetry import LoggerFactory, track
ModuleNotFoundError: No module named 'azureml.rai'
```

Looks like there is a missing dependency, azureml-rai-utils, in the environment for the prod components.  Adding the dependency to the tabular environment to fix the issue and re-release the tabular components.