### PR TITLE
Update autogenerated RAG flows to use Index Lookup

### DIFF
--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
@@ -162,6 +162,7 @@ jobs:
     component: 'azureml:llm_rag_create_promptflow:0.0.62'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
+      mlindex_asset_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
       llm_connection_name: ${{parent.inputs.llm_connection}}
       llm_config: ${{parent.inputs.llm_config}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_user_id/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_user_id/spec.yaml
@@ -166,6 +166,7 @@ jobs:
       type: user_identity
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
+      mlindex_asset_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
       llm_connection_name: ${{parent.inputs.llm_connection}}
       llm_config: ${{parent.inputs.llm_config}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
@@ -151,6 +151,7 @@ jobs:
     component: 'azureml:llm_rag_create_promptflow:0.0.62'
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
+      mlindex_asset_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
       llm_connection_name: ${{parent.inputs.llm_connection}}
       llm_config: ${{parent.inputs.llm_config}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_user_id/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_user_id/spec.yaml
@@ -155,6 +155,7 @@ jobs:
       type: user_identity
     inputs:
       mlindex_asset_id: ${{parent.jobs.register_mlindex_asset_job.outputs.asset_id}}
+      mlindex_asset_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       mlindex_name: ${{parent.inputs.embeddings_dataset_name}}
       llm_connection_name: ${{parent.inputs.llm_connection}}
       llm_config: ${{parent.inputs.llm_config}}

--- a/assets/large_language_models/rag/components/create_promptflow/spec.yaml
+++ b/assets/large_language_models/rag/components/create_promptflow/spec.yaml
@@ -19,11 +19,16 @@ inputs:
     description: "JSON file containing prompt options to create variants from. Must either have single key of 'best_prompt' with a value of a list of prompt strings or have best prompts specific to certain metrics."
   mlindex_asset_id:
     type: uri_file
+    mode: ro_mount
     description: "Asset ID for MLIndex file that contains information about index to use for document lookup in promptflow"
   mlindex_name:
     type: string
     optional: true
     description: "Name of the MLIndex asset"
+  mlindex_asset_uri:
+    type: uri_folder
+    mode: direct
+    description: Folder containing MLIndex to use in the generated flow.
   llm_connection_name:
     type: string
     optional: true
@@ -47,6 +52,7 @@ code: '../src'
 command: >-
   python flow_creation.py
   --mlindex_asset_id '${{inputs.mlindex_asset_id}}'
+  --mlindex_asset_uri '${{inputs.mlindex_asset_uri}}'
   $[[--best_prompts '${{inputs.best_prompts}}']]
   $[[--mlindex_name '${{inputs.mlindex_name}}']]
   $[[--llm_connection_name '${{inputs.llm_connection_name}}']]

--- a/assets/large_language_models/rag/components/create_promptflow/spec.yaml
+++ b/assets/large_language_models/rag/components/create_promptflow/spec.yaml
@@ -19,7 +19,6 @@ inputs:
     description: "JSON file containing prompt options to create variants from. Must either have single key of 'best_prompt' with a value of a list of prompt strings or have best prompts specific to certain metrics."
   mlindex_asset_id:
     type: uri_file
-    mode: ro_mount
     description: "Asset ID for MLIndex file that contains information about index to use for document lookup in promptflow"
   mlindex_name:
     type: string
@@ -27,7 +26,7 @@ inputs:
     description: "Name of the MLIndex asset"
   mlindex_asset_uri:
     type: uri_folder
-    mode: direct
+    mode: ro_mount
     description: Folder containing MLIndex to use in the generated flow.
   llm_connection_name:
     type: string

--- a/assets/large_language_models/rag/components/src/flow_creation.py
+++ b/assets/large_language_models/rag/components/src/flow_creation.py
@@ -281,8 +281,8 @@ def main(args, ws, current_run, activity_logger: Logger):
     print(mlindex_asset_id)
     print(top_prompts)
 
-    with open(mlindex_asset_id, "r") as f:
-        mlindex_content = f.read()
+    with open(os.path.join(args.mlindex_asset_uri, "MLIndex"), "r", encoding="utf-8") as src:
+        mlindex_content = src.read()
 
     if isinstance(top_prompts, str):
         top_prompts = [top_prompts, top_prompts, top_prompts]
@@ -432,6 +432,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--best_prompts", type=str)
     parser.add_argument("--mlindex_asset_id", type=str)
+    parser.add_argument("--mlindex_asset_uri", type=str)
     parser.add_argument("--mlindex_name", type=str, required=False,
                         dest='mlindex_name', default='Baker_Example_With_Variants')
     parser.add_argument(

--- a/assets/large_language_models/rag/components/src/flow_creation.py
+++ b/assets/large_language_models/rag/components/src/flow_creation.py
@@ -8,6 +8,7 @@ import errno
 import uuid
 
 import requests
+import textwrap
 import traceback
 import time
 from pathlib import Path
@@ -280,6 +281,9 @@ def main(args, ws, current_run, activity_logger: Logger):
     print(mlindex_asset_id)
     print(top_prompts)
 
+    with open(mlindex_asset_id, "r") as f:
+        mlindex_content = f.read()
+
     if isinstance(top_prompts, str):
         top_prompts = [top_prompts, top_prompts, top_prompts]
 
@@ -311,6 +315,8 @@ def main(args, ws, current_run, activity_logger: Logger):
         "@@Completion_Provider", completion_provider)
     flow_with_variants = flow_with_variants.replace(
         "@@MLIndex_Asset_Id", mlindex_asset_id)
+    flow_with_variants = flow_with_variants.replace(
+        "@@MLIndex_Content", textwrap.indent(mlindex_content, '      '))
 
     api_name = "chat" if completion_model_name.startswith("gpt-") else "completion"
     flow_with_variants = flow_with_variants.replace("@@API", api_name)

--- a/assets/large_language_models/rag/components/src/flow_yamls/chat_flow.dag.yaml
+++ b/assets/large_language_models/rag/components/src/flow_yamls/chat_flow.dag.yaml
@@ -34,33 +34,24 @@ nodes:
   api: @@API
   module: promptflow.tools.aoai
   use_variants: false
-- name: embed_the_question
+- name: lookup_question_from_indexed_docs
   type: python
   source:
     type: package
-    tool: promptflow.tools.embedding.embedding
+    tool: promptflow_vectordb.tool.common_index_lookup.search
   inputs:
-    connection: @@Embedding_Connection
-    deployment_name: @@Embedding_Deployment_Name
-    input: ${modify_query_with_history.output}
-  aggregation: false
-- name: search_question_from_indexed_docs
-  type: python
-  source:
-    type: package
-    tool: promptflow_vectordb.tool.vector_index_lookup.VectorIndexLookup.search
-  inputs:
-    path: @@MLIndex_Asset_Id
-    query: ${embed_the_question.output}
+    mlindex_content: >
+@@MLIndex_Content
+    queries: ${modify_query_with_history.output}
+    query_type: Vector
     top_k: 2
-  aggregation: false
 - name: generate_prompt_context
   type: python
   source:
     type: code
     path: generate_prompt_context.py
   inputs:
-    search_result: ${search_question_from_indexed_docs.output}
+    search_result: ${lookup_question_from_indexed_docs.output}
   aggregation: false
 - name: Prompt_variants
   use_variants: true

--- a/assets/large_language_models/rag/components/src/flow_yamls/chat_flow.dag.yaml
+++ b/assets/large_language_models/rag/components/src/flow_yamls/chat_flow.dag.yaml
@@ -23,7 +23,7 @@ nodes:
     temperature: 1
     top_p: 1
     stop: ""
-    max_tokens: 0
+    max_tokens: 1000
     presence_penalty: 0
     frequency_penalty: 0
     logit_bias: ""

--- a/assets/large_language_models/rag/components/src/flow_yamls/flow.dag.yaml
+++ b/assets/large_language_models/rag/components/src/flow_yamls/flow.dag.yaml
@@ -8,33 +8,24 @@ outputs:
     reference: ${answer_the_question_with_context.output}
     evaluation_only: false
 nodes:
-- name: embed_the_question
+- name: lookup_question_from_indexed_docs
   type: python
   source:
     type: package
-    tool: promptflow.tools.embedding.embedding
+    tool: promptflow_vectordb.tool.common_index_lookup.search
   inputs:
-    connection: @@Embedding_Connection
-    deployment_name: @@Embedding_Deployment_Name
-    input: ${flow.question}
-  aggregation: false
-- name: search_question_from_indexed_docs
-  type: python
-  source:
-    type: package
-    tool: promptflow_vectordb.tool.vector_index_lookup.VectorIndexLookup.search
-  inputs:
-    path: @@MLIndex_Asset_Id
-    query: ${embed_the_question.output}
+    mlindex_content: >
+@@MLIndex_Content
+    queries: ${flow.question}
+    query_type: Vector
     top_k: 2
-  aggregation: false
 - name: generate_prompt_context
   type: python
   source:
     type: code
     path: generate_prompt_context.py
   inputs:
-    search_result: ${search_question_from_indexed_docs.output}
+    search_result: ${lookup_question_from_indexed_docs.output}
   aggregation: false
 - name: Prompt_variants
   use_variants: true


### PR DESCRIPTION
This PR updates the autogenerated flow that is produced at the end of index build, so that lookups are performed with the new Index Lookup tool, instead of the legacy Vector Index Lookup tool.

Pipeline run from test: https://ml.azure.com/runs/94b25ea7-5060-41fa-817f-b4ace4d8a146?wsid=/subscriptions/79a1ba0c-35bb-436b-bff2-3074d5ff1f89/resourceGroups/azureml-rag-ci/providers/Microsoft.MachineLearningServices/workspaces/azureml-rag-eastus2euap&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#

Generated sample flow from test: https://ml.azure.com/prompts/flow/77e30de2-0c14-4aac-8154-37d5131034e0/e9c2a569-f840-4a04-84bc-f0bf37afdc8d/details?wsid=/subscriptions/79a1ba0c-35bb-436b-bff2-3074d5ff1f89/resourceGroups/azureml-rag-ci/providers/Microsoft.MachineLearningServices/workspaces/azureml-rag-eastus2euap&tid=72f988bf-86f1-41af-91ab-2d7cd011db47