### PR TITLE
Fix container path for mmeft model

### DIFF
--- a/assets/models/system/mmeft/model.yaml
+++ b/assets/models/system/mmeft/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: finetuning-multimodal-models
-  container_path: mlflow_models/microsoft/mmeft/mlflow_model_folder/
+  container_path: mlflow_models/microsoft/mmeft/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:


### PR DESCRIPTION
This pull request includes a small change to the `assets/models/system/mmeft/model.yaml` file. The change corrects the `container_path` by removing the trailing slash.

* [`assets/models/system/mmeft/model.yaml`](diffhunk://#diff-32c710ca1ed25d498ba94991f91f41d170dad481afdc48b80130cba0d5395c8aL3-R3): Corrected the `container_path` by removing the trailing slash.