### PR TITLE
Refine promptflow CI to support test_data.json config 

### DIFF
--- a/assets/promptflow/.cspell.json
+++ b/assets/promptflow/.cspell.json
@@ -148,7 +148,8 @@
       "AYOD",
       "Featur",
       "showno",
-      "amlraipfmodels"
+      "amlraipfmodels",
+      "zhizho"
     ],
     "flagWords": [
       "Prompt Flow"

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -112,8 +112,7 @@ def check_flow_run_status(
     submitted_flow_run_links,
     submitted_flow_run_ids,
     check_run_status_interval,
-    check_run_status_max_attempts,
-    subscription_id
+    check_run_status_max_attempts
 ):
     """Check flow run status."""
     for flow_run_id, flow_run_link in zip(flow_runs_to_check, submitted_flow_run_links):
@@ -123,7 +122,7 @@ def check_flow_run_status(
         while current_attempt < check_run_status_max_attempts:
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
             command = f"pfazure run show -n {flow_run_id}" \
-                f" -s {subscription_id} -g {args.resource_group} -w {args.workspace_name}"
+                f" --subscription {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
             log_debug(
                     f"command : {command}")
             res = run_command(command)
@@ -264,7 +263,7 @@ if __name__ == "__main__":
     log_debug(f"\nrun ids to check: {submitted_flow_run_ids}")
     log_debug(f"\n{flow_runs_count} bulk test runs need to check status.")
     check_flow_run_status(flow_runs_to_check, submitted_flow_run_links, submitted_flow_run_ids,
-                          check_run_status_interval, check_run_status_max_attempts, args.subscription_id)
+                          check_run_status_interval, check_run_status_max_attempts)
 
     if len(submitted_flow_run_ids) > 0:
         failure_message = f"Not all bulk test runs or bulk test evaluation runs are completed after " \

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -121,7 +121,8 @@ def check_flow_run_status(
         current_attempt = 0
         while current_attempt < check_run_status_max_attempts:
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
-            command = f"pfazure run show -n {flow_run_id} -s {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
+            command = f"pfazure run show -n {flow_run_id}" \
+                 f" -s {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
             log_debug(
                     f"command : {command}")
             res = run_command(command)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -123,6 +123,10 @@ def check_flow_run_status(
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
+                log_debug(
+                    f"error info {bulk_test_run.error}")
+                if bulk_test_run.error != null:
+                    failed_flow_runs.update({flow_run_id: flow_run_link})
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -123,9 +123,9 @@ def check_flow_run_status(
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
-                for run in bulk_test_run.get_children():
-                    log_debug(
-                        f"child run info {run}")
+                child_run = run_workspace.get_run(run_id=flow_run_id + "_0")
+                log_debug(
+                        f"child run info {child_run}")
                 log_debug(
                     f"run details with log {bulk_test_run.get_details_with_logs()}")
                 break

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -12,7 +12,7 @@ import time
 import copy
 from azureml.core import Workspace
 
-from utils.utils import get_diff_files
+from utils.utils import get_diff_files, run_command
 from utils.logging_utils import log_debug, log_error, log_warning
 from azure.storage.blob import BlobServiceClient
 from azure.identity import AzureCliCredential
@@ -121,13 +121,12 @@ def check_flow_run_status(
         current_attempt = 0
         while current_attempt < check_run_status_max_attempts:
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
+            command = f"pfazure run show --name {flow_run_id} --subscription {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
+            res = run_command(command)
+            log_debug(
+                    f"run details in res: {res}")
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
-                child_run = run_workspace.get_run(run_id=flow_run_id + "_0")
-                log_debug(
-                        f"child run info {child_run}")
-                log_debug(
-                    f"run details with log {bulk_test_run.get_details_with_logs()}")
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -124,7 +124,7 @@ def check_flow_run_status(
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
                 log_debug(
-                    f"run info {bulk_test_run}")
+                    f"run info {bulk_test_run.get_details}")
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -124,9 +124,7 @@ def check_flow_run_status(
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
                 log_debug(
-                    f"error info {bulk_test_run.error}")
-                if not bulk_test_run.error:
-                    failed_flow_runs.update({flow_run_id: flow_run_link})
+                    f"run info {bulk_test_run}")
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -112,7 +112,8 @@ def check_flow_run_status(
     submitted_flow_run_links,
     submitted_flow_run_ids,
     check_run_status_interval,
-    check_run_status_max_attempts
+    check_run_status_max_attempts,
+    subscription_id
 ):
     """Check flow run status."""
     for flow_run_id, flow_run_link in zip(flow_runs_to_check, submitted_flow_run_links):
@@ -122,7 +123,7 @@ def check_flow_run_status(
         while current_attempt < check_run_status_max_attempts:
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
             command = f"pfazure run show -n {flow_run_id}" \
-                f" -s {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
+                f" -s {subscription_id} -g {args.resource_group} -w {args.workspace_name}"
             log_debug(
                     f"command : {command}")
             res = run_command(command)
@@ -263,7 +264,7 @@ if __name__ == "__main__":
     log_debug(f"\nrun ids to check: {submitted_flow_run_ids}")
     log_debug(f"\n{flow_runs_count} bulk test runs need to check status.")
     check_flow_run_status(flow_runs_to_check, submitted_flow_run_links, submitted_flow_run_ids,
-                          check_run_status_interval, check_run_status_max_attempts)
+                          check_run_status_interval, check_run_status_max_attempts, args.subscription_id)
 
     if len(submitted_flow_run_ids) > 0:
         failure_message = f"Not all bulk test runs or bulk test evaluation runs are completed after " \

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -121,8 +121,9 @@ def check_flow_run_status(
         current_attempt = 0
         while current_attempt < check_run_status_max_attempts:
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
-            command = f"pfazure run show --name {flow_run_id}" \
-                f"--subscription {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
+            command = f"pfazure run show -n {flow_run_id} -s {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
+            log_debug(
+                    f"command : {command}")
             res = run_command(command)
             log_debug(
                     f"run details in res: {res}")

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -128,7 +128,7 @@ def check_flow_run_status(
                 res = run_command(command)
                 log_debug(f"log debug info: {res.stdout}.")
                 stdout_obj = json.loads(res.stdout)
-                log_debug(f"stdout error info: {stdout_obj.error}.")
+                log_debug(f"stdout error info: {stdout_obj.get("error")}")
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -126,7 +126,9 @@ def check_flow_run_status(
                 command = f"pfazure run show -n {flow_run_id}" \
                     f" --subscription {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
                 res = run_command(command)
-                log_debug(f"log debug info: {res.stdout.error}.")
+                log_debug(f"log debug info: {res.stdout}.")
+                stdout_obj = json.loads(res.stdout)
+                log_debug(f"stdout error info: {stdout_obj.error}.")
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -124,7 +124,7 @@ def check_flow_run_status(
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
                 log_debug(
-                    f"run info {bulk_test_run.get_details()}")
+                    f"run info {bulk_test_run.get_children()}")
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -122,7 +122,7 @@ def check_flow_run_status(
         while current_attempt < check_run_status_max_attempts:
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
             command = f"pfazure run show -n {flow_run_id}" \
-                 f" -s {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
+                f" -s {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
             log_debug(
                     f"command : {command}")
             res = run_command(command)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -124,7 +124,7 @@ def check_flow_run_status(
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
                 log_debug(
-                    f"run info {bulk_test_run.get_details}")
+                    f"run info {bulk_test_run.get_details()}")
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -123,8 +123,11 @@ def check_flow_run_status(
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
+                for run in bulk_test_run.get_children():
+                    log_debug(
+                        f"child run info {run}")
                 log_debug(
-                    f"run info {bulk_test_run.get_children()}")
+                    f"run details with log {bulk_test_run.get_details_with_logs()}")
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -125,7 +125,7 @@ def check_flow_run_status(
                 submitted_flow_run_ids.remove(flow_run_id)
                 log_debug(
                     f"error info {bulk_test_run.error}")
-                if bulk_test_run.error != null:
+                if not bulk_test_run.error:
                     failed_flow_runs.update({flow_run_id: flow_run_link})
                 break
             elif bulk_test_run.status == "Failed":

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -121,15 +121,12 @@ def check_flow_run_status(
         current_attempt = 0
         while current_attempt < check_run_status_max_attempts:
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
-            command = f"pfazure run show -n {flow_run_id}" \
-                f" --subscription {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
-            log_debug(
-                    f"command : {command}")
-            res = run_command(command)
-            log_debug(
-                    f"run details in res: {res}")
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
+                command = f"pfazure run show -n {flow_run_id}" \
+                    f" --subscription {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
+                res = run_command(command)
+                log_debug(f"log debug info: {res.stdout.error}.")
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -123,12 +123,15 @@ def check_flow_run_status(
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
             if bulk_test_run.status == "Completed":
                 submitted_flow_run_ids.remove(flow_run_id)
+                # get the run detail with error info
                 command = f"pfazure run show -n {flow_run_id}" \
                     f" --subscription {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
                 res = run_command(command)
-                log_debug(f"log debug info: {res.stdout}.")
                 stdout_obj = json.loads(res.stdout)
-                log_debug(f"stdout error info: {stdout_obj.get("error")}")
+                error_info = stdout_obj.get("error")
+                log_debug(f"stdout error info: {error_info}")
+                if error_info:
+                    failed_flow_runs.update({flow_run_id: flow_run_link})
                 break
             elif bulk_test_run.status == "Failed":
                 submitted_flow_run_ids.remove(flow_run_id)

--- a/scripts/promptflow-ci/promptflow_ci.py
+++ b/scripts/promptflow-ci/promptflow_ci.py
@@ -121,7 +121,8 @@ def check_flow_run_status(
         current_attempt = 0
         while current_attempt < check_run_status_max_attempts:
             bulk_test_run = run_workspace.get_run(run_id=flow_run_id)
-            command = f"pfazure run show --name {flow_run_id} --subscription {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
+            command = f"pfazure run show --name {flow_run_id}" \
+                f"--subscription {args.subscription_id} -g {args.resource_group} -w {args.workspace_name}"
             res = run_command(command)
             log_debug(
                     f"run details in res: {res}")

--- a/scripts/promptflow-ci/test-configs/count-cars/test_data.json
+++ b/scripts/promptflow-ci/test-configs/count-cars/test_data.json
@@ -1,0 +1,7 @@
+[
+  {
+      "image_1": {"data:image/png;path": "cars1.jpg"},
+      "image_2": {"data:image/png;path": "cars2.jpg"},
+      "system_message": "You are an AI assistant. You task is to check the number of red cars in the image. Reply in plain json, with key \"red cars\", and possible values of number of red cars."
+  }
+]

--- a/scripts/promptflow-ci/test-configs/detect-defects/test_data.json
+++ b/scripts/promptflow-ci/test-configs/detect-defects/test_data.json
@@ -1,0 +1,7 @@
+[
+  {
+      "reference_image": {"data:image/png;path": "DefectDetectorReference.jpg"},
+      "test_image": {"data:image/png;path": "DefectDetectorTest.jpg"},
+      "system_message": "You're a professional defect detector.\r\nYour job is to compare the test image with reference image, please answer the question with \"No defect detected\" or \"Defect detected\", \r\nalso explain your decision as detail as possible."
+  }
+]

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -53,7 +53,7 @@ def _assign_flow_values(flow_dirs):
                 yaml.dump(flow_dag, dag_file, allow_unicode=True)
         test_data_file = Path(os.path.join(config_dir, TEST_DATA_FILE))
         if config_dir.exists() and test_data_file.exists():
-            log_debug(f"Using the test_data.json file from the test-configs to run the flow.")
+            log_debug("Using the test_data.json file from the test-configs to run the flow.")
             shutil.copy(os.path.join(config_dir, TEST_DATA_FILE), flow_dir)
         else:
             with open(flow_dir/"test_data.json", 'w', encoding="utf-8") as data_file:

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import shutil
 from pathlib import Path
 import yaml
 import concurrent.futures
@@ -16,6 +17,7 @@ from utils.utils import run_command
 
 CONFIG_ROOT = 'scripts/promptflow-ci/test-configs'
 CONFIG_FILE = 'test_config.json'
+TEST_DATA_FILE = 'test_data.json'
 
 
 def _assign_flow_values(flow_dirs):
@@ -49,10 +51,14 @@ def _assign_flow_values(flow_dirs):
 
             with open(flow_dir / "flow.dag.yaml", "w", encoding="utf-8") as dag_file:
                 yaml.dump(flow_dag, dag_file, allow_unicode=True)
-        if not os.path.exists(Path(flow_dir)/"samples.json"):
-            with open(flow_dir/"samples.json", 'w', encoding="utf-8") as sample_file:
-                samples = []
-                sample = {}
+        test_data_file = Path(os.path.join(config_dir, TEST_DATA_FILE))
+        if config_dir.exists() and test_data_file.exists():
+            log_debug(f"Using the test_data.json file from the test-configs to run the flow.")
+            shutil.copy(os.path.join(config_dir, TEST_DATA_FILE), flow_dir)
+        else:
+            with open(flow_dir/"test_data.json", 'w', encoding="utf-8") as data_file:
+                datas = []
+                data = {}
                 for key, val in flow_dag["inputs"].items():
                     value = val.get("default")
                     if isinstance(value, list):
@@ -61,9 +67,9 @@ def _assign_flow_values(flow_dirs):
                     elif isinstance(value, str):
                         if value == "":
                             value = "default"
-                    sample[key] = value
-                samples.append(sample)
-                json.dump(sample, sample_file, indent=4)
+                    data[key] = value
+                datas.append(data)
+                json.dump(datas, data_file, indent=4)
     log_debug("=======Complete overriding values for flows=======\n")
     return flow_dirs
 
@@ -74,7 +80,7 @@ def _create_run_yamls(flow_dirs):
     run_yaml = {
         "$schema": "https://azuremlschemas.azureedge.net/promptflow/latest/Run.schema.json",
         "flow": '.',
-        "data": 'samples.json'
+        "data": 'test_data.json'
     }
     for flow_dir in flow_dirs:
         with open(flow_dir / "run.yml", "w", encoding="utf-8") as dag_file:


### PR DESCRIPTION
Refine promptflow CI:
1. Support test_data.json config, before we use the default inputs values in flow.dag.yaml to construct a samples.json file to submit the examples. But this only works for sample input types, e.g.: str, list.
For complex inputs type, like image, the construct samples.json file is like below:
![image](https://github.com/Azure/azureml-assets/assets/49388944/5d0d2eb9-9cd4-4396-a826-f2377cb6b4b5)
But actually the right format for it should be like below:
![image](https://github.com/Azure/azureml-assets/assets/49388944/6eb28434-f0cd-499e-b28d-7d9e75be9d59)

So here we provide a way for flow owner to config their test data by themself so that the promptflow-ci can run successfully.
Resolve this issue: [Task 2935578](https://msdata.visualstudio.com/Vienna/_workitems/edit/2935578): update promptflow CI to support image in bulk run
Successfully run: https://ml.azure.com/prompts/flow/bulkrun/run/test_variant_0_20240227_084313_118109/0/details?wsid=/subscriptions/96aede12-2f73-41cb-b983-6d11a904839b/resourcegroups/promptflow/providers/Microsoft.MachineLearningServices/workspaces/chjinche-pf-eus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47

2. Before we only check the bulk run status in Promptflow-CI, but in a case that the bulk run status is completed, but inner line run status is failed, the failed status will not reflect to Promptflow-CI which is not right. [Task 2938867](https://msdata.visualstudio.com/Vienna/_workitems/edit/2938867): Current the CI is check the bulk run status which is not reflect the real status for the inline line run

In this PR, we will check if the completed bulk run has inner error info, then we will mark the promptflow-CI as failed, and guide the flow owner to investigate the failure:
Check run details about the error info:
![image](https://github.com/Azure/azureml-assets/assets/49388944/b9351db0-23ee-4e49-9edb-1e61c11a8709)
Mark the promptflow-CI as failed:
![image](https://github.com/Azure/azureml-assets/assets/49388944/681d1d20-23d4-45f0-abd4-b55930c9f95a)
Failed run link: https://ml.azure.com/prompts/flow/bulkrun/run/test_variant_0_20240227_084219_600940/details?wsid=/subscriptions/96aede12-2f73-41cb-b983-6d11a904839b/resourceGroups/promptflow/providers/Microsoft.MachineLearningServices/workspaces/chjinche-pf-eus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47


