### PR TITLE
Shrsha/fix bug ts collect

### DIFF
--- a/assets/model_monitoring/components/src/genai_token_statistics_compute_metrics/metrics_processor.py
+++ b/assets/model_monitoring/components/src/genai_token_statistics_compute_metrics/metrics_processor.py
@@ -6,27 +6,17 @@
 import json
 from genai_token_statistics_compute_metrics.constants import (
     INCLUDE_SPAN_TYPE,
-    TOTAL_TOKEN_COUNT,
-    TOTAL_PROMPT_COUNT,
-    TOTAL_COMPLETION_COUNT,
-    AVG_TOKEN_COUNT,
-    AVG_PROMPT_COUNT,
-    AVG_COMPLETION_COUNT,
-    MODEL_COMPLETION_COUNT,
     COMPLETION_COUNT_KEYS,
     PROMPT_COUNT_KEYS,
     TOTAL_COUNT_KEYS,
     MODEL_KEYS)
+from pyspark.sql.functions import sum as _sum, avg as _avg, count as _count, lit
 from pyspark.sql import DataFrame, Row
-from pyspark.sql.types import StructType, StringType, DoubleType, StructField
+from pyspark.sql.types import StructType, StringType, StructField, IntegerType
 from shared_utilities.span_tree_utils import SpanTreeNode, SpanTree
 from shared_utilities.constants import (
-    SIGNAL_METRICS_METRIC_NAME,
-    SIGNAL_METRICS_METRIC_VALUE,
-    SIGNAL_METRICS_THRESHOLD_VALUE,
     ROOT_SPAN_COLUMN
 )
-from shared_utilities.io_utils import init_spark
 from typing import Optional, List
 
 
@@ -35,15 +25,9 @@ class MetricsProcessor:
 
     def __init__(self):
         """Initialize metrics for computation."""
-        self.total_prompt_count = 0
-        self.total_completion_count = 0
-        self.total_token_count = 0
-        self.avg_prompt_count = 0
-        self.avg_completion_count = 0
-        self.avg_total_count = 0
-        self.model_data = {}
-        self.request_data = []
-        self.total_requests = 0
+        self.metrics_df = []
+        self.requests_df = []
+        self.metrics_model_df = []
 
     def create_span_tree_from_dataframe_row(self, row: Row) -> Optional[SpanTreeNode]:
         """Create a SpanTree from a DataFrame row."""
@@ -55,15 +39,57 @@ class MetricsProcessor:
         """Create a list of SpanTrees from a DataFrame."""
         # Convert the DataFrame to an RDD and then to a list of Rows
         df.rdd.foreach(self.process_row)
-    
+
     def process(self, df_traces: DataFrame):
         """Process the aggregated trace data to compute metrics.
 
         Args:
             df_traces (DataFrame): Aggregated traces from the GenAI processor.
         """
+        print("process")
         df_traces = df_traces.select(ROOT_SPAN_COLUMN)
-        self.create_span_tree_from_dataframe(df_traces)
+        # Create an RDD of tuples with the necessary counts
+        counts_and_requests_rdd = df_traces.rdd.flatMap(self.process_row)
+        counts_rdd = counts_and_requests_rdd.filter(lambda x: isinstance(x, tuple))
+        requests_rdd = counts_and_requests_rdd.filter(lambda x: isinstance(x, dict))
+
+        # Convert the RDD to a DataFrame
+        counts_schema = StructType([
+            StructField("prompt_count", IntegerType(), True),
+            StructField("completion_count", IntegerType(), True),
+            StructField("total_count", IntegerType(), True),
+            StructField("model", StringType(), True)
+        ])
+        counts_df = counts_rdd.toDF(schema=counts_schema)
+
+        requests_schema = StructType([
+            StructField("prompt_count", IntegerType(), True),
+            StructField("input", StringType(), True),
+            StructField("completion_count", IntegerType(), True),
+            StructField("output", StringType(), True),
+        ])
+        requests_df = requests_rdd.toDF(schema=requests_schema)
+
+        # Perform aggregation to compute the metrics
+        metrics_df = counts_df.agg(
+            _sum('prompt_count').alias('total_prompt_count'),
+            _sum('completion_count').alias('total_completion_count'),
+            _sum('total_count').alias('total_token_count'),
+            _avg('prompt_count').alias('avg_prompt_count'),
+            _avg('completion_count').alias('avg_completion_count'),
+            _avg('total_count').alias('avg_total_count'),
+            _count(lit(1)).alias('total_requests')
+        )
+        metrics_model_df = counts_df.groupBy("model").agg(
+            _sum('prompt_count').alias('total_prompt_count'),
+            _sum('completion_count').alias('total_completion_count'),
+            _count(lit(1)).alias('total_requests')
+        )
+
+        # Store the metrics DataFrame as an instance variable for later use
+        self.metrics_model_df = metrics_model_df
+        self.metrics_df = metrics_df
+        self.requests_df = requests_df
 
     def process_row(self, row: Row):
         """Process the aggregated trace data to compute metrics.
@@ -72,114 +98,43 @@ class MetricsProcessor:
             df_traces (DataFrame): Aggregated traces from the GenAI processor.
         """
         tree = self.create_span_tree_from_dataframe_row(row)
