### PR TITLE
Use pull_request_target trigger for promptflow_ci

### DIFF
--- a/.github/workflows/promptflow-ci.yml
+++ b/.github/workflows/promptflow-ci.yml
@@ -2,6 +2,13 @@ name: Promptflow CI
 on:
   # Triggers the Promptflow CI on pull request targeting the main branch
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - assets/promptflow/models/**
+      - .github/workflows/promptflow-ci.yml
+      - scripts/promptflow-ci/**
   pull_request_target:
     branches:
       - main
@@ -9,6 +16,11 @@ on:
       - assets/promptflow/models/**
       - .github/workflows/promptflow-ci.yml
       - scripts/promptflow-ci/**
+    types:
+      - opened
+      - labeled
+      - synchronize
+      - reopened
 
 env:
   PROMPTFLOW_DIR: "assets/promptflow/models"
@@ -18,8 +30,12 @@ permissions:
   id-token: write
 
 jobs:
+  check-execution-context:
+    uses: Azure/azureml-assets/.github/workflows/check-execution-context.yaml@main
+
   check_spec_yaml:
     runs-on: ubuntu-latest
+    needs: check-execution-context
     name: Check spec.yaml fields
     timeout-minutes: 45
     steps:
@@ -38,6 +54,7 @@ jobs:
 
   run_promptflow_ci_job:
     runs-on: ubuntu-latest
+    needs: check-execution-context
     name: Flow tests
     environment: Testing
     timeout-minutes: 60

--- a/.github/workflows/promptflow-ci.yml
+++ b/.github/workflows/promptflow-ci.yml
@@ -112,13 +112,3 @@ jobs:
             exit 1
           fi
           rm -rf cspell_check.log
-
-  check_ci_status:
-    runs-on: ubuntu-latest
-    name: fail ci if continue is false
-    if: fromJSON(needs.check-execution-context.outputs.continue) == false
-    needs: check-execution-context
-    steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - name: Fail CI
-      run: exit -1

--- a/.github/workflows/promptflow-ci.yml
+++ b/.github/workflows/promptflow-ci.yml
@@ -112,3 +112,13 @@ jobs:
             exit 1
           fi
           rm -rf cspell_check.log
+
+  check_ci_status:
+    runs-on: ubuntu-latest
+    name: fail ci if continue is false
+    if: fromJSON(needs.check-execution-context.outputs.continue) == false
+    needs: check-execution-context
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Fail CI
+      run: exit -1

--- a/.github/workflows/promptflow-ci.yml
+++ b/.github/workflows/promptflow-ci.yml
@@ -37,6 +37,7 @@ jobs:
 
   check_spec_yaml:
     runs-on: ubuntu-latest
+    if: fromJSON(needs.check-execution-context.outputs.continue)
     needs: check-execution-context
     name: Check spec.yaml fields
     timeout-minutes: 45
@@ -56,6 +57,7 @@ jobs:
 
   run_promptflow_ci_job:
     runs-on: ubuntu-latest
+    if: fromJSON(needs.check-execution-context.outputs.continue)
     needs: check-execution-context
     name: Flow tests
     environment: Testing

--- a/.github/workflows/promptflow-ci.yml
+++ b/.github/workflows/promptflow-ci.yml
@@ -42,9 +42,12 @@ jobs:
     name: Check spec.yaml fields
     timeout-minutes: 45
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-    
+    - name: Clone branch
+      uses: Azure/azureml-assets/.github/actions/clone-repo@main
+      with:
+        forked-pr: ${{ needs.check-execution-context.outputs.forked_pr }}
+        fetch-depth: 2
+
     - name: Set up Python 3.9 environment
       uses: actions/setup-python@v4
       with:
@@ -65,8 +68,11 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - name: Clone branch
+        uses: Azure/azureml-assets/.github/actions/clone-repo@main
+        with:
+          forked-pr: ${{ needs.check-execution-context.outputs.forked_pr }}
+          fetch-depth: 2
 
       - name: Use Node.js 18.x  
         uses: actions/setup-node@v3

--- a/.github/workflows/promptflow-ci.yml
+++ b/.github/workflows/promptflow-ci.yml
@@ -2,7 +2,7 @@ name: Promptflow CI
 on:
   # Triggers the Promptflow CI on pull request targeting the main branch
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:

--- a/.github/workflows/promptflow-ci.yml
+++ b/.github/workflows/promptflow-ci.yml
@@ -28,6 +28,8 @@ env:
 permissions:
   # Required for OIDC login to Azure
   id-token: write
+  # Required to clone repo
+  contents: read
 
 jobs:
   check-execution-context:

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -160,6 +160,7 @@ if __name__ == "__main__":
     # Bug 2773738: Add retry when ClientAuthenticationError
     # https://msdata.visualstudio.com/Vienna/_workitems/edit/2773738
     # Skip template_chat_flow because not able to extract samples.json for test.
+    # Skip template_eval_flow because current default input fails.
     args = parser.parse_args()
 
     # Get changed models folder or all models folder

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     parser.add_argument('--flow_submit_mode', type=str, default="sync")
     parser.add_argument('--run_time', type=str, default="default-mir")
     parser.add_argument('--skipped_flows', type=str,
-                        default="bring_your_own_data_qna,template_chat_flow")
+                        default="bring_your_own_data_qna,template_chat_flow,template_eval_flow")
     # Skip bring_your_own_data_qna test, the flow has a bug.
     # Bug 2773738: Add retry when ClientAuthenticationError
     # https://msdata.visualstudio.com/Vienna/_workitems/edit/2773738
@@ -183,7 +183,7 @@ if __name__ == "__main__":
         flows_dirs = [flow_dir for flow_dir in changed_models if Path(
             flow_dir).name not in skipped_flows]
     # Check download models
-    log_debug(f"Flows to validate: {changed_models}.")
+    log_debug(f"Flows to validate: {flows_dirs}.")
     errors = []
     for model_dir in flows_dirs:
         try:

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
         subscription_id=args.subscription_id,
         resource_group=args.resource_group,
     )
-
+    log_debug(f"\nrun ids to check: {submitted_flow_run_ids}")
     log_debug(f"\n{flow_runs_count} bulk test runs need to check status.")
     check_flow_run_status(flow_runs_to_check, submitted_flow_run_links, submitted_flow_run_ids,
                           check_run_status_interval, check_run_status_max_attempts)

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -96,7 +96,11 @@ def get_run_id_and_url(res, sub, rg, ws):
             match = re.search(r'"name": "(.*?)",', line)
             if match:
                 run_id = match.group(1)
-                portal_url = f"https://ml.azure.com/prompts/flow/bulkrun/run/{run_id}/details?wsid=/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.MachineLearningServices/workspaces/{ws}"
+                portal_url = (
+                    f"https://ml.azure.com/prompts/flow/bulkrun/run/{run_id}/details"
+                    f"?wsid=/subscriptions/{sub}/resourceGroups/{rg}/providers"
+                    f"/Microsoft.MachineLearningServices/workspaces/{ws}"
+                    )
                 log_debug(f"runId: {run_id}")
     return run_id, portal_url
 

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -114,6 +114,7 @@ def submit_flow_runs_using_pfazure(flow_dirs, sub, rg, ws):
             try:
                 flow_dir = futures[future]
                 res = future.result()
+                log_debug(res)
                 run_id, portal_url = get_run_id_and_url(res)
                 results[run_id] = portal_url
             except Exception as exc:

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -86,17 +86,17 @@ def submit_func(run_path, sub, rg, ws):
     return res
 
 
-def get_run_id_and_url(res):
+def get_run_id_and_url(res, sub, rg, ws):
     """Resolve run_id an url from log."""
     run_id = ""
     portal_url = ""
     for line in res:
         log_debug(line)
-        if ('"portal_url":' in line):
-            match = re.search(r'/run/(.*?)/details', line)
+        if ('"name":' in line):
+            match = re.search(r'"name": "(.*?)",', line)
             if match:
-                portal_url = line.strip()
                 run_id = match.group(1)
+                portal_url = f"https://ml.azure.com/prompts/flow/bulkrun/run/{run_id}/details?wsid=/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.MachineLearningServices/workspaces/{ws}"
                 log_debug(f"runId: {run_id}")
     return run_id, portal_url
 
@@ -114,8 +114,7 @@ def submit_flow_runs_using_pfazure(flow_dirs, sub, rg, ws):
             try:
                 flow_dir = futures[future]
                 res = future.result()
-                log_debug(res)
-                run_id, portal_url = get_run_id_and_url(res)
+                run_id, portal_url = get_run_id_and_url(res, sub, rg, ws)
                 results[run_id] = portal_url
             except Exception as exc:
                 failure_message = f"Submit test run failed. Flow dir: {flow_dir}.  Error: {exc}."


### PR DESCRIPTION
Modify promptflow_ci workflow, use pull_reqeust_target trigger to unblock forked repo PRs.
For security reasons, according to [assets-test.yaml](https://github.com/Azure/azureml-assets/blob/55474f4eedd8862a44649880b81bfd3c30821d8f/.github/workflows/assets-test.yaml#L38C1-L47C25) and [environment-ci.yaml](https://github.com/Azure/azureml-assets/blob/55474f4eedd8862a44649880b81bfd3c30821d8f/.github/workflows/environments-ci.yaml#L30C1-L38C35), add a  check-execution-context task before the `check_spec_yaml` and `run_promptflow_ci_job` job.

Also fix ci because of sdk change.