### PR TITLE
fix gsq column name mapping for evaluation

### DIFF
--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -628,8 +628,8 @@ def apply_annotation(
                 data=rows,
                 task_type="qa",
                 data_mapping={
-                    "questions": PROMPT,
-                    "contexts": CONTEXT,
+                    "question": PROMPT,
+                    "context": CONTEXT,
                     "answer": COMPLETION,
                     "ground_truth": GROUND_TRUTH
                 },


### PR DESCRIPTION
fix gsq column name mapping for evaluation

GSQ seems to be outputting incorrect metrics (1) due to column mapping issue where promptflow is not being passed the correct columns from the generated template.