### PR TITLE
Do not save images to disk before inference

### DIFF
--- a/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
@@ -4,9 +4,6 @@
 """Helper utils for vision Mlflow models."""
 
 import logging
-import os
-import tempfile
-import uuid
 import PIL
 import pandas as pd
 import base64
@@ -18,30 +15,13 @@ from ast import literal_eval
 import numpy as np
 
 from PIL import Image, UnidentifiedImageError
-from typing import Tuple, Union
+from typing import Union
 
 
 logger = logging.getLogger(__name__)
 
 # Uncomment the following line for mlflow debug mode
 # logging.getLogger("mlflow").setLevel(logging.DEBUG)
-
-
-def create_temp_file(request_body: bytes, parent_dir: str) -> Tuple[str, Image.Image]:
-    """Create temporory file from image bytes, save image and return path to the file and PIL Image.
-
-    :param request_body: Image
-    :type request_body: bytes
-    :param parent_dir: directory name
-    :type parent_dir: str
-    :return: Path to the file, PIL Image
-    :rtype: Tuple[str, Image.Image]
-    """
-    with tempfile.NamedTemporaryFile(dir=parent_dir, mode="wb", delete=False) as image_file_fp:
-        img_path = image_file_fp.name + ".png"
-        img = get_pil_image(request_body)
-        img.save(img_path)
-        return img_path, img
 
 
 def get_pil_image(image: bytes) -> PIL.Image.Image:
@@ -58,24 +38,6 @@ def get_pil_image(image: bytes) -> PIL.Image.Image:
     except UnidentifiedImageError as e:
         logger.error("Invalid image format. Please use base64 encoding for input images.")
         raise e
-
-
-def save_image(output_folder: str, img: PIL.Image.Image, format: str) -> str:
-    """
-    Save image in a folder designated for batch output and return image file path.
-
-    :param output_folder: directory path where we need to save files
-    :type output_folder: str
-    :param img: image object
-    :type img: PIL.Image.Image
-    :param format: format to save image
-    :type format: str
-    :return: file name of image.
-    :rtype: str
-    """
-    filename = f"image_{uuid.uuid4()}.{format.lower()}"
-    img.save(os.path.join(output_folder, filename), format=format)
-    return filename
 
 
 def image_to_base64(img: PIL.Image.Image, format: str) -> str:

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/vision/predict.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/vision/predict.py
@@ -3,26 +3,22 @@
 
 """Huggingface predict file for Image classification MLflow model."""
 
+import io
 import logging
 
 import pandas as pd
-import tempfile
-
 import torch
 
-from datasets import load_dataset
-from transformers import (
-    AutoImageProcessor,
-    AutoModelForImageClassification,
-    TrainingArguments,
-    Trainer,
-)
-from typing import List, Dict, Any, Tuple
+from typing import Any, Dict, Generator, List
+
+from datasets import Dataset
+from PIL import Image
+from transformers import TrainingArguments, Trainer
 
 try:
     # Use try/except since vision_utils is added as part of model export and not available when initializing
     # model wrapper for save_model().
-    from vision_utils import create_temp_file, process_image_pandas_series
+    from vision_utils import process_image
 except ImportError:
     pass
 
@@ -70,7 +66,7 @@ def predict(input_data: pd.DataFrame, task, model, tokenizer, **kwargs) -> pd.Da
     image is in base64 String format.
     :param task: Task type of the model.
     :type task: HFTaskLiterals
-    :param tokenizer: Preprocessing configuration loader.
+    :param tokenizer: Image preprocessing object.
     :type tokenizer: transformers.AutoImageProcessor
     :param model: Pytorch model weights.
     :type model: transformers.AutoModelForImageClassification
