### PR TITLE
MoMo component release 07/12/24

### DIFF
--- a/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_drift_compute_metrics
 display_name: Data Drift - Compute Metrics
 description: Compute data drift metrics given a baseline and a deployment's model data input.
-version: 0.3.24
+version: 0.3.25
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_drift_signal_monitor
 display_name: Data Drift - Signal Monitor
 description: Computes the data drift between a baseline and production data assets.
-version: 0.3.45
+version: 0.3.44
 is_deterministic: true
 
 inputs:
@@ -63,7 +63,7 @@ outputs:
 jobs:
   compute_feature_importances:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.24
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.23
     inputs:
       baseline_data:
         type: mltable

--- a/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_drift_signal_monitor
 display_name: Data Drift - Signal Monitor
 description: Computes the data drift between a baseline and production data assets.
-version: 0.3.44
+version: 0.3.45
 is_deterministic: true
 
 inputs:
@@ -63,7 +63,7 @@ outputs:
 jobs:
   compute_feature_importances:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.23
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.24
     inputs:
       baseline_data:
         type: mltable
@@ -82,7 +82,7 @@ jobs:
       type: aml_token
   feature_selection:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.18
+    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.19
     inputs:
       input_data_1:
         type: mltable
@@ -103,7 +103,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.24
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.25
     inputs:
       production_dataset:
         type: mltable
@@ -130,7 +130,7 @@ jobs:
       type: aml_token
   compute_histogram_buckets:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.18
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.19
     inputs:
       input_data_1:
         type: mltable
@@ -150,7 +150,7 @@ jobs:
       type: aml_token
   compute_baseline_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.18
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.19
     inputs:
       input_data:
         type: mltable
@@ -170,7 +170,7 @@ jobs:
       type: aml_token
   compute_target_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.18
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.19
     inputs:
       input_data:
         type: mltable
@@ -190,7 +190,7 @@ jobs:
       type: aml_token
   output_signal_metrics:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.22
+    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.23
     inputs:
       signal_metrics:
         type: mltable
@@ -218,7 +218,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.24
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/data_quality/data_quality_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_quality_compute_metrics
 display_name:  Data Quality - Compute Metrics
 description: Compute data quality metrics leveraged by the data quality monitor.
-version: 0.3.22
+version: 0.3.23
 is_deterministic: true
 
 inputs:

--- a/assets/model_monitoring/components/data_quality/data_quality_metrics_joiner/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_metrics_joiner/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_quality_metrics_joiner
 display_name:  Data Quality - Metrics Joiner
 description: Join baseline and target data quality metrics into a single output.
-version: 0.3.16
+version: 0.3.17
 is_deterministic: true
 
 inputs:

--- a/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_quality_signal_monitor
 display_name: Data Quality - Signal Monitor
 description: Computes the data quality of a target dataset with reference to a baseline.
-version: 0.3.43
+version: 0.3.42
 is_deterministic: true
 
 inputs:
@@ -63,7 +63,7 @@ outputs:
 jobs:
   compute_feature_importances:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.24
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.23
     inputs:
       baseline_data:
         type: mltable

--- a/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_quality_signal_monitor
 display_name: Data Quality - Signal Monitor
 description: Computes the data quality of a target dataset with reference to a baseline.
-version: 0.3.42
+version: 0.3.43
 is_deterministic: true
 
 inputs:
@@ -63,7 +63,7 @@ outputs:
 jobs:
   compute_feature_importances:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.23
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.24
     inputs:
       baseline_data:
         type: mltable
@@ -82,7 +82,7 @@ jobs:
       type: aml_token
   feature_selection:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.18
+    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.19
     inputs:
       input_data_1:
         type: mltable
@@ -103,7 +103,7 @@ jobs:
       type: aml_token
   compute_baseline_data_statistics:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_data_statistics/versions/0.3.18
+    component: azureml://registries/azureml/components/data_quality_data_statistics/versions/0.3.19
     inputs:
       baseline_data:
         type: mltable
@@ -120,7 +120,7 @@ jobs:
       type: aml_token
   compute_baseline_data_quality:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.22
