### PR TITLE
fix e2e model monitoring auth test failures by moving requirements install above login to azure

### DIFF
--- a/.github/actions/create-azure-resources/action.yaml
+++ b/.github/actions/create-azure-resources/action.yaml
@@ -18,11 +18,12 @@ runs:
   using: composite
   steps:
     - name: Log in to Azure
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        enable-AzPSSession: true
 
     - name: Create Azure resources
       shell: bash

--- a/.github/workflows/assets-validation.yaml
+++ b/.github/workflows/assets-validation.yaml
@@ -60,7 +60,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         if: env.client_id != '' && env.tenant_id != ''
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           client-id: ${{ env.client_id }}
           tenant-id: ${{ env.tenant_id }}

--- a/.github/workflows/model-monitoring-ci.yml
+++ b/.github/workflows/model-monitoring-ci.yml
@@ -93,6 +93,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
+
+      - name: Install dependencies
+        run: pip install -r ${{ env.testsRootPath }}/requirements.txt
+
       - name: Log in to Azure and create resources
         uses: ./.github/actions/create-azure-resources
         with:
@@ -100,9 +104,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           scripts-setup-dir: ${{ env.scripts_setup_dir }}
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.testsRootPath }}/requirements.txt
 
       - name: Test asset
         run: python -m pytest --junitxml=${{ env.pytest_report_folder }}/group_${{ matrix.group }}_${{ env.pytest_report_file }} ${{ env.momoComponentsRootPath }} -o log_level=DEBUG -n 8 -m "not gsq_test" --ignore ${{ env.momoComponentsRootPath }}/tests/unit/test_gsq_histogram.py --ignore ${{ env.momoComponentsRootPath }}/tests/unit/test_gsq_metrics.py --splits 6 --group ${{ matrix.group }}

--- a/.github/workflows/model-monitoring-gsq-ci.yml
+++ b/.github/workflows/model-monitoring-gsq-ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install fusepy
         run: sudo apt-get install -y fuse
 
+      - name: Install dependencies
+        run: pip install -r ${{ env.testsRootPath }}/gsq-requirements.txt
+
       - name: Log in to Azure and create resources
         uses: ./.github/actions/create-azure-resources
         with:
@@ -56,9 +59,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           scripts-setup-dir: ${{ env.scripts_setup_dir }}
-
-      - name: Install dependencies
-        run: pip install -r ${{ env.testsRootPath }}/gsq-requirements.txt
 
       - name: Test asset
         run: python -m pytest --junitxml=${{ env.pytest_report_folder }}/${{ env.pytest_report_file }} ${{ env.momoComponentsRootPath }}/tests/unit/test_gsq_metrics.py ${{ env.momoComponentsRootPath }}/tests/unit/test_gsq_histogram.py ${{ env.momoComponentsRootPath }}/tests/e2e/test_generation_safety_quality_e2e.py -o log_level=DEBUG -m gsq_test

--- a/.github/workflows/promptflow-ci.yml
+++ b/.github/workflows/promptflow-ci.yml
@@ -91,7 +91,7 @@ jobs:
           pip install -r scripts/promptflow-ci/requirement.txt
 
       - name: Azure login
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
fix e2e model monitoring auth test failures by moving requirements install above login to azure

E2E tests for model monitoring dpv2 components are failing with authentication errors like below.  This seems to be failing for several days now.  It looks like the azure-cli and azure-identity pip requirements install is resetting the azure authentication done in the pipeline.  This PR moves the requirements install above the azure authentication in the pipeline to fix the authentication errors.

```
...
2024-04-11T22:33:55.2085515Z WARNING  azure.identity._internal.decorators:decorators.py:54 AzureCliCredential.get_token failed: Please run 'az login' to set up an account
2024-04-11T22:33:55.2086305Z Traceback (most recent call last):
2024-04-11T22:33:55.2087263Z   File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/azure/identity/_credentials/azure_cli.py", line 148, in _run_command
2024-04-11T22:33:55.2088120Z     return subprocess.check_output(args, **kwargs)
...
2024-04-11T22:33:55.2091021Z     raise CalledProcessError(retcode, process.args,
2024-04-11T22:33:55.2092631Z subprocess.CalledProcessError: Command '['/bin/sh', '-c', 'az account get-access-token --output json --resource https://management.azure.com --tenant ***']' returned non-zero exit status 1.
...
2024-04-11T22:33:55.2093821Z During handling of the above exception, another exception occurred:
...
2024-04-11T22:33:55.2098844Z   File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/azure/identity/_credentials/azure_cli.py", line 154, in _run_command
2024-04-11T22:33:55.2099761Z     raise CredentialUnavailableError(message=NOT_LOGGED_IN)
2024-04-11T22:33:55.2100551Z azure.identity._exceptions.CredentialUnavailableError: Please run 'az login' to set up an account
```

Copilot summary:

This pull request primarily focuses on improving the organization and order of operations in the GitHub Actions workflows for model monitoring. The key changes involve repositioning the steps for installing dependencies in two workflow files: `.github/workflows/model-monitoring-ci.yml` and `.github/workflows/model-monitoring-gsq-ci.yml`.

Here are the most important changes:

* `model-monitoring-ci.yml` workflow updates:
  * The step to install dependencies has been moved up in the workflow sequence, occurring after setting up Python but before logging in to Azure and creating resources.
  * The previous location of the dependency installation step has been removed.

* `model-monitoring-gsq-ci.yml` workflow updates:
  * Similar to the changes in `model-monitoring-ci.yml`, the dependency installation step has been moved up to follow the installation of fusepy and precede the Azure login and resource creation.
  * The original location of the dependency installation step has been removed.

These changes should help streamline the workflows by ensuring dependencies are installed early in the process, which could potentially prevent issues down the line.