### PR TITLE
ACFT-HF-NLP-GPU release 46

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install -r requirements.txt --no-cache-dir
 RUN python -m nltk.downloader punkt
 RUN MAX_JOBS=4 pip install flash-attn==2.5.5 --no-build-isolation
 
-# dummy number to change when needing to force rebuild without changing the definition: 4
+# dummy number to change when needing to force rebuild without changing the definition: 3

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install -r requirements.txt --no-cache-dir
 RUN python -m nltk.downloader punkt
 RUN MAX_JOBS=4 pip install flash-attn==2.5.5 --no-build-isolation
 
-# dummy number to change when needing to force rebuild without changing the definition: 3
+# dummy number to change when needing to force rebuild without changing the definition: 4

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -1,7 +1,7 @@
-azureml-acft-accelerator=={{latest-pypi-version}}
-azureml_acft_common_components=={{latest-pypi-version}}
-azureml-acft-contrib-hf-nlp=={{latest-pypi-version}}
-azureml-evaluate-mlflow=={{latest-pypi-version}}
+azureml-acft-accelerator==0.0.47.post1
+azureml_acft_common_components==0.0.46
+azureml-acft-contrib-hf-nlp==0.0.47.post1
+azureml-evaluate-mlflow==0.0.46.post1
 mltable=={{latest-pypi-version}}
 mpi4py==3.1.5
 sentencepiece==0.1.99


### PR DESCRIPTION
Need to manually update acft packages version because the {{latest-pypi-version}} is not updating from 47.0.0 which is a yanked version. 
current release branch requirements.txt -> https://github.com/Azure/azureml-assets/blob/042a94a2ca77c4e883552fb1e5a24de79e78cbe1/latest/environment/acft-hf-nlp-gpu/context/requirements.txt