+    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.23
     inputs:
       input_data:
         type: mltable
@@ -145,7 +145,7 @@ jobs:
       type: aml_token
   compute_target_data_quality:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.22
+    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.23
     inputs:
       input_data:
         type: mltable
@@ -168,7 +168,7 @@ jobs:
       type: aml_token
   join_data_quality_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_metrics_joiner/versions/0.3.16
+    component: azureml://registries/azureml/components/data_quality_metrics_joiner/versions/0.3.17
     inputs:
       baseline_metrics:
         type: mltable
@@ -188,7 +188,7 @@ jobs:
       type: aml_token
   output_signal_metrics:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.22
+    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.23
     inputs:
       signal_metrics:
         type: mltable
@@ -210,7 +210,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.24
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/data_quality/data_quality_statistics/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_statistics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_quality_data_statistics
 display_name: Data Quality - Data Statistics
 description: Compute data statistics leveraged by the data quality monitor.
-version: 0.3.18
+version: 0.3.19
 is_deterministic: true
 
 inputs:

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_compute_metrics/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/SparkComponent.json
 type: spark
 
 name: feature_attribution_drift_compute_metrics
-version: 0.3.19
+version: 0.3.20
 display_name: Feature Attribution Drift - Compute Metrics
 is_deterministic: true
 description: Feature attribution drift using model monitoring.

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: feature_attribution_drift_signal_monitor
 display_name: Feature Attribution Drift - Signal Monitor
 description: Computes the feature attribution between a baseline and production data assets.
-version: 0.3.35
+version: 0.3.36
 is_deterministic: true
 
 inputs:
@@ -44,7 +44,7 @@ outputs:
 jobs:
   compute_baseline_explanations:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.23
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.24
     inputs:
       baseline_data:
         type: mltable
@@ -63,7 +63,7 @@ jobs:
       type: aml_token
   compute_production_explanations:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.23
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.24
     inputs:
       baseline_data:
         type: mltable
@@ -82,7 +82,7 @@ jobs:
       type: aml_token
   compute_feature_attribution:
     type: spark
-    component: azureml://registries/azureml/components/feature_attribution_drift_compute_metrics/versions/0.3.19
+    component: azureml://registries/azureml/components/feature_attribution_drift_compute_metrics/versions/0.3.20
     inputs:
       production_data:
         type: mltable
@@ -101,7 +101,7 @@ jobs:
       type: aml_token
   output_signal_metrics:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.22
+    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.23
     inputs:
       signal_metrics:
         type: mltable
@@ -122,7 +122,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.24
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: feature_attribution_drift_signal_monitor
 display_name: Feature Attribution Drift - Signal Monitor
 description: Computes the feature attribution between a baseline and production data assets.
-version: 0.3.36
+version: 0.3.35
 is_deterministic: true
 
 inputs:
@@ -44,7 +44,7 @@ outputs:
 jobs:
   compute_baseline_explanations:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.24
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.23
     inputs:
       baseline_data:
         type: mltable
@@ -63,7 +63,7 @@ jobs:
       type: aml_token
   compute_production_explanations:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.24
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.23
     inputs:
       baseline_data:
         type: mltable

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_importance_metrics/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_importance_metrics/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/SparkComponent.json
 type: spark
 
 name: feature_importance_metrics
-version: 0.3.24
+version: 0.3.23
 display_name: Feature importance
 is_deterministic: true
 description: Feature importance for model monitoring.

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_importance_metrics/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_importance_metrics/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/SparkComponent.json
 type: spark
 
 name: feature_importance_metrics
-version: 0.3.23
+version: 0.3.24
 display_name: Feature importance
 is_deterministic: true
 description: Feature importance for model monitoring.

--- a/assets/model_monitoring/components/genai_token_statistics/genai_token_statistics_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/genai_token_statistics/genai_token_statistics_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: genai_token_statistics_compute_metrics
 display_name:  GenAI Token Statistics - Compute Metrics
 description: Compute token statistics metrics.
-version: 0.0.11
+version: 0.0.12
 is_deterministic: true
 
 inputs:

