### PR TITLE
upgrading component versions to fix phi3 deepcopy issue

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/components/finetune/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: chat_completion_finetune
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Chat Completion Finetune
 description: Component to finetune Hugging Face pretrained models for chat completion task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/chat_completion_finetune) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/51
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/52
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_finetune
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_finetune
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_finetune
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: false

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_finetune
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_finetune
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: false

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_finetune
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: ft_nlp_model_converter
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: chat_completion_model_import
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Chat Completion Model Import
 description: Component to import PyTorch / MLFlow model. See [docs](https://aka.ms/azureml/components/chat_completion_model_import) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/51
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/52
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_model_import
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_model_import
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_model_import
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_model_import
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_model_import
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_model_import
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: chat_completion_pipeline
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Chat Completion Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for chat completion task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/chat_completion_pipeline) to learn more.
@@ -495,7 +495,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -532,7 +532,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   chat_completion_model_import:
     type: command
-    component: azureml:chat_completion_model_import:0.0.43
+    component: azureml:chat_completion_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -543,7 +543,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   chat_completion_datapreprocess:
     type: command
-    component: azureml:chat_completion_datapreprocess:0.0.43
+    component: azureml:chat_completion_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -560,7 +560,7 @@ jobs:
       model_selector_output: '${{parent.jobs.chat_completion_model_import.outputs.output_dir}}'
   chat_completion_finetune:
     type: command
-    component: azureml:chat_completion_finetune:0.0.43
+    component: azureml:chat_completion_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -618,7 +618,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/chat_completion/spec.yaml
@@ -513,7 +513,7 @@ jobs:
       train_mltable_path: '${{parent.inputs.train_mltable_path}}'
       validation_mltable_path: '${{parent.inputs.validation_mltable_path}}'
       test_mltable_path: '${{parent.inputs.test_mltable_path}}'
-      # user_column_names: ''
+      user_column_names: 'messages'
       num_train_epochs: '${{parent.inputs.num_train_epochs}}'
       max_steps: '${{parent.inputs.max_steps}}'
       per_device_train_batch_size: '${{parent.inputs.per_device_train_batch_size}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: question_answering_pipeline
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Question Answering Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for extractive question answering task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/question_answering_pipeline) to learn more.
@@ -541,7 +541,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -578,7 +578,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   question_answering_model_import:
     type: command
-    component: azureml:question_answering_model_import:0.0.43
+    component: azureml:question_answering_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -589,7 +589,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   question_answering_datapreprocess:
     type: command
-    component: azureml:question_answering_datapreprocess:0.0.43
+    component: azureml:question_answering_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -614,7 +614,7 @@ jobs:
       model_selector_output: '${{parent.jobs.question_answering_model_import.outputs.output_dir}}'
   question_answering_finetune:
     type: command
-    component: azureml:question_answering_finetune:0.0.43
+    component: azureml:question_answering_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -671,7 +671,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: summarization_pipeline
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Summarization Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for summarization task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/summarization_pipeline) to learn more.
@@ -512,7 +512,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -549,7 +549,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   summarization_model_import:
     type: command
-    component: azureml:summarization_model_import:0.0.43
+    component: azureml:summarization_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -560,7 +560,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   summarization_datapreprocess:
     type: command
-    component: azureml:summarization_datapreprocess:0.0.43
+    component: azureml:summarization_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -580,7 +580,7 @@ jobs:
       model_selector_output: '${{parent.jobs.summarization_model_import.outputs.output_dir}}'
   summarization_finetune:
     type: command
-    component: azureml:summarization_finetune:0.0.43
+    component: azureml:summarization_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -637,7 +637,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_classification_pipeline
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Classification Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for text classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/text_classification_pipeline) to learn more.
@@ -514,7 +514,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -551,7 +551,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_classification_model_import:
     type: command
-    component: azureml:text_classification_model_import:0.0.43
+    component: azureml:text_classification_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -562,7 +562,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   text_classification_datapreprocess:
     type: command
-    component: azureml:text_classification_datapreprocess:0.0.43
+    component: azureml:text_classification_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -583,7 +583,7 @@ jobs:
       model_selector_output: '${{parent.jobs.text_classification_model_import.outputs.output_dir}}'
   text_classification_finetune:
     type: command
