### PR TITLE
stabilityai-stable-diffusion-xl-base-1-0 sku update

### DIFF
--- a/assets/models/system/stabilityai-stable-diffusion-xl-base-1-0/spec.yaml
+++ b/assets/models/system/stabilityai-stable-diffusion-xl-base-1-0/spec.yaml
@@ -3,9 +3,8 @@ name: stabilityai-stable-diffusion-xl-base-1-0
 path: ./
 properties:
   SharedComputeCapacityEnabled: true
-  inference-min-sku-spec: 6|1|112|336
-  inference-recommended-sku: Standard_NC6s_v3, Standard_NC12s_v3, Standard_NC24s_v3,
-    Standard_ND40rs_v2, Standard_ND96amsr_A100_v4, Standard_ND96asr_v4
+  inference-min-sku-spec: 40|8|672|2900
+  inference-recommended-sku: Standard_ND40rs_v2, Standard_ND96amsr_A100_v4, Standard_ND96asr_v4
 tags:
   Preview: ""
   SharedComputeCapacityEnabled: ""
@@ -17,11 +16,8 @@ tags:
   training_dataset: LAION-5B
   inference_compute_allow_list:
     [
-      Standard_NC6s_v3,
-      Standard_NC12s_v3,
-      Standard_NC24s_v3,
       Standard_ND40rs_v2,
       Standard_ND96amsr_A100_v4,
       Standard_ND96asr_v4
     ]
-version: 3
+version: 4

--- a/assets/models/system/stabilityai-stable-diffusion-xl-base-1-0/spec.yaml
+++ b/assets/models/system/stabilityai-stable-diffusion-xl-base-1-0/spec.yaml
@@ -24,4 +24,4 @@ tags:
       Standard_ND96amsr_A100_v4,
       Standard_ND96asr_v4
     ]
-version: 2
+version: 3


### PR DESCRIPTION
stabilityai-stable-diffusion-xl-base-1-0 sku update - the inference fails on NC6S, NC12S, NC24S with cuda OOM

[NC6S](https://ml.azure.com/endpoints/realtime/text-to-image-1717584063/detail?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/automlimage_eastus2_rg/providers/Microsoft.MachineLearningServices/workspaces/vision_multimodal_aml_demo&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)

[NC12S](https://ml.azure.com/endpoints/realtime/text-to-image-1717588881/detail?wsid=/subscriptions/381b38e9-9840-4719-a5a0-61d9585e1e91/resourceGroups/automlimage_eastus2_rg/providers/Microsoft.MachineLearningServices/workspaces/vision_multimodal_aml_demo&tid=72f988bf-86f1-41af-91ab-2d7cd011db47) 


Error: 
`ERROR:entry_module:Error collecting model_inputs collection request. name 'inputs_collector' is not defined
2024-06-05 12:28:18,724 E [929] azmlinfsrv - Encountered Exception: Traceback (most recent call last):
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/azureml_inference_server_http/server/user_script.py", line 132, in invoke_run
    run_output = self._wrapped_user_run(**run_parameters, request_headers=dict(request.headers))
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/azureml_inference_server_http/server/user_script.py", line 156, in <lambda>
    self._wrapped_user_run = lambda request_headers, **kwargs: self._user_run(**kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/inference_schema/schema_decorators.py", line 68, in decorator_input
    return user_run(*args, **kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/inference_schema/schema_decorators.py", line 68, in decorator_input
    return user_run(*args, **kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/inference_schema/schema_decorators.py", line 96, in decorator_input
    return user_run(*args, **kwargs)
  File "/var/mlflow_resources/mlflow_score_script.py", line 420, in run
    result = model.predict(input_data, params=params)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/mlflow/pyfunc/__init__.py", line 501, in predict
    return _predict()
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/mlflow/pyfunc/__init__.py", line 487, in _predict
    return self._predict_fn(data, params=params)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/mlflow/pyfunc/model.py", line 469, in predict
    return self.python_model.predict(self.context, self._convert_input(model_input))
  File "/var/azureml-app/azureml-models/SDXL-Base/1/mlflow_model_folder/code/stable_diffusion_mlflow_wrapper.py", line 97, in predict
    output = self._pipe(text_prompts)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 27, in decorate_context
    return func(*args, **kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/diffusers/pipelines/stable_diffusion_xl/pipeline_stable_diffusion_xl.py", line 1039, in __call__
    noise_pred = self.unet(
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/diffusers/models/unet_2d_condition.py", line 1066, in forward
    sample, res_samples = downsample_block(
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/diffusers/models/unet_2d_blocks.py", line 1160, in forward
    hidden_states = attn(
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/diffusers/models/transformer_2d.py", line 375, in forward
    hidden_states = block(
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/diffusers/models/attention.py", line 258, in forward
    attn_output = self.attn1(
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/diffusers/models/attention_processor.py", line 522, in forward
    return self.processor(
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/diffusers/models/attention_processor.py", line 743, in __call__
    attention_probs = attn.get_attention_scores(query, key, attention_mask)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/diffusers/models/attention_processor.py", line 598, in get_attention_scores
    attention_scores = torch.baddbmm(
torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 640.00 MiB (GPU 0; 15.77 GiB total capacity; 7.32 GiB already allocated; 484.19 MiB free; 7.60 GiB reserved in total by PyTorch) If reserved memory is >> allocated memory try setting max_split_size_mb to avoid fragmentation.  See documentation for Memory Management and PYTORCH_CUDA_ALLOC_CONF

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/azureml_inference_server_http/server/routes.py", line 222, in handle_score
    timed_result = main_blueprint.user_script.invoke_run(request, timeout_ms=config.scoring_timeout)
  File "/opt/miniconda/envs/userenv/lib/python3.8/site-packages/azureml_inference_server_http/server/user_script.py", line 139, in invoke_run
    raise UserScriptException(ex) from ex
azureml_inference_server_http.server.user_script.UserScriptException: Caught an unhandled exception from the user script`