### PR TITLE
Address cred not found in model valdn

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.16.33 (2023-01-222)
+### 🐛 Bugs Fixed
+- [#2161](https://github.com/Azure/azureml-assets/pull/2161) Fix credential not found issue for asset validation 
+
 ## 1.16.32 (2023-01-19)
 ### 🐛 Bugs Fixed
 - [#2155](https://github.com/Azure/azureml-assets/pull/2155) Fix no-op model metadata update

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -54,6 +54,7 @@ try:
     credential = AzureCliCredential()
     token = credential.get_token("https://management.azure.com/.default")
 except Exception as e:
+    credential = None
     logger.log_warning(f"Exception in creating credential. {e}")
 
 

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -52,8 +52,9 @@ SUPPORTED_INFERENCE_SKU_FILE_PATH = Path(__file__).parent / SUPPORTED_INFERENCE_
 credential = None
 try:
     credential = AzureCliCredential()
+    token = credential.get_token("https://management.azure.com/.default")
 except Exception as e:
-    logger.log_warning(f"exception in creating credential. {e}")
+    logger.log_warning(f"Exception in creating credential. {e}")
 
 
 class MLFlowModelProperties:
@@ -638,8 +639,8 @@ def confirm_model_validation_results(
                 error_count += 1
 
             # check is batch supported?
-            supports_batch_str = latest_model.tags.get("disable-batch", "true")
-            supports_batch = True if supports_batch_str.lower() == "true" else False
+            disable_batch_str = latest_model.tags.get("disable-batch", "false")
+            supports_batch = True if disable_batch_str.lower() == "false" else False
 
             if supports_batch and batch_deployment_status != ModelValidationState.COMPLETED:
                 logger.log_error(

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.32",
+   version="1.16.33",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
**Problem**

![image](https://github.com/Azure/azureml-assets/assets/61145377/1543000d-3fec-4d05-a4b5-d9af8b73347b)


Validate assets in azureml-asset where credential is not enabled, it still goes and tries for fetching sku details. 

**Solution**
credential.get_token() would make sure, that it raises exception if credential not found in agent running validation

**Test**

azureml-asset test: [build](https://msdata.visualstudio.com/Vienna/_build/results?buildId=116578528&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9)

azureml-assets test: [wf run](https://github.com/Azure/azureml-assets/actions/runs/7610729081)