### PR TITLE
Revert request_id logic in trace aggregator

### DIFF
--- a/assets/model_monitoring/components/src/model_data_collector_preprocessor/trace_aggregator.py
+++ b/assets/model_monitoring/components/src/model_data_collector_preprocessor/trace_aggregator.py
@@ -59,7 +59,9 @@ def aggregate_spans_into_traces(
 
     # for PromptFlow we need to replace the trace_id values with request_id in order to handle edge cases
     # where PF has same trace_id but multiple LLM requests
-    enlarged_span_logs = enlarged_span_logs.rdd.map(_replace_trace_with_request_id).toDF(enlarged_span_logs.schema)
+    # TODO: Prompt flow team doesn't guarantee that all spans will have request_id due to a backlog of work.
+    # Uncomment the code below when we get a guarantee from them
+    # enlarged_span_logs = enlarged_span_logs.rdd.map(_replace_trace_with_request_id).toDF(enlarged_span_logs.schema)
 
     grouped_spans_df = enlarged_span_logs.groupBy('trace_id').agg(
         collect_list(

--- a/assets/model_monitoring/components/tests/unit/test_trace_aggregator.py
+++ b/assets/model_monitoring/components/tests/unit/test_trace_aggregator.py
@@ -310,8 +310,8 @@ class TestGenAISparkPreprocessor:
              datetime(2024, 2, 5, 6), datetime(2024, 2, 5, 7)),
             # request_id data
             # TODO: uncomment when we want to test replacing trace_id with request_id
-            # (_span_log_data_request_id, _preprocessed_log_schema, _trace_log_data_request_id, _trace_log_schema, True,
-            #  datetime(2024, 2, 5, 9), datetime(2024, 2, 5, 10))
+            # (_span_log_data_request_id, _preprocessed_log_schema, _trace_log_data_request_id, _trace_log_schema,
+            #  True, datetime(2024, 2, 5, 9), datetime(2024, 2, 5, 10))
         ]
     )
     def test_trace_aggregator(

--- a/assets/model_monitoring/components/tests/unit/test_trace_aggregator.py
+++ b/assets/model_monitoring/components/tests/unit/test_trace_aggregator.py
@@ -309,8 +309,9 @@ class TestGenAISparkPreprocessor:
             (_span_log_data_lookback, _preprocessed_log_schema, _trace_log_data_lookback, _trace_log_schema, True,
              datetime(2024, 2, 5, 6), datetime(2024, 2, 5, 7)),
             # request_id data
-            (_span_log_data_request_id, _preprocessed_log_schema, _trace_log_data_request_id, _trace_log_schema, True,
-             datetime(2024, 2, 5, 9), datetime(2024, 2, 5, 10))
+            # TODO: uncomment when we want to test replacing trace_id with request_id
+            # (_span_log_data_request_id, _preprocessed_log_schema, _trace_log_data_request_id, _trace_log_schema, True,
+            #  datetime(2024, 2, 5, 9), datetime(2024, 2, 5, 10))
         ]
     )
     def test_trace_aggregator(


### PR DESCRIPTION
Promptflow has lots limited bandwidth and hasn't fully implemented request_id so they don't guarantee request_id on every span. Therefore our trace aggregation logic is broken until we have request_id on every span so revert the change until further notice.