### PR TITLE
Updating model card for microsoft-phi-2

### DIFF
--- a/assets/models/system/microsoft-phi-2/model.yaml
+++ b/assets/models/system/microsoft-phi-2/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/microsoft-phi-2/1702485256/mlflow_model_folder
+  container_path: huggingface/microsoft-phi-2/1704358138/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:


### PR DESCRIPTION
1. changes to finetune config to remove hf_predict_module as phi_predict - to let it use the default predict method.
2. config.json - add eos_token
uploaded to registry link : https://ml.azure.com/registries/azureml-preview-test1/models/microsoft-phi-2/version/10?tid=72f988bf-86f1-41af-91ab-2d7cd011db47#artifacts

Run without hf_predict module: https://ml.azure.com/runs/0bfc52fe-58ee-418c-b2c5-6b10400c11af?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourceGroups/training_rg/providers/Microsoft.MachineLearningServices/workspaces/finetune_dev_southcentralus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#


Run without script is giving the expected and similar results
problem: with external script phi_predict.py, there were lot of restrictions regarding return_full_text = false property, fixed max_length, which was not giving right FT results.
