### PR TITLE
enabling lora for Phi models

### DIFF
--- a/assets/models/system/microsoft-phi-2/model.yaml
+++ b/assets/models/system/microsoft-phi-2/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/microsoft-phi-2/1710512835/mlflow_model_folder
+  container_path: huggingface/microsoft-phi-2/1711001952/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/microsoft-phi-2/spec.yaml
+++ b/assets/models/system/microsoft-phi-2/spec.yaml
@@ -84,9 +84,9 @@ tags:
     - ds_mii
   model_specific_defaults:
     apply_deepspeed: "true"
-    apply_lora: "false"
+    apply_lora: "true"
     apply_ort: "false"
     precision: 16
-    max_seq_length: 1024
+    max_seq_length: 2048
   task: text-generation
-version: 14
+version: 15


### PR DESCRIPTION
> Updated the model defaults
- Enabling _model_max_length_ to 2048 with help of gradient checkpointing
- Enabling LoRA with setting lora modules as mentioned in peft library - https://github.com/huggingface/peft/blob/main/src/peft/utils/constants.py
![image](https://github.com/Azure/azureml-assets/assets/12165281/7facb631-f0d6-4069-bd05-7f7492cfe586)

> Updated the model artifacts with a new finetune config.
- Sanity test with 2048 seq len - https://ml.azure.com/experiments/id/fbbb3ee6-0f97-4b26-98da-4278cf839973/runs/7ea3da35-c034-4ea7-9c8b-feb533161922?wsid=%2Fsubscriptions%2F72c03bf3-4e69-41af-9532-dfcdc3eefef4%2FresourceGroups%2Fhyperdrive-service-static-rg%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Ftrain-finetune-dev-eastus&flight=itpmerge&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
- Latest sanity tests will be run as part of model validation pipeline
