### PR TITLE
add evaluation to GSQ model monitoring component output

### DIFF
--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
@@ -7,7 +7,7 @@ description: Compute annotation histogram given a deployment's model data input.
 version: 0.4.12
 is_deterministic: false
 inputs:
-  production_dataset: 
+  production_dataset:
     type: mltable
     mode: direct
   metric_names:
@@ -84,6 +84,10 @@ outputs:
   relevance_violations:
     type: mltable
     mode: direct
+  evaluation:
+    type: mltable
+    mode: direct
+    description: evaluation results
 
 conf:
   spark.driver.cores: 4
@@ -147,3 +151,4 @@ args: >-
   --similarity_violations ${{outputs.similarity_violations}}
   --coherence_violations ${{outputs.coherence_violations}}
   --relevance_violations ${{outputs.relevance_violations}}
+  --evaluation ${{outputs.evaluation}}

--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -134,6 +134,8 @@ jobs:
         type: mltable
       similarity_violations:
         type: mltable
+      evaluation:
+        type: mltable
     resources:
       instance_type: ${{parent.inputs.instance_type}}
       runtime_version: "3.3"

--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py
@@ -337,6 +337,7 @@ def run():
     parser.add_argument("--similarity_violations", type=str, required=True)
 
     parser.add_argument("--workspace_connection_arm_id", type=str, required=True)
+    parser.add_argument("--evaluation", type=str, required=True)
     args = parser.parse_args()
 
     request_args = {
@@ -380,7 +381,8 @@ def run():
         completion_column_name=args.completion_column_name,
         context_column_name=args.context_column_name,
         ground_truth_column_name=args.ground_truth_column_name,
-        violations=violations
+        violations=violations,
+        evaluation=args.evaluation
     )
 
 
@@ -457,7 +459,8 @@ def apply_annotation(
     context_column_name,
     ground_truth_column_name,
     samples_index,
-    violations
+    violations,
+    evaluation
 ):
     """Apply annotation to all samples in the production_dataset."""
     metric_names = process_metric_names(metric_names)
@@ -597,8 +600,10 @@ def apply_annotation(
     all_metrics_pdf = None
     samples_index_rows = []
     metrics_list = []
+    compact_metric_names = []
     for metric_name in metric_names:
         metric_name_compact = get_compact_metric_name(metric_name)
+        compact_metric_names.append(metric_name_compact)
         column_name = COMPACT_METRIC_NAME_TO_COLUMN[metric_name_compact]
         metrics_list.append(column_name)
     has_context = CONTEXT in production_df.columns
@@ -669,8 +674,7 @@ def apply_annotation(
                     qca[CONTEXT] = row[CONTEXT]
                 if has_ground_truth:
                     qca[GROUND_TRUTH] = row[GROUND_TRUTH]
-                for metric_name in metric_names:
-                    metric_name_compact = get_compact_metric_name(metric_name)
+                for metric_name_compact in compact_metric_names:
                     qca[metric_name_compact] = 1
                 rows.append(qca)
             tabular_result = pd.DataFrame(rows)
@@ -688,8 +692,7 @@ def apply_annotation(
         schema_fields.append(StructField(GROUND_TRUTH, StringType(), True))
     if has_correlation_id:
         schema_fields.append(StructField(CORRELATION_ID, StringType(), True))
-    for metric_name in metric_names:
-        metric_name_compact = get_compact_metric_name(metric_name)
+    for metric_name_compact in compact_metric_names:
         schema_fields.append(StructField(metric_name_compact, IntegerType(), True))
     schema = StructType(schema_fields)
     if is_test_connection:
@@ -706,10 +709,9 @@ def apply_annotation(
     print("showing annotations dataframe: ")
     annotations_df.show()
 
-    for metric_name in metric_names:
+    for metric_name_compact in compact_metric_names:
         # Run inference over input dataset
-        print(f"Begin {metric_name} processing.")
-        metric_name_compact = get_compact_metric_name(metric_name)
+        print(f"Begin {metric_name_compact} processing.")
         # Get rating counts
         filtered_annotations_df = annotations_df.select(
             metric_name_compact).filter(col(metric_name_compact) != -1)
@@ -774,6 +776,15 @@ def apply_annotation(
             StructField(ASSET, StringType(), True),
         ]
     )
+
+    # Save the annotations dataframe as output
+    io_utils.save_spark_df_as_mltable(annotations_df, evaluation)
+    samples_index_rows.append({METRIC_NAME: "Evaluation",
+                               GROUP: "",
+                               GROUP_DIMENSION: "",
+                               SAMPLES_NAME: "Evaluation",
+                               ASSET: f"azureml_{run_id}_output_data_evaluation:1"})
+
     # Create a new DataFrame for the samples index data
     samples_df = spark.createDataFrame(samples_index_rows, metadata_schema)
     io_utils.save_spark_df_as_mltable(samples_df, samples_index)

--- a/assets/model_monitoring/components/tests/unit/test_gsq_histogram.py
+++ b/assets/model_monitoring/components/tests/unit/test_gsq_histogram.py
@@ -270,6 +270,8 @@ def call_apply_annotation(metric_names, prompt_column_name=QUESTION,
     for k, v in violations.items():
         violations[k] = fuse_prefix + os.path.join(test_path, v)
 
+    evaluation_path = fuse_prefix + os.path.join(test_path, "evaluation")
+
     apply_annotation(
         metric_names=metric_names,
         production_dataset=mltable_path,
@@ -286,5 +288,6 @@ def call_apply_annotation(metric_names, prompt_column_name=QUESTION,
         context_column_name=context_column_name,
         ground_truth_column_name=None,
         samples_index=samples_index_path,
-        violations=violations
+        violations=violations,
+        evaluation=evaluation_path
     )


### PR DESCRIPTION
For new model monitoring UI, GSQ component needs to output a table of question/answer/context input data with corresponding scores.  This PR adds this table as an additional output port in the GSQ model monitoring component.

Update: based on discussion in model monitoring scrum, I've removed the average scores as an output table.  These will just be added as part of the compute metrics component based on the histogram table output.

Screenshot of new output ports:
![image](https://github.com/Azure/azureml-assets/assets/24683184/1ca6201e-ac93-4d78-aa46-828491958e6d)

Screenshot of new signal output file with paths to output ports:
![image](https://github.com/Azure/azureml-assets/assets/24683184/40718c44-6e92-4e90-8a56-01780ba7b9eb)