--- a/assets/model_monitoring/components/genai_token_statistics/genai_token_statistics_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/genai_token_statistics/genai_token_statistics_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: genai_token_statistics_signal_monitor
 display_name: GenAI Token Statistics - Signal Monitor
 description: Computes the token and cost metrics over LLM outputs.
-version: 0.0.11
+version: 0.0.12
 is_deterministic: true
 inputs:
   monitor_name:
@@ -30,7 +30,7 @@ outputs:
 jobs:
   compute_metrics:
     type: spark
-    component: azureml://registries/azureml/components/genai_token_statistics_compute_metrics/versions/0.0.11
+    component: azureml://registries/azureml/components/genai_token_statistics_compute_metrics/versions/0.0.12
     inputs:
       production_dataset:
         type: mltable
@@ -49,7 +49,7 @@ jobs:
       type: aml_token
   output_signal_metrics: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.26
+    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.27
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_histogram
 display_name: Annotation - Compute Histogram
 description: Compute annotation histogram given a deployment's model data input.
-version: 0.4.26
+version: 0.4.27
 is_deterministic: false
 inputs:
   production_dataset:

--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_metrics
 display_name: Annotation - Compute Metrics
 description: Compute annotation metrics given a deployment's model data input.
-version: 0.4.19
+version: 0.4.20
 is_deterministic: True
 inputs:
   annotation_histogram: 

--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: generation_safety_quality_signal_monitor
 display_name: Generation Safety & Quality - Signal Monitor
 description: Computes the content generation safety metrics over LLM outputs.
-version: 0.5.17
+version: 0.5.18
 is_deterministic: true
 inputs:
   monitor_name:
@@ -109,7 +109,7 @@ outputs:
 jobs:
   input_schema_adaptor:
     type: spark
-    component: azureml://registries/azureml/components/gsq_input_schema_adaptor/versions/0.0.14
+    component: azureml://registries/azureml/components/gsq_input_schema_adaptor/versions/0.0.15
     inputs:
       production_dataset:
         type: mltable
@@ -124,7 +124,7 @@ jobs:
       type: aml_token
   compute_histogram:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.26
+    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.27
     inputs:
       production_dataset:
         type: mltable
@@ -167,7 +167,7 @@ jobs:
       type: aml_token
   compute_metrics:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.19
+    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.20
     inputs:
       annotation_histogram:
         type: mltable
@@ -189,7 +189,7 @@ jobs:
       type: aml_token
   output_signal_metrics: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.26
+    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.27
     inputs:
       signal_metrics:
         type: mltable
@@ -211,7 +211,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.24
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/generation_safety_quality/input_schema_adaptor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/input_schema_adaptor/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_input_schema_adaptor
 display_name: Input Schema Adaptor
 description: Adapt data to fit into GSQ component.
-version: 0.0.14
+version: 0.0.15
 is_deterministic: True
 inputs:
   production_dataset:

--- a/assets/model_monitoring/components/model_monitor/genai_mdc_preprocessor/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/genai_mdc_preprocessor/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: genai_mdc_preprocessor
 display_name: GenAI MDC - Preprocessor
 description: Filters the raw span log based on the window provided, and aggregates it to trace level.
-version: 0.0.19
+version: 0.0.20
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/model_monitor/model_data_collector_preprocessor/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_data_collector_preprocessor/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_data_collector_preprocessor
 display_name: Model Data Collector - Preprocessor
 description: Filters the data based on the window provided.
-version: 0.4.20
+version: 0.4.21
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/model_monitor/model_monitor_azmon_metric_publisher/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_azmon_metric_publisher/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_azmon_metric_publisher
 display_name: Model Monitor - Azure Monitor Metric Publisher
 description: Azure Monitor Publisher for the computed model monitor metrics.
-version: 0.3.22
+version: 0.3.23
 is_deterministic: true
 
 code: ../../src/

--- a/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_compute_histogram
 display_name: Model Monitor - Compute Histogram
 description: Compute a histogram given an input data and associated histogram buckets.
-version: 0.3.18
+version: 0.3.19
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram_buckets/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram_buckets/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_compute_histogram_buckets
 display_name: Model Monitor - Compute Histogram Buckets
 description: Compute histogram buckets given up to two datasets.
