### PR TITLE
Deprecating data-labeling-sam

### DIFF
--- a/assets/data-labeling/environments/data-labeling-sam/spec.yaml
+++ b/assets/data-labeling/environments/data-labeling-sam/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/environment.schema.json
 
 description: >-
-  GPU based environment for AML Data Labeling SAM Embedding Generation.
+  DEPRECATED: Please use data-labeling instead.
 
 name: "{{asset.name}}"
 version: "{{asset.version}}"
@@ -16,3 +16,4 @@ tags:
   OS: Ubuntu20.04
   Python: 3.9
   GPU: Cuda11
+  Deprecated:


### PR DESCRIPTION
Removing data-labeling-sam since it is not in use. SAM feature is longer being developed, and thus no need for the environment.