### PR TITLE
limiting the max sequence length for phi-2

### DIFF
--- a/assets/models/system/microsoft-phi-2/spec.yaml
+++ b/assets/models/system/microsoft-phi-2/spec.yaml
@@ -48,5 +48,6 @@ tags:
     apply_lora: 'false'
     apply_ort: 'false'
     precision: 16
+    max_seq_length: 1536
   task: text-generation
-version: 9
+version: 10


### PR DESCRIPTION
Changes
======
1. Limiting _max_seq_length_ to 1536 to avoid OOM issues with ND40 compute.
2. Updated the _model_specific_defaults_ to that effect.
