### PR TITLE
Pin mltable for acft-multimodal

### DIFF
--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/requirements.txt
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/requirements.txt
@@ -23,6 +23,6 @@ aiohttp==3.9.1
 certifi==2023.07.22
 numpy==1.22
 azure-ai-ml==1.11.1
-azureml-dataprep==4.12.4
+azureml-dataprep==5.1.3
 # Downgraded azureml-metrics, to prevent bug related to logger in azureml-metrics. Should be upgraded in next pypi release of acft-multimodal
 azureml-metrics==0.0.33

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/requirements.txt
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/requirements.txt
@@ -4,7 +4,7 @@ azureml-acft-common-components=={{latest-pypi-version}}
 azureml-acft-contrib-hf-nlp=={{latest-pypi-version}}
 azureml-acft-multimodal-components=={{latest-pypi-version}}
 # needed by multimodal
-mltable=={{latest-pypi-version}}
+mltable==1.5.0
 transformers==4.36.2
 peft==0.4.0
 deepspeed==0.9.5
@@ -23,6 +23,6 @@ aiohttp==3.9.1
 certifi==2023.07.22
 numpy==1.22
 azure-ai-ml==1.11.1
-azureml-dataprep==5.1.3
+azureml-dataprep==4.12.4
 # Downgraded azureml-metrics, to prevent bug related to logger in azureml-metrics. Should be upgraded in next pypi release of acft-multimodal
 azureml-metrics==0.0.33


### PR DESCRIPTION
Spinning mltable since upgrading mltable requires upgrading dataprep which is causing build failure

Failed build: https://dev.azure.com/msdata/Vienna/_build/results?buildId=117213294&view=results