-    component: azureml:text_classification_finetune:0.0.43
+    component: azureml:text_classification_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -640,7 +640,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline
 description: Pipeline component for text generation
@@ -528,7 +528,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -566,7 +566,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -578,7 +578,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -598,7 +598,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -656,7 +656,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_high
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_low
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_medium
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_high
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_low
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_medium
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_high
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_low
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_medium
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.43
+    component: azureml:text_generation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.43
+    component: azureml:text_generation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.43
+    component: azureml:text_generation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: token_classification_pipeline
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Token Classification Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for token classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/token_classification_pipeline) to learn more.
@@ -507,7 +507,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -544,7 +544,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   token_classification_model_import:
     type: command
-    component: azureml:token_classification_model_import:0.0.43
+    component: azureml:token_classification_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -555,7 +555,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   token_classification_datapreprocess:
     type: command
-    component: azureml:token_classification_datapreprocess:0.0.43
+    component: azureml:token_classification_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -574,7 +574,7 @@ jobs:
       model_selector_output: '${{parent.jobs.token_classification_model_import.outputs.output_dir}}'
   token_classification_finetune:
     type: command
-    component: azureml:token_classification_finetune:0.0.43
+    component: azureml:token_classification_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -631,7 +631,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: translation_pipeline
-version: 0.0.45
+version: 0.0.46
 type: pipeline
 display_name: Translation Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for translation task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/translation_pipeline) to learn more.
@@ -504,7 +504,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.43
+    component: azureml:ft_nlp_common_validation:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -541,7 +541,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   translation_model_import:
     type: command
-    component: azureml:translation_model_import:0.0.43
+    component: azureml:translation_model_import:0.0.44
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -552,7 +552,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   translation_datapreprocess:
     type: command
-    component: azureml:translation_datapreprocess:0.0.43
+    component: azureml:translation_datapreprocess:0.0.44
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -571,7 +571,7 @@ jobs:
       model_selector_output: '${{parent.jobs.translation_model_import.outputs.output_dir}}'
   translation_finetune:
     type: command
-    component: azureml:translation_finetune:0.0.43
+    component: azureml:translation_finetune:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -628,7 +628,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.43
+    component: azureml:ft_nlp_model_converter:0.0.44
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: chat_completion_datapreprocess
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Chat Completion DataPreProcess
 description: Component to preprocess data for chat completion task. See [docs](https://aka.ms/azureml/components/chat_completion_datapreprocess) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/51
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/52
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_datapreprocess
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_datapreprocess
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_datapreprocess
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_datapreprocess
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_datapreprocess
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_datapreprocess
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: ft_nlp_common_validation
-version: 0.0.43
+version: 0.0.44
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -122,16 +122,6 @@ class PyTorch_to_MlFlow_ModelConverter:
         with open(mlflow_infer_params_file_path, 'r') as fp:
             mlflow_inference_params = json.load(fp)
 
-        # Ignore `return_full_text` key for chat completion
-        # HACK for now - Ideal place to do this is in preprocess_for_finetune.py of chat completion task
-        if self.mlflow_task_type == MLFlowHFFlavourTasks.CHAT_COMPLETION:
-            if MLFlowHFFlavourConstants.INFERENCE_PARAMS_SAVE_KEY in mlflow_inference_params:
-                mlflow_inference_params[MLFlowHFFlavourConstants.INFERENCE_PARAMS_SAVE_KEY].pop(
-                    "return_full_text", None
-                )
-                logger.info(
-                    f"Removing `return_full_text` from {MLFlowHFFlavourConstants.INFERENCE_PARAMS_SAVE_KEY} key.")
-
         misc_conf = {
             MLFlowHFFlavourConstants.TASK_TYPE: self.mlflow_task_type,
             MLFlowHFFlavourConstants.TRAIN_LABEL_LIST: self.class_names,


### PR DESCRIPTION
Changes
---------
1. Upgraded env for chat completion components.
2. Rest of the component versions remain as it is.
3. Passing "messages" key to the data validation components.
4. Removing the hack to remove the "return_full_text" key in model convertor adapters. This is already handled during preprocessing (pypi release should have these changes).