### PR TITLE
Add Asset Properties to the Spec Config Object

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.16.35 (2023-02-28)
+### 🐛 Bugs Fixed
+- [#2407](https://github.com/Azure/azureml-assets/pull/2407) Surface properties in the spec configuration 
+
 ## 1.16.34 (2023-01-29)
 ### 🐛 Bugs Fixed
 - [#2196](https://github.com/Azure/azureml-assets/pull/2196) Allow evaluation results to have names similar to models 

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -452,7 +452,7 @@ class Spec(Config):
         return deps
 
     @property
-    def properties(self) -> str:
+    def properties(self) -> Dict[str, str]:
         """Asset properties."""
         return self._yaml.get('properties', {})
 

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -448,8 +448,12 @@ class Spec(Config):
                     if isinstance(component, str):
                         # Skip inline environments
                         deps[AssetType.COMPONENT].add(component)
-
         return deps
+    
+    @property
+    def properties(self) -> str:
+        """Asset properties."""
+        return self._yaml.get('properties', {})
 
 
 class AssetPath:
@@ -1159,7 +1163,7 @@ class AssetConfig(Config):
     def name(self) -> str:
         """Retrieve the asset's name from its YAML file, falling back to the spec if not set.
 
-        Raises:
+        Raises:spec_as_object
             ValidationException: If the name isn't set in the asset's YAML file and the name from spec includes a
                 template tag.
 

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -450,7 +450,7 @@ class Spec(Config):
                         deps[AssetType.COMPONENT].add(component)
 
         return deps
-    
+
     @property
     def properties(self) -> str:
         """Asset properties."""

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -448,7 +448,7 @@ class Spec(Config):
                     if isinstance(component, str):
                         # Skip inline environments
                         deps[AssetType.COMPONENT].add(component)
-                        
+
         return deps
     
     @property

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -1163,7 +1163,7 @@ class AssetConfig(Config):
     def name(self) -> str:
         """Retrieve the asset's name from its YAML file, falling back to the spec if not set.
 
-        Raises:spec_as_object
+        Raises:
             ValidationException: If the name isn't set in the asset's YAML file and the name from spec includes a
                 template tag.
 

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -448,6 +448,7 @@ class Spec(Config):
                     if isinstance(component, str):
                         # Skip inline environments
                         deps[AssetType.COMPONENT].add(component)
+                        
         return deps
     
     @property

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.34",
+   version="1.16.35",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
Enable properties validation by loading the spec properties bag into config