### PR TITLE
upgrade padding side for mistral to left

### DIFF
--- a/assets/models/system/Mistral-7B-v0-1/spec.yaml
+++ b/assets/models/system/Mistral-7B-v0-1/spec.yaml
@@ -10,7 +10,7 @@ properties:
   evaluation-recommended-sku: Standard_NC6s_v3, Standard_NC12s_v3, Standard_NC24s_v3, Standard_NC24rs_v3, Standard_ND40rs_v2, Standard_NC24ads_A100_v4, Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96amsr_A100_v4, Standard_ND96asr_v4
   finetune-min-sku-spec: 40|8|672|2948
   finetune-recommended-sku: Standard_ND40rs_v2, Standard_ND96amsr_A100_v4, Standard_ND96asr_v4
-  finetuning-tasks: text-generation
+  finetuning-tasks: text-generation, text-classification
   languages: EN
 tags:
   Featured: ""
@@ -57,4 +57,4 @@ tags:
   license: apache-2.0
   task: text-generation
   author: mistralai
-version: 7
+version: 8


### PR DESCRIPTION
Changes:
1. Changing the padding side to "left" for mistral model. This is to keep the padding story same across evaluation and finetune. During model.generate(), the padding token is supposed to be on the left. This change is to ensure that padding is kept to left even during finetune.
2. Enabling text classification for mistral models.

Sanity runs are done using preview test1 registry:
1. [Text Classification sanity run](https://ml.azure.com/experiments/id/b7cddcb0-2b90-4476-ba3f-771acff0e2a0/runs/6012ec84-92dc-4cba-b12d-479451a28fba?wsid=%2Fsubscriptions%2F72c03bf3-4e69-41af-9532-dfcdc3eefef4%2FresourceGroups%2Fhyperdrive-service-static-rg%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Ftrain-finetune-dev-eastus&flight=itpmerge&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)
2. [Text Generation sanity run](https://ml.azure.com/experiments/id/b7cddcb0-2b90-4476-ba3f-771acff0e2a0/runs/6012ec84-92dc-4cba-b12d-479451a28fba?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&flight=itpmerge&tid=72f988bf-86f1-41af-91ab-2d7cd011db47&pipelineChildMetrics=true)  - Evaluation in progress
