### PR TITLE
acft-hf-nlp-gpu environment version 38

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -21,4 +21,4 @@ RUN pip install -r requirements.txt --no-cache-dir
 RUN python -m nltk.downloader punkt
 RUN MAX_JOBS=4 pip install flash-attn==2.3.3 --no-build-isolation
 
-# dummy number to change when needing to force rebuild without changing the definition: 2
+# dummy number to change when needing to force rebuild without changing the definition: 1

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -21,4 +21,4 @@ RUN pip install -r requirements.txt --no-cache-dir
 RUN python -m nltk.downloader punkt
 RUN MAX_JOBS=4 pip install flash-attn==2.3.3 --no-build-isolation
 
-# dummy number to change when needing to force rebuild without changing the definition: 1
+# dummy number to change when needing to force rebuild without changing the definition: 2

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -1,7 +1,7 @@
 azureml-acft-accelerator=={{latest-pypi-version}}
 azureml_acft_common_components=={{latest-pypi-version}}
 azureml-acft-contrib-hf-nlp=={{latest-pypi-version}}
-mltable=={{latest-pypi-version}}
+mltable==1.5.0
 datasets==2.14.6
 mpi4py==3.1.4
 sentencepiece==0.1.99


### PR DESCRIPTION
Need to pin mltable==1.5.0 because of dependency conflict

<img width="700" alt="image" src="https://github.com/Azure/azureml-assets/assets/116672436/39abd19f-b40a-4dfd-999d-a3b7f9612638">

https://github.com/Azure/azureml-assets/actions/runs/7554471426/job/20567370212?pr=2139