### PR TITLE
Revert "added maas-inference tag for mistral models (#2178)"

### DIFF
--- a/assets/models/system/Mistral-7B-Instruct-v0-1/spec.yaml
+++ b/assets/models/system/Mistral-7B-Instruct-v0-1/spec.yaml
@@ -11,7 +11,6 @@ tags:
   Featured: ""
   Preview: ""
   SharedComputeCapacityEnabled: ""
-  maas-inference: true
   disable-batch: "true"
   inference_compute_allow_list:
     [

--- a/assets/models/system/Mistral-7B-v0-1/spec.yaml
+++ b/assets/models/system/Mistral-7B-v0-1/spec.yaml
@@ -15,7 +15,6 @@ properties:
 tags:
   Featured: ""
   SharedComputeCapacityEnabled: ""
-  maas-inference: true
   huggingface_model_id: mistralai/Mistral-7B-v0.1
   evaluation_compute_allow_list:
     [

--- a/assets/models/system/Mixtral-8x7B-v0-1/spec.yaml
+++ b/assets/models/system/Mixtral-8x7B-v0-1/spec.yaml
@@ -10,7 +10,6 @@ tags:
   Featured: ''
   Preview: ''
   SharedComputeCapacityEnabled: ''
-  maas-inference: true
   disable-batch: 'true'
   huggingface_model_id: mistralai/Mixtral-8x7B-v0.1
   inference_compute_allow_list:

--- a/assets/models/system/mistralai-Mixtral-8x7B-Instruct-v01/spec.yaml
+++ b/assets/models/system/mistralai-Mixtral-8x7B-Instruct-v01/spec.yaml
@@ -10,7 +10,6 @@ tags:
   Featured: ''
   Preview: ''
   SharedComputeCapacityEnabled: ''
-  maas-inference: true
   disable-batch: 'true'
   huggingface_model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
   inference_compute_allow_list:


### PR DESCRIPTION
This reverts commit f4b9e8fc57d4023f8c34c899f5d479bdcd555230.