### PR TITLE
T5 small release component changes

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/components/finetune/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: chat_completion_finetune
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/chat_completion/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Chat Completion Finetune
 description: Component to finetune Hugging Face pretrained models for chat completion task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/chat_completion_finetune) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/57
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_finetune
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_finetune
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_finetune
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: false

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_classification/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: false
 display_name: Text Classification Finetune
 description: Component to finetune Hugging Face pretrained models for text classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/text_classification_finetune) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/50
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Generation Finetune
 description: Component to finetune model for Text Generation task
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/54
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_finetune
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_finetune
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: false

--- a/assets/training/finetune_acft_hf_nlp/components/finetune/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/finetune/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_finetune
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/chat_completion/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Chat Completion Model Converter
 description: Component to convert the chat completion finetune job output from pytorch to mlflow model
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/57
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/model_converter
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: chat_completion_model_converter
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: ft_nlp_model_converter
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/text_classification/README.md
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/text_classification/README.md
@@ -1,0 +1,30 @@
+## Common Model Converter
+
+### Name 
+
+ft_nlp_model_converter
+
+### Version 
+
+0.0.17
+
+### Type 
+
+command
+
+### Description 
+
+Component to convert the finetune job output to pytorch and mlflow model
+
+## Inputs 
+
+| Name              | Description                                                                                                                                                                                                                                                                                   | Type         | Default    | Optional | Enum |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ---------- | -------- | ---- |
+| model_path | Pytorch model asset path. Pass the finetune job pytorch model output.                                                                                                                                                                                                  | uri_folder | -          | False     | NA   |
+| converted_model  | Exisiting converted MlFlow path. Pass the finetune job mlflow model output. | mlflow_model       | - | True     | NA   |
+
+## Outputs 
+
+| Name            | Description        | Type     |
+| --------------- | ------------------ | -------- |
+| output_dir | Output folder containing _best_ finetuned model in mlflow format. | mlflow_model |

--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/text_classification/asset.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/text_classification/asset.yaml
@@ -1,0 +1,3 @@
+type: component
+spec: spec.yaml
+categories: ["Foundational Models", "Finetune"]

--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/text_classification/spec.yaml
@@ -1,0 +1,35 @@
+$schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
+name: text_classification_model_converter
+version: 0.0.50
+type: command
+
+is_deterministic: True
+
+display_name: Text Classification Model Converter
+description: Component to convert the text classification finetune job output from pytorch to mlflow model
+
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
+
+code: ../../../src/model_converter
+
+inputs:
+  model_path:
+    type: uri_folder
+    optional: false
+    description: Pytorch model asset path. Pass the finetune job pytorch model output.
+    mode: rw_mount
+
+  # Validation parameters
+  system_properties:
+    type: string
+    optional: true
+    description: Validation parameters propagated from pipeline.
+
+outputs:
+  mlflow_model_folder:
+    type: mlflow_model
+    description: Output folder containing _best_ finetuned model in mlflow format.
+    mode: rw_mount
+
+command: >-
+  python model_converter.py --model_path '${{inputs.model_path}}' $[[--system_properties '${{inputs.system_properties}}']] --output_dir '${{outputs.mlflow_model_folder}}'

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: chat_completion_model_import
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/chat_completion/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Chat Completion Model Import
 description: Component to import PyTorch / MLFlow model. See [docs](https://aka.ms/azureml/components/chat_completion_model_import) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/57
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_model_import
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_model_import
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_model_import
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_classification/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Classification Model Import
 description: Component to import PyTorch / MLFlow model. See [docs](https://aka.ms/azureml/components/text_classification_model_import) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/50
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_model_import
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/text_generation/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Generation Model Import
 description: Import PyTorch / MLFlow model
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/54
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_model_import
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/model_import/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_import/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_model_import
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: chat_completion_pipeline
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Chat Completion Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for chat completion task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/chat_completion_pipeline) to learn more.
@@ -495,7 +495,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -532,7 +532,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   chat_completion_model_import:
     type: command
-    component: azureml:chat_completion_model_import:0.0.49
+    component: azureml:chat_completion_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -543,7 +543,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   chat_completion_datapreprocess:
     type: command
-    component: azureml:chat_completion_datapreprocess:0.0.49
+    component: azureml:chat_completion_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -560,7 +560,7 @@ jobs:
       model_selector_output: '${{parent.jobs.chat_completion_model_import.outputs.output_dir}}'
   chat_completion_finetune:
     type: command
-    component: azureml:chat_completion_finetune:0.0.49
+    component: azureml:chat_completion_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -618,7 +618,7 @@ jobs:
       # mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   chat_completion_model_converter:
     type: command
-    component: azureml:chat_completion_model_converter:0.0.49
+    component: azureml:chat_completion_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: question_answering_pipeline
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Question Answering Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for extractive question answering task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/question_answering_pipeline) to learn more.
@@ -541,7 +541,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -578,7 +578,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   question_answering_model_import:
     type: command
