### PR TITLE
adding the scores for gpt-4o model and gpt star metrics for gpt-4-turbo-2024-04-09 model.

### DIFF
--- a/assets/evaluation_results/boolq_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/boolq_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/boolq_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/boolq_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: boolq_gpt-4o_chat_completion
+version: 2.13.06
+display_name: boolq_gpt-4o_chat_completion
+description: boolq_gpt-4o_chat_completion
+dataset_family: boolq
+dataset_name: boolq
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.9051987767584098
+
+
+properties:
+  n_shot: 5
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "train"

--- a/assets/evaluation_results/gsm8k_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/gsm8k_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/gsm8k_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/gsm8k_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: gsm8k_gpt-4o_chat_completion
+version: 2.13.06
+display_name: gsm8k_gpt-4o_chat_completion
+description: gsm8k_gpt-4o_chat_completion
+dataset_family: gsm8k
+dataset_name: gsm8k
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.9423805913570887
+
+
+properties:
+  n_shot: 8
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "test"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/hellaswag_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/hellaswag_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/hellaswag_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/hellaswag_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: hellaswag_gpt-4o_chat_completion
+version: 2.13.06
+display_name: hellaswag_gpt-4o_chat_completion
+description: hellaswag_gpt-4o_chat_completion
+dataset_family: hellaswag
+dataset_name: hellaswag
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.8914558852818164
+
+
+properties:
+  n_shot: 5
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "train"

--- a/assets/evaluation_results/human_eval_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/human_eval_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/human_eval_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/human_eval_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: human_eval_gpt-4o_chat_completion
+version: 2.13.06
+display_name: human_eval_gpt-4o_chat_completion
+description: human_eval_gpt-4o_chat_completion
+dataset_family: human_eval
+dataset_name: human_eval
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: text-generation
+  accuracy_metric_name: pass@1
+
+metrics:
+  accuracy: 0.9207317073170732
+
+
+properties:
+  n_shot: 0
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "test"
+  fewshot_sampling_ratio: None
+  fewshot_split: "None"

--- a/assets/evaluation_results/mmlu_humanities_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/mmlu_humanities_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/mmlu_humanities_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/mmlu_humanities_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: mmlu_humanities_gpt-4o_chat_completion
+version: 2.13.06
+display_name: mmlu_humanities_gpt-4o_chat_completion
+description: mmlu_humanities_gpt-4o_chat_completion
+dataset_family: mmlu
+dataset_name: mmlu_humanities
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.8021253985122211
+
+
+properties:
+  n_shot: 5
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "test"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/mmlu_other_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/mmlu_other_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/mmlu_other_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/mmlu_other_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: mmlu_other_gpt-4o_chat_completion
+version: 2.13.06
+display_name: mmlu_other_gpt-4o_chat_completion
+description: mmlu_other_gpt-4o_chat_completion
+dataset_family: mmlu
+dataset_name: mmlu_other
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.8715803025426456
+
+
+properties:
+  n_shot: 5
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "test"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/mmlu_social_sciences_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/mmlu_social_sciences_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/mmlu_social_sciences_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/mmlu_social_sciences_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: mmlu_social_sciences_gpt-4o_chat_completion
+version: 2.13.06
+display_name: mmlu_social_sciences_gpt-4o_chat_completion
+description: mmlu_social_sciences_gpt-4o_chat_completion
+dataset_family: mmlu
+dataset_name: mmlu_social_sciences
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.9129021774455639
+
+
+properties:
+  n_shot: 5
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "test"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/mmlu_stem_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/mmlu_stem_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/mmlu_stem_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/mmlu_stem_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: mmlu_stem_gpt-4o_chat_completion
+version: 2.13.06
+display_name: mmlu_stem_gpt-4o_chat_completion
+description: mmlu_stem_gpt-4o_chat_completion
+dataset_family: mmlu
+dataset_name: mmlu_stem
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.6955280685061845
+
+
+properties:
+  n_shot: 5
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "test"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/openbookqa_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/openbookqa_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/openbookqa_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/openbookqa_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: openbookqa_gpt-4o_chat_completion
+version: 2.13.06
+display_name: openbookqa_gpt-4o_chat_completion
+description: openbookqa_gpt-4o_chat_completion
+dataset_family: openbookqa
+dataset_name: openbookqa
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.882
+
+
+properties:
+  n_shot: 10
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "train"

--- a/assets/evaluation_results/piqa_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/piqa_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/piqa_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/piqa_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: piqa_gpt-4o_chat_completion
+version: 2.13.06
+display_name: piqa_gpt-4o_chat_completion
+description: piqa_gpt-4o_chat_completion
+dataset_family: piqa
+dataset_name: piqa
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.8443960826985855
+
+
+properties:
+  n_shot: 5
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 0.3
+  fewshot_split: "train"

--- a/assets/evaluation_results/social_iqa_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/social_iqa_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/social_iqa_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/social_iqa_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: social_iqa_gpt-4o_chat_completion
+version: 2.13.06
+display_name: social_iqa_gpt-4o_chat_completion
+description: social_iqa_gpt-4o_chat_completion
+dataset_family: social_iqa
+dataset_name: social_iqa
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.7896622313203685
+
+
+properties:
+  n_shot: 5
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 0.3
+  fewshot_split: "train"

