### PR TITLE
add batch allowlist for mistral base model

### DIFF
--- a/assets/models/system/Mistral-7B-v0-1/spec.yaml
+++ b/assets/models/system/Mistral-7B-v0-1/spec.yaml
@@ -29,7 +29,7 @@ tags:
       Standard_ND96amsr_A100_v4,
       Standard_ND96asr_v4,
     ]
-   batch_compute_allow_list:
+  batch_compute_allow_list:
     [
       Standard_ND40rs_v2,
       Standard_NC24ads_A100_v4,

--- a/assets/models/system/Mistral-7B-v0-1/spec.yaml
+++ b/assets/models/system/Mistral-7B-v0-1/spec.yaml
@@ -28,7 +28,16 @@ tags:
       Standard_NC96ads_A100_v4,
       Standard_ND96amsr_A100_v4,
       Standard_ND96asr_v4,
-    ]    
+    ]
+   batch_compute_allow_list:
+    [
+      Standard_ND40rs_v2,
+      Standard_NC24ads_A100_v4,
+      Standard_NC48ads_A100_v4,
+      Standard_NC96ads_A100_v4,
+      Standard_ND96amsr_A100_v4,
+      Standard_ND96asr_v4,
+    ] 
   inference_compute_allow_list:
     [
       Standard_NC12s_v3,


### PR DESCRIPTION
Add batch compute allowlist as there are several instance when models are not batch deployable on min inference sku 