### PR TITLE
fix RAI tabular components test

### DIFF
--- a/assets/responsibleai/tabular/components/causal/spec.yaml
+++ b/assets/responsibleai/tabular/components/causal/spec.yaml
@@ -60,10 +60,6 @@ code: ../src/
 
 environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/39
 
-# For debugging
-environment_variables:
-   AZUREML_COMPUTE_USE_COMMON_RUNTIME: true
-
 command: >-
   python create_causal.py
   --rai_insights_dashboard ${{inputs.rai_insights_dashboard}}

--- a/assets/responsibleai/tabular/jobs/pipeline_boston_analyze.yml
+++ b/assets/responsibleai/tabular/jobs/pipeline_boston_analyze.yml
@@ -35,7 +35,7 @@ jobs:
     type: command
     component: file:../components/insight_create/spec.yaml
     limits:
-      timeout: 120
+      timeout: 3600
     inputs:
       title: Boston Housing Analysis
       task_type: regression
@@ -49,7 +49,7 @@ jobs:
     type: command
     component: file:../components/explanation/spec.yaml
     limits:
-      timeout: 120
+      timeout: 3600
     inputs:
       comment: Some random string
       rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
@@ -58,7 +58,7 @@ jobs:
     type: command
     component: file:../components/causal/spec.yaml
     limits:
-      timeout: 120
+      timeout: 3600
     inputs:
       rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       treatment_features: '["ZN", "NOX"]'
@@ -70,7 +70,7 @@ jobs:
     type: command
     component: file:../components/counterfactual/spec.yaml
     limits:
-      timeout: 600
+      timeout: 7200
     inputs:
       rai_insights_dashboard: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       total_CFs: 10
@@ -79,7 +79,7 @@ jobs:
 
   error_analysis_01:
     limits:
-      timeout: 120
+      timeout: 3600
     type: command
     component: file:../components/error_analysis/spec.yaml
     inputs:
@@ -91,7 +91,7 @@ jobs:
     type: command
     component: file:../components/insight_gather/spec.yaml
     limits:
-      timeout: 120
+      timeout: 3600
     inputs:
       constructor: ${{parent.jobs.create_rai_job.outputs.rai_insights_dashboard}}
       insight_1: ${{parent.jobs.causal_01.outputs.causal}}

--- a/assets/responsibleai/tabular/jobs/train_boston.yml
+++ b/assets/responsibleai/tabular/jobs/train_boston.yml
@@ -21,7 +21,7 @@ outputs:
     type: path
 
 code: ./src_boston/
-environment: azureml://registries/azureml/environments/AzureML-responsibleai-0.20-ubuntu20.04-py38-cpu/versions/4
+environment: azureml://registries/azureml/environments/responsibleai-ubuntu20.04-py38-cpu/versions/39
 command: >-
   python train.py
   --training_data ${{inputs.training_data}}


### PR DESCRIPTION
fix RAI tabular components test

The test for tabular components hasn't been run in a while and has been failing for several different issues:

1.) An environment variable in causal component test "AZUREML_COMPUTE_USE_COMMON_RUNTIME" was causing failures
2.) Component timeouts due to very low timeout values (which passed in a much older version of azure-ai-ml package that didn't actually use those timeouts)
3.) Very old RAI docker for training model which caused errors on model deserialize due to very old scikit-learn package version