### PR TITLE
Support JSONL input for model evaluation of vision models

### DIFF
--- a/assets/training/model_evaluation/components/model_prediction/spec.yaml
+++ b/assets/training/model_evaluation/components/model_prediction/spec.yaml
@@ -3,7 +3,7 @@ name: model_prediction
 display_name: Model Prediction
 description: Generate predictions on a given mlflow model for supported tasks.
 
-version: 0.0.26
+version: 0.0.27
 type: command
 tags:
   type: evaluation


### PR DESCRIPTION
As part of vision and multimodal benchmarking, extend the model evaluation pipeline to take JSONL files as input in addition to MLTable's. The benchmarking framework produces JSONL files for text tasks and we decided to keep this format for vision+multimodal tasks and make changes to the model prediction component. Note: the input JSONL file contains image urls.

Tested by running the pipeline generated with the benchmarking framework for
a. image classification with ViTB on Resisc45: https://ml.azure.com/experiments/id/9f7237b4-3232-49d3-ae02-e07326242835/runs/funny_steelpan_r07mqvyk2r?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourcegroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/benchmarking&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
b. image classification with SwinV2 on GTSRB: https://ml.azure.com/experiments/id/9f7237b4-3232-49d3-ae02-e07326242835/runs/silver_pin_fstqkf18y6?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourcegroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/benchmarking&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
The dataset_downloader component in the benchmarking framework has been modified to produce JSONL files with image urls.
