### PR TITLE
Evaluation specification updated as per evaluation sku list

### DIFF
--- a/assets/models/system/tiiuae-falcon-40b/spec.yaml
+++ b/assets/models/system/tiiuae-falcon-40b/spec.yaml
@@ -7,7 +7,7 @@ properties:
   datasets: tiiuae/falcon-refinedweb
   languages: en, de, es, fr
   evaluation-min-sku-spec: 24|4|448|1344
-  evaluation-recommended-sku: Standard_NC24rs_v3, Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
+  evaluation-recommended-sku: Standard_NC24s_v3, Standard_NC24rs_v3, Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   finetune-min-sku-spec: 40|8|672|2900
   finetune-recommended-sku: Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   finetuning-tasks: text-classification

--- a/assets/models/system/tiiuae-falcon-40b/spec.yaml
+++ b/assets/models/system/tiiuae-falcon-40b/spec.yaml
@@ -6,7 +6,7 @@ properties:
   SHA: 3d7c5902f1dc9da830979a826cd96114b3ba4ec1
   datasets: tiiuae/falcon-refinedweb
   languages: en, de, es, fr
-  evaluation-min-sku-spec: 24|4|448|2900
+  evaluation-min-sku-spec: 24|4|448|1344
   evaluation-recommended-sku: Standard_NC24rs_v3, Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
   finetune-min-sku-spec: 40|8|672|2900
   finetune-recommended-sku: Standard_ND40rs_v2, Standard_ND96asr_v4, Standard_ND96amsr_A100_v4
@@ -45,4 +45,4 @@ tags:
     precision: '4'
   inference_supported_envs:
   - vllm
-version: 5
+version: 6

--- a/assets/models/system/tiiuae-falcon-40b/spec.yaml
+++ b/assets/models/system/tiiuae-falcon-40b/spec.yaml
@@ -23,6 +23,7 @@ tags:
   huggingface_model_id: tiiuae/falcon-40b
   evaluation_compute_allow_list:
     [
+      Standard_NC24s_v3,
       Standard_NC24rs_v3,
       Standard_ND40rs_v2,
       Standard_ND96asr_v4,


### PR DESCRIPTION
Update the eval min sku specification , by adding Standard_NC24s_v3 in evaluation compute allow list and evaluation recommended sku.