### PR TITLE
Update validate_assets.py: Ignore .whl files in build context

### DIFF
--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -304,7 +304,7 @@ def validate_build_context(environment_config: assets.EnvironmentConfig) -> int:
     # Iterate over all files in the build context
     for file_path in environment_config.release_paths:
         for ext in BUILD_CONTEXT_IGNORED_FILE_EXTENSIONS:
-            if file_path.endswith(ext):
+            if str(file_path).endswith(ext):
                 _log_warning(file_path, f"Ignoring validation for file with extension: '{ext}'")
                 continue
         with open(file_path) as f:

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -153,6 +153,11 @@ BUILD_CONTEXT_DISALLOWED_PATTERNS = [
     re.compile(r"extra-index-url", re.IGNORECASE),
 ]
 
+# Docker build context file extensions to be ignored 
+BUILD_CONTEXT_IGNORED_FILE_EXTENSIONS = [
+    ".whl",
+]
+
 # Directory path for config files related to asset validation, relative to the current source path
 CONFIG_DIRECTORY = "config"
 
@@ -298,6 +303,10 @@ def validate_build_context(environment_config: assets.EnvironmentConfig) -> int:
     error_count = 0
     # Iterate over all files in the build context
     for file_path in environment_config.release_paths:
+        for ext in BUILD_CONTEXT_IGNORED_FILE_EXTENSIONS:
+            if file_path.endswith(ext):
+                _log_warning(file_path, f"Ignoring validation for file with extension: '{ext}'")
+                continue
         with open(file_path) as f:
             # Read file into memory, normalize EOL characters
             contents = f.read()

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -153,7 +153,7 @@ BUILD_CONTEXT_DISALLOWED_PATTERNS = [
     re.compile(r"extra-index-url", re.IGNORECASE),
 ]
 
-# Docker build context file extensions to be ignored 
+# Docker build context file extensions to be ignored
 BUILD_CONTEXT_IGNORED_FILE_EXTENSIONS = [
     ".whl",
 ]


### PR DESCRIPTION
Ignore python wheel files (.whl) when validating files in Env build context. Currently we try to read all files inside Env's build context. We need to commit .whl files for python packages that are not yet available on pypi. One such package is singularityrt: https://github.com/Azure/azureml-assets/pull/2892

A failing GH Actions run for reference: https://github.com/Azure/azureml-assets/actions/runs/9065729716/job/24906950702?pr=2892

```python
Traceback (most recent call last):
  File "/home/runner/work/azureml-assets/azureml-assets/scripts/azureml-assets/azureml/assets/validate_assets.py", line 1150, in <module>
    success = validate_assets(input_dirs=input_dirs,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/azureml-assets/azureml-assets/scripts/azureml-assets/azureml/assets/validate_assets.py", line 1057, in validate_assets
    error_count += validate_build_context(asset_config.extra_config_as_object())
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/azureml-assets/azureml-assets/scripts/azureml-assets/azureml/assets/validate_assets.py", line 303, in validate_build_context
    contents = f.read()
               ^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xbc in position 15: invalid start byte
```