### PR TITLE
update phi models with lora support

### DIFF
--- a/assets/models/system/microsoft-phi-1-5/spec.yaml
+++ b/assets/models/system/microsoft-phi-1-5/spec.yaml
@@ -40,8 +40,9 @@ tags:
   license: other
   model_specific_defaults:
     apply_deepspeed: 'true'
-    apply_lora: 'false'
+    apply_lora: 'true'
     apply_ort: 'false'
     precision: 16
+    ignore_mismatched_sizes: 'false'
   task: text-generation
-version: 6
+version: 7

--- a/assets/models/system/microsoft-phi-2/spec.yaml
+++ b/assets/models/system/microsoft-phi-2/spec.yaml
@@ -43,8 +43,9 @@ tags:
   license: mit
   model_specific_defaults:
     apply_deepspeed: 'true'
-    apply_lora: 'false'
+    apply_lora: 'true'
     apply_ort: 'false'
     precision: 16
+    ignore_mismatched_sizes: 'false'
   task: text-generation
-version: 8
+version: 9


### PR DESCRIPTION
Changes
======
1. Phi-2
> Finetune config updated.
- upgraded version from 1->2
![image](https://github.com/Azure/azureml-assets/assets/12165281/52b6cf8f-5511-49b3-8cb8-2a7626c1b0a3)
> model defaults updated
- lora enabled by default
- _ignore_mismatched_sizes_ set to false


2. Phi-1.5
> Finetune config updated.
- upgraded version from 1->2
![image](https://github.com/Azure/azureml-assets/assets/12165281/8518db45-8bd6-4980-a673-0e81fd1223e2)
> model defaults updated
- lora enabled by default
- _ignore_mismatched_sizes_ set to false

