### PR TITLE
MLflow convertor for DinoV2 embeddings

### DIFF
--- a/assets/training/model_management/src/azureml/model/mgmt/processors/factory.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/factory.py
@@ -65,8 +65,9 @@ def get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, trans
         elif task == SupportedTasks.AUTOMATIC_SPEECH_RECOGNITION.value:
             return ASRMLflowConvertorFactory.create_mlflow_convertor(model_dir, output_dir, temp_dir, translate_params)
         # Models from Hugging face framework exported in PyFunc mlflow flavor
-        elif task in \
-                [PyFuncSupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value, PyFuncSupportedTasks.EMBEDDINGS_CLIP.value]:
+        elif task in [
+            PyFuncSupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value, PyFuncSupportedTasks.EMBEDDINGS_CLIP.value
+        ]:
             return CLIPMLflowConvertorFactory.create_mlflow_convertor(
                 model_dir, output_dir, temp_dir, translate_params
             )

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/factory.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/factory.py
@@ -14,6 +14,7 @@ from azureml.model.mgmt.processors.transformers.config import (
 from azureml.model.mgmt.processors.pyfunc.config import (
     MMLabDetectionTasks,
     MMLabTrackingTasks,
+    ModelFamilyPrefixes,
     SupportedTasks as PyFuncSupportedTasks,
 )
 from azureml.model.mgmt.processors.pyfunc.text_to_image.config import SupportedTextToImageModelFamily
@@ -44,9 +45,9 @@ logger = get_logger(__name__)
 def get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, translate_params):
     """Instantiate and return MLflow convertor."""
     task = translate_params["task"]
-
-    # TODO: do not assume 1-to-1 association between tasks and models when making a convertor. There are ways to get
-    # around this but they are hacky.
+    model_id = translate_params.get("model_id")
+    if model_id is None:
+        model_id = ""
 
     if model_framework == ModelFramework.HUGGINGFACE.value:
         # Models from Hugging face framework exported in transformers mlflow flavor
@@ -65,13 +66,13 @@ def get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, trans
         elif task == SupportedTasks.AUTOMATIC_SPEECH_RECOGNITION.value:
             return ASRMLflowConvertorFactory.create_mlflow_convertor(model_dir, output_dir, temp_dir, translate_params)
         # Models from Hugging face framework exported in PyFunc mlflow flavor
-        elif task in [
-            PyFuncSupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value, PyFuncSupportedTasks.EMBEDDINGS_CLIP.value
-        ]:
+        elif (task == PyFuncSupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value) or (
+                (task == PyFuncSupportedTasks.EMBEDDINGS.value) and model_id.startswith(ModelFamilyPrefixes.CLIP.value)
+        ):
             return CLIPMLflowConvertorFactory.create_mlflow_convertor(
                 model_dir, output_dir, temp_dir, translate_params
             )
-        elif task == PyFuncSupportedTasks.EMBEDDINGS_DINOV2.value:
+        elif (task == PyFuncSupportedTasks.EMBEDDINGS.value) and model_id.startswith(ModelFamilyPrefixes.DINOV2.value):
             return DinoV2MLflowConvertorFactory.create_mlflow_convertor(
                 model_dir, output_dir, temp_dir, translate_params
             )
@@ -84,7 +85,10 @@ def get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, trans
                 model_dir, output_dir, temp_dir, translate_params
             )
         else:
-            raise Exception(f"Models from {model_framework} for {task} not supported for MLflow conversion")
+            raise Exception(
+                f"Models from {model_framework} for task {task} and model {model_id} "
+                "not supported for MLflow conversion"
+            )
     elif model_framework == ModelFramework.MMLAB.value:
         # Models from MMLAB model framework exported in PyFunc mlflow flavor
         if MMLabDetectionTasks.has_value(task):

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/config.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/config.py
@@ -29,9 +29,12 @@ class SupportedTasks(_CustomEnum):
     # MmTrack video tasks
     MM_MULTI_OBJECT_TRACKING = "video-multi-object-tracking"
 
-    # CLIP task
+    # CLIP tasks
     ZERO_SHOT_IMAGE_CLASSIFICATION = "zero-shot-image-classification"