+        print("tree before", tree)
         if tree is None:
-            return
-        
+            return []
+        counts_and_requests = []
         for span in tree:
             span_type = span.span_type
             if span_type in INCLUDE_SPAN_TYPE:
                 attributes = json.loads(span.get_node_attribute(attribute_key="attributes"))
-                parent = tree.get_span_tree_node_by_span_id(span.parent_id)
                 # in some cases we have LLM/Embedding span with no parent so need to check
                 # before accessing its parent object
+                parent = tree.get_span_tree_node_by_span_id(span.parent_id)
                 parent_input = None
                 parent_output = None
                 if parent is not None:
                     parent_input = parent.input
                     parent_output = parent.output
+                # Extract the counts and model information
+                completion_count = self.get_value_from_attributes(attributes, COMPLETION_COUNT_KEYS)
+                prompt_count = self.get_value_from_attributes(attributes, PROMPT_COUNT_KEYS)
+                total_count = self.get_value_from_attributes(attributes, TOTAL_COUNT_KEYS)
+                model = self.get_value_from_attributes(attributes, MODEL_KEYS)
 
-                self.calculate_metrics(attributes=attributes,
-                                       span_type=span_type,
-                                       root_input=parent_input,
-                                       root_output=parent_output)
-        self.calculate_averages()
+                # Append a tuple with the counts and model to the list
+                if model is not None:
+                    counts_and_requests.append((prompt_count, completion_count, total_count, model))
 
-    def metrics_generator(self):
-        """Return: metrics_data_df (DataFrame): metrics dataframe."""
-        spark = init_spark()
-        schema = StructType([
-            StructField(SIGNAL_METRICS_METRIC_NAME, StringType(), True),
-            StructField(SIGNAL_METRICS_METRIC_VALUE, DoubleType(), True),
-            StructField(SIGNAL_METRICS_THRESHOLD_VALUE, StringType(), True)
-        ])
-        metrics_data = [
-            (TOTAL_TOKEN_COUNT, float(self.total_token_count), 0.0),
-            (TOTAL_PROMPT_COUNT, float(self.total_prompt_count), 0.0),
-            (TOTAL_COMPLETION_COUNT, float(self.total_completion_count), 0.0),
-            (AVG_TOKEN_COUNT, float(self.avg_total_count), 0.0),
-            (AVG_PROMPT_COUNT, float(self.avg_prompt_count), 0.0),
-            (AVG_COMPLETION_COUNT, float(self.avg_completion_count), 0.0)
-        ]
-        for model_name, model_info in self.model_data.items():
-            if MODEL_COMPLETION_COUNT in model_info:
-                metrics_data.append((f"{model_name}.CompletionCount",
-                                     float(model_info[MODEL_COMPLETION_COUNT]),
-                                     0.0))
-            metrics_data.append((f"{model_name}.TotalRequests", float(model_info["total_requests"]), 0.0))
-            metrics_data.append((f"{model_name}.PromptCount", float(model_info["model_prompt_count"]), 0.0))
-        metrics_data_df = spark.createDataFrame(metrics_data, schema=schema)
-        print("metrics calculated")
-        metrics_data_df.show()
-        return metrics_data_df
+                # Append requests data if available
+                if parent_input is not None and parent_output is not None:
+                    counts_and_requests.append({
+                        "prompt_count": prompt_count,
+                        "input": parent_input,
+                        "completion_count": completion_count,
+                        "output": parent_output
+                    })
 
