### PR TITLE
add average score metrics for pass rate metrics in GSQ compute metrics model monitoring component

### DIFF
--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py
@@ -183,7 +183,10 @@ def compute_metrics(histogram_df, threshold_args, metric_names):
                     metadata_schema,
                 )
             aggregated_metrics_df = aggregated_metrics_df.union(threshold_row)
-        if average_score_metric_name in input_metric_names:
+        # for now, compute average score if either average score or pass rate is requested
+        compute_average = average_score_metric_name in input_metric_names
+        compute_average = compute_average or full_pass_rate_metric_name in input_metric_names
+        if compute_average:
             average_metric_score = _calculate_average_metric_score(
                 histogram_df, full_per_instance_score_metric_name)
             metric_df = spark.createDataFrame(

--- a/assets/model_monitoring/components/tests/unit/test_gsq_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_gsq_metrics.py
@@ -78,6 +78,18 @@ class TestGSQMetrics:
             else:
                 assert result_metric_value == expected_metric_value
 
+    def test_pass_rate_includes_average_scores(self,
+                                               code_zip_test_setup,
+                                               gsq_preprocessor_test_setup):
+        """Test average score included with AggregatedGroundednessPassRate."""
+        histogram_df = get_histogram_data()
+        spark = init_spark()
+        histogram_df = spark.createDataFrame(histogram_df)
+        metric_names = "AggregatedGroundednessPassRate"
+        result = call_compute_metrics(histogram_df, metric_names)
+        result_df = result.toPandas()
+        assert "AverageGroundednessScore" in result_df[METRIC_NAME_COLUMN].values
+
 
 def get_histogram_data():
     """Get histogram data for testing."""


### PR DESCRIPTION
add average score metrics for pass rate metrics in GSQ compute metrics model monitoring component

For compute metrics model monitoring component the average score metrics need to be specified for the metrics parameter in order to be computed.  However, these metrics can't be added to service in time for March release due to MFE service contracts that will take too long to deploy.  Hence, this is a quick fix to ensure that the average score metrics will be computed if the corresponding pass rate metrics are already passed to the component.

Copilot summary:
This pull request primarily focuses on the computation of average scores in the model monitoring components of the system. It includes changes in two files: `run.py` and `test_gsq_metrics.py`.

Changes in the computation of average scores:

* [`assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py`](diffhunk://#diff-dd3c42ed361cf38e9b3a532f9f43b421a7cfb496d4991362e176feb453868ec2L186-R189): Modified the `compute_metrics` function to compute average score if either average score or pass rate is requested. This change allows the function to compute the average score more efficiently and accurately.

Changes in testing:

* [`assets/model_monitoring/components/tests/unit/test_gsq_metrics.py`](diffhunk://#diff-514d7af69dc6e9efeaf4c5c40f4faea1bf5f1a43aab05d6770793d7b79f0b67aR81-R92): Added a new test function `test_pass_rate_includes_average_scores` to ensure that the average score is included with `AggregatedGroundednessPassRate`. This test verifies the changes made in `run.py` and ensures that the average score is correctly computed and included.