### PR TITLE
Mark MoMo e2e test as fail/pass in display name

### DIFF
--- a/assets/model_monitoring/components/tests/e2e/conftest.py
+++ b/assets/model_monitoring/components/tests/e2e/conftest.py
@@ -658,7 +658,10 @@ def submit_pipeline_job(ml_client: MLClient, request):
     """Submit pipeline job to ml ws. Handle deletion if the testcase is cancelled/stopped."""
     submitted_jobs = []
 
-    def _submit_job(job: Job, experiment_name: str):
+    def _submit_job(job: Job, experiment_name: str, expect_failure: bool = False):
+        if job.display_name is not None:
+            job.display_name += "_should_FAIL" if expect_failure else "_should_PASS"
+        
         pipeline_job = ml_client.jobs.create_or_update(
             job, experiment_name=experiment_name, skip_validation=True
         )

--- a/assets/model_monitoring/components/tests/e2e/conftest.py
+++ b/assets/model_monitoring/components/tests/e2e/conftest.py
@@ -661,7 +661,7 @@ def submit_pipeline_job(ml_client: MLClient, request):
     def _submit_job(job: Job, experiment_name: str, expect_failure: bool = False):
         if job.display_name is not None:
             job.display_name += "_should_FAIL" if expect_failure else "_should_PASS"
-        
+
         pipeline_job = ml_client.jobs.create_or_update(
             job, experiment_name=experiment_name, skip_validation=True
         )

--- a/assets/model_monitoring/components/tests/e2e/test_create_manifest_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_create_manifest_e2e.py
@@ -17,7 +17,8 @@ from tests.e2e.utils.constants import (
 
 
 def _submit_data_drift_and_create_manifest_job(
-    submit_pipeline_job, ml_client: MLClient, get_component, experiment_name, baseline_data, target_data
+    submit_pipeline_job, ml_client: MLClient, get_component, experiment_name, baseline_data, target_data,
+    expect_failure: bool = False
 ):
     dd_model_monitor = get_component(COMPONENT_NAME_DATA_DRIFT_SIGNAL_MONITOR)
     create_manifest = get_component(COMPONENT_NAME_CREATE_MANIFEST)
@@ -69,7 +70,7 @@ def _submit_data_drift_and_create_manifest_job(
     )
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes

--- a/assets/model_monitoring/components/tests/e2e/test_data_drift_signal_monitor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_data_drift_signal_monitor_e2e.py
@@ -33,7 +33,8 @@ def _submit_data_drift_model_monitor_job(
     target_data,
     target_column="target",
     override_numerical_features=None,
-    override_categorical_features=None
+    override_categorical_features=None,
+    expect_failure: bool = False
 ):
     dd_model_monitor = get_component(COMPONENT_NAME_DATA_DRIFT_SIGNAL_MONITOR)
 
@@ -62,7 +63,7 @@ def _submit_data_drift_model_monitor_job(
     print(pipeline_job)
     pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
     pipeline_job = submit_pipeline_job(
-       pipeline_job, experiment_name
+       pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes
@@ -107,6 +108,7 @@ class TestDataDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_IRIS_BASELINE_DATA,
             DATA_ASSET_EMPTY,
+            expect_failure=True
         )
 
         # empty production data should fail the job
@@ -124,6 +126,7 @@ class TestDataDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_IRIS_BASELINE_DATA,
             DATA_ASSET_IRIS_PREPROCESSED_MODEL_INPUTS_NO_COMMON_COLUMNS,
+            expect_failure=True
         )
 
         # No common columns should fail the job in the feature selector step and compute histogram step.
@@ -157,6 +160,7 @@ class TestDataDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_EMPTY,
             DATA_ASSET_EMPTY,
+            expect_failure=True
         )
 
         # empty production and target data should fail the job