-    def get_latest_run(self):
-        """Return: sample_data_df (DataFrame): returns input, output and tokens for current run."""
-        spark = init_spark()
-        schema = StructType([
-            StructField("PromptCount", DoubleType(), True),
-            StructField("Input", StringType(), True),
-            StructField("CompletionCount", DoubleType(), True),
-            StructField("Output", StringType(), True)
-        ])
-        request_data_tuples = [(float(d["prompt_count"]),
-                                d["input"],
-                                float(d["completion_count"]),
-                                d["output"]) for d in self.request_data]
-        sample_data_df = spark.createDataFrame(request_data_tuples, schema=schema)
-        sample_data_df.show()
-        return sample_data_df
-
-    def calculate_metrics(self, attributes: dict, span_type: str,
-                          root_input: Optional[str], root_output: Optional[str]):
-        """Args.
-
-        attributes (dict): attributes.
-        span_type (str): LLM, Embedding, Tool, Flow.
-        root_input Optional(str): input from Flow.
-        root_output Optional(str): output from Flow.
-        """
-        completion_count = self.get_value_from_attributes(attributes, COMPLETION_COUNT_KEYS)
-        prompt_count = self.get_value_from_attributes(attributes, PROMPT_COUNT_KEYS)
-        total_count = self.get_value_from_attributes(attributes, TOTAL_COUNT_KEYS)
-        model = self.get_value_from_attributes(attributes, MODEL_KEYS)
-        if model is not None:
-            # TODO:Convert this calculation to pyspark logic.
-            self.total_prompt_count += prompt_count
-            self.total_completion_count += completion_count
-            self.total_token_count += total_count
-            self.total_requests += 1
-
-            if model not in self.model_data:
-                self.model_data[model] = {
-                    "model_name": model,
-                    "model_type": span_type,
-                    "model_prompt_count": 0,
-                    "model_completion_count": 0,
-                    "total_requests": 0
-                }
-            if self.has_completion_count(span_type):
-                self.model_data[model]["model_completion_count"] += completion_count
-            self.model_data[model]["model_prompt_count"] += prompt_count
-            self.model_data[model]["total_requests"] += 1
-
-        if root_input is not None and root_output is not None:
-
-            self.request_data.append({
-                "prompt_count": prompt_count,
-                "input": root_input,
-                "completion_count": completion_count,
-                "output": root_output
-            })
+        # Return the list of tuples
+        return counts_and_requests
 
     def get_value_from_attributes(self, attributes, keys):
         """Get usage values from attributes."""
@@ -191,9 +146,3 @@ class MetricsProcessor:
     def has_completion_count(self, span_type):
         """Check if model is completion type."""
         return span_type == "LLM"
-
-    def calculate_averages(self):
-        """Calculate the averages per request."""
-        self.avg_prompt_count = self.total_prompt_count / self.total_requests if self.total_requests else 0
-        self.avg_completion_count = self.total_completion_count / self.total_requests if self.total_requests else 0
-        self.avg_total_count = self.total_token_count / self.total_requests if self.total_requests else 0

--- a/assets/model_monitoring/components/src/genai_token_statistics_compute_metrics/metrics_processor.py
+++ b/assets/model_monitoring/components/src/genai_token_statistics_compute_metrics/metrics_processor.py
@@ -17,7 +17,7 @@ from shared_utilities.span_tree_utils import SpanTreeNode, SpanTree
 from shared_utilities.constants import (
     ROOT_SPAN_COLUMN
 )
-from typing import Optional, List
+from typing import Optional
 
 
 class MetricsProcessor:
@@ -35,18 +35,12 @@ class MetricsProcessor:
             return None
         return SpanTree.create_tree_from_json_string(row.root_span)
 
-    def create_span_tree_from_dataframe(self, df: DataFrame) -> List[Optional[SpanTreeNode]]:
-        """Create a list of SpanTrees from a DataFrame."""
-        # Convert the DataFrame to an RDD and then to a list of Rows
-        df.rdd.foreach(self.process_row)
-
     def process(self, df_traces: DataFrame):
         """Process the aggregated trace data to compute metrics.
 
         Args:
             df_traces (DataFrame): Aggregated traces from the GenAI processor.
         """
