### PR TITLE
add gsq e2e test

### DIFF
--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -41,6 +41,8 @@ logging.basicConfig(level=logging.INFO)
 
 DEFAULT_INDENT = 2
 
+TEST_CONNECTION = "test_connection"
+
 RATING = "rating"
 INDEX = "index"
 LABEL_KEYS = [RATING]
@@ -1307,6 +1309,26 @@ def _parse_responses(
         job.response_data["index_mapping"] = index_mapping
 
 
+def _get_model_type(token_manager, get_model_endpoint):
+    try:
+        headers = {
+            "Content-Type": "application/json",
+            "api-key": token_manager.get_token()
+        }
+        response = requests.get(url=get_model_endpoint, headers=headers, timeout=HTTP_REQUEST_TIMEOUT)
+        if response.status_code == 200:
+            response_data = response.json()
+            model_type = response_data["model"]
+        else:
+            raise Exception(
+                "Received unexpected HTTP status: "
+                f"{response.status_code} {response.text}"
+            )
+    except Exception:
+        raise Exception("Error encountered while attempting to get model type")
+    return model_type
+
+
 class _JobManager:
     """Handles batching and job state management."""
 
@@ -1350,9 +1372,18 @@ class _JobManager:
         )
         print(f"Generated prompts: \n{prompts_to_print}\n")
 
