### PR TITLE
Fix the cross-wiring bug of results and errors in v2 split outputs

### DIFF
--- a/assets/batch_score/components/driver/src/batch_score/common/post_processing/output_handler.py
+++ b/assets/batch_score/components/driver/src/batch_score/common/post_processing/output_handler.py
@@ -68,10 +68,18 @@ class SeparateFileOutputHandler(OutputHandler):
         with open(success_file_path, "w", encoding="utf-8") as success_writer, \
              open(error_file_path, "w", encoding="utf-8") as error_writer:
             for item in mini_batch_results:
-                if '"status": "SUCCESS"' in item:
+                if self.__is_item_successful(item):
                     success_writer.write(item + "\n")
                 else:
                     error_writer.write(item + "\n")
 
         lu.get_logger().info(f"Completed saving {len(mini_batch_results)} results to files {success_file_path} \
                                and {error_file_path}.")
+
+    def __is_item_successful(self, item):
+        if '"status": "SUCCESS"' in item:  # V1 output schema
+            return True
+        elif '"status_code": 200' in item:  # V2 output schema
+            return True
+        else:
+            return False


### PR DESCRIPTION
E2E tests:
Both jobs have results in expected files
- [Chat completion with split output](https://ml.azure.com/experiments/id/e7e78963-3e59-4957-b7e3-ce9f6e87e60d/runs/lemon_diamond_0mbybxwrz8?wsid=/subscriptions/c0afea91-faba-4d71-bcb6-b08134f69982/resourcegroups/batchscore-test-centralus/providers/Microsoft.MachineLearningServices/workspaces/ws-batchscore-centralus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)
- [Completion with split output](https://ml.azure.com/experiments/id/e7e78963-3e59-4957-b7e3-ce9f6e87e60d/runs/serene_evening_yklwd0b6yx?wsid=/subscriptions/c0afea91-faba-4d71-bcb6-b08134f69982/resourcegroups/batchscore-test-centralus/providers/Microsoft.MachineLearningServices/workspaces/ws-batchscore-centralus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)