-    EMBEDDINGS = "embeddings"
+    EMBEDDINGS_CLIP = "embeddings-clip"
+
+    # DinoV2 task
+    EMBEDDINGS_DINOV2 = "embeddings-dinov2"
 
     # BLIP tasks
     IMAGE_TO_TEXT = "image-to-text"

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/config.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/config.py
@@ -31,10 +31,9 @@ class SupportedTasks(_CustomEnum):
 
     # CLIP tasks
     ZERO_SHOT_IMAGE_CLASSIFICATION = "zero-shot-image-classification"
-    EMBEDDINGS_CLIP = "embeddings-clip"
 
-    # DinoV2 task
-    EMBEDDINGS_DINOV2 = "embeddings-dinov2"
+    # Embedding tasks
+    EMBEDDINGS = "embeddings"
 
     # BLIP tasks
     IMAGE_TO_TEXT = "image-to-text"
@@ -56,3 +55,13 @@ class SupportedTasks(_CustomEnum):
     IMAGE_CLASSIFICATION_MULTILABEL = "image-classification-multilabel"
     IMAGE_OBJECT_DETECTION = "image-object-detection"
     IMAGE_INSTANCE_SEGMENTATION = "image-instance-segmentation"
+
+
+class ModelFamilyPrefixes(_CustomEnum):
+    """Prefixes for some of the models converted to PyFunc MLflow."""
+
+    # CLIP model family.
+    CLIP = "openai/clip-vit"
+
+    # DinoV2 model family.
+    DINOV2 = "facebook/dinov2"

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convertors.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convertors.py
@@ -24,7 +24,11 @@ from azureml.model.mgmt.processors.pyfunc.config import (
     MMLabDetectionTasks, MMLabTrackingTasks, SupportedTasks)
 
 from azureml.model.mgmt.processors.pyfunc.clip.config import \
-    MLflowSchemaLiterals as CLIPMLFlowSchemaLiterals, MLflowLiterals as CLIPMLflowLiterals
+    MLflowSchemaLiterals as CLIPMLFlowSchemaLiterals, MLflowLiterals as CLIPMLflowLiterals, \
+    Tasks as CLIPTasks
+from azureml.model.mgmt.processors.pyfunc.dinov2.config import \
+    MLflowSchemaLiterals as DinoV2MLFlowSchemaLiterals, MLflowLiterals as DinoV2MLflowLiterals, \
+    Tasks as DinoV2Tasks
 from azureml.model.mgmt.processors.pyfunc.blip.config import \
     MLflowSchemaLiterals as BLIPMLFlowSchemaLiterals, MLflowLiterals as BLIPMLflowLiterals
 from azureml.model.mgmt.processors.pyfunc.text_to_image.config import (
@@ -224,7 +228,7 @@ class CLIPMLFlowConvertor(PyFuncMLFLowConvertor):
         """Initialize MLflow convertor for CLIP models."""
         super().__init__(**kwargs)
         if self._task not in \
-                [SupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value, SupportedTasks.EMBEDDINGS.value]:
+                [SupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value, SupportedTasks.EMBEDDINGS_CLIP.value]:
             raise Exception("Unsupported task")
 
     def get_model_signature(self) -> ModelSignature:
@@ -251,7 +255,7 @@ class CLIPMLFlowConvertor(PyFuncMLFLowConvertor):
                             CLIPMLFlowSchemaLiterals.OUTPUT_COLUMN_LABELS),
                 ]
             )
