### PR TITLE
RAI Text & Vision Env Vulnerability Fixes

### DIFF
--- a/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
@@ -7,8 +7,7 @@ ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
 
 # Create conda environment
 COPY conda_dependencies.yaml .
-# TODO: revert back -q after env is debugged
-RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml && \
+RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
     rm conda_dependencies.yaml && \
     conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
     conda clean -a -y

--- a/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
@@ -7,7 +7,8 @@ ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
 
 # Create conda environment
 COPY conda_dependencies.yaml .
-RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
+# TODO: revert back -q after env is debugged
+RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml && \
     rm conda_dependencies.yaml && \
     conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
     conda clean -a -y

--- a/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python=3.9
   - pip
-  - pytorch
+  - pytorch>=2.2.2
   - captum
   - cpuonly
   - pip:

--- a/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
@@ -26,3 +26,4 @@ dependencies:
     - datasets
     - typing-extensions<4.6.1
     - gevent-websocket
+    - torch>=2.2.2

--- a/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
@@ -24,6 +24,6 @@ dependencies:
     - transformers>=4.17.0
     - nlp-feature-extractors==0.1.0
     - datasets
-    - typing-extensions<4.6.1
+    - typing-extensions>=4.8.0
     - gevent-websocket
     - torch>=2.2.2

--- a/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
@@ -12,7 +12,7 @@ dependencies:
   - captum
   - cpuonly
   - pip:
-    - numpy==1.22.0
+    - numpy==1.23.0
     - ml-wrappers~=0.5.5
     - responsibleai~=0.36.0
     - raiwidgets~=0.36.0

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -31,8 +31,8 @@ RUN pip install 'azureml-core=={{latest-pypi-version}}' \
 RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
                 'azureml-automl-dnn-vision=={{latest-pypi-version}}'
 
-# Install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
-RUN conda install -c pytorch -p $AZUREML_CONDA_ENVIRONMENT_PATH torch>=2.2.2
+# Force install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
+RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install torch>=2.2.2 --force-reinstall --no-deps
 
 RUN pip install 'shap==0.41.0' \
                 'scikit-learn>=1.5.1' \

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -32,7 +32,7 @@ RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
                 'azureml-automl-dnn-vision=={{latest-pypi-version}}'
 
 # Install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
-RUN conda install -p $AZUREML_CONDA_ENVIRONMENT_PATH torch>=2.2.2
+RUN conda install -c pytorch -p $AZUREML_CONDA_ENVIRONMENT_PATH torch>=2.2.2
 
 RUN pip install 'shap==0.41.0' \
                 'scikit-learn>=1.5.1' \

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -31,6 +31,9 @@ RUN pip install 'azureml-core=={{latest-pypi-version}}' \
 RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
                 'azureml-automl-dnn-vision=={{latest-pypi-version}}'
 
+# Install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
+RUN conda install -p $AZUREML_CONDA_ENVIRONMENT_PATH torch>=2.2.2
+
 RUN pip install 'shap==0.41.0' \
                 'scikit-learn>=1.5.1' \
                 'interpret-community==0.31.0' \

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -31,12 +31,6 @@ RUN pip install 'azureml-core=={{latest-pypi-version}}' \
 RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
                 'azureml-automl-dnn-vision=={{latest-pypi-version}}'
 
-# # Force install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
-# RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install torch>=2.2.2 --force-reinstall --no-deps
-# Install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
-RUN conda remove pytorch -y
-RUN conda install -c pytorch -p $AZUREML_CONDA_ENVIRONMENT_PATH pytorch>=2.2.2
-
 RUN pip install 'shap==0.41.0' \
                 'scikit-learn>=1.5.1' \
                 'interpret-community==0.31.0' \
@@ -58,6 +52,9 @@ RUN pip install 'cryptography>=42.0.4'
 RUN pip install 'Werkzeug>=3.0.3' \
                 'tqdm>=4.66.3' \
                 'onnx>=1.16.0'
