### PR TITLE
Upgrade cryptography to 42.0.4 to fix vulnerability issue

### DIFF
--- a/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
 RUN pip install 'pyarrow>=14.0.1'
 
 # To resolve vulnerability issue regarding crytography
-RUN pip install 'cryptography>=42.0.0'
+RUN pip install 'cryptography>=42.0.4'
 
 # Install huggingface evaluate package from source
 # see issue https://github.com/huggingface/datasets/issues/6182

--- a/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -41,7 +41,7 @@ RUN pip install 'pyarrow>=14.0.1'
 RUN pip install 'Werkzeug==2.2.3'
 
 # To resolve vulnerability issue regarding crytography
-RUN pip install 'cryptography>=42.0.0'
+RUN pip install 'cryptography>=42.0.4'
 
 # TODO: remove rai-core-flask pin with next raiwidgets release
 RUN pip install 'rai-core-flask==0.7.4'

--- a/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -43,7 +43,7 @@ RUN pip install 'shap==0.41.0' \
 RUN pip install 'pyarrow>=14.0.1'
 
 # To resolve vulnerability issue regarding crytography
-RUN pip install 'cryptography>=42.0.0'
+RUN pip install 'cryptography>=42.0.4'
 
 RUN pip freeze
 


### PR DESCRIPTION
Following are links for downloading patches to fix the vulnerabilities:
<P> <A HREF="https://github.com/advisories/GHSA-6vqw-3v5j-54x4" TARGET="_blank">GHSA-6vqw-3v5j-54x4:cryptography</A>,
"ScanResult": #table cols="5"
Package Installed_Version Required_Version Language Install_Path
cryptography 42.0.3 42.0.4 Python azureml-envs/responsibleai/lib/python3.8/site-packages/cryptography-42.0.3.dist-info/METADATA
cryptography 42.0.2 42.0.4 Python opt/miniconda/lib/python3.10/site-packages/cryptography-42.0.2.dist-info/METADATA,