### PR TITLE
action analyzer bug fix for default topic as query intention

### DIFF
--- a/assets/model_monitoring/components/src/action_analyzer/action_analyzer_output_actions/run.py
+++ b/assets/model_monitoring/components/src/action_analyzer/action_analyzer_output_actions/run.py
@@ -9,7 +9,7 @@ from pyspark.sql.types import (
     BooleanType
 )
 from pyspark.sql import Window
-from pyspark.sql.functions import collect_set, col, udf, mean, max
+from pyspark.sql.functions import collect_set, col, udf, max
 from shared_utilities.io_utils import try_read_mltable_in_spark, np_encoder
 import os
 import json
@@ -187,7 +187,7 @@ def run():
     action_bad_group_df.show()
 
     action_good_group_df = action_with_group_df.filter(is_query_in_action_sample(col(GROUP_LIST_COLUMN),
-                                                                                 col("action_good_group_set")) 
+                                                                                 col("action_good_group_set"))
                                                        & ~col(GROUP_LIST_COLUMN).contains("_bad_group"))
     print("good group")
     action_good_group_df.show()

--- a/assets/model_monitoring/components/src/action_analyzer/action_analyzer_output_actions/run.py
+++ b/assets/model_monitoring/components/src/action_analyzer/action_analyzer_output_actions/run.py
@@ -165,9 +165,10 @@ def run():
         args.data_with_action_metric_score, "data_with_action_metric_score"
     )
 
-    # get the group with highest confidence score
+    # get the group with highest confidence score (except the default group)
     w = Window.partitionBy(INDEX_ID_COLUMN)
-    max_conf_df = action_data_df.withColumn("max_confidence", max(CONFIDENCE_SCORE_COLUMN).over(w))\
+    max_conf_df = action_data_df.filter(~col(BAD_GROUP_COLUMN).endswith("_default"))\
+                                .withColumn("max_confidence", max(CONFIDENCE_SCORE_COLUMN).over(w))\
                                 .where(col(CONFIDENCE_SCORE_COLUMN) == col('max_confidence'))\
                                 .withColumn("most_significant_group", col(BAD_GROUP_COLUMN))\
                                 .select(INDEX_ID_COLUMN, "most_significant_group")
@@ -186,7 +187,8 @@ def run():
     action_bad_group_df.show()
 
     action_good_group_df = action_with_group_df.filter(is_query_in_action_sample(col(GROUP_LIST_COLUMN),
-                                                                                 col("action_good_group_set")))
+                                                                                 col("action_good_group_set")) 
+                                                       & ~col(GROUP_LIST_COLUMN).contains("_bad_group"))
     print("good group")
     action_good_group_df.show()
 

--- a/assets/model_monitoring/components/src/action_analyzer/action_analyzer_output_actions/run.py
+++ b/assets/model_monitoring/components/src/action_analyzer/action_analyzer_output_actions/run.py
@@ -175,7 +175,7 @@ def run():
 
     merged_action = action_data_df.groupby(INDEX_ID_COLUMN).agg(collect_set(BAD_GROUP_COLUMN).alias("action_bad_group_set"),  # noqa: E501
                                                                 collect_set(GOOD_GROUP_COLUMN).alias("action_good_group_set"),  # noqa: E501
-                                                                mean(CONFIDENCE_SCORE_COLUMN).alias("action_confidence_score")).withColumn(ACTION_ID_COLUMN, _generate_guid())  # noqa: E501
+                                                                max(CONFIDENCE_SCORE_COLUMN).alias("action_confidence_score")).withColumn(ACTION_ID_COLUMN, _generate_guid())  # noqa: E501
 
     # join the action data with all debugging info and highest confident group
     merged_action = merged_action.join(max_conf_df, [INDEX_ID_COLUMN], "inner")


### PR DESCRIPTION
Action analyzer bug fix:
1. do not use default topic as query intention
2. only choose queries with all e2e scores == 5 as good samples. Because before a query may be returned in both positive samples and negative samples (for different e2e metrics)
3. use max confidence score as the action score
