### PR TITLE
Mixtral8x7bv0_baseimageissue and removed .ptfiles

### DIFF
--- a/assets/models/system/Mixtral-8x7B-v0-1/spec.yaml
+++ b/assets/models/system/Mixtral-8x7B-v0-1/spec.yaml
@@ -24,4 +24,4 @@ tags:
   license: apache-2.0
   task: text-generation
   author: mistralai
-version: 6
+version: 7


### PR DESCRIPTION
Removed .pt files and also increased specyaml file version to 7 as baseimage is missing in the model