--- a/assets/model_monitoring/components/tests/e2e/test_data_joiner_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_data_joiner_e2e.py
@@ -26,7 +26,8 @@ def _submit_data_joiner_job(
     left_input_data,
     left_join_column,
     right_input_data,
-    right_join_column
+    right_join_column,
+    expect_failure: bool = False
 ):
     data_joiner_component = get_component(COMPONENT_NAME_DATA_JOINER)
 
@@ -55,7 +56,7 @@ def _submit_data_joiner_job(
     )
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes

--- a/assets/model_monitoring/components/tests/e2e/test_data_quality_signal_monitor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_data_quality_signal_monitor_e2e.py
@@ -31,7 +31,8 @@ def _submit_data_quality_signal_monitor_job(
     filter_type=None,
     filter_value=None,
     override_numerical_features=None,
-    override_categorical_features=None
+    override_categorical_features=None,
+    expect_failure: bool = False
 ):
     dd_signal_monitor = get_component(COMPONENT_NAME_DATA_QUALITY_SIGNAL_MONITOR)
 
@@ -57,7 +58,7 @@ def _submit_data_quality_signal_monitor_job(
     pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes
@@ -143,7 +144,8 @@ class TestDataQualityModelMonitor:
             DATA_ASSET_EMPTY,
             "target",
             "TopNByAttribution",
-            "3"
+            "3",
+            expect_failure = True
         )
 
         # empty target data should cause the pipeline to fail

--- a/assets/model_monitoring/components/tests/e2e/test_data_quality_signal_monitor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_data_quality_signal_monitor_e2e.py
@@ -145,7 +145,7 @@ class TestDataQualityModelMonitor:
             "target",
             "TopNByAttribution",
             "3",
-            expect_failure = True
+            expect_failure=True
         )
 
         # empty target data should cause the pipeline to fail

--- a/assets/model_monitoring/components/tests/e2e/test_feature_attribution_drift_signal_monitor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_feature_attribution_drift_signal_monitor_e2e.py
@@ -175,7 +175,7 @@ class TestFeatureAttributionDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_IRIS_BASELINE_DATA,
             DATA_ASSET_EMPTY,
-            expect_failure = True
+            expect_failure=True
         )
 
         # empty target data should cause the pipeline to fail

