### PR TITLE
resetting lora default to false

### DIFF
--- a/assets/models/system/microsoft-phi-2/spec.yaml
+++ b/assets/models/system/microsoft-phi-2/spec.yaml
@@ -84,7 +84,7 @@ tags:
     - ds_mii
   model_specific_defaults:
     apply_deepspeed: "true"
-    apply_lora: "true"
+    apply_lora: "false"
     apply_ort: "false"
     precision: 16
     max_seq_length: 2048


### PR DESCRIPTION
This is getting reverted as the validation component block the runs when _lora_ is enabled for Phi-2. Even w/o lora, the model specific defaults work with ND40 - https://ml.azure.com/experiments/id/779217d8-783e-458c-abe7-99e1fc79d145/runs/6515966b-b1eb-42e8-8691-1fb083f6ae81?wsid=/subscriptions/ed2cab61-14cc-4fb3-ac23-d72609214cfd/resourceGroups/training_rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-workspace&flight=itpmerge&tid=72f988bf-86f1-41af-91ab-2d7cd011db47

The finetune is in progress with GPU usage of around 12GB
![image](https://github.com/Azure/azureml-assets/assets/12165281/f4df88ac-d424-4fd7-b183-6ac052cc7eb1)


