### PR TITLE
Update Promptflow CI use config file for flow test settings.

### DIFF
--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -49,7 +49,8 @@ def download_blob_to_file(container_name, container_path, storage_name, target_d
     blob_service_client = BlobServiceClient(account_url, credential=cli_auth)
     container_client = blob_service_client.get_container_client(container_name)
 
-    log_debug(f"Downloading blobs under path {container_path} to {target_dir}.")
+    log_debug(
+        f"Downloading blobs under path {container_path} to {target_dir}.")
     blob_list = container_client.list_blobs(container_path)
     for blob in blob_list:
         relative_path = os.path.relpath(blob.name, container_path)
@@ -168,7 +169,8 @@ if __name__ == "__main__":
     diff_files_list = {path.split('/')[-1] for path in diff_files}
     log_debug(f"Git diff files include:{diff_files}.")
 
-    if "promptflow_ci.py" in diff_files_list or "promptflow-ci.yml" in diff_files_list:
+    if ("promptflow_ci.py" in diff_files_list or "promptflow-ci.yml" in diff_files_list
+            or "flow_utils.py" in diff_files_list):
         log_debug("promptflow_ci.py or promptflow_ci.yml changed, test all models.")
         changed_models = get_all_models()
     else:

--- a/scripts/promptflow-ci/test-configs/ask-wikipedia/test_config.json
+++ b/scripts/promptflow-ci/test-configs/ask-wikipedia/test_config.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {
+      "name": "augmented_qna",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/bring-your-own-data-chat-qna/test_config.json
+++ b/scripts/promptflow-ci/test-configs/bring-your-own-data-chat-qna/test_config.json
@@ -1,0 +1,25 @@
+{
+  "nodes": [
+    {
+      "name": "modify_query_with_history",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    },
+    {
+      "name": "embed_the_question",
+      "inputs": {
+        "connection": "aoai_connection",
+        "deployment_name": "text-embedding-ada-002"
+      }
+    },
+    {
+      "name": "chat_with_context",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/bring-your-own-data-qna/test_config.json
+++ b/scripts/promptflow-ci/test-configs/bring-your-own-data-qna/test_config.json
@@ -1,0 +1,18 @@
+{
+  "nodes": [
+    {
+      "name": "embed_the_question",
+      "inputs": {
+        "connection": "aoai_connection",
+        "deployment_name": "text-embedding-ada-002"
+      }
+    },
+    {
+      "name": "answer_the_question_with_context",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/chat-with-wikipedia/test_config.json
+++ b/scripts/promptflow-ci/test-configs/chat-with-wikipedia/test_config.json
@@ -1,0 +1,18 @@
+{
+  "nodes": [
+    {
+      "name": "extract_query_from_question",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    },
+    {
+      "name": "augmented_chat",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/playground-ayod-rag/test_config.json
+++ b/scripts/promptflow-ci/test-configs/playground-ayod-rag/test_config.json
@@ -1,0 +1,18 @@
+{
+  "nodes": [
+    {
+      "name": "DetermineIntent",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    },
+    {
+      "name": "DetermineReply",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/qna-ada-similarity-eval/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-ada-similarity-eval/test_config.json
@@ -1,0 +1,18 @@
+{
+  "nodes": [
+    {
+      "name": "embedd_ground_truth",
+      "inputs": {
+        "connection": "aoai_connection",
+        "deployment_name": "text-embedding-ada-002"
+      }
+    },
+    {
+      "name": "embedd_answer",
+      "inputs": {
+        "connection": "aoai_connection",
+        "deployment_name": "text-embedding-ada-002"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/qna-coherence-eval/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-coherence-eval/test_config.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {
+      "name": "coherence_score",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/qna-fluency-eval/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-fluency-eval/test_config.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {
+      "name": "fluency_score",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/qna-gpt-similarity-eval/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-gpt-similarity-eval/test_config.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {
+      "name": "similarity_score",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/qna-groundedness-eval/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-groundedness-eval/test_config.json
@@ -1,7 +1,7 @@
 {
   "nodes": [
     {
-      "name": "coherence_score",
+      "name": "groundedness_score",
       "connection": "aoai_connection",
       "inputs": {
         "deployment_name": "gpt-35-turbo"

--- a/scripts/promptflow-ci/test-configs/qna-groundedness-eval/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-groundedness-eval/test_config.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {
+      "name": "coherence_score",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/qna-non-rag-metrics-eval/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-non-rag-metrics-eval/test_config.json
@@ -1,0 +1,53 @@
+{
+  "nodes": [
+    {
+      "name": "gpt_coherence",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    },
+    {
+      "name": "gpt_fluency",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    },
+    {
+      "name": "gpt_groundedness",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    },
+    {
+      "name": "gpt_relevance",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    },
+    {
+      "name": "gpt_similarity",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    },
+    {
+      "name": "embeded_ground_truth",
+      "inputs": {
+        "connection": "aoai_connection",
+        "deployment_name": "text-embedding-ada-002"
+      }
+    },
+    {
+      "name": "embeded_answer",
+      "inputs": {
+        "connection": "aoai_connection",
+        "deployment_name": "text-embedding-ada-002"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/qna-rag-metrics-eval/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-rag-metrics-eval/test_config.json
@@ -1,0 +1,25 @@
+{
+  "nodes": [
+    {
+      "name": "gpt_groundedness",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-4"
+      }
+    },
+    {
+      "name": "gpt_retrieval_score",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-4"
+      }
+    },
+    {
+      "name": "gpt_relevance",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-4"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/qna-relevance-eval/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-relevance-eval/test_config.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {
+      "name": "relevance_score",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/qna-with-your-own-data-using-faiss-index/test_config.json
+++ b/scripts/promptflow-ci/test-configs/qna-with-your-own-data-using-faiss-index/test_config.json
@@ -1,0 +1,24 @@
+{
+  "nodes": [
+    {
+      "name": "lookup",
+      "inputs": {
+        "path": "https://github.com/Azure/azureml-assets/tree/main/assets/promptflow/data/faiss-index-lookup/faiss_index_sample"
+      }
+    },
+    {
+      "name": "generate_embedding",
+      "inputs": {
+        "deployment_name": "text-embedding-ada-002",
+        "connection": "aoai_connection"
+      }
+    },
+    {
+      "name": "answer_the_question_with_context",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/template-chat-flow/test_config.json
+++ b/scripts/promptflow-ci/test-configs/template-chat-flow/test_config.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {
+      "name": "chat",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/template-standard-flow/test_config.json
+++ b/scripts/promptflow-ci/test-configs/template-standard-flow/test_config.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {
+      "name": "joke",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/use-functions-with-chat-models/test_config.json
+++ b/scripts/promptflow-ci/test-configs/use-functions-with-chat-models/test_config.json
@@ -1,0 +1,11 @@
+{
+  "nodes": [
+    {
+      "name": "use_functions_with_chat_models",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/test-configs/web-classification/test_config.json
+++ b/scripts/promptflow-ci/test-configs/web-classification/test_config.json
@@ -1,0 +1,18 @@
+{
+  "nodes": [
+    {
+      "name": "summarize_text_content",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    },
+    {
+      "name": "classify_with_llm",
+      "connection": "aoai_connection",
+      "inputs": {
+        "deployment_name": "gpt-35-turbo"
+      }
+    }
+  ]
+}

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -21,8 +21,23 @@ CONFIG_FILE = 'test_config.json'
 def _assign_flow_values(flow_dirs):
     """Assign the flow values and update flow.dag.yaml."""
     log_debug("\n=======Start overriding values for flows=======")
-
     for flow_dir in flow_dirs:
+        if not os.path.exists(Path(flow_dir)/"samples.json"):
+            with open(flow_dir/"samples.json", 'w', encoding="utf-8") as sample_file:
+                samples = []
+                sample = {}
+                for key, val in flow_dag["inputs"].items():
+                    value = val.get("default")
+                    if isinstance(value, list):
+                        if not value:
+                            value.append("default")
+                    elif isinstance(value, str):
+                        if value == "":
+                            value = "default"
+                    sample[key] = value
+                samples.append(sample)
+                json.dump(sample, sample_file, indent=4)
+
         with open(Path(flow_dir) / "flow.dag.yaml", "r") as dag_file:
             flow_dag = yaml.safe_load(dag_file)
         flow_name = flow_dir.parents[0].name
@@ -52,22 +67,6 @@ def _assign_flow_values(flow_dirs):
 
         with open(flow_dir / "flow.dag.yaml", "w", encoding="utf-8") as dag_file:
             yaml.dump(flow_dag, dag_file, allow_unicode=True)
-
-        if not os.path.exists(Path(flow_dir)/"samples.json"):
-            with open(flow_dir/"samples.json", 'w', encoding="utf-8") as sample_file:
-                samples = []
-                sample = {}
-                for key, val in flow_dag["inputs"].items():
-                    value = val.get("default")
-                    if isinstance(value, list):
-                        if not value:
-                            value.append("default")
-                    elif isinstance(value, str):
-                        if value == "":
-                            value = "default"
-                    sample[key] = value
-                samples.append(sample)
-                json.dump(sample, sample_file, indent=4)
     log_debug("=======Complete overriding values for flows=======\n")
     return flow_dirs
 

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -14,8 +14,9 @@ from utils.logging_utils import log_debug, log_error, log_warning
 from utils.utils import run_command
 
 
-CONFIG_ROOT= 'scripts/promptflow-ci/test-configs'
+CONFIG_ROOT = 'scripts/promptflow-ci/test-configs'
 CONFIG_FILE = 'test_config.json'
+
 
 def _assign_flow_values(flow_dirs):
     """Assign the flow values and update flow.dag.yaml."""

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -123,6 +123,7 @@ def submit_flow_runs_using_pfazure(flow_dirs, sub, rg, ws):
             try:
                 flow_dir = futures[future]
                 res = future.result()
+                log_debug(f"Submit test run in flow dir:{flow_dir}.")
                 run_id, portal_url = get_run_id_and_url(res, sub, rg, ws)
                 results[run_id] = portal_url
             except Exception as exc:


### PR DESCRIPTION
This PR update the CI to read these settings in config file, so that each contributor can update their own flow config.
This helps contributors to test their promptflow model, which needs some specific connections or inputs in flow nodes.
