### PR TITLE
Add AzureMLOnBehalfOfCredential  to AOAI finetuning component

### DIFF
--- a/assets/training/aoai/proxy_components/command_components/aoai_finetuning/spec.yaml
+++ b/assets/training/aoai/proxy_components/command_components/aoai_finetuning/spec.yaml
@@ -28,6 +28,14 @@ inputs:
     optional: True
     description: Subscription for the AOAI resource.
 
+  authentication_type:
+    type: string
+    optional: True
+    description: Authentication type for the AOAI endpoint. If not provided, it will default to 'managed_identity'.
+    enum:
+    - managed_identity
+    - user_identity
+
   training_file_path:
     type: uri_file
     optional: True
@@ -108,6 +116,7 @@ command: >-
   --endpoint_name ${{inputs.endpoint_name}}
   $[[--endpoint_resource_group ${{inputs.endpoint_resource_group}}]]
   $[[--endpoint_subscription ${{inputs.endpoint_subscription}}]]
+  $[[--authentication_type ${{inputs.authentication_type}}]]
   $[[--training_file_path ${{inputs.training_file_path}}]]
   $[[--validation_file_path ${{inputs.validation_file_path}}]]
   $[[--training_import_path ${{inputs.training_import_path}}]]

--- a/assets/training/aoai/proxy_components/src/common/azure_openai_client_manager.py
+++ b/assets/training/aoai/proxy_components/src/common/azure_openai_client_manager.py
@@ -5,8 +5,12 @@
 
 import requests
 from azure.identity import ManagedIdentityCredential
+from azure.ai.ml.identity import AzureMLOnBehalfOfCredential
 from azure.mgmt.cognitiveservices import CognitiveServicesManagementClient
 from azure.mgmt.cognitiveservices.models import ApiKeys
+from azure.core.pipeline.policies import BearerTokenCredentialPolicy
+from azure.core.pipeline import PipelineRequest, PipelineContext
+from azure.core.rest import HttpRequest
 from openai import AzureOpenAI
 import os
 from typing import Optional
@@ -74,18 +78,44 @@ class AzureOpenAIClientManager:
         logger.info("Endpoint: {}".format(account.properties.endpoint))
         return account.properties.endpoint
 
+    def _get_bearer_token_provider(self, credential, *scopes):
+        policy = BearerTokenCredentialPolicy(credential, *scopes)
+
+        def _make_request():
+            return PipelineRequest(HttpRequest("CredentialWrapper", "https://fakeurl"), PipelineContext(None))
+
+        def wrapper() -> str:
+            request = _make_request()
+            policy.on_request(request)
+            return request.http_request.headers["Authorization"][len("Bearer ") :]
+        return wrapper
+
     def _get_azure_openai_client(self) -> AzureOpenAI:
         """Get azure openai client."""
-        if self._get_client_id() is None:
-            logger.info("Managed identity client id is empty, will fail...")
-            raise Exception("Managed identity client id is empty")
-        else:
-            logger.info("Managed identity client id is set, will use managed identity authentication")
-            client = CognitiveServicesManagementClient(credential=self._get_credential(),
-                                                       subscription_id=self.endpoint_subscription)
-            return AzureOpenAI(azure_endpoint=self.get_endpoint_from_cognitive_service_account(client),
-                               api_key=self.get_key_from_cognitive_service_account(client),
-                               api_version=AzureOpenAIClientManager.api_version)
+        try:
+            logger.info("Trying to get azure openai client using AzureMLOnBehalfOfCredential")
+            credential = AzureMLOnBehalfOfCredential()
+            client = CognitiveServicesManagementClient(
+                credential=credential,
+                subscription_id=self.endpoint_subscription
+            )
+            return AzureOpenAI(
+                azure_endpoint=self.get_endpoint_from_cognitive_service_account(client),
+                azure_ad_token_provider=self._get_bearer_token_provider(credential, "https://cognitiveservices.azure.com/.default"),
+                api_version=AzureOpenAIClientManager.api_version,
+            )
+        except:
+            logger.info("Failed to get azure openai client using AzureMLOnBehalfOfCredential, will try using ManagedIdentityCredential")
+            if self._get_client_id() is None:
+                logger.info("Managed identity client id is empty, will fail...")
+                raise Exception("Managed identity client id is empty")
+            else:
+                logger.info("Managed identity client id is set, will use managed identity authentication")
+                client = CognitiveServicesManagementClient(credential=self._get_credential(),
+                                                           subscription_id=self.endpoint_subscription)
+                return AzureOpenAI(azure_endpoint=self.get_endpoint_from_cognitive_service_account(client),
+                                api_key=self.get_key_from_cognitive_service_account(client),
+                                api_version=AzureOpenAIClientManager.api_version)
 
     @property
     def data_upload_url(self) -> str:

