### PR TITLE
Update HumanEval Post Processor to handle partial code with same function name

### DIFF
--- a/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
+++ b/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
@@ -27,23 +27,18 @@ def _parse_args():
     parser.add_argument(
         "--prediction_dataset",
         type=str,
-        required=False,
-        default="C:/Users/sagoswami/Downloads/mistral/predictions.jsonl",
+        required=True,
         help="Path to load the prediction dataset."
     )
     parser.add_argument(
         "--ground_truth_dataset",
         type=str,
-        help="Path to load the actual dataset.",
-        required=False,
-        default="C:/Users/sagoswami/Downloads/mistral/ground_truth.jsonl",
+        help="Path to load the actual dataset."
     )
     parser.add_argument(
         "--output_dataset",
         type=str,
-        help="Path to the jsonl output file to write the processed data.",
-        required=False,
-        default="C:/Users/sagoswami/Downloads/mistral/op.jsonl"
+        help="Path to the jsonl output file to write the processed data."
     )
     argss = parser.parse_args()
     return argss
@@ -198,11 +193,10 @@ def run_humaneval_postprocessor(
         # Extract the prediction data from the markdown tags
         pred_combined_prompt = _extract_text_from_markdown_tag(row["original_prediction"], tag_type)
 
-        # Check if the function name is present in the prediction
         func_name_index = pred_combined_prompt.find(str("def " + row["entry_point"] + "("))
         return_keyword_index = pred_combined_prompt.find("return")
 
-        # If function definition is not present or multiple functions present in the prediction
+        # If function definition is not present or present after the first function body prediction
         if func_name_index == -1 or return_keyword_index < func_name_index:
             # If spaces were stripped from endpoint responses, add those back.
             if len(pred_combined_prompt) > 0 and pred_combined_prompt[0].isspace():

--- a/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
+++ b/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
@@ -187,7 +187,7 @@ def run_humaneval_postprocessor(
         func_name_index = row["original_prediction"].find(str("def " + row["entry_point"] + "("))
         return_keyword_index = row["original_prediction"].find("return")
 
-        if func_name_index != -1 and return_keyword_index > func_name_index:    
+        if func_name_index != -1 and return_keyword_index > func_name_index:
             # If the model regenerates the prompt/ function name
             pred_combined_prompt = _extract_text_from_markdown_tag(row["original_prediction"], tag_type='python')
         else:

--- a/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
+++ b/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
@@ -184,10 +184,7 @@ def run_humaneval_postprocessor(
     # Post processing the prediction and ground truth columns
     for row in pred_dict_full:
         gt = "\n" + row["test"] + "\n" + "check(" + row["entry_point"] + ")"
-        if "python" in row["original_prediction"]:
-            tag_type = "python"
-        else:
-            tag_type = ""
+        tag_type = "python" if "python" in row["original_prediction"] else ""
 
         # Extract the prediction data from the markdown tags
         pred_combined_prompt = _extract_text_from_markdown_tag(row["original_prediction"], tag_type)

--- a/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
+++ b/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
@@ -27,23 +27,18 @@ def _parse_args():
     parser.add_argument(
         "--prediction_dataset",
         type=str,
-        required=False,
-        help="Path to load the prediction dataset.",
-        default = "C:/Users/sagoswami/Downloads/gpt/predictions.jsonl"
+        required=True,
+        help="Path to load the prediction dataset."
     )
     parser.add_argument(
         "--ground_truth_dataset",
         type=str,
-        help="Path to load the actual dataset.",
-        required= False,
-        default = "C:/Users/sagoswami/Downloads/gpt/ground_truth.jsonl"
+        help="Path to load the actual dataset."
     )
     parser.add_argument(
         "--output_dataset",
         type=str,
-        help="Path to the jsonl output file to write the processed data.",
-        required= False,
-        default = "C:/Users/sagoswami/Downloads/gpt/output.jsonl"
+        help="Path to the jsonl output file to write the processed data."
     )
     argss = parser.parse_args()
     return argss
@@ -188,8 +183,6 @@ def run_humaneval_postprocessor(
 
     # Post processing the prediction and ground truth columns
     for row in pred_dict_full:
-        if row['completion']!= "HumanEval/38":
-            continue
         gt = "\n" + row["test"] + "\n" + "check(" + row["entry_point"] + ")"
         tag_type = "python" if "```python" in row["original_prediction"] else ""
 
@@ -209,8 +202,7 @@ def run_humaneval_postprocessor(
                 prefix = "    "
             pred_combined_prompt = row["prompt"] + "\n" + prefix + pred_combined_prompt
         else:
-            # If function name is present in the prediction
-            # we need to remove the function name from the prompt
+            # If function name is present in the prediction, then remove from prompt
             prompt_header = row["prompt"].split(str("def " + row["entry_point"]))[0]
             pred_combined_prompt = prompt_header + "\n" + pred_combined_prompt
 

--- a/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
+++ b/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
@@ -194,8 +194,8 @@ def run_humaneval_postprocessor(
         func_name_index = pred_combined_prompt.find(str("def " + row["entry_point"]))
         return_keyword_index = pred_combined_prompt.find("return")
 
-        # If function definition is not present or present after the initial function body prediction       
-        if def_index == -1 or return_keyword_index < def_index or func_name_index==-1:
+        # If function definition is not present or present after the initial function body prediction
+        if def_index == -1 or return_keyword_index < def_index or func_name_index == -1:
             # If spaces were stripped from endpoint responses, add those back.
             if len(pred_combined_prompt) > 0 and pred_combined_prompt[0].isspace():
                 prefix = ""

--- a/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
+++ b/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
@@ -184,7 +184,6 @@ def run_humaneval_postprocessor(
     # Post processing the prediction and ground truth columns
     for row in pred_dict_full:
         gt = "\n" + row["test"] + "\n" + "check(" + row["entry_point"] + ")"
-
         if "python" in row["original_prediction"]:
             tag_type = "python"
         else:
@@ -193,10 +192,11 @@ def run_humaneval_postprocessor(
         # Extract the prediction data from the markdown tags
         pred_combined_prompt = _extract_text_from_markdown_tag(row["original_prediction"], tag_type)
 
+        # Get the index of the first function definition and return keyword
         func_name_index = pred_combined_prompt.find(str("def " + row["entry_point"] + "("))
         return_keyword_index = pred_combined_prompt.find("return")
 
-        # If function definition is not present or present after the first function body prediction
+        # If function definition is not present or present after the initial function body prediction
         if func_name_index == -1 or return_keyword_index < func_name_index:
             # If spaces were stripped from endpoint responses, add those back.
             if len(pred_combined_prompt) > 0 and pred_combined_prompt[0].isspace():

--- a/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
+++ b/assets/aml-benchmark/scripts/custom_inference_postprocessors/humaneval.py
@@ -184,7 +184,10 @@ def run_humaneval_postprocessor(
     # Post processing the prediction and ground truth columns
     for row in pred_dict_full:
         gt = "\n" + row["test"] + "\n" + "check(" + row["entry_point"] + ")"
-        if str("def " + row["entry_point"] + "(") in row["original_prediction"]:
+        func_name_index = row["original_prediction"].find(str("def " + row["entry_point"] + "("))
+        return_keyword_index = row["original_prediction"].find("return")
+
+        if func_name_index != -1 and return_keyword_index > func_name_index:    
             # If the model regenerates the prompt/ function name
             pred_combined_prompt = _extract_text_from_markdown_tag(row["original_prediction"], tag_type='python')
         else:


### PR DESCRIPTION
1. Previously, if partial code was followed by more functions but with the same name, it was not appending the initial part of the code.

Example-
Input-
def sort(arr):
 
Prediction:
    return arr.sorted()\ndef sort(arr): return arr.sorted()\nreturn
 
post processedprediction-
return arr.sorted()\ndef sort(arr)...

2. Handle the scenario when the code is in ```code_here``` but does not have python as tag_type?