### PR TITLE
reverting the model version and blob path

### DIFF
--- a/assets/models/system/microsoft-phi-2/model.yaml
+++ b/assets/models/system/microsoft-phi-2/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/microsoft-phi-2/1711001952/mlflow_model_folder
+  container_path: huggingface/microsoft-phi-2/1711016297/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/microsoft-phi-2/spec.yaml
+++ b/assets/models/system/microsoft-phi-2/spec.yaml
@@ -89,4 +89,4 @@ tags:
     precision: 16
     max_seq_length: 2048
   task: text-generation
-version: 15
+version: 14


### PR DESCRIPTION
>Reverted the version
Version 13 is the latest in azureml-msr and since 14th is not released, the validation failed. Hence, reverting the version.

>Model bits changed
Cloned the bits that were used for version 13. Updated the finetune config on top of that.