### PR TITLE
t5 specific changes to not copy base model dependencies

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -9,9 +9,12 @@ from pathlib import Path
 import json
 import shutil
 import yaml
+import os
 
 from azureml.acft.accelerator.utils.code_utils import get_model_custom_code_files, copy_code_files
 from azureml.acft.accelerator.utils.license_utils import download_license_file
+from azureml.acft.accelerator.utils.run_utils import is_main_process
+
 
 from azureml.acft.common_components.utils.mlflow_utils import update_acft_metadata
 
@@ -44,6 +47,11 @@ MLFLOW_TASK_HF_PRETRAINED_CLASS_MAP = {
     MLFlowHFFlavourTasks.TRANSLATION: "AutoModelForSeq2SeqLM",
     MLFlowHFFlavourTasks.CHAT_COMPLETION: "AutoModelForCausalLM",
 }
+UNWANTED_PACKAGES = [
+    "apex>",
+    "apex<",
+    "apex="
+]
 
 
 class ModelConverter(ABC):
@@ -229,6 +237,44 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         super().__init__()
         super(ModelConverter, self).__init__(component_args)
 
+    @staticmethod
+    def _remove_unwanted_packages(model_save_path: str):
+        """Remove unwanted packages from conda and requirements file"""
+        if is_main_process():
+            req_file_path = os.path.join(model_save_path, "requirements.txt")
+            conda_file_path = os.path.join(model_save_path, "conda.yaml")
+            requirements = None
+            if os.path.exists(req_file_path):
+                with open(req_file_path, "r") as f:
+                    requirements = f.readlines()
+                if requirements:
+                    for package in UNWANTED_PACKAGES:
+                        requirements = [item for item in requirements if not item.startswith(package)]
+                    logger.info("Updated requirements.txt file")
+
+            conda_dict = None
+            if os.path.exists(conda_file_path):
+                with open(conda_file_path, "r") as f:
+                    conda_dict = yaml.safe_load(f)
+                if conda_dict is not None and "dependencies" in conda_dict:
+                    for i in range(len(conda_dict["dependencies"])):
+                        if "pip" in conda_dict["dependencies"][i] and isinstance(conda_dict["dependencies"][i], dict):
+                            pip_list = conda_dict["dependencies"][i]["pip"]
+                            if len(pip_list) > 0:
+                                for package in UNWANTED_PACKAGES:
+                                    pip_list = [item for item in pip_list if not item.startswith(package)]
+                                conda_dict["dependencies"][i]["pip"] = pip_list
+                                break
+                    with open(conda_file_path, "w") as f:
+                        yaml.safe_dump(conda_dict, f)
+                    logger.info("Updated conda.yaml file")
+
+
+    def _t5_model_on_text_classification_condition_meets(self, model_type):
+        """Check for t5 text-classification"""
+        return self.mlflow_task_type == "text-classification" and model_type == 't5'
+
+
     def convert_model(self) -> None:
         """Convert pytorch model to oss mlflow model."""
         # load model and tokenizer
@@ -236,13 +282,17 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
 
         self.set_mlflow_model_parameters(model)
 
-        conda_file_path = Path(self.ft_pytorch_model_path, MLFlowHFFlavourConstants.CONDA_YAML_FILE)
-        if conda_file_path.is_file():
-            self.mlflow_save_model_kwargs.update({"conda_env": str(conda_file_path)})
-            logger.info(
-                f"Found {MLFlowHFFlavourConstants.CONDA_YAML_FILE} from base model. "
-                "Using it for saving Mlflow model."
-            )
+        # Temp Fix:
+        # specific check for t5 text-classification so that base model dependencies doesn't get pass
+        # and use transformers version 4.40.0 from infer dependencies
+        if not self._t5_model_on_text_classification_condition_meets(model.config.model_type):
+            conda_file_path = Path(self.ft_pytorch_model_path, MLFlowHFFlavourConstants.CONDA_YAML_FILE)
+            if conda_file_path.is_file():
+                self.mlflow_save_model_kwargs.update({"conda_env": str(conda_file_path)})
+                logger.info(
+                    f"Found {MLFlowHFFlavourConstants.CONDA_YAML_FILE} from base model. "
+                    "Using it for saving Mlflow model."
+                )
 
         # saving oss mlflow model
         model_pipeline = pipeline(task=self.mlflow_task_type, model=model, tokenizer=tokenizer, config=model.config)
@@ -266,5 +316,9 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         self.download_license_file(self.model_name, self.ft_pytorch_model_path, self.mlflow_model_save_path)
         self.add_model_signature()
         self.copy_finetune_config(self.ft_pytorch_model_path, self.mlflow_model_save_path)
