### PR TITLE
Version bumped as release failed for llama-2-7b-chat model with version related error

### DIFF
--- a/assets/models/system/Llama-2-7b-chat/spec.yaml
+++ b/assets/models/system/Llama-2-7b-chat/spec.yaml
@@ -47,4 +47,4 @@ tags:
     - vllm
     - ds_mii
 
-version: 1
+version: 21


### PR DESCRIPTION
@skasturi @novaturient95 

Ref release link 
https://msdata.visualstudio.com/Vienna/_releaseProgress?releaseId=1546543&_a=release-pipeline-progress

Error details
Issue: 
 
2024-05-15 12:13:41.822356: ##[error]Error creating model Llama-2-7b-chat: ERROR: (UserError) Asset azureml://registries/azureml-meta/models/Llama-2-7b-chat/versions/1 was deleted at 07/17/2023 16:50:49 +00:00, it cannot be recreated. Please try again with a different version.
2024-05-15 12:13:41.822491: Code: UserError
2024-05-15 12:13:41.822550: Message: Asset azureml://registries/azureml-meta/models/Llama-2-7b-chat/versions/1 was deleted at 07/17/2023 16:50:49 +00:00, it cannot be recreated. Please try again with a different version.