### PR TITLE
Add support for mini batch size.

### DIFF
--- a/assets/aml-benchmark/components/batch_benchmark_inference/spec.yaml
+++ b/assets/aml-benchmark/components/batch_benchmark_inference/spec.yaml
@@ -218,7 +218,7 @@ jobs:
   # Inference
   endpoint_batch_score:
     type: parallel
-    component: azureml:batch_score_llm:1.1.3
+    component: azureml:batch_score_llm:1.1.4
     inputs:
       async_mode: False
       data_input_table: ${{parent.jobs.batch_inference_preparer.outputs.formatted_data}}
@@ -231,12 +231,12 @@ jobs:
     resources:
       instance_count: ${{parent.inputs.instance_count}}
     max_concurrency_per_instance:  ${{parent.inputs.max_concurrency_per_instance}}
-    mini_batch_size: 100KB
+    mini_batch_size: ${{parent.inputs.mini_batch_size}}
     retry_settings:
       timeout: 6000
       max_retries: 10
     environment_variables:
-      BATCH_SCORE_INITIAL_REQUEST_TIMEOUT: '4'
+      BATCH_SCORE_INITIAL_REQUEST_TIMEOUT: '180'
       BATCH_SCORE_DELAY_AFTER_SUCCESSFUL_REQUEST: 'False'
       BATCH_SCORE_MAX_REQUEST_TIMEOUT: '300'
       

--- a/assets/aml-benchmark/components/batch_benchmark_inference_with_inference_compute/spec.yaml
+++ b/assets/aml-benchmark/components/batch_benchmark_inference_with_inference_compute/spec.yaml
@@ -222,7 +222,7 @@ jobs:
   # Inference
   endpoint_batch_score:
     type: parallel
-    component: azureml:batch_score_llm:1.1.3
+    component: azureml:batch_score_llm:1.1.4
     inputs:
       async_mode: False
       data_input_table: ${{parent.jobs.batch_inference_preparer.outputs.formatted_data}}
@@ -235,13 +235,13 @@ jobs:
     resources:
       instance_count: ${{parent.inputs.instance_count}}
     max_concurrency_per_instance:  ${{parent.inputs.max_concurrency_per_instance}}
-    mini_batch_size: 100KB
+    mini_batch_size: ${{parent.inputs.mini_batch_size}}
     retry_settings:
       timeout: 6000
       max_retries: 10
     compute: ${{parent.inputs.inference_compute}}
     environment_variables:
-      BATCH_SCORE_INITIAL_REQUEST_TIMEOUT: '4'
+      BATCH_SCORE_INITIAL_REQUEST_TIMEOUT: '180'
       BATCH_SCORE_DELAY_AFTER_SUCCESSFUL_REQUEST: 'False'
       BATCH_SCORE_MAX_REQUEST_TIMEOUT: '300'
       


### PR DESCRIPTION
1. Add support for mini_batch_size.
2. Update to latest batch score component.
3. Make initial request timeout to 3 minutes to limit too many timeouts due to low timeouts.