### PR TITLE
Don't promote inputs/output from attributes in GenAI preprocessor (#2487)

### DIFF
--- a/assets/models/system/Mixtral-8x7B-v0-1/spec.yaml
+++ b/assets/models/system/Mixtral-8x7B-v0-1/spec.yaml
@@ -8,20 +8,20 @@ properties:
   inference-recommended-sku: Standard_ND40rs_v2, Standard_ND96amsr_A100_v4, Standard_ND96asr_v4
   languages: EN
 tags:
-  Featured: ''
-  Preview: ''
-  SharedComputeCapacityEnabled: ''
-  disable-batch: 'true'
+  Featured: ""
+  Preview: ""
+  SharedComputeCapacityEnabled: ""
+  disable-batch: "true"
   huggingface_model_id: mistralai/Mixtral-8x7B-v0.1
   inference_compute_allow_list:
     [
       Standard_ND40rs_v2,
-      Standard_ND96amsr_A100_v4,
-      Standard_ND96asr_v4,
+     Standard_ND96amsr_A100_v4, 
+     Standard_ND96asr_v4
     ]
   inference_supported_envs:
-  - vllm
+    - vllm
   license: apache-2.0
   task: text-generation
   author: mistralai
-version: 5
+version: 6


### PR DESCRIPTION
* don't promote input/output fields in genai preprocessor

* support input/output property from attributes json string

* promote root_span input/output in trace logs

* fix input/output property

* fix UT for promote span input/outpu in traces

* fix e2e data asset version

* fix root_span strings for correct input/output

* fix root spans

* syntax

* syntax