### PR TITLE
add validation check for GSQ threshold value is invalid

### DIFF
--- a/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py
+++ b/assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_metrics/run.py
@@ -151,7 +151,10 @@ def run():
         threshold_pair = threshold.split(":")
         if len(threshold_pair) == 2:
             threshold_name, threshold_value = threshold_pair
-            threshold_args[threshold_name] = float(threshold_value)
+            try:
+                threshold_args[threshold_name] = float(threshold_value)
+            except ValueError:
+                print("Invalid threshold value found: ", threshold_value)
     metric_names = args.metric_names
     aggregated_metrics_df = compute_metrics(histogram_df, threshold_args, metric_names)
     save_spark_df_as_mltable(aggregated_metrics_df, args.signal_metrics)


### PR DESCRIPTION
Fix this below bug. 

Traceback (most recent call last):
  File "generation_safety_quality/annotation_compute_metrics/run.py", line 314, in <module>
    run()
  File "generation_safety_quality/annotation_compute_metrics/run.py", line 154, in run
    threshold_args[threshold_name] = float(threshold_value)
ValueError: could not convert string to float: ''

reproed locally 
![image](https://github.com/Azure/azureml-assets/assets/90874573/42fc4e3e-f4ab-423d-908b-0550e28fe6a1)
