### PR TITLE
[Internal] Add 'Azure/promptflow-builtin' and 'azure/aml-assets' code owner for '/scripts/promptflow-ci/' folder"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,4 @@
 /assets/batch_score/ @Azure/aml-batch-inferencing
 /assets/promptflow/ @Azure/promptflow-builtin @azure/aml-assets
 /assets/training/model_management/environments/foundation-model-inference @Azure/aml-ossmodels
+/scripts/promptflow-ci/ @Azure/promptflow-builtin @azure/aml-assets


### PR DESCRIPTION
It could be possible that we need to update the promptflow ci workflow file because of package upgrade. For example: https://github.com/Azure/azureml-assets/pull/2699. Request to add '@Azure/promptflow-builtin @azure/aml-assets' code owner for '/scripts/promptflow-ci/' folder". 