### PR TITLE
update phi-3-medium-128k-instruct bits

### DIFF
--- a/assets/models/system/phi-3-medium-128k-instruct/model.yaml
+++ b/assets/models/system/phi-3-medium-128k-instruct/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/phi-3-medium-128k-instruct/mlflow_model_folder
+  container_path: huggingface/phi-3-medium-128k-instruct/1716972887/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/phi-3-medium-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-medium-128k-instruct/spec.yaml
@@ -3,6 +3,7 @@ name: Phi-3-medium-128k-instruct
 path: ./
 properties:
   SharedComputeCapacityEnabled: true
+  SHA: 1e10cf49da9eceb263824a4e4646d0ecba4f7dec
   languages: en
   inference-min-sku-spec: 48|2|440|128
   inference-recommended-sku: Standard_NC48ads_A100_v4, Standard_NC96ads_A100_v4, Standard_ND96amsr_A100_v4
@@ -50,4 +51,4 @@ tags:
     logging_steps: 10
     save_total_limit: 1
     max_seq_length: 4096
-version: 1
+version: 2


### PR DESCRIPTION
update phi-3-medium-128k-instruct bits

### Online validation
model: https://ml.azure.com/registries/azureml-preview-test1/models/phi3-updated/version/1?tid=72f988bf-86f1-41af-91ab-2d7cd011db47#artifacts
endpoint: https://ml.azure.com/endpoints/realtime/jais-westus3-ws-lqtkd/test?wsid=/subscriptions/79a1ba0c-35bb-436b-bff2-3074d5ff1f89/resourceGroups/jais-rg/providers/Microsoft.MachineLearningServices/workspaces/jais-westus3-ws&tid=72f988bf-86f1-41af-91ab-2d7cd011db47

![image](https://github.com/Azure/azureml-assets/assets/61145377/3bd15b04-90b0-44e4-905e-b51d3516b5cb)
