### PR TITLE
upgrade gunicorn to 22.0.0 to fix vulnerability and remove pins to update flask to latest

### DIFF
--- a/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -25,7 +25,8 @@ RUN pip install 'azureml-core=={{latest-pypi-version}}' \
 
 RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
                 'azureml-telemetry=={{latest-pypi-version}}' \
-                'Werkzeug==3.0.2'
+                'Werkzeug==3.0.2' \
+                'gunicorn>=22.0.0'
 
 # azureml-dataset-runtime[fuse] upper bound for pyarrow is 11.0.0
 # so we install pyarrow in extra step to avoid conflict

--- a/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-text-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -20,7 +20,6 @@ dependencies:
     - markupsafe<=2.1.2
     - itsdangerous<=2.1.2
     - responsibleai-text[qa]==0.2.7
-    - click<8.0.0
     - mltable==1.5.0
     - transformers>=4.17.0
     - nlp-feature-extractors==0.1.0

--- a/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -50,6 +50,9 @@ RUN pip install 'cryptography>=42.0.4'
 # TODO: remove rai-core-flask pin with next raiwidgets release
 RUN pip install 'rai-core-flask==0.7.4'
 
+# To resolve vulnerability issue
+RUN pip install 'gunicorn>=22.0.0'
+
 RUN pip freeze
 
 # This is needed for mpi to locate libpython

--- a/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/Dockerfile
@@ -38,7 +38,8 @@ RUN pip install 'shap==0.41.0' \
                 'setuptools>=65.5.1' \
                 'numpy==1.22.0' \
                 'scipy==1.10.0' \
-                'statsmodels==0.14.0'
+                'statsmodels==0.14.0' \
+                'gunicorn>=22.0.0'
 
 # azureml-dataset-runtime[fuse] upper bound for pyarrow is 11.0.0
 # so we install pyarrow in extra step to avoid conflict

--- a/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision-ubuntu20.04-py38-cpu/context/conda_dependencies.yaml
@@ -21,7 +21,6 @@ dependencies:
     - vision_explanation_methods
     - responsibleai-vision==0.3.8
     - opencv-python==4.3.0.36
-    - click<8.0.0
     - mltable==1.5.0
     - fastai
     - ipython<8.13


### PR DESCRIPTION
upgrade gunicorn to 22.0.0 to fix vulnerability and remove pins to update flask to latest

Fixes two separate issues:
1.) Fix gunicorn image vulnerability which is OOSLA on our tabular/vision/text images. For more context please see:
https://github.com/advisories/GHSA-w3h3-4rj7-4ph4 
https://nvd.nist.gov/vuln/detail/CVE-2024-1135 

2.) Remove pin on click package which is causing an older version of flask to be installed - which, in theory, should be upgrading to latest since other packages have been updated like werkzeug recently. This is currently causing errors when attaching to the dashboard (although component pipelines run fine) due to incompatibility with werkzeug with the error:
```
cannot import name 'url_quote' from 'werkzeug.urls'
```
This issue was found during testing after the most recent major upgrade which hasn't been released to production yet.
For more information please see:
https://stackoverflow.com/questions/77213053/why-did-flask-start-failing-with-importerror-cannot-import-name-url-quote-fr