### PR TITLE
Explicitly install the dependencies

### DIFF
--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.80
+version: 0.0.81
 name: llm_ingest_dataset_to_acs_basic
 display_name: LLM - Dataset to ACS Pipeline
 is_deterministic: false
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.73'
+    component: 'azureml:llm_rag_validate_deployments:0.0.74'
     identity:
       type: user_identity
     inputs:
@@ -136,7 +136,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.70'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.71'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -159,7 +159,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.63'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.64'
     inputs:
       chunks_source:
         type: uri_folder
@@ -209,7 +209,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.67'
+    component: 'azureml:llm_rag_update_acs_index:0.0.68'
     inputs:
       embeddings:
         type: uri_folder
@@ -229,7 +229,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.67'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.68'
     inputs:
       storage_uri: ${{parent.jobs.create_acs_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_user_id/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_acs_user_id/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.78
+version: 0.0.79
 name: llm_ingest_dataset_to_acs_user_id
 display_name: LLM - Dataset to ACS Pipeline
 is_deterministic: false
@@ -110,7 +110,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.73'
+    component: 'azureml:llm_rag_validate_deployments:0.0.74'
     identity:
       type: user_identity
     inputs:
@@ -136,7 +136,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.70'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.71'
     identity:
       type: user_identity
     inputs:
@@ -161,7 +161,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.63'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.64'
     identity:
       type: user_identity
     inputs:
@@ -215,7 +215,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_update_acs_index:0.0.67'
+    component: 'azureml:llm_rag_update_acs_index:0.0.68'
     identity:
       type: user_identity
     inputs:
@@ -237,7 +237,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.67'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.68'
     identity:
       type: user_identity
     inputs:

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_basic/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.79
+version: 0.0.80
 name: llm_ingest_dataset_to_faiss_basic
 display_name: LLM - Dataset to FAISS Pipeline
 is_deterministic: false
@@ -102,7 +102,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.73'
+    component: 'azureml:llm_rag_validate_deployments:0.0.74'
     identity:
       type: user_identity
     inputs:
@@ -125,7 +125,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.70'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.71'
     inputs:
       input_data: ${{parent.inputs.input_data}}
       input_glob: ${{parent.inputs.input_glob}}
@@ -148,7 +148,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.63'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.64'
     inputs:
       chunks_source:
         type: uri_folder
@@ -198,7 +198,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.68'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.69'
     inputs:
       embeddings:
         type: uri_folder
@@ -216,7 +216,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.67'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.68'
     inputs:
       storage_uri: ${{parent.jobs.create_faiss_index_job.outputs.index}}
       asset_name: ${{parent.inputs.embeddings_dataset_name}}

--- a/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_user_id/spec.yaml
+++ b/assets/large_language_models/components_pipelines/data_ingestion_dataset_to_faiss_user_id/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 tags:
     Preview: ""
 
-version: 0.0.78
+version: 0.0.79
 name: llm_ingest_dataset_to_faiss_user_id
 display_name: LLM - Dataset to FAISS Pipeline
 is_deterministic: false
@@ -102,7 +102,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_validate_deployments:0.0.73'
+    component: 'azureml:llm_rag_validate_deployments:0.0.74'
     identity:
       type: user_identity
     inputs:
@@ -125,7 +125,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_crack_and_chunk:0.0.70'
+    component: 'azureml:llm_rag_crack_and_chunk:0.0.71'
     identity:
       type: user_identity
     inputs:
@@ -150,7 +150,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_generate_embeddings:0.0.63'
+    component: 'azureml:llm_rag_generate_embeddings:0.0.64'
     identity:
       type: user_identity
     inputs:
@@ -204,7 +204,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_create_faiss_index:0.0.68'
+    component: 'azureml:llm_rag_create_faiss_index:0.0.69'
     identity:
       type: user_identity
     inputs:
@@ -224,7 +224,7 @@ jobs:
       properties:
         compute_specification:
           automatic: true
-    component: 'azureml:llm_rag_register_mlindex_asset:0.0.67'
+    component: 'azureml:llm_rag_register_mlindex_asset:0.0.68'
     identity:
       type: user_identity
     inputs:

--- a/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.70
+version: 0.0.71
 name: llm_rag_crack_and_chunk
 display_name: LLM - Crack and Chunk Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_and_chunk_and_embed/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.41
+version: 0.0.42
 name: llm_rag_crack_and_chunk_and_embed
 display_name: LLM - Crack, Chunk and Embed Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/crack_chunk_embed_index_and_register/spec.yaml
+++ b/assets/large_language_models/rag/components/crack_chunk_embed_index_and_register/spec.yaml
@@ -1,5 +1,5 @@
 name: llm_rag_crack_chunk_embed_index_and_register
-version: 0.0.29
+version: 0.0.30
 tags:
     Preview: ""
 

--- a/assets/large_language_models/rag/components/crawl_url/spec.yaml
+++ b/assets/large_language_models/rag/components/crawl_url/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.28
+version: 0.0.29
 name: llm_rag_crawl_url
 display_name: LLM - Crawl URL to Retrieve Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
+++ b/assets/large_language_models/rag/components/create_faiss_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.68
+version: 0.0.69
 name: llm_rag_create_faiss_index
 display_name: LLM - Create FAISS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/create_promptflow/spec.yaml
+++ b/assets/large_language_models/rag/components/create_promptflow/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.79
+version: 0.0.80
 name: llm_rag_create_promptflow
 display_name: LLM - Create Prompt Flow
 is_deterministic: true

--- a/assets/large_language_models/rag/components/data_import_acs/spec.yaml
+++ b/assets/large_language_models/rag/components/data_import_acs/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.64
+version: 0.0.65
 name: llm_rag_data_import_acs
 display_name: LLM - Import Data from ACS
 is_deterministic: false

--- a/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.63
+version: 0.0.64
 name: llm_rag_generate_embeddings
 display_name: LLM - Generate Embeddings
 is_deterministic: true

--- a/assets/large_language_models/rag/components/generate_embeddings_parallel/spec.yaml
+++ b/assets/large_language_models/rag/components/generate_embeddings_parallel/spec.yaml
@@ -4,7 +4,7 @@ type: parallel
 tags:
     Preview: ""
 
-version: 0.0.69
+version: 0.0.70
 name: llm_rag_generate_embeddings_parallel
 display_name: LLM - Generate Embeddings Parallel
 is_deterministic: true

--- a/assets/large_language_models/rag/components/git_clone/spec.yaml
+++ b/assets/large_language_models/rag/components/git_clone/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.67
+version: 0.0.68
 name: llm_rag_git_clone
 display_name: LLM - Clone Git Repo
 is_deterministic: true

--- a/assets/large_language_models/rag/components/image_embed_index/spec.yaml
+++ b/assets/large_language_models/rag/components/image_embed_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.21
+version: 0.0.22
 name: llm_rag_image_embed_index
 display_name: LLM - Embedding images with Florence 
 is_deterministic: true

--- a/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
+++ b/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.67
+version: 0.0.68
 name: llm_rag_qa_data_generation
 display_name: LLM - Generate QnA Test Data
 is_deterministic: true

--- a/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
+++ b/assets/large_language_models/rag/components/register_mlindex_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.67
+version: 0.0.68
 name: llm_rag_register_mlindex_asset
 display_name: LLM - Register Vector Index Asset
 is_deterministic: true

--- a/assets/large_language_models/rag/components/register_qa_data_asset/spec.yaml
+++ b/assets/large_language_models/rag/components/register_qa_data_asset/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.60
+version: 0.0.61
 name: llm_rag_register_qa_data_asset
 display_name: LLM - Register QA Generation Data Asset
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_acs_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_acs_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.67
+version: 0.0.68
 name: llm_rag_update_acs_index
 display_name: LLM - Update ACS Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_azure_cosmos_mongo_vcore_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_azure_cosmos_mongo_vcore_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.23
+version: 0.0.24
 name: llm_rag_update_cosmos_mongo_vcore_index
 display_name: LLM - Update Azure Cosmos Mongo vCore Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_milvus_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_milvus_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.23
+version: 0.0.24
 name: llm_rag_update_milvus_index
 display_name: LLM - Update Milvus Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/update_pinecone_index/spec.yaml
+++ b/assets/large_language_models/rag/components/update_pinecone_index/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.35
+version: 0.0.36
 name: llm_rag_update_pinecone_index
 display_name: LLM - Update Pinecone Index
 is_deterministic: true

--- a/assets/large_language_models/rag/components/validate_deployments/spec.yaml
+++ b/assets/large_language_models/rag/components/validate_deployments/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.73
+version: 0.0.74
 name: llm_rag_validate_deployments
 display_name: LLM - Validate Deployments
 is_deterministic: false

--- a/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
@@ -41,7 +41,7 @@ dependencies:
   - polling2~=0.5.0
   - psutil~=5.8.0
   - pymssql==2.2.7
-  - pymongo # explicitly install for [azure_cosmos_mongo_vcore, azure_cosmos_nosql]
+  - pymongo # explicitly install for [azure_cosmos_mongo_vcore]
   - pypdf~=3.17.1
   - sentence-transformers
   - sqlalchemy==1.4.46

--- a/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
@@ -14,6 +14,7 @@ dependencies:
   - azure-identity=={{latest-pypi-version}}
   - azure-keyvault-secrets==4.6.0
   - azure-mgmt-cognitiveservices~=13.4.0
+  - azure-search-documents>=11.4.0 # explicitly install for [cognitive_search]
     # Azure ML
   - azureml-contrib-services
   - azureml-core=={{latest-pypi-version}}
@@ -40,6 +41,7 @@ dependencies:
   - polling2~=0.5.0
   - psutil~=5.8.0
   - pymssql==2.2.7
+  - pymongo # explicitly install for [azure_cosmos_mongo_vcore, azure_cosmos_nosql]
   - pypdf~=3.17.1
   - sentence-transformers
   - sqlalchemy==1.4.46

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
@@ -42,7 +42,7 @@ dependencies:
   - pandas>=1
   - polling2~=0.5.0
   - psutil~=5.8.0
-  - pymongo # explicitly install for [azure_cosmos_mongo_vcore, azure_cosmos_nosql]
+  - pymongo # explicitly install for [azure_cosmos_mongo_vcore]
   - pymssql==2.2.7
   - pypdf~=3.17.1
   - sentence-transformers

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
@@ -16,6 +16,7 @@ dependencies:
   - azure-keyvault-secrets==4.6.0
   - azure-mgmt-cognitiveservices~=13.4.0
   - azure-mgmt-core<2.0.0,>=1.3.0
+  - azure-search-documents>=11.4.0 # explicitly install for [cognitive_search]
     # Azure ML packages
   - azureml-contrib-services
   - azureml-core=={{latest-pypi-version}}
@@ -41,11 +42,13 @@ dependencies:
   - pandas>=1
   - polling2~=0.5.0
   - psutil~=5.8.0
+  - pymongo # explicitly install for [azure_cosmos_mongo_vcore, azure_cosmos_nosql]
   - pymssql==2.2.7
   - pypdf~=3.17.1
   - sentence-transformers
   - sqlalchemy==1.4.46
   - tika~=2.6.0
+  - unstructured # explicitly install for [document_parsing]
     # Package dependency needed for AML run token authentication
   - python-dateutil>=2.7.3,<3.0.0
   - PyJWT<3.0.0


### PR DESCRIPTION
I found environment build issue in my test. This PR will explicitly install those missing packages.

== Details ===
If the extra-install's name has underscore '_'  in it, the packages cannot be installed in the environment build process. 

for example. azure-search-documents in not installed with 
`azureml-rag[cognitive_search]`
although cognitive_search is defined as

        "cognitive_search": [
            "azure-search-documents>=11.4.0",
        ],