### PR TITLE
[Vulnerable Image] Add lower boundary for requests

### DIFF
--- a/assets/data-labeling/environments/data-labeling/context/conda_dependencies.yaml
+++ b/assets/data-labeling/environments/data-labeling/context/conda_dependencies.yaml
@@ -15,4 +15,5 @@ dependencies:
   - pycairo==1.20.1
   - pydicom=={{latest-pypi-version}}
   - python-rle==0.0.3
+  - requests>=2.32.0
   


### PR DESCRIPTION
"Image": public/azureml/curated/data-labeling,
"Registry": azuremlmcr.azurecr.io,
"Tag": 23,
"Owner": DataLabeling,
"DueDate": 2024-06-20,
"TimeRemaining": 08.03,
"AssetId": sha256:524ad3164b4e2598da426ed78aa5b57057a9776de84110bcfd81c4f39a044751,
"VulnerabilityId": 999064,
"RunId": 2024-06-11T16:07:16.9406875Z,
"IsActionable": true,
"VulnerabilityName": Python (Pip) Security Update for requests (GHSA-9wx4-h78v-vm56),
"Risk": MEDIUM,
"Solution": Refer to Github security advisory <A HREF="https://github.com/advisories/GHSA-9wx4-h78v-vm56" TARGET="_blank">GHSA-9wx4-h78v-vm56</A> for updates and patch information.<BR>
<P>Patch:<BR>
Following are links for downloading patches to fix the vulnerabilities:
<P> <A HREF="https://github.com/advisories/GHSA-9wx4-h78v-vm56" TARGET="_blank">GHSA-9wx4-h78v-vm56:requests</A>,
"ScanResult": #table cols="5"
Package Installed_Version Required_Version Language Install_Path
requests 2.31.0 2.32.0 Python opt/miniconda/lib/python3.10/site-packages/requests-2.31.0.dist-info/METADATA,
"Supported": true,
"VulnerabilityId1": ,
"ExtDate": ,
"justification": ,
"contact": 