### PR TITLE
porting changes from AzureMlCli -> azureml-assets

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
+++ b/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
@@ -476,7 +476,10 @@ def get_parser():
         help="Loads Optimizer, Scheduler and Trainer state for finetuning if true",
     )
     parser.add_argument(
-        "--save_strategy", type=str, default=SaveStrategy.EVALUATION_STRATEGY, help="The checkpoint save strategy to adopt during training.",
+        "--save_strategy",
+        type=str,
+        default=SaveStrategy.EVALUATION_STRATEGY,
+        help="The checkpoint save strategy to adopt during training.",
     )
     parser.add_argument(
         "--save_steps",

--- a/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
+++ b/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
@@ -28,6 +28,7 @@ from azureml.acft.contrib.hf.nlp.constants.constants import (
     MLFlowHFFlavourConstants,
     LOGS_TO_BE_FILTERED_IN_APPINSIGHTS,
     MLFLOW_FLAVORS,
+    SaveStrategy,
 )
 from azureml.acft.contrib.hf.nlp.task_factory import get_task_runner
 from azureml.acft.contrib.hf.nlp.utils.common_utils import deep_update
@@ -50,6 +51,8 @@ from azureml._common._error_definition.azureml_error import AzureMLError  # type
 logger = get_logger_app("azureml.acft.contrib.hf.scripts.src.finetune.finetune")
 
 COMPONENT_NAME = "ACFT-Finetune"
+
+PHI3_MINI_4K_INSTRUCT_MODEL_TYPE = "phi3mini"
 
 
 DEFAULT_DEEPSPEED_STAGE2_CONFIG = str(Path(__file__).parent.resolve() / "zero2.json")
@@ -175,6 +178,7 @@ ACFT_REGEX_PREFIX = "acft_regex:"
 
 DEEPSPEED_STAGE3_SUPPORTED_TASKS = [
     Tasks.TEXT_GENERATION,
+    Tasks.CHAT_COMPLETION
 ]
 DEEPSPEED_STAGE3_SUPPORTED_TASKS_REGEX_LIST = "|".join(DEEPSPEED_STAGE3_SUPPORTED_TASKS)
 # the below regex exludes DEEPSPEED_STAGE3_SUPPORTED_TASKS and matches other words
@@ -186,6 +190,8 @@ DEEPSPEED_STAGE3_SUPPORTED_MODEL_TYPES = [
     HfModelTypes.FALCON,
     HfModelTypes.MISTRAL,
     HfModelTypes.MIXTRAL,
+    HfModelTypes.PHI_LONGROPE,
+    PHI3_MINI_4K_INSTRUCT_MODEL_TYPE,
 ]
 DEEPSPEED_STAGE3_SUPPORTED_MODEL_TYPES_REGEX_LIST = "|".join(DEEPSPEED_STAGE3_SUPPORTED_MODEL_TYPES)
 # the below regex exludes DEEPSPEED_STAGE3_SUPPORTED_MODEL_TYPES and matches other words
@@ -197,6 +203,8 @@ FORCE_GRADIENT_CHECKPOINTING_MODEL_TYPES = [
     HfModelTypes.FALCON,
     HfModelTypes.MISTRAL,
     HfModelTypes.MIXTRAL,
+    HfModelTypes.PHI_LONGROPE,
+    PHI3_MINI_4K_INSTRUCT_MODEL_TYPE,
 ]
 
 FORCE_FLASH_ATTENTION_2_MODEL_TYPES = [
@@ -204,6 +212,8 @@ FORCE_FLASH_ATTENTION_2_MODEL_TYPES = [
     HfModelTypes.FALCON,
     HfModelTypes.MISTRAL,
     HfModelTypes.MIXTRAL,
+    HfModelTypes.PHI_LONGROPE,
+    PHI3_MINI_4K_INSTRUCT_MODEL_TYPE,
 ]
 
 
@@ -464,6 +474,15 @@ def get_parser():
         type=str2bool,
         default="false",
         help="Loads Optimizer, Scheduler and Trainer state for finetuning if true",
+    )
+    parser.add_argument(
+        "--save_strategy", type=str, default=SaveStrategy.EVALUATION_STRATEGY, help="The checkpoint save strategy to adopt during training.",
+    )
+    parser.add_argument(
+        "--save_steps",
+        type=int,
+        default=100,
+        help="Number of update steps between two checkpoint saves if save_strategy='steps'",
     )
     parser.add_argument(
         "--save_total_limit",
@@ -1131,6 +1150,7 @@ def finetune(args: Namespace):
                         )
                     )
                 )
+        logger.info("Enabling QLoRA finetuning")
         if not args.apply_lora:
             logger.info("Lora is not enabled. Setting it to true.")
             setattr(args, "apply_lora", True)
@@ -1165,8 +1185,10 @@ def finetune(args: Namespace):
     else:
         logger.info(f"evaluation_steps_interval: {args.evaluation_steps_interval}")
 
