### PR TITLE
Allow evaluation results to have names similar to models

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,7 +3,11 @@
 
 ### 🐛 Bugs Fixed
 
-## 1.16.33 (2023-01-222)
+## 1.16.34 (2023-01-29)
+### 🐛 Bugs Fixed
+- [#2196](https://github.com/Azure/azureml-assets/pull/2196) Allow evaluation results to have names similar to models 
+
+## 1.16.33 (2023-01-22)
 ### 🐛 Bugs Fixed
 - [#2161](https://github.com/Azure/azureml-assets/pull/2161) Fix credential not found issue for asset validation 
 

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -31,7 +31,7 @@ WARNING_TEMPLATE = "Warning during validation of {file}: {warning}"
 # Common naming convention
 NAMING_CONVENTION_URL = "https://github.com/Azure/azureml-assets/wiki/Asset-naming-convention"
 INVALID_STRINGS = [["azureml", "azure"], "aml"]  # Disallow these in any asset name
-NON_MODEL_INVALID_STRINGS = ["microsoft"]  # Allow these in model names
+NON_MODEL_INVALID_STRINGS = ["microsoft"]  # Allow these in model names and model eval results
 NON_MODEL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_.-]{0,254}$")
 
 # Asset config convention
@@ -383,7 +383,7 @@ def validate_name(asset_config: assets.AssetConfig) -> int:
 
     # Check for invalid strings
     invalid_strings = INVALID_STRINGS + [asset_config.type.value]
-    if asset_config.type is not assets.AssetType.MODEL:
+    if asset_config.type not in [assets.AssetType.MODEL, assets.AssetType.EVALUATIONRESULT]:
         invalid_strings += [NON_MODEL_INVALID_STRINGS]
     asset_name_lowercase = asset_name.lower()
     for string_group in invalid_strings:

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -31,7 +31,8 @@ WARNING_TEMPLATE = "Warning during validation of {file}: {warning}"
 # Common naming convention
 NAMING_CONVENTION_URL = "https://github.com/Azure/azureml-assets/wiki/Asset-naming-convention"
 INVALID_STRINGS = [["azureml", "azure"], "aml"]  # Disallow these in any asset name
-NON_MODEL_INVALID_STRINGS = ["microsoft"]  # Allow these in model names and model eval results
+NON_MODEL_INVALID_STRINGS = ["microsoft"]  # Allow these in model names and other assets related to models
+MODEL_RELATED_ASSETS = [assets.AssetType.MODEL, assets.AssetType.EVALUATIONRESULT]
 NON_MODEL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_.-]{0,254}$")
 
 # Asset config convention
@@ -383,7 +384,7 @@ def validate_name(asset_config: assets.AssetConfig) -> int:
 
     # Check for invalid strings
     invalid_strings = INVALID_STRINGS + [asset_config.type.value]
-    if asset_config.type not in [assets.AssetType.MODEL, assets.AssetType.EVALUATIONRESULT]:
+    if asset_config.type not in MODEL_RELATED_ASSETS:
         invalid_strings += [NON_MODEL_INVALID_STRINGS]
     asset_name_lowercase = asset_name.lower()
     for string_group in invalid_strings:

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.33",
+   version="1.16.34",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
Currently, 'microsoft' is disallowed in asset names except for models (e.g. we publish a model named 'microsoft-phi-2').  We would like to publish evaluation results that are based on those models, so this PR updates the naming rules to allow 'microsoft' in eval results as well.