### PR TITLE
[DRI] dummy changes to fix vulnerability in RAI images

### DIFF
--- a/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -31,7 +31,8 @@ RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
 # so we install pyarrow in extra step to avoid conflict
 RUN pip install 'pyarrow>=14.0.1'
 
-# To resolve vulnerability issue regarding crytography
+# To resolve vulnerability issue
+# regarding crytography (GHSA-3ww4-gg4f-jr7f)
 RUN pip install 'cryptography>=42.0.4'
 
 # Install huggingface evaluate package from source

--- a/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -44,7 +44,8 @@ RUN pip install 'pyarrow>=14.0.1'
 # To resolve vulnerability issue
 RUN pip install 'Werkzeug==2.2.3'
 
-# To resolve vulnerability issue regarding crytography
+# To resolve vulnerability issue regarding
+# crytography (GHSA-3ww4-gg4f-jr7f)
 RUN pip install 'cryptography>=42.0.4'
 
 # TODO: remove rai-core-flask pin with next raiwidgets release

--- a/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -46,7 +46,8 @@ RUN pip install 'shap==0.41.0' \
 # so we install pyarrow in extra step to avoid conflict
 RUN pip install 'pyarrow>=14.0.1'
 
-# To resolve vulnerability issue regarding crytography
+# To resolve vulnerability issue
+# regarding crytography
 RUN pip install 'cryptography>=42.0.4'
 
 RUN pip freeze


### PR DESCRIPTION
dummy changes to fix vulnerability in RAI images:
* responsibleai-text-ubuntu20.04-py38-cpu
* responsibleai-ubuntu20.04-py38-cpu
* responsibleai-vision-ubuntu20.04-py38-cpu