### PR TITLE
Add chat-completion in supported task types

### DIFF
--- a/assets/common/components/mlflow_model_local_validation/spec.yaml
+++ b/assets/common/components/mlflow_model_local_validation/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 
 name: mlflow_model_local_validation
-version: 0.0.9
+version: 0.0.10
 type: command
 
 is_deterministic: True
@@ -41,6 +41,7 @@ inputs:
   task_name:
     description: A Hugging face task on which model was trained on
     enum:
+      - chat-completion
       - fill-mask
       - token-classification
       - question-answering

--- a/assets/training/model_management/components/convert_model_to_mlflow/spec.yaml
+++ b/assets/training/model_management/components/convert_model_to_mlflow/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 
 name: convert_model_to_mlflow
-version: 0.0.25
+version: 0.0.26
 type: command
 
 is_deterministic: True
@@ -51,6 +51,7 @@ inputs:
   task_name:
     type: string
     enum:
+      - chat-completion
       - fill-mask
       - token-classification
       - question-answering

--- a/assets/training/model_management/components/import_model/spec.yaml
+++ b/assets/training/model_management/components/import_model/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: import_model
 display_name: Import model
 description: Import a model into a workspace or a registry
-version: 0.0.29
+version: 0.0.30
 
 # Pipeline inputs
 inputs:
@@ -61,6 +61,7 @@ inputs:
   task_name:
     description: A Hugging face task on which model was trained on
     enum:
+      - chat-completion
       - fill-mask
       - token-classification
       - question-answering
@@ -253,7 +254,7 @@ jobs:
         type: uri_folder
 
   convert_model_to_mlflow:
-    component: azureml:convert_model_to_mlflow:0.0.25
+    component: azureml:convert_model_to_mlflow:0.0.26
     compute: ${{parent.inputs.compute}}
     resources:
       instance_type: '${{parent.inputs.instance_type}}'
@@ -277,7 +278,7 @@ jobs:
         type: mlflow_model
 
   mlflow_model_local_validation:
-    component: azureml:mlflow_model_local_validation:0.0.9
+    component: azureml:mlflow_model_local_validation:0.0.10
     compute: ${{parent.inputs.compute}}
     resources:
       instance_type: '${{parent.inputs.instance_type}}'

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/config.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/config.py
@@ -83,6 +83,7 @@ class SupportedTasks(_CustomEnum):
     """Supported Hugging face tasks for conversion to MLflow."""
 
     # NLP tasks
+    CHAT_COMPLETION = "chat-completion"
     FILL_MASK = "fill-mask"
     TOKEN_CLASSIFICATION = "token-classification"
     QUESTION_ANSWERING = "question-answering"

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/config.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/config.py
@@ -62,6 +62,7 @@ class SupportedVisionTasks(_CustomEnum):
 class SupportedNLPTasks(_CustomEnum):
     """Supported NLP Hugging face tasks."""
 
+    CHAT_COMPLETION = "chat-completion"
     FILL_MASK = "fill-mask"
     TOKEN_CLASSIFICATION = "token-classification"
     QUESTION_ANSWERING = "question-answering"

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/convertors.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/transformers/convertors.py
@@ -535,6 +535,7 @@ class NLPMLflowConvertor(HFMLFLowConvertor):
         "token-classification": AutoModelForTokenClassification,
         "question-answering": AutoModelForQuestionAnswering,
         "summarization": AutoModelForSeq2SeqLM,
+        "chat-completion": AutoModelForCausalLM,
         "text-generation": AutoModelForCausalLM,
         "translation": AutoModelForSeq2SeqLM,
     }
@@ -547,7 +548,7 @@ class NLPMLflowConvertor(HFMLFLowConvertor):
 
     def get_model_signature(self):
         """Return model signature for NLP models."""
-        if self._task == SupportedNLPTasks.TEXT_GENERATION.value:
+        if self._task == SupportedNLPTasks.TEXT_GENERATION.value or self._task == SupportedNLPTasks.CHAT_COMPLETION:
             inputs = Schema([ColSpec(DataType.string)])
             outputs = Schema([ColSpec(DataType.string)])
             params = ParamSchema([ParamSpec("top_p", "float", default=0.8),


### PR DESCRIPTION
chat-completion is a supported task in azureml-evaluate-mlflow. 
Enabled that through import component 

### Test
validated run: [link](https://ml.azure.com/experiments/id/73851a87-795e-4ac3-9c8b-15f6ab747801/runs/8c38332e-026b-4bf1-97c5-53424c3a70cc?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/jais-rg/providers/Microsoft.MachineLearningServices/workspaces/jais-eastus01&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)