### PR TITLE
acft-hf-nlp-gpu env: hardcode 48 version

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/asset.yaml
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/asset.yaml
@@ -1,5 +1,5 @@
 name: acft-hf-nlp-gpu
-version: auto
+version: "48"
 type: environment
 spec: spec.yaml
 extra_config: environment.yaml


### PR DESCRIPTION
Last couple of PRs, that had changes in `acft-hf-nlp-gpu` env and were merged to `main`, have increased env version in the `release` branch.

- 47 -> 48 https://github.com/Azure/azureml-assets/commit/9555751580f7eb9ceb9472fa93a3d3ce420cf68e
- 48 -> 49 https://github.com/Azure/azureml-assets/commit/1f3985e6eb4bc3691103821fc66c4811651b8491

We cannot release version 49 before releasing version 48. So hardcoding version 48 to unblock us to release.