### PR TITLE
remove logit_bias and stop from rai eval flow yaml

### DIFF
--- a/assets/promptflow/models/qna-non-rag-metrics-eval/model.yaml
+++ b/assets/promptflow/models/qna-non-rag-metrics-eval/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: rai-eval-flows
-  container_path: models/qna_non_rag_metrics_eval/v2
+  container_path: models/qna_non_rag_metrics_eval/v3
   storage_name: amlraipfmodels
   type: azureblob
 publish:

--- a/assets/promptflow/models/qna-non-rag-metrics-eval/spec.yaml
+++ b/assets/promptflow/models/qna-non-rag-metrics-eval/spec.yaml
@@ -9,4 +9,4 @@ properties:
   azureml.promptflow.description: Compute the quality of the answer for the given question based on the ground_truth and the context
   inference-min-sku-spec: 2|0|14|28
   inference-recommended-sku: Standard_DS3_v2
-version: 2
+version: 3

--- a/assets/promptflow/models/qna-rag-metrics-eval/model.yaml
+++ b/assets/promptflow/models/qna-rag-metrics-eval/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: rai-eval-flows
-  container_path: models/qna_rag_metrics_eval/v3
+  container_path: models/qna_rag_metrics_eval/v4
   storage_name: amlraipfmodels
   type: azureblob
 publish:

--- a/assets/promptflow/models/qna-rag-metrics-eval/spec.yaml
+++ b/assets/promptflow/models/qna-rag-metrics-eval/spec.yaml
@@ -9,4 +9,4 @@ properties:
   azureml.promptflow.description: Compute the quality of the answer for the given question based on the retrieved documents
   inference-min-sku-spec: 2|0|14|28
   inference-recommended-sku: Standard_DS3_v2
-version: 3
+version: 4


### PR DESCRIPTION
Update RAI QA and QA RAG evaluation flows:
* remove `logit_bias` and `stop` from the flow yaml of RAI Q&A evaluation flow
* remove `logit_bias` and `stop` from the flow yaml of RAI Q&A RAG evaluation flow