### PR TITLE
Component release 0.0.43

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/components/finetune/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_finetune
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_finetune
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_finetune
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: false

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_finetune
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Generation Finetune
 description: Component to finetune model for Text Generation task
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/50
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/51
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_finetune
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: false

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_finetune
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: ft_nlp_model_converter
-version: 0.0.42
+version: 0.0.43
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Common Model Converter
 description: Component to convert the finetune job output to pytorch and mlflow model
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/50
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/51
 
 code: ../../../src/model_converter
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_model_import
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_model_import
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_model_import
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_model_import
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Generation Model Import
 description: Import PyTorch / MLFlow model
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/50
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/51
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_model_import
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_model_import
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: question_answering_pipeline
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Question Answering Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for extractive question answering task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/question_answering_pipeline) to learn more.
@@ -541,7 +541,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -578,7 +578,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   question_answering_model_import:
     type: command
-    component: azureml:question_answering_model_import:0.0.40
+    component: azureml:question_answering_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -589,7 +589,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   question_answering_datapreprocess:
     type: command
-    component: azureml:question_answering_datapreprocess:0.0.40
+    component: azureml:question_answering_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -614,7 +614,7 @@ jobs:
       model_selector_output: '${{parent.jobs.question_answering_model_import.outputs.output_dir}}'
   question_answering_finetune:
     type: command
-    component: azureml:question_answering_finetune:0.0.40
+    component: azureml:question_answering_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -671,7 +671,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: summarization_pipeline
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Summarization Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for summarization task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/summarization_pipeline) to learn more.
@@ -512,7 +512,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -549,7 +549,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   summarization_model_import:
     type: command
-    component: azureml:summarization_model_import:0.0.40
+    component: azureml:summarization_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -560,7 +560,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   summarization_datapreprocess:
     type: command
-    component: azureml:summarization_datapreprocess:0.0.40
+    component: azureml:summarization_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -580,7 +580,7 @@ jobs:
       model_selector_output: '${{parent.jobs.summarization_model_import.outputs.output_dir}}'
   summarization_finetune:
     type: command
-    component: azureml:summarization_finetune:0.0.40
+    component: azureml:summarization_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -637,7 +637,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_classification_pipeline
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Classification Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for text classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/text_classification_pipeline) to learn more.
@@ -514,7 +514,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -551,7 +551,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_classification_model_import:
     type: command
-    component: azureml:text_classification_model_import:0.0.40
+    component: azureml:text_classification_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -562,7 +562,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   text_classification_datapreprocess:
     type: command
-    component: azureml:text_classification_datapreprocess:0.0.40
+    component: azureml:text_classification_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -583,7 +583,7 @@ jobs:
       model_selector_output: '${{parent.jobs.text_classification_model_import.outputs.output_dir}}'
   text_classification_finetune:
     type: command
-    component: azureml:text_classification_finetune:0.0.40
+    component: azureml:text_classification_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -640,7 +640,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline
 description: Pipeline component for text generation
@@ -528,7 +528,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -566,7 +566,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -578,7 +578,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -598,7 +598,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -656,7 +656,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_high
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_low
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_medium
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_high
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_low
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_medium
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_high
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_low
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_medium
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.40
+    component: azureml:text_generation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.40
+    component: azureml:text_generation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.40
+    component: azureml:text_generation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: token_classification_pipeline
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Token Classification Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for token classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/token_classification_pipeline) to learn more.
@@ -507,7 +507,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -544,7 +544,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   token_classification_model_import:
     type: command
-    component: azureml:token_classification_model_import:0.0.40
+    component: azureml:token_classification_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -555,7 +555,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   token_classification_datapreprocess:
     type: command
-    component: azureml:token_classification_datapreprocess:0.0.40
+    component: azureml:token_classification_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -574,7 +574,7 @@ jobs:
       model_selector_output: '${{parent.jobs.token_classification_model_import.outputs.output_dir}}'
   token_classification_finetune:
     type: command
-    component: azureml:token_classification_finetune:0.0.40
+    component: azureml:token_classification_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -631,7 +631,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: translation_pipeline
-version: 0.0.42
+version: 0.0.43
 type: pipeline
 display_name: Translation Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for translation task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/translation_pipeline) to learn more.
@@ -504,7 +504,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.40
+    component: azureml:ft_nlp_common_validation:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -541,7 +541,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   translation_model_import:
     type: command
-    component: azureml:translation_model_import:0.0.40
+    component: azureml:translation_model_import:0.0.41
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -552,7 +552,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   translation_datapreprocess:
     type: command