+
+        # Temp fix for t5 text-classification
+        if self._t5_model_on_text_classification_condition_meets(model.config.model_type):
+            self._remove_unwanted_packages(self.mlflow_model_save_path)
 
         logger.info("Saved MLFlow model using OSS flavour.")

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -20,7 +20,7 @@ from azureml.acft.common_components.utils.mlflow_utils import update_acft_metada
 
 from azureml.acft.contrib.hf.nlp.utils.common_utils import deep_update
 from azureml.acft.contrib.hf.nlp.constants.constants import (
-    MLFlowHFFlavourConstants, MLFlowHFFlavourTasks, SaveFileConstants,
+    MLFlowHFFlavourConstants, MLFlowHFFlavourTasks, SaveFileConstants, HfModelTypes,
 )
 
 import mlflow
@@ -272,7 +272,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
 
     def _t5_model_on_text_classification_condition_meets(self, model_type):
         """Check for t5 text-classification"""
-        return self.mlflow_task_type == "text-classification" and model_type == 't5'
+        return self.mlflow_task_type == MLFlowHFFlavourTasks.SINGLE_LABEL_CLASSIFICATION and model_type == HfModelTypes.T5
 
 
     def convert_model(self) -> None:

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -239,7 +239,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
 
     @staticmethod
     def remove_unwanted_packages(model_save_path: str):
-        """Remove unwanted packages from conda and requirements file"""
+        """Remove unwanted packages from conda and requirements file."""
         if is_main_process():
             req_file_path = os.path.join(model_save_path, "requirements.txt")
             conda_file_path = os.path.join(model_save_path, "conda.yaml")
@@ -269,8 +269,8 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
                         yaml.safe_dump(conda_dict, f)
                     logger.info("Updated conda.yaml file")
 
-    def is_t5_text_classification_finetune(self, model_type):
-        """Check for t5 text-classification"""
+    def is_t5_text_classification_finetune(self, model_type) -> bool:
+        """Check for t5 text-classification."""
         return self.mlflow_task_type == MLFlowHFFlavourTasks.SINGLE_LABEL_CLASSIFICATION and \
             model_type == HfModelTypes.T5
 

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -284,7 +284,9 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         # Temp Fix:
         # specific check for t5 text-classification so that base model dependencies doesn't get pass
         # and use transformers version 4.40.0 from infer dependencies
-        if not self.is_t5_text_classification_finetune(model.config.model_type):
+        if self.is_t5_text_classification_finetune(model.config.model_type):
+            self.remove_unwanted_packages(self.mlflow_model_save_path)
+        else:
             conda_file_path = Path(self.ft_pytorch_model_path, MLFlowHFFlavourConstants.CONDA_YAML_FILE)
             if conda_file_path.is_file():
                 self.mlflow_save_model_kwargs.update({"conda_env": str(conda_file_path)})
@@ -315,9 +317,5 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         self.download_license_file(self.model_name, self.ft_pytorch_model_path, self.mlflow_model_save_path)
         self.add_model_signature()
         self.copy_finetune_config(self.ft_pytorch_model_path, self.mlflow_model_save_path)
-
-        # Temp fix for t5 text-classification
-        if self.is_t5_text_classification_finetune(model.config.model_type):
-            self.remove_unwanted_packages(self.mlflow_model_save_path)
 
         logger.info("Saved MLFlow model using OSS flavour.")

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -270,7 +270,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
                     logger.info("Updated conda.yaml file")
 
 
-    def _t5_model_on_text_classification_condition_meets(self, model_type):
+    def _is_t5_text_classification_finetune(self, model_type):
         """Check for t5 text-classification"""
         return self.mlflow_task_type == MLFlowHFFlavourTasks.SINGLE_LABEL_CLASSIFICATION and model_type == HfModelTypes.T5
 
@@ -285,7 +285,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         # Temp Fix:
         # specific check for t5 text-classification so that base model dependencies doesn't get pass
         # and use transformers version 4.40.0 from infer dependencies
-        if not self._t5_model_on_text_classification_condition_meets(model.config.model_type):
+        if not self._is_t5_text_classification_finetune(model.config.model_type):
             conda_file_path = Path(self.ft_pytorch_model_path, MLFlowHFFlavourConstants.CONDA_YAML_FILE)
             if conda_file_path.is_file():
                 self.mlflow_save_model_kwargs.update({"conda_env": str(conda_file_path)})
@@ -318,7 +318,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         self.copy_finetune_config(self.ft_pytorch_model_path, self.mlflow_model_save_path)
 
         # Temp fix for t5 text-classification
-        if self._t5_model_on_text_classification_condition_meets(model.config.model_type):
+        if self._is_t5_text_classification_finetune(model.config.model_type):
             self._remove_unwanted_packages(self.mlflow_model_save_path)
 
         logger.info("Saved MLFlow model using OSS flavour.")

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -271,7 +271,8 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
 
     def _is_t5_text_classification_finetune(self, model_type):
         """Check for t5 text-classification"""