-        elif self._task == SupportedTasks.EMBEDDINGS.value:
+        elif self._task == SupportedTasks.EMBEDDINGS_CLIP.value:
             output_schema = Schema(
                 [
                     ColSpec(CLIPMLFlowSchemaLiterals.OUTPUT_COLUMN_DATA_TYPE,
@@ -271,10 +275,10 @@ class CLIPMLFlowConvertor(PyFuncMLFLowConvertor):
 
         if self._task == SupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value:
             from clip_mlflow_wrapper import CLIPMLFlowModelWrapper
-            mlflow_model_wrapper = CLIPMLFlowModelWrapper(task_type=self._task)
-        elif self._task == SupportedTasks.EMBEDDINGS.value:
+            mlflow_model_wrapper = CLIPMLFlowModelWrapper(task_type=CLIPTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value)
+        elif self._task == SupportedTasks.EMBEDDINGS_CLIP.value:
             from clip_embeddings_mlflow_wrapper import CLIPEmbeddingsMLFlowModelWrapper
-            mlflow_model_wrapper = CLIPEmbeddingsMLFlowModelWrapper(task_type=self._task)
+            mlflow_model_wrapper = CLIPEmbeddingsMLFlowModelWrapper(task_type=CLIPTasks.EMBEDDINGS.value)
         else:
             raise Exception("Unsupported task")
 
@@ -300,7 +304,7 @@ class CLIPMLFlowConvertor(PyFuncMLFLowConvertor):
             os.path.join(self.MODEL_DIR, "config.py"),
             os.path.join(self.COMMON_DIR, "vision_utils.py")
         ]
-        if self._task == SupportedTasks.EMBEDDINGS.value:
+        if self._task == SupportedTasks.EMBEDDINGS_CLIP.value:
             code_path.append(os.path.join(self.MODEL_DIR, "clip_embeddings_mlflow_wrapper.py"))
 
         return code_path
@@ -313,6 +317,83 @@ class CLIPMLFlowConvertor(PyFuncMLFLowConvertor):
         """
         artifacts_dict = {
             CLIPMLflowLiterals.MODEL_DIR: self._model_dir
+        }
+        return artifacts_dict
+
+
+class DinoV2MLFlowConvertor(PyFuncMLFLowConvertor):
+    """PyFunc MLfLow convertor for DinoV2 models."""
+
+    MODEL_DIR = os.path.join(os.path.dirname(__file__), "dinov2")
+    COMMON_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "common")
+
+    def __init__(self, **kwargs):
+        """Initialize MLflow convertor for DinoV2 models."""
+        super().__init__(**kwargs)
+
+        if self._task != SupportedTasks.EMBEDDINGS_DINOV2.value:
+            raise Exception("Unsupported task")
+
+    def get_model_signature(self) -> ModelSignature:
+        """Return MLflow model signature with input and output schema for the given input task.
+
+        :return: MLflow model signature.
+        :rtype: mlflow.models.signature.ModelSignature
+        """
+        input_schema = Schema(
+            [
+                ColSpec(DataType.string, DinoV2MLFlowSchemaLiterals.INPUT_COLUMN_IMAGE),
+            ]
+        )
+
+        output_schema = Schema(
+            [
+                ColSpec(DataType.string, DinoV2MLFlowSchemaLiterals.OUTPUT_COLUMN_IMAGE_FEATURES),
+            ]
+        )
+
+        return ModelSignature(inputs=input_schema, outputs=output_schema)
+
+    def save_as_mlflow(self):
+        """Prepare model for save to MLflow."""
+        sys.path.append(self.MODEL_DIR)
+
+        from dinov2_embeddings_mlflow_wrapper import DinoV2EmbeddingsMLFlowModelWrapper
+        mlflow_model_wrapper = DinoV2EmbeddingsMLFlowModelWrapper(task_type=DinoV2Tasks.EMBEDDINGS.value)
+
+        artifacts_dict = self._prepare_artifacts_dict()
+        conda_env_file = os.path.join(self.MODEL_DIR, "conda.yaml")
+        code_path = self._get_code_path()
+
+        super()._save(
+            mlflow_model_wrapper=mlflow_model_wrapper,
+            artifacts_dict=artifacts_dict,
+            conda_env=conda_env_file,
+            code_path=code_path,
+        )
+
+    def _get_code_path(self):
+        """Return code path for saving mlflow model depending on task type.
+
+        :return: code path
+        :rtype: List[str]
+        """
+        code_path = [
+            os.path.join(self.MODEL_DIR, "dinov2_embeddings_mlflow_wrapper.py"),
+            os.path.join(self.MODEL_DIR, "config.py"),
+            os.path.join(self.COMMON_DIR, "vision_utils.py")
+        ]
+
+        return code_path
+
+    def _prepare_artifacts_dict(self) -> Dict:
+        """Prepare artifacts dict for MLflow model.
+
+        :return: artifacts dict
+        :rtype: Dict
+        """
+        artifacts_dict = {
+            DinoV2MLflowLiterals.MODEL_DIR: self._model_dir
         }
         return artifacts_dict
 

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convertors.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/convertors.py
@@ -228,7 +228,7 @@ class CLIPMLFlowConvertor(PyFuncMLFLowConvertor):
         """Initialize MLflow convertor for CLIP models."""
         super().__init__(**kwargs)
         if self._task not in \
-                [SupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value, SupportedTasks.EMBEDDINGS_CLIP.value]:
+                [SupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value, SupportedTasks.EMBEDDINGS.value]:
             raise Exception("Unsupported task")
 
     def get_model_signature(self) -> ModelSignature:
@@ -255,7 +255,7 @@ class CLIPMLFlowConvertor(PyFuncMLFLowConvertor):
                             CLIPMLFlowSchemaLiterals.OUTPUT_COLUMN_LABELS),
                 ]
             )
-        elif self._task == SupportedTasks.EMBEDDINGS_CLIP.value:
+        elif self._task == SupportedTasks.EMBEDDINGS.value:
             output_schema = Schema(
                 [
                     ColSpec(CLIPMLFlowSchemaLiterals.OUTPUT_COLUMN_DATA_TYPE,
@@ -276,7 +276,7 @@ class CLIPMLFlowConvertor(PyFuncMLFLowConvertor):
         if self._task == SupportedTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value:
             from clip_mlflow_wrapper import CLIPMLFlowModelWrapper
             mlflow_model_wrapper = CLIPMLFlowModelWrapper(task_type=CLIPTasks.ZERO_SHOT_IMAGE_CLASSIFICATION.value)
-        elif self._task == SupportedTasks.EMBEDDINGS_CLIP.value:
+        elif self._task == SupportedTasks.EMBEDDINGS.value:
             from clip_embeddings_mlflow_wrapper import CLIPEmbeddingsMLFlowModelWrapper
             mlflow_model_wrapper = CLIPEmbeddingsMLFlowModelWrapper(task_type=CLIPTasks.EMBEDDINGS.value)
         else:
@@ -304,7 +304,7 @@ class CLIPMLFlowConvertor(PyFuncMLFLowConvertor):
             os.path.join(self.MODEL_DIR, "config.py"),
             os.path.join(self.COMMON_DIR, "vision_utils.py")
         ]
-        if self._task == SupportedTasks.EMBEDDINGS_CLIP.value:
+        if self._task == SupportedTasks.EMBEDDINGS.value:
             code_path.append(os.path.join(self.MODEL_DIR, "clip_embeddings_mlflow_wrapper.py"))
 
         return code_path
@@ -331,7 +331,7 @@ class DinoV2MLFlowConvertor(PyFuncMLFLowConvertor):
         """Initialize MLflow convertor for DinoV2 models."""
         super().__init__(**kwargs)
 
-        if self._task != SupportedTasks.EMBEDDINGS_DINOV2.value:
+        if self._task != SupportedTasks.EMBEDDINGS.value:
             raise Exception("Unsupported task")
 
     def get_model_signature(self) -> ModelSignature:

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/dinov2/conda.yaml
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/dinov2/conda.yaml
@@ -1,0 +1,11 @@
+channels:
+- conda-forge
+dependencies:
+- python=3.8.17
+- pip<=23.2.1
+- pip:
+  - mlflow==2.6.0
+  - torch==1.13.1
+  - transformers==4.33.1
+  - accelerate==0.22.0
+name: mlflow-env

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/dinov2/config.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/dinov2/config.py
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Common Config."""
+
+from enum import Enum
+
+
+class _CustomEnum(Enum):
+    @classmethod
+    def has_value(cls, value):
+        return value in cls._value2member_map_
+
+
+class Tasks(_CustomEnum):
+    """Tasks supported."""
+
+    EMBEDDINGS = "embeddings"
+
+
+class MLflowSchemaLiterals:
+    """MLflow model signature related schema."""
+
+    INPUT_COLUMN_IMAGE = "image"
+    OUTPUT_COLUMN_IMAGE_FEATURES = "image_features"
+
+
+class MLflowLiterals:
+    """MLflow export related literals."""
+
+    MODEL_DIR = "model_dir"

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/dinov2/dinov2_embeddings_mlflow_wrapper.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/dinov2/dinov2_embeddings_mlflow_wrapper.py
@@ -1,0 +1,93 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""MLflow PythonModel wrapper that loads the DinoV2 model, preprocesses inputs and performs embedding inference."""
+
+import io
+
+import mlflow
+import pandas as pd
+
+from PIL import Image
+from transformers import AutoImageProcessor, AutoModel
+
+from config import MLflowSchemaLiterals, MLflowLiterals, Tasks
+
+
+class DinoV2EmbeddingsMLFlowModelWrapper(mlflow.pyfunc.PythonModel):
+    """MLflow model wrapper for DinoV2 embeddings model, used for getting feature embeddings."""
+
+    def __init__(
+        self,
+        task_type: str,
+    ) -> None:
+        """Initialize wrapper class.
+
+        :param task_type: Task type used for inference.
+        :type task_type: str
+        """
+        super().__init__()
+
+        self._task_type = task_type
+
+    def load_context(self, context: mlflow.pyfunc.PythonModelContext) -> None:
+        """
+        Load a MLflow model with pyfunc.load_model().
+
+        :param context: MLflow context containing artifacts that the model can use for inference
+        :type context: mlflow.pyfunc.PythonModelContext
+        """
+        from vision_utils import get_current_device
+
+        if self._task_type == Tasks.EMBEDDINGS.value:
+            try:
+                model_dir = context.artifacts[MLflowLiterals.MODEL_DIR]
+                self._processor = AutoImageProcessor.from_pretrained(model_dir)
+                self._model = AutoModel.from_pretrained(model_dir)
+                self._device = get_current_device()
+                self._model.to(self._device)
+
+                print("Model loaded successfully")
+
+            except Exception as e:
+                print("Failed to load the the model.")
+                print(e)
+                raise
+
+        else:
+            raise ValueError(f"invalid task type {self._task_type}")
+
+    def predict(self, context: mlflow.pyfunc.PythonModelContext, input_data: pd.DataFrame) -> pd.DataFrame:
+        """Perform inference on the input data.
+
+        :param context: MLflow context containing artifacts that the model can use for inference
+        :type context: mlflow.pyfunc.PythonModelContext
+        :param input_data: input images, either as publicly accessible urls or base64 strings
+        :type input_data: Pandas DataFrame with column "image"
+        :return: image embeddings
+        :rtype: Pandas DataFrame with column "image_features"
+        """
+        from vision_utils import process_image
+
+        # Initialize the result embedding list to empty.
+        embeddings = []
+
+        # Go through the input images.
+        for image in input_data[MLflowSchemaLiterals.INPUT_COLUMN_IMAGE]:
+            # Decode the image and make a PIL Image object.
+            pil_image = Image.open(io.BytesIO(process_image(image)))
+
+            # Do inference and extract the embeddings out of the output structure.
+            inputs = self._processor(images=pil_image, return_tensors="pt")
+            outputs = self._model(**{
+                key: inputs[key].to(self._device) for key in inputs
+            })
+            embedding = outputs.last_hidden_state[0, 0, :]
+
+            # Offload to CPU, convert to Python list and accumulate into result embedding list.
+            embedding = embedding.detach().cpu().numpy().tolist()
+            embeddings.append(embedding)
+
+        # Convert embeddings to Pandas dataframe and return.
+        df_responses = pd.DataFrame({MLflowSchemaLiterals.OUTPUT_COLUMN_IMAGE_FEATURES: embeddings})
+        return df_responses

--- a/assets/training/model_management/tests/unittests/test_preprocess.py
+++ b/assets/training/model_management/tests/unittests/test_preprocess.py
@@ -274,7 +274,7 @@ class TestFactoryModule(unittest.TestCase):
         output_dir = "/path/to/output_dir"
         temp_dir = "/path/to/temp_dir"
 
-        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS.value}
+        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS_CLIP.value}
         mock_convertor = mock_clip_factory.create_mlflow_convertor.return_value
         result = get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, translate_params)
         self.assertEqual(result, mock_convertor)

--- a/assets/training/model_management/tests/unittests/test_preprocess.py
+++ b/assets/training/model_management/tests/unittests/test_preprocess.py
@@ -274,7 +274,7 @@ class TestFactoryModule(unittest.TestCase):
         output_dir = "/path/to/output_dir"
         temp_dir = "/path/to/temp_dir"
 
-        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS_CLIP.value}
+        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS.value}
         mock_convertor = mock_clip_factory.create_mlflow_convertor.return_value
         result = get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, translate_params)
         self.assertEqual(result, mock_convertor)
@@ -354,7 +354,7 @@ class TestFactoryModule(unittest.TestCase):
         output_dir = "/path/to/output_dir"
         temp_dir = "/path/to/temp_dir"
 
-        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS_DINOV2.value}
+        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS.value}
         mock_convertor = mock_dinov2_factory.create_mlflow_convertor.return_value
         result = get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, translate_params)
         self.assertEqual(result, mock_convertor)

--- a/assets/training/model_management/tests/unittests/test_preprocess.py
+++ b/assets/training/model_management/tests/unittests/test_preprocess.py
@@ -346,6 +346,25 @@ class TestFactoryModule(unittest.TestCase):
             translate_params,
         )
 
+    @patch("azureml.model.mgmt.processors.factory.DinoV2MLflowConvertorFactory")
+    def test_get_dinov2_embeddings_mlflow_convertor(self, mock_dinov2_factory):
+        """Test clip model MLflow convertor."""
+        model_framework = ModelFramework.HUGGINGFACE.value
+        model_dir = "/path/to/model_dir"
+        output_dir = "/path/to/output_dir"
+        temp_dir = "/path/to/temp_dir"
+
+        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS_DINOV2.value}
+        mock_convertor = mock_dinov2_factory.create_mlflow_convertor.return_value
+        result = get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, translate_params)
+        self.assertEqual(result, mock_convertor)
+        mock_dinov2_factory.create_mlflow_convertor.assert_called_once_with(
+            model_dir,
+            output_dir,
+            temp_dir,
+            translate_params,
+        )
+
     def test_get_mlflow_convertor_unsupported_task_hf(self):
         """Test unsupported task case."""
         model_framework = "Huggingface"

--- a/assets/training/model_management/tests/unittests/test_preprocess.py
+++ b/assets/training/model_management/tests/unittests/test_preprocess.py
@@ -14,6 +14,7 @@ from azureml.model.mgmt.processors.factory import (
     SupportedVisionTasks,
     SupportedTasks,
     MMLabDetectionTasks,
+    ModelFamilyPrefixes,
     PyFuncSupportedTasks,
     TextToImageMLflowConvertorFactory,
 )
@@ -274,7 +275,7 @@ class TestFactoryModule(unittest.TestCase):
         output_dir = "/path/to/output_dir"
         temp_dir = "/path/to/temp_dir"
 
-        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS.value}
+        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS.value, "model_id": ModelFamilyPrefixes.CLIP.value}
         mock_convertor = mock_clip_factory.create_mlflow_convertor.return_value
         result = get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, translate_params)
         self.assertEqual(result, mock_convertor)
@@ -354,7 +355,7 @@ class TestFactoryModule(unittest.TestCase):
         output_dir = "/path/to/output_dir"
         temp_dir = "/path/to/temp_dir"
 
-        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS.value}
+        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS.value, "model_id": ModelFamilyPrefixes.DINOV2.value}
         mock_convertor = mock_dinov2_factory.create_mlflow_convertor.return_value
         result = get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, translate_params)
         self.assertEqual(result, mock_convertor)

--- a/assets/training/model_management/tests/unittests/test_preprocess.py
+++ b/assets/training/model_management/tests/unittests/test_preprocess.py
@@ -355,7 +355,9 @@ class TestFactoryModule(unittest.TestCase):
         output_dir = "/path/to/output_dir"
         temp_dir = "/path/to/temp_dir"
 
-        translate_params = {"task": PyFuncSupportedTasks.EMBEDDINGS.value, "model_id": ModelFamilyPrefixes.DINOV2.value}
+        translate_params = {
+            "task": PyFuncSupportedTasks.EMBEDDINGS.value, "model_id": ModelFamilyPrefixes.DINOV2.value
+        }
         mock_convertor = mock_dinov2_factory.create_mlflow_convertor.return_value
         result = get_mlflow_convertor(model_framework, model_dir, output_dir, temp_dir, translate_params)
         self.assertEqual(result, mock_convertor)


### PR DESCRIPTION
Model publish pipeline runs for two model versions:
1. (base) https://ml.azure.com/experiments/id/d1873606-5a43-4303-9053-6fb512612c9f/runs/salmon_room_fzdtnq608y?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/phmantri_eastus/providers/Microsoft.MachineLearningServices/workspaces/phmantri_eastus_2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
2. (giant) https://ml.azure.com/experiments/id/d1873606-5a43-4303-9053-6fb512612c9f/runs/teal_sun_rgtvcp3p17?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/phmantri_eastus/providers/Microsoft.MachineLearningServices/workspaces/phmantri_eastus_2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#