@@ -78,71 +74,10 @@ def predict(input_data: pd.DataFrame, task, model, tokenizer, **kwargs) -> pd.Da
     :rtype: Pandas DataFrame with columns ['filename', 'probs', 'labels'] for classification and
     ['filename', 'boxes'] for object detection, instance segmentation
     """
-    # Decode the base64 image column
-    decoded_images = input_data.loc[:, [MLflowSchemaLiterals.INPUT_COLUMN_IMAGE]].apply(
-        axis=1, func=process_image_pandas_series
-    )
-
-    # arguments for Trainer
-    test_args = TrainingArguments(
-        output_dir=".",
-        do_train=False,
-        do_predict=True,
-        per_device_eval_batch_size=kwargs.get(MLflowLiterals.BATCH_SIZE_KEY, 1),
-        dataloader_drop_last=False,
-        remove_unused_columns=False,
-    )
-
-    # To Do: change image height and width based on kwargs.
-
-    with tempfile.TemporaryDirectory() as tmp_output_dir:
-        image_path_list = decoded_images.iloc[:, 0].map(lambda row: create_temp_file(row, tmp_output_dir)[0]).tolist()
-        conf_scores = run_inference_batch(
-            test_args,
-            image_processor=tokenizer,
-            model=model,
-            image_path_list=image_path_list,
-            task_type=task,
-        )
-
-    df_result = pd.DataFrame(
-        columns=[
-            MLflowSchemaLiterals.OUTPUT_COLUMN_PROBS,
-            MLflowSchemaLiterals.OUTPUT_COLUMN_LABELS,
-        ]
-    )
-
-    labels = kwargs.get(MLflowLiterals.TRAIN_LABEL_LIST)
-    labels = [labels.tolist()] * len(conf_scores)
-    df_result[MLflowLiterals.PROBS], df_result[MLflowLiterals.LABELS] = (
-        conf_scores.tolist(),
-        labels,
-    )
-    return df_result
-
-
-def run_inference_batch(
-    test_args: TrainingArguments,
-    image_processor: AutoImageProcessor,
-    model: AutoModelForImageClassification,
-    image_path_list: List,
-    task_type: HFTaskLiterals,
-) -> Tuple[torch.tensor]:
-    """Perform inference on batch of input images.
-
-    :param test_args: Training arguments path.
-    :type test_args: transformers.TrainingArguments
-    :param image_processor: Preprocessing configuration loader.
-    :type image_processor: transformers.AutoImageProcessor
-    :param model: Pytorch model weights.
-    :type model: transformers.AutoModelForImageClassification
-    :param image_path_list: list of image paths for inferencing.
-    :type image_path_list: List
-    :param task_type: Task type of the model.
-    :type task_type: HFTaskLiterals
-    :return: Predicted probabilities
-    :rtype: Tuple of torch.tensor
-    """
+    # Make generator that reads all the input images and collator that produces B*C*H*W tensors.
+    def image_generator_fn() -> Generator[Dict[str, Any], None, None]:
+        for image in input_data[HFMiscellaneousConstants.DEFAULT_IMAGE_KEY]:
+            yield {"image": Image.open(io.BytesIO(process_image(image)))}
 
     def collate_fn(examples: List[Dict[str, Any]]) -> Dict[str, torch.tensor]:
         """Collator function for eval dataset.
