### PR TITLE
upgrade dinov2 Giant model

### DIFF
--- a/assets/models/system/facebook-dinov2-image-embeddings-giant/spec.yaml
+++ b/assets/models/system/facebook-dinov2-image-embeddings-giant/spec.yaml
@@ -73,4 +73,4 @@ tags:
             Standard_ND96amsr_A100_v4,
             Standard_ND40rs_v2
         ]
-version: 1
+version: 2


### PR DESCRIPTION
Removed ds2v2 from allowed lists for inference.