### PR TITLE
Add torchvision to image generation environments

### DIFF
--- a/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 def save_image(output_folder: str, img: PIL.Image.Image, format: str) -> str:
     """
     Save image in a folder designated for batch output and return image file path.
+
     :param output_folder: directory path where we need to save files
     :type output_folder: str
     :param img: image object

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
@@ -3,17 +3,19 @@
 
 """Helper utils for vision Mlflow models."""
 
-import logging
-import PIL
-import pandas as pd
 import base64
 import io
+import logging
 import re
 import requests
-import torch
-from ast import literal_eval
-import numpy as np
+import uuid
 
+import PIL
+import pandas as pd
+import numpy as np
+import torch
+
+from ast import literal_eval
 from PIL import Image, UnidentifiedImageError
 from typing import Union
 
@@ -22,6 +24,22 @@ logger = logging.getLogger(__name__)
 
 # Uncomment the following line for mlflow debug mode
 # logging.getLogger("mlflow").setLevel(logging.DEBUG)
+
+def save_image(output_folder: str, img: PIL.Image.Image, format: str) -> str:
+    """
+    Save image in a folder designated for batch output and return image file path.
+    :param output_folder: directory path where we need to save files
+    :type output_folder: str
+    :param img: image object
+    :type img: PIL.Image.Image
+    :param format: format to save image
+    :type format: str
+    :return: file name of image.
+    :rtype: str
+    """
+    filename = f"image_{uuid.uuid4()}.{format.lower()}"
+    img.save(os.path.join(output_folder, filename), format=format)
+    return filename
 
 
 def get_pil_image(image: bytes) -> PIL.Image.Image:

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
@@ -6,6 +6,7 @@
 import base64
 import io
 import logging
+import os
 import re
 import requests
 import uuid

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/common/vision_utils.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 # Uncomment the following line for mlflow debug mode
 # logging.getLogger("mlflow").setLevel(logging.DEBUG)
 
+
 def save_image(output_folder: str, img: PIL.Image.Image, format: str) -> str:
     """
     Save image in a folder designated for batch output and return image file path.

--- a/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/text_to_image/conda.yaml
+++ b/assets/training/model_management/src/azureml/model/mgmt/processors/pyfunc/text_to_image/conda.yaml
@@ -8,6 +8,7 @@ dependencies:
 - pip:
   - mlflow==2.6.0
   - torch==1.13.1
+  - torchvision==0.14.1
   - transformers==4.33.2
   - diffusers==0.23.0
   - accelerate==0.22.0

--- a/assets/training/model_management/tests/unittests/test_vision_utils.py
+++ b/assets/training/model_management/tests/unittests/test_vision_utils.py
@@ -23,6 +23,7 @@ class TestVisionUtilities:
     """Test vision utility functions."""
 
     def test_save_image(self):
+        """Test that save_image() behaves correctly for png files."""
         image = Image.new("RGB", (640, 480))
         image.putpixel((320, 240), (0, 0, 255))
         image.putpixel((320, 241), (255, 255, 0))

--- a/assets/training/model_management/tests/unittests/test_vision_utils.py
+++ b/assets/training/model_management/tests/unittests/test_vision_utils.py
@@ -4,18 +4,34 @@
 """Test vision utility code."""
 
 import base64
+import os
 import pytest
 import requests
+import tempfile
 
 import pandas as pd
 
 from unittest.mock import patch
+from PIL import Image, ImageChops
 
-from azureml.model.mgmt.processors.common.vision_utils import process_image, process_image_pandas_series, _is_valid_url
+from azureml.model.mgmt.processors.common.vision_utils import (
+    process_image, process_image_pandas_series, save_image, _is_valid_url
+)
 
 
 class TestVisionUtilities:
     """Test vision utility functions."""
+
+    def test_save_image(self):
+        image = Image.new("RGB", (640, 480))
+        image.putpixel((320, 240), (0, 0, 255))
+        image.putpixel((320, 241), (255, 255, 0))
+
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            image_file_name = save_image(temporary_directory_name, image, "png")
+
+            image2 = Image.open(os.path.join(temporary_directory_name, image_file_name))
+            assert not ImageChops.difference(image, image2).getbbox()
 
     def test_process_image_bytes(self):
         """Test process_image() with a bytes object."""


### PR DESCRIPTION
Add torchvision to conda.yaml under src\azureml-acft-image-components\scripts\pipelines\model_publish_pipeline\stabilityai_stable_diffusion_2_1.yaml in order to run model evaluation pipeline on SD models. Ideally, this should be dealt with by the model prediction component (in download_dependencies.py, which contains dependency management logic), but this is the short-term solution.

Model publish pipeline run: https://ml.azure.com/experiments/id/d1873606-5a43-4303-9053-6fb512612c9f/runs/mango_ball_w2czsl079y?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/phmantri_eastus/providers/Microsoft.MachineLearningServices/workspaces/phmantri_eastus_2&tid=72f988bf-86f1-41af-91ab-2d7cd011db47# .

Context: https://github.com/Azure/azureml-assets/compare/main...rdondera/sd (benchmarking the Stable Diffusion model on MSCOCO). Note the line `install_deps += ["torchvision==0.14.1"]` in download_dependencies.py .