-version: 0.3.18
+version: 0.3.19
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/model_monitor/model_monitor_create_manifest/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_create_manifest/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_create_manifest
 display_name: Model Monitor - Create Manifest
 description: Creates the model monitor metric manifest.
-version: 0.3.15
+version: 0.3.16
 is_deterministic: true
 
 code: ../../src/

--- a/assets/model_monitoring/components/model_monitor/model_monitor_data_joiner/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_data_joiner/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_data_joiner
 display_name: Model Monitor - Data Joiner
 description: Joins two data assets on the given columns for model monitor.
-version: 0.3.18
+version: 0.3.19
 is_deterministic: true
 
 code: ../../src/

--- a/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_evaluate_metrics_threshold
 display_name: Model Monitor - Evaluate Metrics Threshold
 description: Evaluate signal metrics against the threshold provided in the monitoring signal.
-version: 0.3.23
+version: 0.3.24
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/model_monitor/model_monitor_feature_selector/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_feature_selector/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_feature_selector
 display_name: Model Monitor - Feature Selector
 description: Selects features to compute signal metrics on.
-version: 0.3.18
+version: 0.3.19
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/model_monitor/model_monitor_metric_outputter/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_metric_outputter/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_metric_outputter
 display_name: Model Monitor - Metric Outputter
 description: Output the computed model monitor metrics.
-version: 0.3.26
+version: 0.3.27
 is_deterministic: true
 
 code: ../../src/

--- a/assets/model_monitoring/components/model_monitor/model_monitor_output_metrics/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_output_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_output_metrics
 display_name: Model Monitor - Output Metrics
 description: Output the computed model monitor metrics to the default datastore.
-version: 0.3.22
+version: 0.3.23
 is_deterministic: true
 
 code: ../../src/

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_correlation_test/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_correlation_test/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: action_analyzer_correlation_test
 display_name: Action Analyzer - Correlation Test
 description: Perform correlation test on different groups to generate actions.
-version: 0.0.12
+version: 0.0.13
 is_deterministic: True
 inputs:
   data_with_action_metric_score:

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_identify_problem_traffic/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_identify_problem_traffic/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: action_analyzer_identify_problem_traffic
 display_name: Action Analyzer - Identify Problem Traffic 
 description: Separate bad queries into different groups.
-version: 0.0.15
+version: 0.0.16
 is_deterministic: True
 inputs:
   signal_output:

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_metrics_calculation/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_metrics_calculation/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: action_analyzer_metrics_calculation
 display_name: Action Analyzer - Metrics Calculation
 description: Calculate futher metrics for generating actions.
-version: 0.0.12
+version: 0.0.13
 is_deterministic: True
 inputs:
   data_with_groups:

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_output_actions/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_output_actions/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: action_analyzer_output_actions
 display_name: Action Analyzer - Output Actions
 description: Merge and output actions.
-version: 0.0.15
+version: 0.0.16
 is_deterministic: True
 inputs:
   action_data:

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/model_monitor_action_analyzer/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/model_monitor_action_analyzer/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: model_monitor_action_analyzer
 display_name: Model Monitor - Action Analyzer
 description: Generate and output actions to the default datastore.
-version: 0.0.16
+version: 0.0.17
 is_deterministic: true
 inputs:
   signal_output:
@@ -52,7 +52,7 @@ outputs:
 jobs:
   identify_problem_traffic:
     type: spark
-    component: azureml://registries/azureml/components/action_analyzer_identify_problem_traffic/versions/0.0.15
+    component: azureml://registries/azureml/components/action_analyzer_identify_problem_traffic/versions/0.0.16
     inputs:
       signal_output: 
         type: uri_folder
@@ -74,7 +74,7 @@ jobs:
       type: aml_token
   metrics_calculation:
     type: spark
-    component: azureml://registries/azureml/components/action_analyzer_metrics_calculation/versions/0.0.12
+    component: azureml://registries/azureml/components/action_analyzer_metrics_calculation/versions/0.0.13
     inputs:
       data_with_groups:
         type: mltable
