### PR TITLE
Skip Azure auth during validate_assets import

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ### 🐛 Bugs Fixed
 
+## 1.16.53 (2024-06-28)
+### 🐛 Bugs Fixed
+- [#2991](https://github.com/Azure/azureml-assets/pull/2991) Don't auth to Azure during import of validate_assets
+
 ## 1.16.52 (2024-06-03)
 ### 🚀 New Features
 - [#3000](https://github.com/Azure/azureml-assets/pull/3000) Allow use of azcopy's --overwrite flag

--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## 1.16.53 (2024-06-28)
 ### 🐛 Bugs Fixed
-- [#2991](https://github.com/Azure/azureml-assets/pull/2991) Don't auth to Azure during import of validate_assets
+- [#3102](https://github.com/Azure/azureml-assets/pull/3102) Don't auth to Azure during import of validate_assets
 
 ## 1.16.52 (2024-06-03)
 ### 🚀 New Features

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.16.52",
+   version="1.16.53",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
This throws off folks when they're troubleshooting failed releases, because the call to get_token() doesn't always work.