### PR TITLE
Update fmi version to 32 for mistral 7b instructv01

### DIFF
--- a/assets/models/system/Mistral-7B-Instruct-v0-1/model.yaml
+++ b/assets/models/system/Mistral-7B-Instruct-v0-1/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/mistralai-Mistral-7B-Instruct-v0-1/20240306/mlflow_model_folder
+  container_path: huggingface/mistralai-Mistral-7B-Instruct-v0-1/20240516/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/Mistral-7B-Instruct-v0-1/spec.yaml
+++ b/assets/models/system/Mistral-7B-Instruct-v0-1/spec.yaml
@@ -29,4 +29,4 @@ tags:
   license: apache-2.0
   task: chat-completion
   author: mistralai
-version: 8
+version: 9


### PR DESCRIPTION
Update fmi version to 32 for mistral 7b instructv01

Endpoint link: 
https://ml.azure.com/endpoints/realtime/model-onboarding-automati-rvsee/test?wsid=/subscriptions/66a54950-50a7-4b7e-b0c5-66ce29be6486/resourceGroups/foundationmodeltest_rg/providers/Microsoft.MachineLearningServices/workspaces/model-onboarding-automation&tid=72f988bf-86f1-41af-91ab-2d7cd011db47

sample inference : 
![image](https://github.com/Azure/azureml-assets/assets/38472520/af395869-ccfb-42f2-9c12-a2d56e2e8b76)
