### PR TITLE
Propogate the system error to RH

### DIFF
--- a/assets/training/model_management/src/azureml/model/mgmt/utils/exceptions.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/utils/exceptions.py
@@ -10,6 +10,9 @@ from azureml._common.exceptions import AzureMLException
 from azureml._common._error_definition.azureml_error import AzureMLError  # type: ignore
 from azureml._common._error_definition.system_error import ClientError  # type: ignore
 
+from azureml.core.run import Run  # type: ignore
+from azureml.automl.core._run import run_lifecycle_utilities
+
 
 class ModelImportErrorStrings:
     """Error strings."""
@@ -207,6 +210,11 @@ def swallow_all_exceptions(logger: logging.Logger):
                 logger.error("Exception {} when calling {}".format(azureml_exception, func.__name__))
                 for handler in logger.handlers:
                     handler.flush()
+
+                # fail the run
+                run = Run.get_context()
+                run_lifecycle_utilities.fail_run(run, azureml_exception, is_aml_compute=True)
+
                 raise azureml_exception
             finally:
                 time.sleep(60)  # Let telemetry logger flush its logs before terminating.

--- a/assets/training/model_management/tests/dev_conda_env.yaml
+++ b/assets/training/model_management/tests/dev_conda_env.yaml
@@ -11,6 +11,7 @@ dependencies:
   - azureml-mlflow~=1.51.0
   - azure-ai-ml~=1.8.0
   - azureml-core~=1.52.0
+  - azureml-automl-core~=1.52.0
   - azureml-telemetry~=1.52.0
   - azureml-evaluate-mlflow~=0.0.19
   - langcodes


### PR DESCRIPTION
Problem
=====
Command component is failing w/ system error which is not getting updated in RH. Sample run to that effect - [Link](https://ml.azure.com/experiments/id/dcf08ea3-32a7-4026-affe-8847ede18d36/runs/3066b823-3c9e-4095-8a47-a7ae1a6096e8?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)
> Error in the component
![image](https://github.com/Azure/azureml-assets/assets/12165281/aeed1d09-6758-4f3e-aba9-159f4548a603)
> RH error
![image](https://github.com/Azure/azureml-assets/assets/12165281/654ccbca-eabe-4d83-86c6-fab99d3a0ae7)


The fix is to update the RH with correct error message before failing - Sanity run attached - [Link](https://ml.azure.com/experiments/id/dcf08ea3-32a7-4026-affe-8847ede18d36/runs/0e116cb3-edc7-4167-88c9-ea87650f0d8b?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)