### PR TITLE
Update python package channel sequence

### DIFF
--- a/assets/inference/environments/minimal-ubuntu20.04-py39-cpu-inference/context/conda_dependencies.yaml
+++ b/assets/inference/environments/minimal-ubuntu20.04-py39-cpu-inference/context/conda_dependencies.yaml
@@ -1,9 +1,9 @@
 name: minimal
 channels:
-- anaconda
 - conda-forge
+- anaconda
 dependencies:
 - python=3.9.13
-- pip=24.0
+- pip
 - pip:
   - azureml-inference-server-http=={{latest-pypi-version}}


### PR DESCRIPTION
Getting "Python (Pip) Security Update for setuptools (GHSA-cx63-2mw6-8hw5)" vulnerability for the py9 curated environment. The only difference with the other environment is the channel sequence.