-        print("process")
         df_traces = df_traces.select(ROOT_SPAN_COLUMN)
         # Create an RDD of tuples with the necessary counts
         counts_and_requests_rdd = df_traces.rdd.flatMap(self.process_row)
@@ -98,7 +92,7 @@ class MetricsProcessor:
             df_traces (DataFrame): Aggregated traces from the GenAI processor.
         """
         tree = self.create_span_tree_from_dataframe_row(row)
-        print("tree before", tree)
+
         if tree is None:
             return []
         counts_and_requests = []

--- a/assets/model_monitoring/components/src/genai_token_statistics_compute_metrics/run.py
+++ b/assets/model_monitoring/components/src/genai_token_statistics_compute_metrics/run.py
@@ -6,6 +6,7 @@
 import argparse
 import os
 
+from pyspark.sql import functions as F
 from pyspark.sql.types import StructField, StructType, StringType
 from genai_token_statistics_compute_metrics.metrics_processor import MetricsProcessor
 from shared_utilities.io_utils import (
@@ -13,6 +14,18 @@ from shared_utilities.io_utils import (
     save_spark_df_as_mltable,
     init_spark
 )
+from shared_utilities.constants import (
+    SIGNAL_METRICS_METRIC_NAME,
+    SIGNAL_METRICS_METRIC_VALUE,
+    SIGNAL_METRICS_THRESHOLD_VALUE
+)
+from genai_token_statistics_compute_metrics.constants import (
+    TOTAL_TOKEN_COUNT,
+    TOTAL_PROMPT_COUNT,
+    TOTAL_COMPLETION_COUNT,
+    AVG_TOKEN_COUNT,
+    AVG_PROMPT_COUNT,
+    AVG_COMPLETION_COUNT)
 
 
 def run():
@@ -29,9 +42,48 @@ def run():
 
     processor = MetricsProcessor()
     processor.process(token_df)
-    metrics_df = processor.metrics_generator()
-    save_spark_df_as_mltable(metrics_df, args.signal_metrics)
-    sample_data = processor.get_latest_run()
+    metrics_df = processor.metrics_df
+
+    flat_metrics_df = metrics_df.select(
+        F.array(
+            F.struct(F.lit(TOTAL_TOKEN_COUNT).alias(SIGNAL_METRICS_METRIC_NAME),
+                     F.col('total_token_count').alias(SIGNAL_METRICS_METRIC_VALUE),
+                     F.lit(0.0).alias(SIGNAL_METRICS_THRESHOLD_VALUE)),
+            F.struct(F.lit(TOTAL_PROMPT_COUNT).alias(SIGNAL_METRICS_METRIC_NAME),
+                     F.col('total_prompt_count').alias(SIGNAL_METRICS_METRIC_VALUE),
+                     F.lit(0.0).alias(SIGNAL_METRICS_THRESHOLD_VALUE)),
+            F.struct(F.lit(TOTAL_COMPLETION_COUNT).alias(SIGNAL_METRICS_METRIC_NAME),
+                     F.col('total_completion_count').alias(SIGNAL_METRICS_METRIC_VALUE),
+                     F.lit(0.0).alias(SIGNAL_METRICS_THRESHOLD_VALUE)),
+            F.struct(F.lit(AVG_TOKEN_COUNT).alias(SIGNAL_METRICS_METRIC_NAME),
+                     F.col('avg_total_count').alias(SIGNAL_METRICS_METRIC_VALUE),
+                     F.lit(0.0).alias(SIGNAL_METRICS_THRESHOLD_VALUE)),
+            F.struct(F.lit(AVG_PROMPT_COUNT).alias(SIGNAL_METRICS_METRIC_NAME),
+                     F.col('avg_prompt_count').alias(SIGNAL_METRICS_METRIC_VALUE),
+                     F.lit(0.0).alias(SIGNAL_METRICS_THRESHOLD_VALUE)),
+            F.struct(F.lit(AVG_COMPLETION_COUNT).alias(SIGNAL_METRICS_METRIC_NAME),
+                     F.col('avg_completion_count').alias(SIGNAL_METRICS_METRIC_VALUE),
+                     F.lit(0.0).alias(SIGNAL_METRICS_THRESHOLD_VALUE)))
+        .alias('metrics')).select(F.explode(F.col('metrics'))
+                                  .alias('metrics')).select(F.col('metrics')[SIGNAL_METRICS_METRIC_NAME]
+                                                            .alias(SIGNAL_METRICS_METRIC_NAME),
+                                                            F.col('metrics')[SIGNAL_METRICS_METRIC_VALUE]
+                                                            .alias(SIGNAL_METRICS_METRIC_VALUE),
+                                                            F.col('metrics')[SIGNAL_METRICS_THRESHOLD_VALUE]
+                                                            .alias(SIGNAL_METRICS_THRESHOLD_VALUE)
+                                                            )
+    flat_metrics_df.show()
+    flat_metrics_rdd = processor.metrics_model_df.rdd.flatMap(lambda row: [
+        (f"{row['model']}.CompletionCount", row['total_completion_count'], 0),
+        (f"{row['model']}.TotalRequests", row['total_requests'], 0),
+        (f"{row['model']}.PromptCount", row['total_prompt_count'], 0)
+    ])
+    flat_model_metrics_df = flat_metrics_rdd.toDF([SIGNAL_METRICS_METRIC_NAME, SIGNAL_METRICS_METRIC_VALUE,
+                                                   SIGNAL_METRICS_THRESHOLD_VALUE])
+
+    flat_metrics_df = flat_model_metrics_df.union(flat_metrics_df)
+    save_spark_df_as_mltable(flat_metrics_df, args.signal_metrics)
+    sample_data = processor.requests_df
     save_spark_df_as_mltable(sample_data, args.token_count)
     samples_index_rows = []
     samples_index_rows.append({"metric_name": "TokenCount",


### PR DESCRIPTION
Test job https://ml.azure.com/experiments/id/4b4e34ef-331f-4b1a-b1b0-88615d6c45ad/runs/lemon_deer_kqsrzgpg25?wsid=/subscriptions/1aefdc5e-3a7c-4d71-a9f9-f5d3b03be19a/resourcegroups/TestingTeamProjectRG/providers/Microsoft.MachineLearningServices/workspaces/shrsha-eastus-test&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#

Output from main branch to prove there is no diff in output after logic change:
metrics calculated
+--------------------+------------------+---------------+
|         metric_name|      metric_value|threshold_value|
+--------------------+------------------+---------------+
|     TotalTokenCount|            4538.0|            0.0|
|    TotalPromptCount|            4441.0|            0.0|
|TotalCompletionCount|              97.0|            0.0|
|       AvgTokenCount| 648.2857142857143|            0.0|
|      AvgPromptCount| 634.4285714285714|            0.0|
|  AvgCompletionCount|13.857142857142858|            0.0|
|gpt-35-turbo-inst...|              97.0|            0.0|
|gpt-35-turbo-inst...|               4.0|            0.0|
|gpt-35-turbo-inst...|            4424.0|            0.0|
| ada.CompletionCount|               0.0|            0.0|
|   ada.TotalRequests|               3.0|            0.0|
|     ada.PromptCount|              17.0|            0.0|
+--------------------+------------------+---------------+

Using AML OBO credential from StoreUrl.get_credential() with blob datastore whose credential type is null.
_AzureMLSparkOnBehalfOfCredential.get_token succeeded
_AzureMLSparkOnBehalfOfCredential.get_token succeeded
+-----------+--------------------+---------------+--------------------+
|PromptCount|               Input|CompletionCount|              Output|
+-----------+--------------------+---------------+--------------------+
|       69.0|{\n  "prompt": "s...|            7.0|" Can you repeat ...|
|     1674.0|{\n  "prompt": "{...|           25.0|" I'm sorry, I do...|
|       72.0|{\n  "prompt": "s...|            9.0|" Can you explain...|
|        1.0|{\n  "mlindex_con...|            0.0|[\n  {\n    "text...|
|     2609.0|{\n  "prompt": "{...|           56.0|" A feature store...|
+-----------+--------------------+---------------+--------------------+