### PR TITLE
Pin gunicorn to 22.0.0

### DIFF
--- a/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
@@ -25,7 +25,7 @@ dependencies:
   - beautifulsoup4~=4.11.2
   - datasets~=2.10.1
   - faiss-cpu~=1.7.3
-  - inference-schema==1.4
+  - inference-schema~=1.7.0
   - lxml
   - markdown
   - mlflow-skinny==2.3.2

--- a/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
@@ -25,6 +25,7 @@ dependencies:
   - beautifulsoup4~=4.11.2
   - datasets~=2.10.1
   - faiss-cpu~=1.7.3
+  - gunicorn==22.0.0
   - inference-schema==1.4
   - lxml
   - markdown

--- a/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
@@ -20,12 +20,11 @@ dependencies:
   - azureml-telemetry=={{latest-pypi-version}}
   - azureml-dataset-runtime=={{latest-pypi-version}}
   - azureml-fsspec
-  - azureml-inference-server-http==0.7.6
+  - azureml-inference-server-http==1.2.1
   - azureml-mlflow=={{latest-pypi-version}}
   - beautifulsoup4~=4.11.2
   - datasets~=2.10.1
   - faiss-cpu~=1.7.3
-  - gunicorn==22.0.0
   - inference-schema==1.4
   - lxml
   - markdown

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
@@ -30,6 +30,7 @@ dependencies:
   - datasets~=2.10.1
   - faiss-cpu~=1.7.3
   - GitPython>=3.1
+  - gunicorn==22.0.0
   - inference-schema==1.4
   - langchain<0.2
   - lxml

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
@@ -22,7 +22,7 @@ dependencies:
   - azureml-contrib-services
   - azureml-core=={{latest-pypi-version}}
   - azureml-dataset-runtime=={{latest-pypi-version}}
-  - azureml-inference-server-http==0.7.6
+  - azureml-inference-server-http==1.2.1
   - azureml-mlflow=={{latest-pypi-version}}
   - azureml-telemetry=={{latest-pypi-version}}
     # Other public packages
@@ -30,7 +30,6 @@ dependencies:
   - datasets~=2.10.1
   - faiss-cpu~=1.7.3
   - GitPython>=3.1
-  - gunicorn==22.0.0
   - inference-schema==1.4
   - langchain<0.2
   - lxml

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
@@ -30,7 +30,7 @@ dependencies:
   - datasets~=2.10.1
   - faiss-cpu~=1.7.3
   - GitPython>=3.1
-  - inference-schema==1.4
+  - inference-schema~=1.7.0
   - langchain<0.2
   - lxml
   - markdown


### PR DESCRIPTION
To address the environment vulnerability reported in 
[Incident 502090819](https://portal.microsofticm.com/imp/v3/incidents/incident/502090819/summary) : Vulnerable RAG/Baker Images : gunicorn 20.1.0->22.0.0 ,

gunicorn is install because of azureml-inference-server-http==0.7.6

This PR will upgrade azureml-inference-server-http to 1.2.1
azureml-inference-server-http 1.2.1 depends on inference-schema~=1.7.0