### PR TITLE
map evaluation table from GSQ model monitoring component to signal_scored_data output port

### DIFF
--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -98,6 +98,9 @@ outputs:
   signal_output:
     type: uri_folder
     mode: direct
+  signal_scored_data:
+    type: mltable
+    mode: direct
 jobs:
   compute_histogram:
     type: spark
@@ -136,6 +139,7 @@ jobs:
         type: mltable
       evaluation:
         type: mltable
+        path: ${{parent.outputs.signal_scored_data}}
     resources:
       instance_type: ${{parent.inputs.instance_type}}
       runtime_version: "3.3"


### PR DESCRIPTION
This PR maps the evaluation data output port of the GSQ histogram component to a new output port in the GSQ pipeline, "signal_scored_data".  See image below of GSQ pipeline:

![image](https://github.com/Azure/azureml-assets/assets/24683184/9ef38207-0953-421b-ab01-0e30e2543d9c)

This will be a new output port of MLTable type in the component:
![image](https://github.com/Azure/azureml-assets/assets/24683184/570edcda-432e-4930-b710-505399dddbaf)
