### PR TITLE
use deployment name instead of model type in GSQ component when calling evaluate API

### DIFF
--- a/assets/model_monitoring/components/tests/unit/test_gsq_histogram.py
+++ b/assets/model_monitoring/components/tests/unit/test_gsq_histogram.py
@@ -12,12 +12,8 @@ import uuid
 import pandas as pd
 import pyarrow as pa
 from generation_safety_quality.annotation_compute_histogram.run import (
-    _check_and_format_azure_endpoint_url,
     apply_annotation,
     SIMILARITY,
-    AZURE_OPENAI_API_DEPLOYMENT_URL_PATTERN,
-    AZURE_ENDPOINT_DOMAIN_VALID_PATTERN_RE,
-    GPT_4,
     TEST_CONNECTION,
     THRESHOLD_PARAMS,
     ALL_METRIC_NAMES,
@@ -33,6 +29,7 @@ import spark_mltable  # noqa, to enable spark.read.mltable
 
 QUESTION = 'question'
 EVALUATION = 'evaluation'
+GPT_4 = 'gpt-4'
 
 
 @pytest.fixture(scope="module")
@@ -62,35 +59,6 @@ def gsq_preprocessor_test_setup():
 @pytest.mark.unit
 class TestGSQHistogram:
     """Test class for GSQ histogram component and utilities."""
-
-    def test_gsq_invalid_deployment_url(self):
-        """Test _check_and_format_azure_endpoint_url method in GSQ component."""
-        url_pattern = AZURE_OPENAI_API_DEPLOYMENT_URL_PATTERN
-        domain_pattern_re = AZURE_ENDPOINT_DOMAIN_VALID_PATTERN_RE
-        version = "2022-12-01"
-        model = "test_model"
-        invalid_url = "https://invalidurl.com"
-        with pytest.raises(InvalidInputError):
-            _check_and_format_azure_endpoint_url(
-                url_pattern, domain_pattern_re, invalid_url,
-                version, model)
-        # this was the url causing the error
-        cog_url = "australiaeast.api.cognitive.microsoft.com"
-        with pytest.raises(InvalidInputError):
-            _check_and_format_azure_endpoint_url(
-                url_pattern, domain_pattern_re, cog_url, version, model)
-
-    def test_gsq_valid_deployment_url(self):
-        """Test _check_and_format_azure_endpoint_url method in GSQ component."""
-        url_pattern = AZURE_OPENAI_API_DEPLOYMENT_URL_PATTERN
-        domain_pattern_re = AZURE_ENDPOINT_DOMAIN_VALID_PATTERN_RE
-        version = "2022-12-01"
-        model = "test_model"
-        valid_url = "abc.openai.azure.com"
-        formatted_url = _check_and_format_azure_endpoint_url(
-            url_pattern, domain_pattern_re, valid_url, version, model)
-        expected_format = f"https://{valid_url}/openai/deployments/{model}?api-version={version}"
-        assert formatted_url == expected_format
 
     def test_gsq_apply_annotation(self, code_zip_test_setup,
                                   gsq_preprocessor_test_setup):


### PR DESCRIPTION
use deployment name instead of model type in GSQ component when calling evaluate API

After new debugging was added, some failures were found to occur due to model_type being erroneously specified instead of the deployment name:

```
OpenAI API hits NotFoundError: Error code: 404 - {'error': {'code': 'DeploymentNotFound', 'message': 'The API deployment for this resource does not exist. If you created the deployment within the last 5 minutes, please wait a moment and try again.'}} [Error reference: 
https://platform.openai.com/docs/guides/error-codes/api-errors]
```

The fix was to change the evaluate deployment_id to use the specified deployment name instead of getting the model_type via API and using that, which actually simplified the code a lot.

Copilot summary:

This pull request primarily involves a cleanup of the `assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py` file. The changes remove unused constants and functions, and refactor the `apply_annotation` and `annotate_batch` functions to simplify the code and remove unnecessary code.

Removal of unused constants and functions:

* Removed HTTP constants and Azure endpoint constants, as they are no longer needed.
* Removed model type constants, which were no longer in use.
* Removed the `_check_and_format_azure_endpoint_url` and `_get_model_type` functions, which were not being used. [[1]](diffhunk://#diff-fc312ce9848984d76b756f6eeac9ba9e473786d7079d3d520636ca805a0616a1L170-L189) [[2]](diffhunk://#diff-fc312ce9848984d76b756f6eeac9ba9e473786d7079d3d520636ca805a0616a1L292-L311)

Refactoring of functions:

* In the `apply_annotation` function, removed lines setting `endpoint_domain_name` and `model_type`, as these are no longer needed. [[1]](diffhunk://#diff-fc312ce9848984d76b756f6eeac9ba9e473786d7079d3d520636ca805a0616a1L604-L608) [[2]](diffhunk://#diff-fc312ce9848984d76b756f6eeac9ba9e473786d7079d3d520636ca805a0616a1L621) [[3]](diffhunk://#diff-fc312ce9848984d76b756f6eeac9ba9e473786d7079d3d520636ca805a0616a1L630-L636)
* In the `annotate_batch` function, changed the `deployment_id` parameter to use `model_deployment_name` instead of `model_type`.

See green run for successful e2e run example:
https://ml.azure.com/runs/hungry_shoe_bkcd0g8vzj?wsid=/subscriptions/a75ae43f-9f72-4699-ba66-d3a173cfe082/resourcegroups/ilmatdpv2rg3/providers/Microsoft.MachineLearningServices/workspaces/ilmatdpv2ws3&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#