-        return self.mlflow_task_type == MLFlowHFFlavourTasks.SINGLE_LABEL_CLASSIFICATION and model_type == HfModelTypes.T5
+        return self.mlflow_task_type == MLFlowHFFlavourTasks.SINGLE_LABEL_CLASSIFICATION and \
+            model_type == HfModelTypes.T5
 
     def convert_model(self) -> None:
         """Convert pytorch model to oss mlflow model."""

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -269,11 +269,9 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
                         yaml.safe_dump(conda_dict, f)
                     logger.info("Updated conda.yaml file")
 
-
     def _is_t5_text_classification_finetune(self, model_type):
         """Check for t5 text-classification"""
         return self.mlflow_task_type == MLFlowHFFlavourTasks.SINGLE_LABEL_CLASSIFICATION and model_type == HfModelTypes.T5
-
 
     def convert_model(self) -> None:
         """Convert pytorch model to oss mlflow model."""

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -284,9 +284,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         # Temp Fix:
         # specific check for t5 text-classification so that base model dependencies doesn't get pass
         # and use transformers version 4.40.0 from infer dependencies
-        if self.is_t5_text_classification_finetune(model.config.model_type):
-            self.remove_unwanted_packages(self.mlflow_model_save_path)
-        else:
+        if not self.is_t5_text_classification_finetune(model.config.model_type):
             conda_file_path = Path(self.ft_pytorch_model_path, MLFlowHFFlavourConstants.CONDA_YAML_FILE)
             if conda_file_path.is_file():
                 self.mlflow_save_model_kwargs.update({"conda_env": str(conda_file_path)})
@@ -317,5 +315,9 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         self.download_license_file(self.model_name, self.ft_pytorch_model_path, self.mlflow_model_save_path)
         self.add_model_signature()
         self.copy_finetune_config(self.ft_pytorch_model_path, self.mlflow_model_save_path)
+
+        # Temp fix for t5 text-classification
+        if self.is_t5_text_classification_finetune(model.config.model_type):
+            self.remove_unwanted_packages(self.mlflow_model_save_path)
 
         logger.info("Saved MLFlow model using OSS flavour.")

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -238,7 +238,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         super(ModelConverter, self).__init__(component_args)
 
     @staticmethod
-    def _remove_unwanted_packages(model_save_path: str):
+    def remove_unwanted_packages(model_save_path: str):
         """Remove unwanted packages from conda and requirements file"""
         if is_main_process():
             req_file_path = os.path.join(model_save_path, "requirements.txt")
@@ -269,7 +269,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
                         yaml.safe_dump(conda_dict, f)
                     logger.info("Updated conda.yaml file")
 
-    def _is_t5_text_classification_finetune(self, model_type):
+    def is_t5_text_classification_finetune(self, model_type):
         """Check for t5 text-classification"""
         return self.mlflow_task_type == MLFlowHFFlavourTasks.SINGLE_LABEL_CLASSIFICATION and \
             model_type == HfModelTypes.T5
@@ -284,7 +284,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         # Temp Fix:
         # specific check for t5 text-classification so that base model dependencies doesn't get pass
         # and use transformers version 4.40.0 from infer dependencies
-        if not self._is_t5_text_classification_finetune(model.config.model_type):
+        if not self.is_t5_text_classification_finetune(model.config.model_type):
             conda_file_path = Path(self.ft_pytorch_model_path, MLFlowHFFlavourConstants.CONDA_YAML_FILE)
             if conda_file_path.is_file():
                 self.mlflow_save_model_kwargs.update({"conda_env": str(conda_file_path)})
@@ -317,7 +317,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         self.copy_finetune_config(self.ft_pytorch_model_path, self.mlflow_model_save_path)
 
         # Temp fix for t5 text-classification
-        if self._is_t5_text_classification_finetune(model.config.model_type):
-            self._remove_unwanted_packages(self.mlflow_model_save_path)
+        if self.is_t5_text_classification_finetune(model.config.model_type):
+            self.remove_unwanted_packages(self.mlflow_model_save_path)
 
         logger.info("Saved MLFlow model using OSS flavour.")


### PR DESCRIPTION
Failures
1. **When we use base model dependencies :** https://ml.azure.com/experiments/id/1d1d2e82-528d-4bd3-980d-d2229601134f/runs/a0c71324-c3d2-4c51-8531-a424178e4688?wsid=%2Fsubscriptions%2F72c03bf3-4e69-41af-9532-dfcdc3eefef4%2FresourceGroups%2Fhyperdrive-service-static-rg%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Ftrain-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
2. Remove apex: Even after using infer dependencies, we were seeing deployment errors of apex, so removed unwanted packages

Successful run: https://ml.azure.com/experiments/id/1d1d2e82-528d-4bd3-980d-d2229601134f/runs/e87a3cf1-3d9c-4292-89de-149a86f7e77f?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47&pipelineChildMetrics=true