### PR TITLE
add threshold param to GSQ compute metrics component

### DIFF
--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_metrics
 display_name: Annotation - Compute Metrics
 description: Compute annotation metrics given a deployment's model data input.
-version: 0.4.11
+version: 0.4.12
 is_deterministic: True
 inputs:
   annotation_histogram: 
@@ -14,6 +14,11 @@ inputs:
     type: string
     description: a comma-separated list of metric names to compute
     optional: false
+  thresholds:
+    type: string
+    optional: true
+    default: ""
+    description: a comma-separated dictionary of threshold:value for each metric
   groundedness_passrate_threshold:
     type: number
     optional: true
@@ -85,6 +90,7 @@ entry:
 args: >-
   --annotation_histogram ${{inputs.annotation_histogram}}
   --metric_names ${{inputs.metric_names}}
+  $[[--thresholds ${{inputs.thresholds}}]]
   $[[--groundedness_passrate_threshold ${{inputs.groundedness_passrate_threshold}}]]
   $[[--relevance_passrate_threshold ${{inputs.relevance_passrate_threshold}}]]
   $[[--similarity_passrate_threshold ${{inputs.similarity_passrate_threshold}}]]

--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: generation_safety_quality_signal_monitor
 display_name: Generation Safety & Quality - Signal Monitor
 description: Computes the content generation safety metrics over LLM outputs.
-version: 0.5.5
+version: 0.5.6
 is_deterministic: true
 inputs:
   monitor_name:
@@ -61,6 +61,11 @@ inputs:
     type: integer
     optional: true
     default: 4
+  thresholds:
+    type: string
+    optional: true
+    default: ""
+    description: a comma-separated dictionary of threshold:value for each metric
   groundedness_passrate_threshold:
     type: number
     optional: true
@@ -162,12 +167,13 @@ jobs:
       type: aml_token
   compute_metrics:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.11
+    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.12
     inputs:
       annotation_histogram:
         type: mltable
         path: ${{parent.jobs.compute_histogram.outputs.histogram}}
       metric_names: ${{parent.inputs.metric_names}}
+      thresholds: ${{parent.inputs.thresholds}}
       groundedness_passrate_threshold: ${{parent.inputs.groundedness_passrate_threshold}}
       similarity_passrate_threshold: ${{parent.inputs.similarity_passrate_threshold}}
       relevance_passrate_threshold: ${{parent.inputs.relevance_passrate_threshold}}

--- a/assets/model_monitoring/components/tests/unit/test_gsq_metrics.py
+++ b/assets/model_monitoring/components/tests/unit/test_gsq_metrics.py
@@ -157,11 +157,16 @@ def get_expected_data():
         ['', 1.0, 'AggregatedCoherencePassRate', 0.7, ''],
         ['', '', 'AcceptableCoherenceScorePerInstance', 4, ''],
         ['', 5.0, 'AverageCoherenceScore', '', ''],
-        ['', 0.0, 'CoherenceViolationCounts', '', ''],
-        ['', 0.0, 'FluencyViolationCounts', '', ''],
-        ['', 1.0, 'GroundednessViolationCounts', '', ''],
-        ['', 2.0, 'RelevanceViolationCounts', '', ''],
-        ['', 3.0, 'TotalViolationCounts', '', ''],
+        ['', 0.0, 'CoherencePassRateViolationCounts', '', ''],
+        ['', 0.0, 'CoherenceAverageScoreViolationCounts', '', ''],
+        ['', 0.0, 'FluencyPassRateViolationCounts', '', ''],
+        ['', 0.0, 'FluencyAverageScoreViolationCounts', '', ''],
+        ['', 1.0, 'GroundednessPassRateViolationCounts', '', ''],
+        ['', 0.0, 'GroundednessAverageScoreViolationCounts', '', ''],
+        ['', 2.0, 'RelevancePassRateViolationCounts', '', ''],
+        ['', 0.0, 'RelevanceAverageScoreViolationCounts', '', ''],
+        ['', 3.0, 'TotalPassRateViolationCounts', '', ''],
+        ['', 0, 'TotalAverageScoreViolationCounts', '', ''],
     ]
     return pd.DataFrame(data, columns=['group', 'metric_value', 'metric_name',
                                        'threshold_value', 'group_dimension'])