--- a/assets/training/aoai/proxy_components/src/common/azure_openai_client_manager.py
+++ b/assets/training/aoai/proxy_components/src/common/azure_openai_client_manager.py
@@ -8,6 +8,7 @@ from azure.identity import ManagedIdentityCredential
 from azure.ai.ml.identity import AzureMLOnBehalfOfCredential
 from azure.mgmt.cognitiveservices import CognitiveServicesManagementClient
 from azure.mgmt.cognitiveservices.models import ApiKeys
+from azure.core.exceptions import ClientAuthenticationError
 from azure.core.pipeline.policies import BearerTokenCredentialPolicy
 from azure.core.pipeline import PipelineRequest, PipelineContext
 from azure.core.rest import HttpRequest
@@ -104,7 +105,7 @@ class AzureOpenAIClientManager:
                 azure_ad_token_provider=self._get_bearer_token_provider(credential, "https://cognitiveservices.azure.com/.default"),
                 api_version=AzureOpenAIClientManager.api_version,
             )
-        except:
+        except ClientAuthenticationError:
             logger.info("Failed to get azure openai client using AzureMLOnBehalfOfCredential, will try using ManagedIdentityCredential")
             if self._get_client_id() is None:
                 logger.info("Managed identity client id is empty, will fail...")

--- a/assets/training/aoai/proxy_components/src/finetuning.py
+++ b/assets/training/aoai/proxy_components/src/finetuning.py
@@ -256,6 +256,7 @@ def parse_args():
     parser.add_argument("--endpoint_name", type=str)
     parser.add_argument("--endpoint_resource_group", type=str)
     parser.add_argument("--endpoint_subscription", type=str)
+    parser.add_argument("--authentication_type", type=str)
 
     parser.add_argument("--training_file_path", type=str)
     parser.add_argument("--validation_file_path", type=str)
@@ -300,7 +301,8 @@ def main():
     try:
         aoai_client_manager = AzureOpenAIClientManager(endpoint_name=args.endpoint_name,
                                                        endpoint_resource_group=args.endpoint_resource_group,
-                                                       endpoint_subscription=args.endpoint_subscription)
+                                                       endpoint_subscription=args.endpoint_subscription,
+                                                       authentication_type=args.authentication_type)
         finetune_component = AzureOpenAIFinetuning(aoai_client_manager)
         add_custom_dimenions_to_app_insights_handler(logger, finetune_component)
         CancelHandler.register_cancel_handler(finetune_component)

--- a/assets/training/aoai/proxy_components/src/finetuning.py
+++ b/assets/training/aoai/proxy_components/src/finetuning.py
@@ -110,7 +110,7 @@ class AzureOpenAIFinetuning(AzureOpenAIProxyComponent):
 
         if validation_file_path is None:
             logger.debug(f"validation file not provided, train data will be split in\
-                         {utils.train_dataset_split_ratio} ratio to create validation data")
+                         {utils.Constants.train_dataset_split_ratio} ratio to create validation data")
 
         logger.debug(f"uploading training file : {train_file_name}")
         train_metadata = self.aoai_client.files.create(file=(train_file_name, train_data, 'application/json'),


### PR DESCRIPTION
This PR adds AzureMLOnBehalfOfCredential credential to AOAI finetuning component. If getting a token with this credential fails, it will fallback to the ManagedIdentityCredential of the compute