### PR TITLE
Update mltable from 1.4.1 to 1.5.0 to fix vulnerability issue

### DIFF
--- a/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -16,6 +16,6 @@ dependencies:
     - pdfkit==1.0.0
     - plotly==5.6.0
     - kaleido==0.2.1
-    - mltable==1.4.1
+    - mltable==1.5.0
     - responsibleai-tabular-automl==0.9.0
     - https://publictestdatasets.blob.core.windows.net/packages/pypi/raiwidgets_big_data/raiwidgets_big_data-0.8.0-py3-none-any.whl


### PR DESCRIPTION
"VulnerabilityName": Python (Pip) Security Update for mltable (GHSA-m5pc-86x8-wcxg),
"AssetId": sha256:723f9c22cdec9a85eb273a155d28c28f9c61cd97e9285331ecad8efd158ac535,
"RunId": 2024-01-02T13:12:47.996Z,
"Solution": Refer to Github security advisory <A HREF="https://github.com/advisories/GHSA-m5pc-86x8-wcxg" TARGET="_blank">GHSA-m5pc-86x8-wcxg</A> for updates and patch information.<BR>
<P>Patch:<BR>
Following are links for downloading patches to fix the vulnerabilities:
<P> <A HREF="https://github.com/advisories/GHSA-m5pc-86x8-wcxg" TARGET="_blank">GHSA-m5pc-86x8-wcxg:mltable</A>,
"ScanResult": #table cols="5"
Package Installed_Version Required_Version Language Install_Path
mltable 1.4.1 1.5.0 Python azureml-envs/responsibleai/lib/python3.8/site-packages/mltable-1.4.1.dist-info/METADATA,