### PR TITLE
Fixing model converter output name and enabling inference optimization for Text Gen task so vLLM is used

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
@@ -32,10 +32,10 @@ inputs:
     description: Validation parameters propagated from pipeline.
 
 outputs:
-  output_dir:
+  mlflow_model_folder:
     type: mlflow_model
     description: output folder containing _best_ finetuned model in mlflow format.
     mode: rw_mount
 
 command: >-
-  python model_converter.py --model_path '${{inputs.model_path}}' $[[--converted_model '${{inputs.converted_model}}']] $[[--system_properties '${{inputs.system_properties}}']] --output_dir '${{outputs.output_dir}}'
+  python model_converter.py --model_path '${{inputs.model_path}}' $[[--converted_model '${{inputs.converted_model}}']] $[[--system_properties '${{inputs.system_properties}}']] --output_dir '${{outputs.mlflow_model_folder}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
@@ -677,7 +677,7 @@ jobs:
       model_path: '${{parent.jobs.question_answering_finetune.outputs.pytorch_model_folder}}'
       converted_model: '${{parent.jobs.question_answering_finetune.outputs.mlflow_model_folder}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   model_prediction:
     type: command
     component: azureml:model_prediction:0.0.21

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
@@ -643,7 +643,7 @@ jobs:
       model_path: '${{parent.jobs.summarization_finetune.outputs.pytorch_model_folder}}'
       converted_model: '${{parent.jobs.summarization_finetune.outputs.mlflow_model_folder}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   model_prediction:
     type: command
     component: azureml:model_prediction:0.0.21

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
@@ -646,7 +646,7 @@ jobs:
       model_path: '${{parent.jobs.text_classification_finetune.outputs.pytorch_model_folder}}'
       converted_model: '${{parent.jobs.text_classification_finetune.outputs.mlflow_model_folder}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   model_prediction:
     type: command
     component: azureml:model_prediction:0.0.21

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
@@ -663,7 +663,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   model_prediction:
     type: command
     component: azureml:model_prediction:0.0.21

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
@@ -679,7 +679,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   # model_prediction:
   #   type: command
   #   component: azureml:model_prediction:0.0.16

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
@@ -679,7 +679,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   # model_prediction:
   #   type: command
   #   component: azureml:model_prediction:0.0.16

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
@@ -679,7 +679,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   # model_prediction:
   #   type: command
   #   component: azureml:model_prediction:0.0.16

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
@@ -679,7 +679,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   # model_prediction:
   #   type: command
   #   component: azureml:model_prediction:0.0.16

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
@@ -679,7 +679,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   # model_prediction:
   #   type: command
   #   component: azureml:model_prediction:0.0.16

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
@@ -679,7 +679,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   # model_prediction:
   #   type: command
   #   component: azureml:model_prediction:0.0.16

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
@@ -679,7 +679,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   # model_prediction:
   #   type: command
   #   component: azureml:model_prediction:0.0.16

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
@@ -679,7 +679,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   # model_prediction:
   #   type: command
   #   component: azureml:model_prediction:0.0.16

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
@@ -679,7 +679,7 @@ jobs:
       converted_model: '${{parent.jobs.text_generation_finetune.outputs.mlflow_model_folder}}'
       system_properties: '${{parent.inputs.system_properties}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   # model_prediction:
   #   type: command
   #   component: azureml:model_prediction:0.0.16

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
@@ -637,7 +637,7 @@ jobs:
       model_path: '${{parent.jobs.token_classification_finetune.outputs.pytorch_model_folder}}'
       converted_model: '${{parent.jobs.token_classification_finetune.outputs.mlflow_model_folder}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   model_prediction:
     type: command
     component: azureml:model_prediction:0.0.21

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
@@ -634,7 +634,7 @@ jobs:
       model_path: '${{parent.jobs.translation_finetune.outputs.pytorch_model_folder}}'
       converted_model: '${{parent.jobs.translation_finetune.outputs.mlflow_model_folder}}'
     outputs:
-      output_dir: '${{parent.outputs.mlflow_model_folder}}'
+      mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   model_prediction:
     type: command
     component: azureml:model_prediction:0.0.21

--- a/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
+++ b/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
@@ -1128,11 +1128,13 @@ def finetune(args: Namespace):
     args.save_strategy = args.evaluation_strategy
     args.save_steps = args.eval_steps
 
-    # remove "azureml.base_image" metadata for icm mitigation.
-    # icm: https://portal.microsofticm.com/imp/v3/incidents/details/458481445/home
-    removed_base_image = metadata.pop("azureml.base_image", None)
-    logger.warning(f"Removed base image meta data for mitigation of FT model not deployable issue, \
+    if args.task_name not in [Tasks.TEXT_GENERATION]:
+        removed_base_image = metadata.pop("azureml.base_image", None)
+        logger.warning(f"Removed base image meta data for mitigation of FT model not deployable issue, \
                     base image value is {removed_base_image}.")
+    else:
+        logger.info("Adding inferencing base image {} for text generation task.".format(metadata["azureml.base_image"]))
+
     args.model_metadata = update_acft_metadata(metadata=metadata,
                                                finetuning_task=args.task_name,
                                                base_model_asset_id=model_asset_id)

--- a/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
+++ b/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
@@ -1133,7 +1133,9 @@ def finetune(args: Namespace):
         logger.warning(f"Removed base image meta data for mitigation of FT model not deployable issue, \
                     base image value is {removed_base_image}.")
     else:
-        logger.info("Adding inferencing base image {} for text generation task.".format(metadata["azureml.base_image"]))
+        logger.info(
+            "Adding inferencing base image {} for text generation task.".format(metadata["azureml.base_image"])
+        )
 
     args.model_metadata = update_acft_metadata(metadata=metadata,
                                                finetuning_task=args.task_name,


### PR DESCRIPTION
Testing
===
Completed run: https://ml.azure.com/runs/ashy_napa_tm7p0ymzsc?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourcegroups/training_rg/workspaces/training_ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
Deployment and Inference: 

![image](https://github.com/Azure/azureml-assets/assets/11567326/e87a85cb-8dd2-4537-b9d6-4ed036d878d7)

Deployment logs to show vLLM was used:
![image](https://github.com/Azure/azureml-assets/assets/11567326/ff96260d-7ec2-456a-81dd-bfafe65d3ab3)