-        _request_prompt_batch(
-            jobs=jobs, token_manager=token_manager, **endpoint_args
-        )
+        if token_manager is None:
+            # Dummy responses for e2e testing
+            for job in jobs:
+                job.response_data = {
+                    "output_examples": [[{RATING: 0}] * num_samples],
+                    "index_mapping": list(range(num_samples))
+                }
+                job.status = _JobStatus.SUCCESS
+        else:
+            _request_prompt_batch(
+                jobs=jobs, token_manager=token_manager, **endpoint_args
+            )
 
         responses_to_print = "\n".join(
             [f"    Response: {job.response_data}" for job in jobs]
@@ -1360,8 +1391,9 @@ class _JobManager:
         print(f"Received responses from annotation: \n{responses_to_print}\n")
 
         # Parse responses for this batch of jobs
-        for job in jobs:
-            _parse_responses(job, num_samples)
+        if token_manager is not None:
+            for job in jobs:
+                _parse_responses(job, num_samples)
 
         # TODO handle errors and attempt retries
         job_results = [
@@ -1622,49 +1654,46 @@ def apply_annotation(
             "TID",
         ]
     }
-    try:
-        # Define authorization token manager
-        token_manager_class = _WorkspaceConnectionTokenManager
+    is_test_connection = False
+    if workspace_connection_arm_id == TEST_CONNECTION:
+        # Used for testing component e2e without consuming OpenAI endpoint
+        endpoint_domain_name = TEST_CONNECTION
+        api_version = "2023-07-01-preview"
+        is_test_connection = True
+        token_manager = None
+    else:
+        try:
+            # Define authorization token manager
+            token_manager_class = _WorkspaceConnectionTokenManager
 
-        token_manager = token_manager_class(
-            connection_name=workspace_connection_arm_id,
-            auth_header=API_KEY
+            token_manager = token_manager_class(
+                connection_name=workspace_connection_arm_id,
+                auth_header=API_KEY
+            )
+        except Exception as e:
+            print(f"Unable to process request: {e}")
+            return
+
+        endpoint_domain_name = token_manager.get_endpoint_domain().replace("https://", "")
+        api_version = token_manager.get_api_version()
+
+        print(
+            "Created token manager for auth type "
+            f"managed identity using auth header {API_KEY}."
         )
-    except Exception as e:
-        print(f"Unable to process request: {e}")
-        return
-
-    endpoint_domain_name = token_manager.get_endpoint_domain().replace("https://", "")
-    api_version = token_manager.get_api_version()
-
-    print(
-        "Created token manager for auth type "
-        f"managed identity using auth header {API_KEY}."
-    )
     endpoint_args["azure_endpoint_domain_name"] = endpoint_domain_name
     endpoint_args["azure_openai_api_version"] = api_version
 
-    # use fixed API version since newer versions aren't supported
-    get_model_endpoint = _check_and_format_azure_endpoint_url(AZURE_OPENAI_API_DEPLOYMENT_URL_PATTERN,
-                                                              AZURE_ENDPOINT_DOMAIN_VALID_PATTERN_RE,
-                                                              endpoint_domain_name, "2022-12-01",
-                                                              model_deployment_name)
-    try:
-        headers = {
-            "Content-Type": "application/json",
-            "api-key": token_manager.get_token()
-        }
-        response = requests.get(url=get_model_endpoint, headers=headers, timeout=HTTP_REQUEST_TIMEOUT)
-        if response.status_code == 200:
-            response_data = response.json()
-            model_type = response_data["model"]
-        else:
-            raise Exception(
-                "Received unexpected HTTP status: "
-                f"{response.status_code} {response.text}"
-            )
-    except Exception:
-        raise Exception("Error encountered while attempting to get model type")
+    if is_test_connection:
+        model_type = GPT_4
+    else:
+        # use fixed API version since newer versions aren't supported
+        get_model_endpoint = _check_and_format_azure_endpoint_url(
+            AZURE_OPENAI_API_DEPLOYMENT_URL_PATTERN,
+            AZURE_ENDPOINT_DOMAIN_VALID_PATTERN_RE,
+            endpoint_domain_name, "2022-12-01",
+            model_deployment_name)
+        model_type = _get_model_type(token_manager, get_model_endpoint)
 
     request_args["max_tokens"] = BASE_MAX_TOKENS * MODEL_TYPE_FACTOR[model_type]
     max_inputs = BASE_MAX_INPUTS * MODEL_TYPE_FACTOR[model_type]

--- a/assets/model_monitoring/components/tests/e2e/conftest.py
+++ b/assets/model_monitoring/components/tests/e2e/conftest.py
@@ -471,12 +471,62 @@ def publish_model_performance_model_monitor_component(
         print(f"Successfully published {component['name']}.")
 
 
+def format_component_name(component_name, asset_version):
+    """Format the component name as an azureml asset."""
+    return f"azureml:{component_name}:{asset_version}"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def publish_generation_safety_signal_monitor_component(
+    main_worker_lock,
+    publish_command_components,
+    model_monitoring_components,
+    root_temporary_directory,
+    asset_version,
+    ml_client,
+):
+    """Publish the data drift model monitor pipeline component to the test workspace."""
+    if not _is_main_worker(main_worker_lock):
+        return
+
+    print_header("Publishing Generation Safety Signal Monitor")
+    out_directory = os.path.join(root_temporary_directory, "command_components")
+    os.makedirs(out_directory, exist_ok=True)
+
+    for component in model_monitoring_components:
+        if component["name"] != "generation_safety_quality_signal_monitor":
+            continue
+        print(f"Publishing {component['name']}..")
+        jobs = component["jobs"]
+        jobs["compute_metrics"]["component"] = format_component_name(
+            "gsq_annotation_compute_metrics", asset_version
+        )
+        jobs["compute_histogram"]["component"] = format_component_name(
+            "gsq_annotation_compute_histogram", asset_version
+        )
+        jobs["output_signal_metrics"]["component"] = format_component_name(
+            "model_monitor_metric_outputter", asset_version
+        )
+        jobs["evaluate_metric_thresholds"][
+            "component"
+        ] = format_component_name("model_monitor_evaluate_metrics_threshold",
+                                  asset_version)
+        component["version"] = asset_version
+        spec_path = os.path.join(
+            out_directory, f"{component['name']}-{generate_random_filename('yaml')}"
+        )
+        write_to_yaml(spec_path, component)
+        ml_client.components.create_or_update(load_component(spec_path))
+        print(f"Successfully published {component['name']}.")
+
+
 @pytest.fixture(scope="session", autouse=True)
 def release_lock(
     publish_data_quality_model_monitor_component,
     publish_prediction_drift_model_monitor_component,
     publish_data_drift_model_monitor_component,
     publish_feature_attr_drift_signal_monitor_component,
+    publish_generation_safety_signal_monitor_component,
     publish_command_components,
     publish_model_performance_model_monitor_component,
     main_worker_lock,

--- a/assets/model_monitoring/components/tests/e2e/test_generation_safety_quality_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_generation_safety_quality_e2e.py
@@ -1,0 +1,85 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""This file contains e2e tests for the data drift model monitor component."""
+
+import pytest
+from azure.ai.ml import MLClient, Output
+from azure.ai.ml.dsl import pipeline
+from azure.ai.ml.exceptions import JobException
+from tests.e2e.utils.constants import (
+    COMPONENT_NAME_GENERATION_SAFETY_QUALITY_SIGNAL_MONITOR,
+    DATA_ASSET_GROUNDEDNESS_PREPROCESSED_TARGET_DATA
+)
+
+
+def _submit_generation_safety_quality_model_monitor_job(
+    ml_client, get_component, experiment_name, production_data
+):
+    generation_safety_quality_signal_monitor = get_component(
+        COMPONENT_NAME_GENERATION_SAFETY_QUALITY_SIGNAL_MONITOR
+    )
+
+    metrics = [
+        "AcceptableCoherenceScorePerInstance",
+        "AggregatedCoherencePassRate",
+        "AcceptableFluencyScorePerInstance",
+        "AggregatedFluencyPassRate",
+        "AggregatedGroundednessPassRate",
+        "AcceptableGroundednessScorePerInstance",
+        "AggregatedRelevancePassRate",
+        "AcceptableRelevanceScorePerInstance"
+    ]
+    metric_names = ",".join(metrics)
+
+    @pipeline()
+    def _generation_safety_quality_signal_monitor_e2e():
+        generation_safety_quality_signal_monitor_output = generation_safety_quality_signal_monitor(
+            signal_name="my-gsq-signal",
+            monitor_name="my-gsq-model-monitor",
+            production_data=production_data,
+            metric_names=metric_names,
+            model_deployment_name="gpt-4",
+            sample_rate=1,
+            monitor_current_time="2023-02-02T00:00:00Z",
+            workspace_connection_arm_id="test_connection",
+            prompt_column_name="question",
+            completion_column_name="answer"
+        )
+        return {
+            "signal_output": generation_safety_quality_signal_monitor_output.outputs.signal_output
+        }
+
+    pipeline_job = _generation_safety_quality_signal_monitor_e2e()
+    pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
+
+    pipeline_job = ml_client.jobs.create_or_update(
+        pipeline_job, experiment_name=experiment_name, skip_validation=True
+    )
+
+    # Wait until the job completes
+    try:
+        ml_client.jobs.stream(pipeline_job.name)
+    except JobException:
+        # ignore JobException to return job final status
+        pass
+
+    return ml_client.jobs.get(pipeline_job.name)
+
+
+@pytest.mark.e2e
+class TestGenerationSafetyQualityModelMonitor:
+    """Test class for GSQ."""
+
+    def test_generation_safety_quality_successful(
+        self, ml_client: MLClient, get_component, test_suite_name
+    ):
+        """Test GSQ is successful with expected data."""
+        pipeline_job = _submit_generation_safety_quality_model_monitor_job(
+            ml_client,
+            get_component,
+            test_suite_name,
+            DATA_ASSET_GROUNDEDNESS_PREPROCESSED_TARGET_DATA
+        )
+
+        assert pipeline_job.status == "Completed"

--- a/assets/model_monitoring/components/tests/e2e/utils/constants.py
+++ b/assets/model_monitoring/components/tests/e2e/utils/constants.py
@@ -113,7 +113,7 @@ DATA_ASSET_IRIS_MODEL_INPUTS_OUTPUTS_WITH_NO_DRIFT = (
 DATA_ASSET_MODEL_INPUTS_JOIN_COLUMN_NAME = 'model_inputs_join_column'
 DATA_ASSET_MODEL_OUTPUTS_JOIN_COLUMN_NAME = 'model_outputs_join_column'
 # Groundedness target dataset as a MLTable.
-DATA_ASSET_GROUNDEDNESS_PREPROCESSED_TARGET_DATA = 'azureml:groundedness_preprocess_target_small:1'
+DATA_ASSET_GROUNDEDNESS_PREPROCESSED_TARGET_DATA = 'azureml:mltable_groundedness_preprocessed_target_small:1'
 
 # For Data Quality with timestamp and boolean type in the MLTable
 DATA_ASSET_VALID_DATATYPE = 'azureml:mltable_validate_datatype_for_data_quality:1'


### PR DESCRIPTION
Add e2e test for generation safety quality component used for model monitoring.

![image](https://github.com/Azure/azureml-assets/assets/24683184/44b61cfb-d176-49bc-b8f2-d60791d1a69a)

The component uses a "test_connection" in the e2e test to avoid calling an openai endpoint so that the component logic is tested without adding complex endpoint setup.