### PR TITLE
Forecasting data type and serve model support

### DIFF
--- a/assets/responsibleai/tabular/components/src/constants.py
+++ b/assets/responsibleai/tabular/components/src/constants.py
@@ -73,6 +73,8 @@ class PropertyKeyValues:
     RAI_INSIGHTS_DATETIME_FEATURES_KEY = "datetime_features"
     RAI_INSIGHTS_TIME_SERIES_ID_FEATURES_KEY = "time_series_id_features"
 
+    RAI_INSIGHTS_DATA_TYPE_KEY = "data_type"
+
 
 class RAIToolType:
     CAUSAL = "causal"


### PR DESCRIPTION
this PR does the following:

-copies model files over to tmp directory that can be modified so that conda env can be successfully installed when the model is served
-adds forecasting data type so that UI knows when to serve model in separate container
