### PR TITLE
Downgrade python 38 for fixing mmtracking env issue

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -1,5 +1,5 @@
 # PTCA image
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu117-py310-torch1131:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
+FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu117-py38-torch1131:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
 RUN apt-get -y update


### PR DESCRIPTION
Downgrading python to fix the mmtracking env build issue.
Pip is not able to resolve the dependencies for scipy since the versions between scipy 1.6.0 to 1.7.3, most of them don't support python 3.10, hence downgrading to python 3.8 fixes the issue