--- a/assets/model_monitoring/components/tests/e2e/test_feature_attribution_drift_signal_monitor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_feature_attribution_drift_signal_monitor_e2e.py
@@ -20,7 +20,8 @@ from tests.e2e.utils.constants import (
 
 
 def _submit_feature_attribution_drift_model_monitor_job(
-    submit_pipeline_job, ml_client, get_component, experiment_name, baseline_data, target_data
+    submit_pipeline_job, ml_client, get_component, experiment_name, baseline_data, target_data,
+    expect_failure: bool = False
 ):
     feature_attr_drift_signal_monitor = get_component(
         COMPONENT_NAME_FEATURE_ATTRIBUTION_DRIFT_SIGNAL_MONITOR
@@ -45,7 +46,7 @@ def _submit_feature_attribution_drift_model_monitor_job(
     pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes
@@ -60,7 +61,7 @@ def _submit_feature_attribution_drift_model_monitor_job(
 
 def _submit_feature_attribution_drift_with_preprocessor_and_datajoiner(
     submit_pipeline_job, ml_client: MLClient, get_component, experiment_name, model_inputs,
-    model_outputs, baseline_data
+    model_outputs, baseline_data, expect_failure: bool = False
 ):
     # Get the components.
     data_joiner_component = get_component(COMPONENT_NAME_DATA_JOINER)
@@ -134,7 +135,7 @@ def _submit_feature_attribution_drift_with_preprocessor_and_datajoiner(
     pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes
@@ -174,6 +175,7 @@ class TestFeatureAttributionDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_IRIS_BASELINE_DATA,
             DATA_ASSET_EMPTY,
+            expect_failure = True
         )
 
         # empty target data should cause the pipeline to fail

--- a/assets/model_monitoring/components/tests/e2e/test_genai_preprocessor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_genai_preprocessor_e2e.py
@@ -16,7 +16,7 @@ from tests.e2e.utils.constants import (
 
 def _submit_genai_preprocessor_job(
     submit_pipeline_job, ml_client: MLClient, get_component, experiment_name,
-    input_data, start_time, end_time
+    input_data, start_time, end_time, expect_failure: bool = False
 ):
     genai_preprocessor_component = get_component(COMPONENT_NAME_GENAI_PREPROCESSOR)
 
@@ -48,7 +48,7 @@ def _submit_genai_preprocessor_job(
     )
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes

--- a/assets/model_monitoring/components/tests/e2e/test_genai_token_statistics_signal_monitor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_genai_token_statistics_signal_monitor_e2e.py
@@ -18,7 +18,8 @@ def _submit_genai_token_statistics_model_monitor_job(
     get_component,
     submit_pipeline_job,
     experiment_name,
-    aggregated_data
+    aggregated_data,
+    expect_failure: bool = False
 ):
     ts_model_monitor = get_component(COMPONENT_NAME_MODEL_TOKEN_STATS_SIGNAL_MONITOR)
 
@@ -38,7 +39,7 @@ def _submit_genai_token_statistics_model_monitor_job(
     pipeline_job = _token_statistics_signal_monitor_e2e()
     pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
     pipeline_job = submit_pipeline_job(
-       pipeline_job, experiment_name=experiment_name
+       pipeline_job, experiment_name=experiment_name, expect_failure=expect_failure
     )
 
     # Wait until the job completes

--- a/assets/model_monitoring/components/tests/e2e/test_generation_safety_quality_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_generation_safety_quality_e2e.py
@@ -15,7 +15,8 @@ from tests.e2e.utils.constants import (
 
 
 def _submit_generation_safety_quality_model_monitor_job(
-    submit_pipeline_job, ml_client, get_component, experiment_name, production_data, data_columns_dict: dict = {}
+    submit_pipeline_job, ml_client, get_component, experiment_name, production_data, data_columns_dict: dict = {},
+    expect_failure: bool = False
 ):
     generation_safety_quality_signal_monitor = get_component(
         COMPONENT_NAME_GENERATION_SAFETY_QUALITY_SIGNAL_MONITOR
@@ -61,7 +62,7 @@ def _submit_generation_safety_quality_model_monitor_job(
     pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes

--- a/assets/model_monitoring/components/tests/e2e/test_model_data_collector_preprocessor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_model_data_collector_preprocessor_e2e.py
@@ -16,7 +16,7 @@ from tests.e2e.utils.constants import (
 
 def _submit_mdc_preprocessor_job(
     submit_pipeline_job, ml_client: MLClient, get_component, experiment_name,
-    extract_correlation_id, input_data, start_time, end_time
+    extract_correlation_id, input_data, start_time, end_time, expect_failure: bool = False
 ):
     mdc_preprocessor_component = get_component(COMPONENT_NAME_MDC_PREPROCESSOR)
 
@@ -45,7 +45,7 @@ def _submit_mdc_preprocessor_job(
     )
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes

--- a/assets/model_monitoring/components/tests/e2e/test_model_monitor_metric_outputter_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_model_monitor_metric_outputter_e2e.py
@@ -16,7 +16,7 @@ from tests.e2e.utils.constants import (
 
 def _submit_metric_outputter_job(
     submit_pipeline_job, ml_client: MLClient, get_component, experiment_name, signal_metrics_input,
-    samples_index_input
+    samples_index_input, expect_failure: bool = False
 ):
     metric_outputter_component = get_component(COMPONENT_NAME_METRIC_OUTPUTTER)
 
@@ -44,7 +44,7 @@ def _submit_metric_outputter_job(
     pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes

--- a/assets/model_monitoring/components/tests/e2e/test_model_performance_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_model_performance_e2e.py
@@ -26,7 +26,7 @@ def _submit_model_performance_signal_monitor_job(
     classification_precision_threshold=None,
     classification_accuracy_threshold=None,
     classification_recall_threshold=None,
-
+    expect_failure: bool = False
 ):
     mp_signal_monitor = get_component(COMPONENT_NAME_MODEL_PERFORMANCE_SIGNAL_MONITOR)
 
@@ -52,7 +52,7 @@ def _submit_model_performance_signal_monitor_job(
     pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes

--- a/assets/model_monitoring/components/tests/e2e/test_prediction_drift_signal_monitor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_prediction_drift_signal_monitor_e2e.py
@@ -17,7 +17,8 @@ from tests.e2e.utils.constants import (
 
 
 def _submit_prediction_drift_model_monitor_job(
-    submit_pipeline_job, ml_client, get_component, experiment_name, baseline_data, target_data
+    submit_pipeline_job, ml_client, get_component, experiment_name, baseline_data, target_data,
+    expect_failure: bool = False
 ):
     prediction_drift_signal_monitor = get_component(
         COMPONENT_NAME_PREDICTION_DRIFT_SIGNAL_MONITOR
@@ -43,7 +44,7 @@ def _submit_prediction_drift_model_monitor_job(
     pipeline_job.outputs.signal_output = Output(type="uri_folder", mode="direct")
 
     pipeline_job = submit_pipeline_job(
-        pipeline_job, experiment_name
+        pipeline_job, experiment_name, expect_failure
     )
 
     # Wait until the job completes
@@ -86,6 +87,7 @@ class TestPredictionDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_IRIS_BASELINE_DATA,
             DATA_ASSET_EMPTY,
+            expect_failure = True
         )
 
         # empty target data should fail the pipeline
@@ -103,6 +105,7 @@ class TestPredictionDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_IRIS_BASELINE_DATA,
             DATA_ASSET_IRIS_PREPROCESSED_MODEL_INPUTS_NO_COMMON_COLUMNS,
+            expect_failure = True
         )
 
         # No common columns should fail the job in the feature selector step.
@@ -120,6 +123,7 @@ class TestPredictionDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_EMPTY,
             DATA_ASSET_EMPTY,
+            expect_failure = True,
         )
 
         # empty production and target data should fail the job

--- a/assets/model_monitoring/components/tests/e2e/test_prediction_drift_signal_monitor_e2e.py
+++ b/assets/model_monitoring/components/tests/e2e/test_prediction_drift_signal_monitor_e2e.py
@@ -87,7 +87,7 @@ class TestPredictionDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_IRIS_BASELINE_DATA,
             DATA_ASSET_EMPTY,
-            expect_failure = True
+            expect_failure=True
         )
 
         # empty target data should fail the pipeline
@@ -105,7 +105,7 @@ class TestPredictionDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_IRIS_BASELINE_DATA,
             DATA_ASSET_IRIS_PREPROCESSED_MODEL_INPUTS_NO_COMMON_COLUMNS,
-            expect_failure = True
+            expect_failure=True
         )
 
         # No common columns should fail the job in the feature selector step.
@@ -123,7 +123,7 @@ class TestPredictionDriftModelMonitor:
             test_suite_name,
             DATA_ASSET_EMPTY,
             DATA_ASSET_EMPTY,
-            expect_failure = True,
+            expect_failure=True,
         )
 
         # empty production and target data should fail the job


### PR DESCRIPTION
This is a quality of life update to explicitly mention in the job name if the e2e test is supposed to pass or fail when looking at a glance in the AML job portal.


**Before and After on AML ws:**
<img width="946" alt="image" src="https://github.com/Azure/azureml-assets/assets/143033175/7a27cf99-18fe-471a-8273-f99f3c8b7586">



**Before:**
<img width="539" alt="image" src="https://github.com/Azure/azureml-assets/assets/143033175/ccb944ae-5b2b-4063-a857-a002a744af78">

**After:**
<img width="508" alt="image" src="https://github.com/Azure/azureml-assets/assets/143033175/f48f6242-7986-432d-8091-5900b5f2a104">