-    component: azureml:question_answering_model_import:0.0.49
+    component: azureml:question_answering_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -589,7 +589,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   question_answering_datapreprocess:
     type: command
-    component: azureml:question_answering_datapreprocess:0.0.49
+    component: azureml:question_answering_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -614,7 +614,7 @@ jobs:
       model_selector_output: '${{parent.jobs.question_answering_model_import.outputs.output_dir}}'
   question_answering_finetune:
     type: command
-    component: azureml:question_answering_finetune:0.0.49
+    component: azureml:question_answering_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -671,7 +671,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: summarization_pipeline
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Summarization Pipeline
 description: Pipeline Component to finetune Hugging Face pretrained models for summarization task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/summarization_pipeline) to learn more.
@@ -512,7 +512,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -549,7 +549,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   summarization_model_import:
     type: command
-    component: azureml:summarization_model_import:0.0.49
+    component: azureml:summarization_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -560,7 +560,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   summarization_datapreprocess:
     type: command
-    component: azureml:summarization_datapreprocess:0.0.49
+    component: azureml:summarization_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -580,7 +580,7 @@ jobs:
       model_selector_output: '${{parent.jobs.summarization_model_import.outputs.output_dir}}'
   summarization_finetune:
     type: command
-    component: azureml:summarization_finetune:0.0.49
+    component: azureml:summarization_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -637,7 +637,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_classification_pipeline
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Classification Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for text classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/text_classification_pipeline) to learn more.
@@ -514,7 +514,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -551,7 +551,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_classification_model_import:
     type: command
-    component: azureml:text_classification_model_import:0.0.49
+    component: azureml:text_classification_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -562,7 +562,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   text_classification_datapreprocess:
     type: command
-    component: azureml:text_classification_datapreprocess:0.0.49
+    component: azureml:text_classification_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -583,7 +583,7 @@ jobs:
       model_selector_output: '${{parent.jobs.text_classification_model_import.outputs.output_dir}}'
   text_classification_finetune:
     type: command
-    component: azureml:text_classification_finetune:0.0.49
+    component: azureml:text_classification_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -640,7 +640,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'
@@ -650,7 +650,7 @@ jobs:
       mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   model_prediction:
     type: command
-    component: azureml:model_prediction:0.0.22
+    component: azureml:model_prediction:0.0.26
     compute: '${{parent.inputs.compute_model_evaluation}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_evaluation}}'
@@ -666,7 +666,7 @@ jobs:
       evaluation_config_params: '${{parent.inputs.evaluation_config_params}}'
   compute_metrics:
     type: command
-    component: azureml:compute_metrics:0.0.22
+    component: azureml:compute_metrics:0.0.26
     compute: '${{parent.inputs.compute_model_evaluation}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_evaluation}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
@@ -650,7 +650,7 @@ jobs:
       mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   model_prediction:
     type: command
-    component: azureml:model_prediction:0.0.26
+    component: azureml://registries/azureml/components/model_prediction/versions/0.0.26
     compute: '${{parent.inputs.compute_model_evaluation}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_evaluation}}'
@@ -666,7 +666,7 @@ jobs:
       evaluation_config_params: '${{parent.inputs.evaluation_config_params}}'
   compute_metrics:
     type: command
-    component: azureml:compute_metrics:0.0.26
+    component: azureml://registries/azureml/components/compute_metrics/versions/0.0.26
     compute: '${{parent.inputs.compute_model_evaluation}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_evaluation}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
@@ -638,9 +638,9 @@ jobs:
       model_selector_output: '${{parent.jobs.text_classification_model_import.outputs.output_dir}}'
     outputs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
-  ft_nlp_model_converter:
+  text_classification_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.50
+    component: azureml:text_classification_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_classification/spec.yaml
@@ -650,7 +650,7 @@ jobs:
       mlflow_model_folder: '${{parent.outputs.mlflow_model_folder}}'
   model_prediction:
     type: command
-    component: azureml://registries/azureml/components/model_prediction/versions/0.0.26
+    component: azureml:model_prediction:0.0.26
     compute: '${{parent.inputs.compute_model_evaluation}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_evaluation}}'
@@ -666,7 +666,7 @@ jobs:
       evaluation_config_params: '${{parent.inputs.evaluation_config_params}}'
   compute_metrics:
     type: command
-    component: azureml://registries/azureml/components/compute_metrics/versions/0.0.26
+    component: azureml:compute_metrics:0.0.26
     compute: '${{parent.inputs.compute_model_evaluation}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_evaluation}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline
 description: Pipeline component for text generation
@@ -528,7 +528,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -566,7 +566,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -578,7 +578,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -598,7 +598,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -656,7 +656,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_high
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_low
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_basic_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_basic_medium
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline Singularity Basic Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_high
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_low
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_premium_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_premium_medium
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline Singularity Premium Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_high/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_high
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard High
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_low/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_low
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard Low
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/text_generation_singularity_standard_medium/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: text_generation_pipeline_singularity_standard_medium
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Text Generation Pipeline Singularity Standard Medium
 description: Pipeline component for text generation
