### PR TITLE
Skip hidden layer scanned tag valdn for models

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.16.47 (2024-05-17)
+### 🐛 Bugs Fixed
+- [#2933](https://github.com/Azure/azureml-assets/pull/2933) skip hiddenlayerscanned tags till most models are scanned
+
 ## 1.16.46 (2024-05-15)
 ### 🐛 Bugs Fixed
 - [#2907](https://github.com/Azure/azureml-assets/pull/2907) add hiddenlayerscanned tags valdn

--- a/scripts/azureml-assets/azureml/assets/validate_assets.py
+++ b/scripts/azureml-assets/azureml/assets/validate_assets.py
@@ -854,15 +854,16 @@ def validate_model_spec(asset_config: assets.AssetConfig) -> int:
         _log_error(asset_config.file_name_with_path, f"{MLFlowModelTags.LICENSE} missing")
         error_count += 1
 
-    if MLFlowModelTags.HIDDEN_LAYERS_SCANNED not in model.tags:
-        _log_error(
-            asset_config.file_name_with_path,
-            (
-                "`hiddenlayerscanned` tag missing. "
-                "Model is not scanned by HiddenLayer ModelScanner tool. Please scan the model and retry"
-            )
-        )
-        error_count += 1
+    # TODO: skip hidden layer valdn till most models are scanned
+    # if MLFlowModelTags.HIDDEN_LAYERS_SCANNED not in model.tags:
+    #     _log_error(
+    #         asset_config.file_name_with_path,
+    #         (
+    #             "`hiddenlayerscanned` tag missing. "
+    #             "Model is not scanned by HiddenLayer ModelScanner tool. Please scan the model and retry"
+    #         )
+    #     )
+    #     error_count += 1
 
     # shared compute check
     if MLFlowModelTags.SHARED_COMPUTE_CAPACITY not in model.tags:

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.46",
+   version="1.16.47",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
Currently, we are checking hidden layer scanned tag for all models. Skip until we have done for all models & not do it components.