@@ -152,23 +87,41 @@ def run_inference_batch(
         :return: Dictionary of pixel values in torch tensor format.
         :rtype: Dict
         """
-        images = [data[HFMiscellaneousConstants.DEFAULT_IMAGE_KEY] for data in examples]
-        return image_processor(images, return_tensors="pt")
+        images = [data["image"] for data in examples]
+        return tokenizer(images, return_tensors="pt")
 
-    inference_dataset = load_dataset("imagefolder", data_files={"val": image_path_list})
-    inference_dataset = inference_dataset["val"]
-
-    # Initialize the trainer
+    # TODO: change image height and width based on kwargs.
+    # Do inference (output: logits).
+    inference_dataset = Dataset.from_generator(image_generator_fn)
     trainer = Trainer(
         model=model,
-        args=test_args,
-        tokenizer=image_processor,
+        args=TrainingArguments(
+            output_dir=".",
+            do_train=False,
+            do_predict=True,
+            per_device_eval_batch_size=kwargs.get(MLflowLiterals.BATCH_SIZE_KEY, 1),
+            dataloader_drop_last=False,
+            remove_unused_columns=False,
+        ),
         data_collator=collate_fn,
     )
     results = trainer.predict(inference_dataset)
-    if task_type == HFTaskLiterals.MULTI_CLASS_IMAGE_CLASSIFICATION:
+
+    # Calculate probabilities from logits.
+    if task == HFTaskLiterals.MULTI_CLASS_IMAGE_CLASSIFICATION:
         probs = torch.nn.functional.softmax(torch.from_numpy(results.predictions), dim=1).numpy()
-    elif task_type == HFTaskLiterals.MULTI_LABEL_CLASSIFICATION:
+    elif task == HFTaskLiterals.MULTI_LABEL_CLASSIFICATION:
         sigmoid = torch.nn.Sigmoid()
         probs = sigmoid(torch.from_numpy(results.predictions)).numpy()
-    return probs
+
+    # Convert to Pandas dataframe and return.
+    df_result = pd.DataFrame(
+        columns=[
+            MLflowSchemaLiterals.OUTPUT_COLUMN_PROBS,
+            MLflowSchemaLiterals.OUTPUT_COLUMN_LABELS,
+        ]
+    )
+    df_result[MLflowLiterals.PROBS] = probs.tolist()
+    df_result[MLflowLiterals.LABELS] = [kwargs.get(MLflowLiterals.TRAIN_LABEL_LIST).tolist()] * len(probs)
+
+    return df_result

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/vision/predict.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/vision/predict.py
@@ -89,7 +89,7 @@ def predict(input_data: pd.DataFrame, task, model, tokenizer, **kwargs) -> pd.Da
         """
         images = [data["image"] for data in examples]
         return tokenizer(images, return_tensors="pt")
-    
+
     # TODO: use in-memory dataset throughout the code (eg instead of list of images).
 
     # TODO: change image height and width based on kwargs.

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/vision/predict.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/vision/predict.py
@@ -89,6 +89,8 @@ def predict(input_data: pd.DataFrame, task, model, tokenizer, **kwargs) -> pd.Da
         """
         images = [data["image"] for data in examples]
         return tokenizer(images, return_tensors="pt")
+    
+    # TODO: use in-memory dataset throughout the code (eg instead of list of images).
 
     # TODO: change image height and width based on kwargs.
     # Do inference (output: logits).


### PR DESCRIPTION
For a number of vision and multimodal models, images are saved to disk before model inference is called. This is unnecessary and it can lead to very high latency when the input images are large, see https://microsoft.sharepoint.com/teams/SDAutoML/_layouts/15/Doc.aspx?sourcedoc={67c6171a-89ef-4188-aba7-3ebbffa8c8e7}&action=edit&wd=target%28Planning-CLIP%2BLLaVA.one%7C52bdff75-be99-4f0d-ab03-58ff4ac7c7be%2FCLIP%20Inference%20Benchmarking%7C68ca017f-4b80-4acf-a206-a36f49548bc7%2F%29&wdorigin=NavigationUrl . This PR avoids the problem by feeding images directly or a generator based dataset to the inference call.

Tested by:
1. spot checks on compute instances
2. running the model deploy pipeline: https://ml.azure.com/experiments/id/d1873606-5a43-4303-9053-6fb512612c9f?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/phmantri_eastus/providers/Microsoft.MachineLearningServices/workspaces/phmantri_eastus_2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47 . Run format: [model|model_and_task]_latopt.

Due to issues with the model publish pipeline, not all runs were successful; whenever a run failed, eg blip2_vqa_latopt, the pipeline was also run with the production code (eg blip2_vqa) and the model was deployed manually (https://ml.azure.com/endpoints?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/phmantri_eastus/providers/Microsoft.MachineLearningServices/workspaces/phmantri_eastus_2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) in order to make sure the failure was not due to the new code.

Speedup: TBD

Note: some results for classification and detection change slightly. Most likely, this is because the code used in HF/MMDetection to read images is slightly incompatible with PIL's code to write images.
