### PR TITLE
get portal_url from result instead of construct them

### DIFF
--- a/assets/promptflow/.cspell.json
+++ b/assets/promptflow/.cspell.json
@@ -156,6 +156,7 @@
     ],
     "ignorePaths":[
       "**.py",
+      "**.pyc",
       "**.jinja2",
       "**.txt",
       "**.json",

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -107,18 +107,13 @@ def get_run_id_and_url(res, sub, rg, ws):
             match = re.search(r'"name": "(.*?)",', line)
             if match:
                 run_id = match.group(1)
-                portal_url = (
-                    f"https://ml.azure.com/prompts/bulkrun/{run_id}/details"
-                    f"?wsid=/subscriptions/{sub}/resourceGroups/{rg}/providers"
-                    f"/Microsoft.MachineLearningServices/workspaces/{ws}"
-                    )
-                log_debug(f"!!!!! runId: {run_id}")
+                log_debug(f"runId: {run_id}")
 
         if ('"portal_url":' in line):
             match = re.search(r'"portal_url": "(.*?)",', line)
             if match:
                 portal_url = match.group(1)
-                log_debug(f"!!!!! portal_url: {portal_url}")
+                log_debug(f"portal_url: {portal_url}")
     return run_id, portal_url
 
 

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -113,7 +113,7 @@ def get_run_id_and_url(res, sub, rg, ws):
                     f"/Microsoft.MachineLearningServices/workspaces/{ws}"
                     )
                 log_debug(f"!!!!! runId: {run_id}")
-        
+
         if ('"portal_url":' in line):
             match = re.search(r'"portal_url": "(.*?)",', line)
             if match:

--- a/scripts/promptflow-ci/utils/flow_utils.py
+++ b/scripts/promptflow-ci/utils/flow_utils.py
@@ -108,11 +108,17 @@ def get_run_id_and_url(res, sub, rg, ws):
             if match:
                 run_id = match.group(1)
                 portal_url = (
-                    f"https://ml.azure.com/prompts/flow/bulkrun/run/{run_id}/details"
+                    f"https://ml.azure.com/prompts/bulkrun/{run_id}/details"
                     f"?wsid=/subscriptions/{sub}/resourceGroups/{rg}/providers"
                     f"/Microsoft.MachineLearningServices/workspaces/{ws}"
                     )
-                log_debug(f"runId: {run_id}")
+                log_debug(f"!!!!! runId: {run_id}")
+        
+        if ('"portal_url":' in line):
+            match = re.search(r'"portal_url": "(.*?)",', line)
+            if match:
+                portal_url = match.group(1)
+                log_debug(f"!!!!! portal_url: {portal_url}")
     return run_id, portal_url
 
 


### PR DESCRIPTION
1. Get portal_url from result instead of construct them:
Before we constructed the portal_url by hardcode it, but this hardcode url has been changed, so we use open [this URL](https://ml.azure.com/prompts/flow/bulkrun/run/test_variant_0_20240425_020710_940752/details?wsid=/subscriptions/96aede12-2f73-41cb-b983-6d11a904839b/resourceGroups/promptflow/providers/Microsoft.MachineLearningServices/workspaces/chjinche-pf-eus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) to review the run will get a 404 page not found error :
![image](https://github.com/Azure/azureml-assets/assets/49388944/50addfdb-2d76-4eae-af21-04661ac52bcc)

Fix, directly use the portal_url in the result from pfazure run create.

2. Add "**.pyc" to ignorePaths in cspell.json file. Because of a bug, currently pfazure run create will try to gen meta for python tool, then it will generate some __pycache__ *.pyc file in current directly, so ignore the *.pyc file for cspell check.

