### PR TITLE
update mistral models to back to huggingface models and fix the task type issue

### DIFF
--- a/assets/models/system/Mistral-7B-Instruct-v0-1/model.yaml
+++ b/assets/models/system/Mistral-7B-Instruct-v0-1/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/mistralai-Mistral-7B-Instruct-v0-1/1699877275/mlflow_model_folder
+  container_path: huggingface/mistralai-Mistral-7B-Instruct-v0-1/20240306/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/Mistral-7B-Instruct-v0-1/spec.yaml
+++ b/assets/models/system/Mistral-7B-Instruct-v0-1/spec.yaml
@@ -3,7 +3,7 @@ name: mistralai-Mistral-7B-Instruct-v01
 path: ./
 properties:
   SharedComputeCapacityEnabled: true
-  SHA: 3dc28cf29d2edd31a0a7b8f0b21637059815b4d5
+  SHA: b70aa86578567ba3301b21c8a27bea4e8f6d6d61
   inference-min-sku-spec: 12|1|220|64
   inference-recommended-sku: Standard_NC12s_v3, Standard_NC24s_v3, Standard_ND40rs_v2, Standard_NC24ads_A100_v4, Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96amsr_A100_v4, Standard_ND96asr_v4
   languages: EN
@@ -29,4 +29,4 @@ tags:
   license: apache-2.0
   task: chat-completion
   author: mistralai
-version: 7
+version: 8

--- a/assets/models/system/Mistral-7B-v0-1/model.yaml
+++ b/assets/models/system/Mistral-7B-v0-1/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/mistralai-Mistral-7B-v0-1/1699878876/mlflow_model_folder
+  container_path: huggingface/mistralai-Mistral-7B-v0-1/20240306/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/Mistral-7B-v0-1/spec.yaml
+++ b/assets/models/system/Mistral-7B-v0-1/spec.yaml
@@ -3,7 +3,7 @@ name: mistralai-Mistral-7B-v01
 path: ./
 properties:
   SharedComputeCapacityEnabled: true
-  SHA: f966a600a1f2c35a067dcb16b24bbf9ac3b85799
+  SHA: 26bca36bde8333b5d7f72e9ed20ccda6a618af24
   inference-min-sku-spec: 12|1|220|64
   inference-recommended-sku: Standard_NC12s_v3, Standard_NC24s_v3, Standard_ND40rs_v2, Standard_NC24ads_A100_v4, Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96amsr_A100_v4, Standard_ND96asr_v4
   evaluation-min-sku-spec: 6|1|112|128
@@ -68,4 +68,4 @@ tags:
   license: apache-2.0
   task: text-generation
   author: mistralai
-version: 14
+version: 13

--- a/assets/models/system/Mixtral-8x7B-v0-1/model.yaml
+++ b/assets/models/system/Mixtral-8x7B-v0-1/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/mistralai-Mixtral-8x7B-v0-1/1709712445/mlflow_model_folder
+  container_path: huggingface/mistralai-Mixtral-8x7B-v0-1/20240306/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/Mixtral-8x7B-v0-1/spec.yaml
+++ b/assets/models/system/Mixtral-8x7B-v0-1/spec.yaml
@@ -24,4 +24,4 @@ tags:
   license: apache-2.0
   task: text-generation
   author: mistralai
-version: 8
+version: 9

--- a/assets/models/system/mistralai-Mixtral-8x7B-Instruct-v01/model.yaml
+++ b/assets/models/system/mistralai-Mixtral-8x7B-Instruct-v01/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/mistralai-Mixtral-8x7B-Instruct-v0-1/1704390002/mlflow_model_folder
+  container_path: huggingface/mistralai-Mixtral-8x7B-Instruct-v0-1/20240306/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/mistralai-Mixtral-8x7B-Instruct-v01/spec.yaml
+++ b/assets/models/system/mistralai-Mixtral-8x7B-Instruct-v01/spec.yaml
@@ -3,6 +3,7 @@ name: mistralai-Mixtral-8x7B-Instruct-v01
 path: ./
 properties:
   SharedComputeCapacityEnabled: true
+  SHA: 5c79a376139be989ef1838f360bf4f1f256d7aec
   inference-min-sku-spec: 40|4|672|256
   inference-recommended-sku: Standard_ND40rs_v2, Standard_NC96ads_A100_v4, Standard_ND96amsr_A100_v4, Standard_ND96asr_v4
   languages: EN
@@ -24,4 +25,4 @@ tags:
   license: apache-2.0
   task: chat-completion
   author: mistralai
-version: 4
+version: 5


### PR DESCRIPTION
as title, 4 mistral models change model paths and SHAs to huggingface models, task type & base_model_task in MLmodel file for instruct models change to chat-completion. 
for mistral-7b-instruct, mistral-8x7b, mistral-8x7b-instruct, since the back to prev-HF models are released (for #2560 PR), need bump versions
for mistral-7b, since did not release it's prev-HF model, config files need to back to before the PR of #2560 so version minus 1.