### PR TITLE
Updated base image python to 3.9

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -1,5 +1,5 @@
 # PTCA image
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu117-py38-torch1131:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
+FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu117-py39-torch1131:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
 RUN apt-get -y update

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/requirements.txt
@@ -3,7 +3,7 @@ azureml-acft-accelerator=={{latest-pypi-version}}
 azureml-acft-common-components[image]~={{latest-pypi-version}}
 azureml-acft-image-components=={{latest-pypi-version}}
 azureml-core=={{latest-pypi-version}}
-azure-ai-ml==1.13.0
+azure-ai-ml==1.18.0
 requests>=2.31.0
 datasets==2.15.0
 transformers==4.36.2


### PR DESCRIPTION
Setting python version to 3.9 from 3.8 due to the scikit-learn package dropping support for python 3.8 and it raises another vulnerability for our environment

Corresponding azuremlcli PR: https://msdata.visualstudio.com/Vienna/_git/AzureMlCli/pullrequest/1407242