@@ -170,4 +175,7 @@ def get_expected_data():
 def call_compute_metrics(histogram_df, metric_names):
     """Call compute_metrics method in GSQ component."""
     threshold_args = {threshold_name: 0.7 for threshold_name in THRESHOLD_PARAMS}
+    for metric in ALL_METRIC_NAMES:
+        if 'AverageScore' in metric:
+            threshold_args[metric] = 4.0
     return compute_metrics(histogram_df, threshold_args, metric_names)


### PR DESCRIPTION
add threshold param to GSQ compute metrics component

Copilot summary:

This pull request includes changes to the model monitoring components in the `assets/model_monitoring/components` directory. The major changes include version updates, addition of a new input parameter `thresholds`, and modifications to the metrics computation in the `run.py` script. There are also corresponding changes in the unit tests.

Version and Component Updates:

* [`assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml`](diffhunk://#diff-e2137c017041a72116c30037bcf11bf4e00c425d35be9c10d941a5daf0908facL7-R7): The version of the `gsq_annotation_compute_metrics` component was updated from 0.4.11 to 0.4.12.
* [`assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml`](diffhunk://#diff-6ad81f384e1e7d651da79e92d15038aa8939cc64a71f71a78f3ca0d059f1311bL7-R7): The version of the `generation_safety_quality_signal_monitor` component was updated from 0.5.5 to 0.5.6, and the `gsq_annotation_compute_metrics` component used was updated to version 0.4.12. [[1]](diffhunk://#diff-6ad81f384e1e7d651da79e92d15038aa8939cc64a71f71a78f3ca0d059f1311bL7-R7) [[2]](diffhunk://#diff-6ad81f384e1e7d651da79e92d15038aa8939cc64a71f71a78f3ca0d059f1311bL165-R165)

Input Parameter Changes:

* [`assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml`](diffhunk://#diff-e2137c017041a72116c30037bcf11bf4e00c425d35be9c10d941a5daf0908facR17-R21): A new input parameter `thresholds` was added. This parameter is optional and is a comma-separated dictionary of threshold:value for each metric.

Metrics Computation Changes:

* [`assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py`](diffhunk://#diff-dd3c42ed361cf38e9b3a532f9f43b421a7cfb496d4991362e176feb453868ec2L21-R23): The metrics computation was modified to handle the new `thresholds` parameter and to calculate average score violation counts in addition to pass rate violation counts. The violation counts metrics names were also updated. [[1]](diffhunk://#diff-dd3c42ed361cf38e9b3a532f9f43b421a7cfb496d4991362e176feb453868ec2L21-R23) [[2]](diffhunk://#diff-dd3c42ed361cf38e9b3a532f9f43b421a7cfb496d4991362e176feb453868ec2L35-R58) [[3]](diffhunk://#diff-dd3c42ed361cf38e9b3a532f9f43b421a7cfb496d4991362e176feb453868ec2R136) [[4]](diffhunk://#diff-dd3c42ed361cf38e9b3a532f9f43b421a7cfb496d4991362e176feb453868ec2R148-R152) [[5]](diffhunk://#diff-dd3c42ed361cf38e9b3a532f9f43b421a7cfb496d4991362e176feb453868ec2L173-R199) [[6]](diffhunk://#diff-dd3c42ed361cf38e9b3a532f9f43b421a7cfb496d4991362e176feb453868ec2L225-R300)

Unit Test Changes:

* [`assets/model_monitoring/components/tests/unit/test_gsq_metrics.py`](diffhunk://#diff-514d7af69dc6e9efeaf4c5c40f4faea1bf5f1a43aab05d6770793d7b79f0b67aL160-R169): The unit tests were updated to reflect the changes in the metrics computation. [[1]](diffhunk://#diff-514d7af69dc6e9efeaf4c5c40f4faea1bf5f1a43aab05d6770793d7b79f0b67aL160-R169) [[2]](diffhunk://#diff-514d7af69dc6e9efeaf4c5c40f4faea1bf5f1a43aab05d6770793d7b79f0b67aR178-R180)