### PR TITLE
update the compute feature importances model monitoring component to use TreeExplainer to optimize execution time

### DIFF
--- a/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_drift_signal_monitor
 display_name: Data Drift - Signal Monitor
 description: Computes the data drift between a baseline and production data assets.
-version: 0.3.26
+version: 0.3.27
 is_deterministic: true
 
 inputs:
@@ -63,7 +63,7 @@ outputs:
 jobs:
   compute_feature_importances:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.9
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.10
     inputs:
       baseline_data:
         type: mltable

--- a/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_quality_signal_monitor
 display_name: Data Quality - Signal Monitor
 description: Computes the data quality of a target dataset with reference to a baseline.
-version: 0.3.24
+version: 0.3.25
 is_deterministic: true
 
 inputs:
@@ -63,7 +63,7 @@ outputs:
 jobs:
   compute_feature_importances:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.9
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.10
     inputs:
       baseline_data:
         type: mltable

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: feature_attribution_drift_signal_monitor
 display_name: Feature Attribution Drift - Signal Monitor
 description: Computes the feature attribution between a baseline and production data assets.
-version: 0.3.17
+version: 0.3.18
 is_deterministic: true
 
 inputs:
@@ -44,7 +44,7 @@ outputs:
 jobs:
   compute_baseline_explanations:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.9
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.10
     inputs:
       baseline_data:
         type: mltable
@@ -63,7 +63,7 @@ jobs:
       type: aml_token
   compute_production_explanations:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.9
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.10
     inputs:
       baseline_data:
         type: mltable

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_importance_metrics/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_importance_metrics/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/SparkComponent.json
 type: spark
 
 name: feature_importance_metrics
-version: 0.3.9
+version: 0.3.10
 display_name: Feature importance
 is_deterministic: true
 description: Feature importance for model monitoring.


### PR DESCRIPTION
update the compute feature importances model monitoring component to use TreeExplainer to optimize execution time

This pull request involves significant changes to the `compute_feature_importance.py` file in the `assets/model_monitoring/components/src/feature_importance_metrics` directory. The changes include replacing the `get_model_wrapper` function with a call to `get_model`, renaming the function to `get_model`, and changing its functionality to create a lightgbm model instead of a model wrapper. The `compute_explanations` function was also modified to use the `TreeExplainer` instead of the `RAIInsights` class for calculating global feature importances.

Main changes:

* [`compute_feature_importance.py`](diffhunk://#diff-722964c327cbff02d1ff2dfa4cb1875410468efc9643ec8c336aae7abda69415L120-R122): Replaced the `get_model_wrapper` function with a call to `get_model`, renamed the function to `get_model`, and changed its functionality to create a lightgbm model instead of a model wrapper. [[1]](diffhunk://#diff-722964c327cbff02d1ff2dfa4cb1875410468efc9643ec8c336aae7abda69415L120-R122) [[2]](diffhunk://#diff-722964c327cbff02d1ff2dfa4cb1875410468efc9643ec8c336aae7abda69415L207-L212) [[3]](diffhunk://#diff-722964c327cbff02d1ff2dfa4cb1875410468efc9643ec8c336aae7abda69415L19-R19)
* `compute_feature_importance.py`: Modified the `compute_explanations` function to use the `TreeExplainer` instead