-    args.save_strategy = args.evaluation_strategy
-    args.save_steps = args.eval_steps
+    if args.save_strategy == SaveStrategy.EVALUATION_STRATEGY:
+        logger.info(f"Setting save strategy to evaluation strategy: {args.evaluation_strategy}, {args.eval_steps}")
+        args.save_strategy = args.evaluation_strategy
+        args.save_steps = args.eval_steps
 
     if args.task_name not in [Tasks.TEXT_GENERATION]:
         removed_base_image = metadata.pop("azureml.base_image", None)

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -42,6 +42,7 @@ MLFLOW_TASK_HF_PRETRAINED_CLASS_MAP = {
     MLFlowHFFlavourTasks.TEXT_GENERATION: "AutoModelForCausalLM",
     MLFlowHFFlavourTasks.SUMMARIZATION: "AutoModelForSeq2SeqLM",
     MLFlowHFFlavourTasks.TRANSLATION: "AutoModelForSeq2SeqLM",
+    MLFlowHFFlavourTasks.CHAT_COMPLETION: "AutoModelForCausalLM",
 }
 
 
@@ -120,6 +121,16 @@ class PyTorch_to_MlFlow_ModelConverter:
         ))
         with open(mlflow_infer_params_file_path, 'r') as fp:
             mlflow_inference_params = json.load(fp)
+
+        # Ignore `return_full_text` key for chat completion
+        # HACK for now - Ideal place to do this is in preprocess_for_finetune.py of chat completion task
+        if self.mlflow_task_type == MLFlowHFFlavourTasks.CHAT_COMPLETION:
+            if MLFlowHFFlavourConstants.INFERENCE_PARAMS_SAVE_KEY in mlflow_inference_params:
+                mlflow_inference_params[MLFlowHFFlavourConstants.INFERENCE_PARAMS_SAVE_KEY].pop(
+                    "return_full_text", None
+                )
+                logger.info(
+                    f"Removing `return_full_text` from {MLFlowHFFlavourConstants.INFERENCE_PARAMS_SAVE_KEY} key.")
 
         misc_conf = {
             MLFlowHFFlavourConstants.TASK_TYPE: self.mlflow_task_type,

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_utils.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_utils.py
@@ -44,6 +44,7 @@ ACFT_TASKS_HUGGINGFACE_MODELS_MAPPING = {
     Tasks.TRANSLATION: AutoModelForSeq2SeqLM,
     Tasks.QUESTION_ANSWERING: AutoModelForQuestionAnswering,
     Tasks.TEXT_GENERATION: AutoModelForCausalLM,
+    Tasks.CHAT_COMPLETION: AutoModelForCausalLM,
 }
 
 
@@ -55,6 +56,7 @@ ACFT_TASKS_PEFT_MODELS_MAPPING = {
     Tasks.TRANSLATION: AutoPeftModelForSeq2SeqLM,
     Tasks.QUESTION_ANSWERING: AutoPeftModelForQuestionAnswering,
     Tasks.TEXT_GENERATION: AutoPeftModelForCausalLM,
+    Tasks.CHAT_COMPLETION: AutoPeftModelForCausalLM,
 }
 
 

--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -93,7 +93,6 @@ def get_model_asset_id() -> str:
 
 def validate_huggingface_id(huggingface_id: str) -> None:
     """Validate the huggingface_id using Hfapi. Raise exception if the huggingface id is invalid."""
-
     from huggingface_hub import HfApi, ModelFilter
     hf_api = HfApi()  # by default endpoint points to https://huggingface.co
 

--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -93,6 +93,7 @@ def get_model_asset_id() -> str:
 
 def validate_huggingface_id(huggingface_id: str) -> None:
     """Validate the huggingface_id using Hfapi. Raise exception if the huggingface id is invalid."""
+
     from huggingface_hub import HfApi, ModelFilter
     hf_api = HfApi()  # by default endpoint points to https://huggingface.co
 

--- a/assets/training/finetune_acft_hf_nlp/src/register_model/register_model.py
+++ b/assets/training/finetune_acft_hf_nlp/src/register_model/register_model.py
@@ -202,6 +202,7 @@ def get_properties(finetune_args_path: str) -> Dict[str, str]:
     additional_properties = {
         "baseModelWeightsVersion": 1.0,
         "hasDeltaWeights": "true",
+        "maas-finetuning": "true",
     }
     properties.update(additional_properties)
     logger.info(f"Adding the following properties to the registered model: {properties}")


### PR DESCRIPTION
Finetune Changes
============
1. Allowing deepspeed stage3 finetune for chat completion task.
2. Adding `mixtral`, `philongrope`, `phi3mini` to the default Gradient Checkpoint allowlist.
3. Adding `mixtral`, `philongrope`, `phi3mini` to the default Flash attention allowlist.
4. Added a temporary hack to remove `return_full_text` in mlflow params.
5. Separating `save_strategy` different from `evaluation_strategy`.
6. Adding `maas-finetuning` flag when registering the model.