### PR TITLE
updating model specific defaults and finetune config for mistral model

### DIFF
--- a/assets/models/system/Mistral-7B-v0-1/spec.yaml
+++ b/assets/models/system/Mistral-7B-v0-1/spec.yaml
@@ -48,13 +48,15 @@ tags:
     ]    
   model_specific_defaults:
     precision: "16"
-    deepspeed_stage: "3"
+    deepspeed_stage: "2"
     apply_deepspeed: "true"
     apply_ort: "true"
+    apply_lora: "true"
+    ignore_mismatched_sizes: "false"
   inference_supported_envs:
     - vllm
     - ds_mii
   license: apache-2.0
   task: text-generation
   author: mistralai
-version: 8
+version: 9


### PR DESCRIPTION
Changes
======
1. Updated finetune_config.json to remove _load_config_kwargs_. Tested these changes with preview test1 component. Sanity [run link](https://ml.azure.com/experiments/id/b7cddcb0-2b90-4476-ba3f-771acff0e2a0/runs/87c7e321-b9ee-48f8-9df0-7c59f67b36c8?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&flight=itpmerge&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)
2. Updated the defaults to include lora and disable mismatched sizes check when loading the checkpoint. Deep Speed stage is set to 2 as text-classification doesn't work with stage3 and lora.