--- a/assets/evaluation_results/squad_v2_gpt-4-turbo-2024-04-09_chat_completion/asset.yaml
+++ b/assets/evaluation_results/squad_v2_gpt-4-turbo-2024-04-09_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/squad_v2_gpt-4-turbo-2024-04-09_chat_completion/spec.yaml
+++ b/assets/evaluation_results/squad_v2_gpt-4-turbo-2024-04-09_chat_completion/spec.yaml
@@ -1,0 +1,32 @@
+type: evaluationresult
+name: squad_v2_gpt-4-turbo-2024-04-09_chat_completion
+version: 2.13.06
+display_name: squad_v2_gpt-4-turbo-2024-04-09_chat_completion
+description: squad_v2_gpt-4-turbo-2024-04-09_chat_completion
+dataset_family: squad_v2
+dataset_name: squad_v2
+
+model_name: gpt-4-turbo-2024-04-09
+model_version: "turbo-2024-04-09"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4/versions/4
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4/versions/4
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: nan
+
+metrics:
+  relevance: 4.038785834738618
+  GPTSimilarity: 3.4300758213984834
+
+
+properties:
+  n_shot: 2
+  evaluation_sampling_ratio: 0.2
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/squad_v2_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/squad_v2_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/squad_v2_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/squad_v2_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,33 @@
+type: evaluationresult
+name: squad_v2_gpt-4o_chat_completion
+version: 2.13.06
+display_name: squad_v2_gpt-4o_chat_completion
+description: squad_v2_gpt-4o_chat_completion
+dataset_family: squad
+dataset_name: squad_v2
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: nan
+
+metrics:
+  groundedness: 4.090295358649789
+  relevance: 4.1897133220910625
+  GPTSimilarity: 3.535804549283909
+
+
+properties:
+  n_shot: 2
+  evaluation_sampling_ratio: 0.2
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/truthfulqa_generation_gpt-4-turbo-2024-04-09_chat_completion/asset.yaml
+++ b/assets/evaluation_results/truthfulqa_generation_gpt-4-turbo-2024-04-09_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/truthfulqa_generation_gpt-4-turbo-2024-04-09_chat_completion/spec.yaml
+++ b/assets/evaluation_results/truthfulqa_generation_gpt-4-turbo-2024-04-09_chat_completion/spec.yaml
@@ -1,0 +1,33 @@
+type: evaluationresult
+name: truthfulqa_generation_gpt-4-turbo-2024-04-09_chat_completion
+version: 2.13.06
+display_name: truthfulqa_generation_gpt-4-turbo-2024-04-09_chat_completion
+description: truthfulqa_generation_gpt-4-turbo-2024-04-09_chat_completion
+dataset_family: truthfulqa_generation
+dataset_name: truthfulqa_generation
+
+model_name: gpt-4-turbo-2024-04-09
+model_version: "turbo-2024-04-09"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4/versions/4
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4/versions/4
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: nan
+
+metrics:
+  coherence: 4.974264705882353
+  fluency: 4.947368421052632
+  GPTSimilarity: 3.0392156862745097
+
+
+properties:
+  n_shot: 6
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/truthfulqa_generation_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/truthfulqa_generation_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/truthfulqa_generation_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/truthfulqa_generation_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,33 @@
+type: evaluationresult
+name: truthfulqa_generation_gpt-4o_chat_completion
+version: 2.13.06
+display_name: truthfulqa_generation_gpt-4o_chat_completion
+description: truthfulqa_generation_gpt-4o_chat_completion
+dataset_family: truthfulqa
+dataset_name: truthfulqa_generation
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: nan
+
+metrics:
+  coherence: 4.947368421052632
+  fluency: 4.950980392156863
+  GPTSimilarity: 2.926560588
+
+
+properties:
+  n_shot: 6
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/truthfulqa_mc1_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/truthfulqa_mc1_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/truthfulqa_mc1_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/truthfulqa_mc1_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: truthfulqa_mc1_gpt-4o_chat_completion
+version: 2.13.06
+display_name: truthfulqa_mc1_gpt-4o_chat_completion
+description: truthfulqa_mc1_gpt-4o_chat_completion
+dataset_family: truthfulqa
+dataset_name: truthfulqa_mc1
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.8249694
+
+
+properties:
+  n_shot: 6
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "dev"

--- a/assets/evaluation_results/winogrande_gpt-4o_chat_completion/asset.yaml
+++ b/assets/evaluation_results/winogrande_gpt-4o_chat_completion/asset.yaml
@@ -1,0 +1,3 @@
+type: evaluationresult
+spec: spec.yaml
+categories: ["EvaluationResult"]

--- a/assets/evaluation_results/winogrande_gpt-4o_chat_completion/spec.yaml
+++ b/assets/evaluation_results/winogrande_gpt-4o_chat_completion/spec.yaml
@@ -1,0 +1,31 @@
+type: evaluationresult
+name: winogrande_gpt-4o_chat_completion
+version: 2.13.06
+display_name: winogrande_gpt-4o_chat_completion
+description: winogrande_gpt-4o_chat_completion
+dataset_family: winogrande
+dataset_name: winogrande
+
+model_name: gpt-4o
+model_version: "5/13/2024"
+model_asset_id: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+relationships:
+  - relationshipType: Source
+    assetId: azureml://registries/azure-openai/models/gpt-4o/versions/1
+
+tags:
+  evaluation_type: text_generation
+  task: question-answering
+  accuracy_metric_name: exact_match
+
+metrics:
+  accuracy: 0.8216258879242304
+
+
+properties:
+  n_shot: 5
+  evaluation_sampling_ratio: 1.0
+  evaluation_split: "validation"
+  fewshot_sampling_ratio: 1.0
+  fewshot_split: "train"


### PR DESCRIPTION
Adding the scores for:
1) gpt4o model on 15 onboarded datasets
2) gpt-4-turbo-2024-04-09 model on squad_v2, truthfulqa_generation datasets 

Note: Not adding groundedness metric for squad_v2 dataset as part of this pull request.