### PR TITLE
read hf_trainer_args from finetune config

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
+++ b/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
@@ -690,6 +690,14 @@ def check_for_invalid_ds_zero3_settings(args: Namespace):
                     setattr(args, key, value)
 
 
+def _set_hf_trainer_args_from_finetune_config(args: Namespace, finetune_config: Dict[str, Any]):
+    """Read :param `hf_trainer_args` from finetune config and set them to args."""
+    hf_trainer_args = finetune_config.get("hf_trainer_args", {})
+    for arg_name, arg_value in hf_trainer_args.items():
+        setattr(args, arg_name, arg_value)
+        logger.info(f"Setting {arg_name} to {arg_value}")
+
+
 def validate_ds_zero3_config(deepspeed_config_json: Dict[str, Any]):
     """Validate the deepspeed zero3 config file.
 
@@ -964,6 +972,8 @@ def finetune(args: Namespace):
             if "lora_target_modules" in ft_config:
                 logger.info(f'Setting lora_target_modules to: {ft_config.get("lora_target_modules")}')
                 setattr(args, "lora_target_modules", ft_config.get("lora_target_modules"))
+            # Reading hf trainer args from finetune config
+            _set_hf_trainer_args_from_finetune_config(args, ft_config)
     else:
         logger.info(f"{SaveFileConstants.ACFT_CONFIG_SAVE_PATH} does not exist")
         setattr(args, "finetune_config", {})


### PR DESCRIPTION
The PR adds the provision in the component to read _hf_trainer_args_ and pass it to TrainerArgs.

> Read the _hf_trainer_args_ from finetune config.
- Set _gradient_checkpointing_ flag or _flash_attention_ flags in the config instead of hardcoding them in the code.

> Sanity run with Phi-2 model.
- Run link: [Phi with samsum](https://ml.azure.com/experiments/id/cc3ecf17-143c-49f1-8a30-243ffec83f23/runs/56bd051b-c676-4423-9d85-745a08ce9d5f?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourceGroups/training_rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-workspace&flight=itpmerge&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)    [Phi with gsm8k](https://ml.azure.com/experiments/id/fbbb3ee6-0f97-4b26-98da-4278cf839973/runs/7ea3da35-c034-4ea7-9c8b-feb533161922?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&flight=itpmerge&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)