-    component: azureml:translation_datapreprocess:0.0.40
+    component: azureml:translation_datapreprocess:0.0.41
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -571,7 +571,7 @@ jobs:
       model_selector_output: '${{parent.jobs.translation_model_import.outputs.output_dir}}'
   translation_finetune:
     type: command
-    component: azureml:translation_finetune:0.0.40
+    component: azureml:translation_finetune:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -628,7 +628,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.40
+    component: azureml:ft_nlp_model_converter:0.0.41
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: chat_completion_datapreprocess
-version: 0.0.42
+version: 0.0.43
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_datapreprocess
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_datapreprocess
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_datapreprocess
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_datapreprocess
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Generation DataPreProcess
 description: Component to preprocess data for text generation task
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/50
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/51
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_datapreprocess
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_datapreprocess
-version: 0.0.40
+version: 0.0.41
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: ft_nlp_common_validation
-version: 0.0.42
+version: 0.0.43
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Common Validation Component
 description: Component to validate the finetune job against Validation Service
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/50
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/51
 
 code: ../../../src/validation
 


### PR DESCRIPTION
Env Update only for text-generation
Updated Env: https://github.com/Azure/azureml-assets/commit/fd8898696433b62dc9c3864a75554f38b0540483
Metrics Comparision with 0.0.42 components:
<html>
<body>
<!--StartFragment--><span><span class="ui-provider a b c d e f g h i j k l m n o p q r s t u v w x y z ab ac ae af ag ah ai aj ak" dir="ltr"><h1>Text Generation Results (Comparision b/w 0.0.42 &amp; Transformers 4.40.0)</h1><p style="margin-left: 40px;">Runs:</p><p style="margin-left: 40px;">&nbsp;0.0.42 = <a aria-label="Link test_text_generation - Azure AI | Machine Learning Studio" href="https://ml.azure.com/experiments/id/c288e65d-ebaf-4e22-bf56-2f8b6169b278/runs/e9481b33-024a-44e3-a6c8-3e7029b7a741?wsid=%2Fsubscriptions%2Fed2cab61-14cc-4fb3-ac23-d72609214cfd%2FresourceGroups%2Ftraining_rg%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Ftrain-finetune-dev-workspace&amp;tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" rel="noreferrer noopener" target="_blank" class="fui-Link ___1rxvrpe f2hkw1w f3rmtva f1ewtqcl fyind8e f1k6fduh f1w7gpdv fk6fouc fjoy568 figsok6 f1hu3pq6 f11qmguv f19f4twv f1tyq0we f1g0x7ka fhxju0i f1qch9an f1cnd47f fqv5qza f1vmzxwi f1o700av f13mvf36 f1cmlufx f9n3di6 f1ids18y f1tx3yz7 f1deo86v f1eh06m1 f1iescvh fhgqx19 f1olyrje f1p93eir f1nev41a f1h8hb77 f1lqvz6u f10aw75t fsle3fq f17ae5zn" title="https://ml.azure.com/experiments/id/c288e65d-ebaf-4e22-bf56-2f8b6169b278/runs/e9481b33-024a-44e3-a6c8-3e7029b7a741?wsid=%2fsubscriptions%2fed2cab61-14cc-4fb3-ac23-d72609214cfd%2fresourcegroups%2ftraining_rg%2fproviders%2fmicrosoft.machinelearningservices%2fworkspaces%2ftrain-finetune-dev-workspace&amp;tid=72f988bf-86f1-41af-91ab-2d7cd011db47#">test_text_generation - Azure AI | Machine Learning Studio</a></p><p style="margin-left: 40px;">Transformers = <a aria-label="Link test_text_generation - Azure AI | Machine Learning Studio" href="https://ml.azure.com/experiments/id/0ece48bb-8c8b-4155-8599-35355145fff3/runs/910cc191-b3d2-4bc6-9f29-ff22181b9d7d?wsid=%2Fsubscriptions%2Fed2cab61-14cc-4fb3-ac23-d72609214cfd%2FresourceGroups%2Ftraining_rg%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Ftrain-finetune-dev-workspace&amp;tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" rel="noreferrer noopener" target="_blank" class="fui-Link ___1rxvrpe f2hkw1w f3rmtva f1ewtqcl fyind8e f1k6fduh f1w7gpdv fk6fouc fjoy568 figsok6 f1hu3pq6 f11qmguv f19f4twv f1tyq0we f1g0x7ka fhxju0i f1qch9an f1cnd47f fqv5qza f1vmzxwi f1o700av f13mvf36 f1cmlufx f9n3di6 f1ids18y f1tx3yz7 f1deo86v f1eh06m1 f1iescvh fhgqx19 f1olyrje f1p93eir f1nev41a f1h8hb77 f1lqvz6u f10aw75t fsle3fq f17ae5zn" title="https://ml.azure.com/experiments/id/0ece48bb-8c8b-4155-8599-35355145fff3/runs/910cc191-b3d2-4bc6-9f29-ff22181b9d7d?wsid=%2fsubscriptions%2fed2cab61-14cc-4fb3-ac23-d72609214cfd%2fresourcegroups%2ftraining_rg%2fproviders%2fmicrosoft.machinelearningservices%2fworkspaces%2ftrain-finetune-dev-workspace&amp;tid=72f988bf-86f1-41af-91ab-2d7cd011db47#">test_text_generation - Azure AI | Machine Learning Studio</a></p>
Display name | compute_metrics (0.0.42) | compute_metrics (Transformers)
-- | -- | --
rougeLsum | 0.2220351 | 0.2072528 (0.015) ↓
rouge1 | 0.2649654 | 0.2482362 (0.017) ↓
rouge2 | 0.1039491 | 0.1000652 (0.004)↓
rougeL | 0.2160850 | 0.2058724 (0.010)↓
bleu_2 | 0.06259758 | 0.05877610 (0.004)↓
mean_perplexity | 52.97975 | 51.73906 (1.241)↓
median_perplexity | 27.93124 | 21.77492 (6.156)↓
bleu_3 | 0.04107254 | 0.03883634 (0.002)↓
bleu_4 | 0.02810928 | 0.02679456 (0.001)↓
bleu_1 | 0.1069760 | 0.1008600 (0.006)↓