+
+# To resolve CVE-2024-5480 vulnerability issue for torch < 2.2.2
+RUN pip install 'torch>=2.2.2'
 
 RUN pip freeze
 

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -31,8 +31,10 @@ RUN pip install 'azureml-core=={{latest-pypi-version}}' \
 RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
                 'azureml-automl-dnn-vision=={{latest-pypi-version}}'
 
-# Force install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
-RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install torch>=2.2.2 --force-reinstall --no-deps
+# # Force install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
+# RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install torch>=2.2.2 --force-reinstall --no-deps
+# Install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
+RUN conda install -c pytorch -p $AZUREML_CONDA_ENVIRONMENT_PATH pytorch>=2.2.2
 
 RUN pip install 'shap==0.41.0' \
                 'scikit-learn>=1.5.1' \

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -34,6 +34,7 @@ RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
 # # Force install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
 # RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install torch>=2.2.2 --force-reinstall --no-deps
 # Install torch version >= 2.2.2 to override azureml-automl-dnn-vision version and fix remote execution issue
+RUN conda remove pytorch -y
 RUN conda install -c pytorch -p $AZUREML_CONDA_ENVIRONMENT_PATH pytorch>=2.2.2
 
 RUN pip install 'shap==0.41.0' \

--- a/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
@@ -26,4 +26,4 @@ dependencies:
     - ipython<8.13
     - typing-extensions>=4.8.0
     - gevent-websocket
-    # - torch>=2.2.2
+    - torch>=2.2.2

--- a/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
@@ -7,7 +7,7 @@ channels:
 dependencies:
   - python=3.9
   - pip
-  - pytorch
+  - pytorch>=2.2.2
   - torchvision
   - captum
   - cpuonly

--- a/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
@@ -24,6 +24,6 @@ dependencies:
     - mltable==1.5.0
     - fastai
     - ipython<8.13
-    - typing-extensions<4.6.1
+    - typing-extensions>=4.8.0
     - gevent-websocket
-    - torch>=2.2.2
+    # - torch>=2.2.2

--- a/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
@@ -26,3 +26,4 @@ dependencies:
     - ipython<8.13
     - typing-extensions<4.6.1
     - gevent-websocket
+    - torch>=2.2.2


### PR DESCRIPTION
PyTorch Distributed RPC Framework Remote Code Execution (RCE) Vulnerability

responsibleai-vision
1.13.1+cu117 Name: torch Version: 1.13.1 Summary: Tensors and Dynamic neural networks in Python with strong GPU acceleration Home-page: https://pytorch.org/  Author: PyTorch Team Author-email: [packages@pytorch.org](mailto:packages@pytorch.org) License: BSD-3 Location: /azureml-envs/responsibleai-vision/lib/python3.9/site-packages Requires: nvidia-cublas-cu11, nvidia-cuda-nvrtc-cu11, nvidia-cuda-runtime-cu11, nvidia-cudnn-cu11, typing-extensions Required-by: azureml-automl-dnn-vision, captum, fastai, pretrainedmodels, pytorch-ignite, resnest, timm, torchmetrics, torchvision

responsibleai-text
2.1.2+cu121 Name: torch Version: 2.1.2 Summary: Tensors and Dynamic neural networks in Python with strong GPU acceleration Home-page: https://pytorch.org/  Author: PyTorch Team Author-email: [packages@pytorch.org](mailto:packages@pytorch.org) License: BSD-3 Location: /azureml-envs/responsibleai-text/lib/python3.9/site-packages Requires: filelock, fsspec, jinja2, networkx, nvidia-cublas-cu12, nvidia-cuda-cupti-cu12, nvidia-cuda-nvrtc-cu12, nvidia-cuda-runtime-cu12, nvidia-cudnn-cu12, nvidia-cufft-cu12, nvidia-curand-cu12, nvidia-cusolver-cu12, nvidia-cusparse-cu12, nvidia-nccl-cu12, nvidia-nvtx-cu12, sympy, triton, typing-extensions Required-by: bert-score, captum

For responsibleai-vision, torch is not force installed to >= 2.2.2 while not touching extended torch-based modules
<img width="346" alt="image" src="https://github.com/user-attachments/assets/68db33de-d551-4f8f-afbf-3b043bab4a16">
