### PR TITLE
[Internal] Add extra requirements "azure" for promptflow package

### DIFF
--- a/scripts/promptflow-ci/requirement.txt
+++ b/scripts/promptflow-ci/requirement.txt
@@ -4,5 +4,6 @@ markdown
 bs4
 azureml-core
 promptflow
+promptflow-azure
 azure-ai-ml
 azure-cli-core

--- a/scripts/promptflow-ci/requirement.txt
+++ b/scripts/promptflow-ci/requirement.txt
@@ -3,7 +3,6 @@ azure-identity
 markdown
 bs4
 azureml-core
-promptflow
-promptflow-azure
+promptflow[azure]
 azure-ai-ml
 azure-cli-core


### PR DESCRIPTION
Add extra requirements "azure" for promptflow package in ci workflow because of promptflow package update.