@@ -520,7 +520,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -563,7 +563,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   text_generation_model_import:
     type: command
-    component: azureml:text_generation_model_import:0.0.49
+    component: azureml:text_generation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -580,7 +580,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_datapreprocess:
     type: command
-    component: azureml:text_generation_datapreprocess:0.0.49
+    component: azureml:text_generation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -605,7 +605,7 @@ jobs:
       system_properties: '${{parent.inputs.system_properties}}'
   text_generation_finetune:
     type: command
-    component: azureml:text_generation_finetune:0.0.49
+    component: azureml:text_generation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -667,7 +667,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: token_classification_pipeline
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Token Classification Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for token classification task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/token_classification_pipeline) to learn more.
@@ -507,7 +507,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -544,7 +544,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   token_classification_model_import:
     type: command
-    component: azureml:token_classification_model_import:0.0.49
+    component: azureml:token_classification_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -555,7 +555,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   token_classification_datapreprocess:
     type: command
-    component: azureml:token_classification_datapreprocess:0.0.49
+    component: azureml:token_classification_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -574,7 +574,7 @@ jobs:
       model_selector_output: '${{parent.jobs.token_classification_model_import.outputs.output_dir}}'
   token_classification_finetune:
     type: command
-    component: azureml:token_classification_finetune:0.0.49
+    component: azureml:token_classification_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -631,7 +631,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: translation_pipeline
-version: 0.0.51
+version: 0.0.52
 type: pipeline
 display_name: Translation Pipeline
 description: Pipeline component to finetune Hugging Face pretrained models for translation task. The component supports optimizations such as LoRA, Deepspeed and ONNXRuntime for performance enhancement. See [docs](https://aka.ms/azureml/components/translation_pipeline) to learn more.
@@ -504,7 +504,7 @@ outputs:
 jobs:
   ft_nlp_common_validation:
     type: command
-    component: azureml:ft_nlp_common_validation:0.0.49
+    component: azureml:ft_nlp_common_validation:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -541,7 +541,7 @@ jobs:
       auto_find_batch_size: '${{parent.inputs.auto_find_batch_size}}'
   translation_model_import:
     type: command
-    component: azureml:translation_model_import:0.0.49
+    component: azureml:translation_model_import:0.0.50
     compute: '${{parent.inputs.compute_model_import}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_model_import}}'
@@ -552,7 +552,7 @@ jobs:
       validation_output: '${{parent.jobs.ft_nlp_common_validation.outputs.validation_info}}'
   translation_datapreprocess:
     type: command
-    component: azureml:translation_datapreprocess:0.0.49
+    component: azureml:translation_datapreprocess:0.0.50
     compute: '${{parent.inputs.compute_preprocess}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_preprocess}}'
@@ -571,7 +571,7 @@ jobs:
       model_selector_output: '${{parent.jobs.translation_model_import.outputs.output_dir}}'
   translation_finetune:
     type: command
-    component: azureml:translation_finetune:0.0.49
+    component: azureml:translation_finetune:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     distribution:
       type: pytorch
@@ -628,7 +628,7 @@ jobs:
       pytorch_model_folder: '${{parent.outputs.pytorch_model_folder}}'
   ft_nlp_model_converter:
     type: command
-    component: azureml:ft_nlp_model_converter:0.0.49
+    component: azureml:ft_nlp_model_converter:0.0.50
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/chat_completion/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Chat Completion DataPreProcess
 description: Component to preprocess data for chat completion task. See [docs](https://aka.ms/azureml/components/chat_completion_datapreprocess) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/57
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/chat_completion/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: chat_completion_datapreprocess
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/question_answering/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/question_answering/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: question_answering_datapreprocess
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/summarization/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/summarization/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: summarization_datapreprocess
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_classification_datapreprocess
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_classification/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Classification DataPreProcess
 description: Component to preprocess data for single label classification task. See [docs](https://aka.ms/azureml/components/text_classification_datapreprocess) to learn more.
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/50
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: text_generation_datapreprocess
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/text_generation/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Text Generation DataPreProcess
 description: Component to preprocess data for text generation task
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/54
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/preprocess
 

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/token_classification/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/token_classification/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: token_classification_datapreprocess
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/translation/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/translation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: translation_datapreprocess
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: ft_nlp_common_validation
-version: 0.0.49
+version: 0.0.50
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/validation/common/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: Common Validation Component
 description: Component to validate the finetune job against Validation Service
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/54
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/59
 
 code: ../../../src/validation
 


### PR DESCRIPTION
Change description
1. Increase all component versions
2. increase model_prediction and compute metrics version from 0.0.22 to 0.0.26 for text-classification pipeline component due to EOL issue with 0.0.22 - tested the t5 all models and backward compatibility models as well.
3. Env upgrade
- chat completion 0.0.57 --> 0.0.59
- text-generation 0.0.54  --> 0.0.59
- text-classification 0.0.50 --> 0.0.59
- validation component 0.0.54 --> 0.0.59
- added new model convertor for text classification with upgraded env