</span></span><!--EndFragment-->
</body>
</html>

Text Generation Results (Comparision b/w 0.0.42 & Transformers 4.40.0)
Runs:
 0.0.42 = [test_text_generation - Azure AI | Machine Learning Studio](https://ml.azure.com/experiments/id/c288e65d-ebaf-4e22-bf56-2f8b6169b278/runs/e9481b33-024a-44e3-a6c8-3e7029b7a741?wsid=%2Fsubscriptions%2Fed2cab61-14cc-4fb3-ac23-d72609214cfd%2FresourceGroups%2Ftraining_rg%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Ftrain-finetune-dev-workspace&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)
Transformers = [test_text_generation - Azure AI | Machine Learning Studio](https://ml.azure.com/experiments/id/0ece48bb-8c8b-4155-8599-35355145fff3/runs/910cc191-b3d2-4bc6-9f29-ff22181b9d7d?wsid=%2Fsubscriptions%2Fed2cab61-14cc-4fb3-ac23-d72609214cfd%2FresourceGroups%2Ftraining_rg%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Ftrain-finetune-dev-workspace&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)
Display name	compute_metrics (0.0.42)	compute_metrics (Transformers)
rougeLsum	0.2220351	0.2072528 (0.015) ↓
rouge1	0.2649654	0.2482362 (0.017) ↓
rouge2	0.1039491	0.1000652 (0.004)↓
rougeL	0.2160850	0.2058724 (0.010)↓
bleu_2	0.06259758	0.05877610 (0.004)↓
mean_perplexity	52.97975	51.73906 (1.241)↓
median_perplexity	27.93124	21.77492 (6.156)↓
bleu_3	0.04107254	0.03883634 (0.002)↓
bleu_4	0.02810928	0.02679456 (0.001)↓
bleu_1	0.1069760	0.1008600 (0.006)↓
 
Metric	Finetune Metrics (0.0.42)	Finetune metrics (Transformers)
loss	2.0097	2.0097
learning_rate	0.00002	0.00002
epoch	1	1
eval_loss	1.956829	1.956829
eval_runtime	11.369	11.2585 (0.111) ↓
eval_samples_per_second	17.592	17.764 (0.172) ↑
eval_steps_per_second	2.199	2.221 (0.022) ↑
checkpoint_save_step	25	25
train_runtime	126.5187	123.3736 (3.145) ↓
train_samples_per_second	1.581	1.621 (0.040)↑
train_steps_per_second	0.198	0.203 (0.005)↑
total_flos	1,78,76,15,45,18,07,744	1,78,76,15,45,18,07,744
train_loss	2.054511	2.054511 (0.000) ↓
grad_norm	Not applicable	2.265910