### PR TITLE
Change the MSCOCO vision adapter for the 2014 dataset

### DIFF
--- a/assets/aml-benchmark/components/src/aml_benchmark/dataset_downloader/vision_dataset_adapter.py
+++ b/assets/aml-benchmark/components/src/aml_benchmark/dataset_downloader/vision_dataset_adapter.py
@@ -4,6 +4,7 @@
 """Vision dataset adapters."""
 
 import io
+import random
 
 from abc import ABC, abstractmethod
 from typing import Optional
@@ -11,7 +12,6 @@ from typing import Optional
 from datasets import Dataset
 from PIL import Image
 
-from aml_benchmark.utils.constants import CAPTION_SEPARATOR
 from aml_benchmark.utils.logging import get_logger
 
 
@@ -112,9 +112,15 @@ class GTSRBAdapter(VisionDatasetAdapter):
 class MSCOCOAdapter(VisionDatasetAdapter):
     """Adapter for MSCOCO HF dataset."""
 
+    SEED = 0
+
+    def __init__(self, _):
+        random.seed(self.SEED)
+
     def get_label(self, instance):
         """Extract the instance's label as a string."""
-        return CAPTION_SEPARATOR.join(instance["annotations"]["caption"])
+        caption_index = random.randint(0, len(instance["annotations"]["caption"]) - 1)
+        return instance["annotations"]["caption"][caption_index]
 
     def get_pil_image(self, instance):
         """Extract the instance's image as a PIL image."""

--- a/assets/aml-benchmark/components/src/aml_benchmark/dataset_downloader/vision_dataset_adapter.py
+++ b/assets/aml-benchmark/components/src/aml_benchmark/dataset_downloader/vision_dataset_adapter.py
@@ -115,6 +115,7 @@ class MSCOCOAdapter(VisionDatasetAdapter):
     SEED = 0
 
     def __init__(self, _):
+        """Make adapter, initializing random number generator."""
         random.seed(self.SEED)
 
     def get_label(self, instance):

--- a/assets/aml-benchmark/components/src/aml_benchmark/utils/constants.py
+++ b/assets/aml-benchmark/components/src/aml_benchmark/utils/constants.py
@@ -63,10 +63,6 @@ class IntermediateNames:
     IMAGE_FILE_NAME_TEMPLATE = "image_{image_counter:09d}.png"
 
 
-# TODO: enforce use of same value as in training/model_evaluation/src/image_constants.py.
-CAPTION_SEPARATOR = "||"
-
-
 ROOT_RUN_PROPERTIES = {
     "PipelineType": "Benchmark"
 }

--- a/assets/aml-benchmark/scripts/data_loaders/mscoco.py
+++ b/assets/aml-benchmark/scripts/data_loaders/mscoco.py
@@ -64,9 +64,9 @@ _LICENSE = "https://creativecommons.org/licenses/by/4.0/legalcode"
 _URLS = {
     "2014": {
         "images": {
-            "train": "http://images.cocodataset.org/zips/train2014.zip",
+            # "train": "http://images.cocodataset.org/zips/train2014.zip",
             "validation": "http://images.cocodataset.org/zips/val2014.zip",
-            "test": "http://images.cocodataset.org/zips/test2014.zip",
+            # "test": "http://images.cocodataset.org/zips/test2014.zip",
         },
         "annotations": {
             "train_validation": "http://images.cocodataset.org/annotations/annotations_trainval2014.zip",


### PR DESCRIPTION
Modify the vision adapter for the MSCOCO dataset to sample one caption per image, to reflect literature practice. Also skip downloading training and test image files for MSCOCO 2014 to prevent running out of disk space in downloader component.

Tested by running the benchmarking pipeline in the cloud: https://ml.azure.com/experiments/id/9f7237b4-3232-49d3-ae02-e07326242835/runs/icy_tooth_6mpy0tvxz5?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/benchmarking&tid=72f988bf-86f1-41af-91ab-2d7cd011db47# . Note that the FID value matches the values reported in the literature.