@@ -91,7 +91,7 @@ jobs:
       type: aml_token
   correlation_test:
     type: spark
-    component: azureml://registries/azureml/components/action_analyzer_correlation_test/versions/0.0.12
+    component: azureml://registries/azureml/components/action_analyzer_correlation_test/versions/0.0.13
     inputs:
       data_with_action_metric_score:
         type: mltable
@@ -106,7 +106,7 @@ jobs:
       type: aml_token
   output_actions:
     type: spark
-    component: azureml://registries/azureml/components/action_analyzer_output_actions/versions/0.0.15
+    component: azureml://registries/azureml/components/action_analyzer_output_actions/versions/0.0.16
     inputs:
       action_data:
         type: mltable

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/model_monitor_action_detector/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/model_monitor_action_detector/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_action_detector
 display_name: Model Monitor - Action Detector
 description: Generate and output actions
-version: 0.0.8
+version: 0.0.9
 is_deterministic: true
 inputs:
   signal_output:

--- a/assets/model_monitoring/components/model_performance/model_performance_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/model_performance/model_performance_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_performance_compute_metrics
 display_name: Model Performance - Compute Metrics
 description: Compute model performance metrics leveraged by the model performance monitor.
-version: 0.0.17
+version: 0.0.18
 is_deterministic: true
 
 code: ../../src

--- a/assets/model_monitoring/components/model_performance/model_performance_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/model_performance/model_performance_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: model_performance_signal_monitor
 display_name: Model Performance - Signal Monitor
 description: Computes the model performance
-version: 0.0.19
+version: 0.0.20
 is_deterministic: true
 inputs:
   task:
@@ -57,7 +57,7 @@ outputs:
 jobs:
   compute_metrics:
     type: spark
-    component: azureml://registries/azureml/components/model_performance_compute_metrics/versions/0.0.17
+    component: azureml://registries/azureml/components/model_performance_compute_metrics/versions/0.0.18
     inputs:
       task: ${{parent.inputs.task}}
       baseline_data_target_column: ${{parent.inputs.baseline_data_target_column}}
@@ -78,7 +78,7 @@ jobs:
       type: aml_token
   output_signal_metrics: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.26
+    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.27
     inputs:
       signal_metrics:
         type: mltable
@@ -99,7 +99,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.24
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: prediction_drift_signal_monitor
 display_name: Prediction Drift - Signal Monitor
 description: Computes the prediction drift between a baseline and a target data assets.
-version: 0.4.19
+version: 0.4.20
 is_deterministic: true
 
 inputs:
@@ -57,7 +57,7 @@ outputs:
 jobs:
   feature_selection:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.18
+    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.19
     inputs:
       input_data_1:
         type: mltable
@@ -77,7 +77,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.24
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.25
     inputs:
       production_dataset:
         type: mltable
@@ -104,7 +104,7 @@ jobs:
       type: aml_token
   compute_histogram_buckets:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.18
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.19
     inputs:
       input_data_1:
         type: mltable
@@ -124,7 +124,7 @@ jobs:
       type: aml_token
   compute_baseline_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.18
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.19
     inputs:
       input_data:
         type: mltable
@@ -144,7 +144,7 @@ jobs:
       type: aml_token
   compute_target_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.18
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.19
     inputs:
       input_data:
         type: mltable
@@ -164,7 +164,7 @@ jobs:
       type: aml_token
   output_signal_metrics: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.22
+    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.23
     inputs:
       signal_metrics:
         type: mltable
@@ -191,7 +191,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.24
     inputs:
       signal_metrics: 
         type: mltable

--- a/assets/model_monitoring/components/token_statistics/token_statistics_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/token_statistics/token_statistics_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: token_statistics_compute_metrics
 display_name:  Token Statistics - Compute Metrics
 description: Compute token statistics metrics.
-version: 0.0.14
+version: 0.0.15
 is_deterministic: true
 
 inputs:


### PR DESCRIPTION
bumps all versions minus: feature_importance_metrics, data_quality_signal_monitor, and data_drift_signal_monitor as those were updated by Ilya manually in this PR: https://github.com/Azure/azureml-assets/pull/3139