### PR TITLE
chore: bump distillation component env version to latest

### DIFF
--- a/assets/training/distillation/components/data_generation/spec.yaml
+++ b/assets/training/distillation/components/data_generation/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: OSS Distillation Generate Data
 description: Component to generate data from teacher model enpoint
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/63
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/66
 
 inputs:
   # Inputs

--- a/assets/training/distillation/components/pipeline/spec.yaml
+++ b/assets/training/distillation/components/pipeline/spec.yaml
@@ -60,8 +60,8 @@ inputs:
       compute is named 'FT-Cluster'. Special characters like \ and ' are invalid in the parameter value.
       If compute cluster name is provided, instance_type field will be ignored and the respective cluster will be used
 
+  # ########################### Data Generator Component ########################### #
 
-  ##  OSS Data generator Input Parameters
   train_file_path:
     type: uri_file
     description: Path to the registered training data asset. The supported data formats are `jsonl`, `json`, `csv`, `tsv` and `parquet`.
@@ -148,7 +148,8 @@ inputs:
       2. CONVERSATION: Generate conversational data (multi/single turn)
       3. NLU_QA: Generate Natural Language Understanding data for Question Answering data
 
-  ## OSS Finetune Input Parameters
+  # ########################### Finetuning Component ########################### #
+
   number_of_gpu_to_use_finetuning:
     type: integer
     default: 1

--- a/assets/training/distillation/components/pipeline_validation/spec.yaml
+++ b/assets/training/distillation/components/pipeline_validation/spec.yaml
@@ -8,7 +8,7 @@ is_deterministic: true
 display_name: OSS Distillation Validate Pipeline
 description: Component to validate inputs to the distillation pipeline
 
-environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/63
+environment: azureml://registries/azureml/environments/acft-hf-nlp-gpu/versions/66
 
 code: ../../src
 


### PR DESCRIPTION
### Description
PR bumps environment version of data generator & pipeline validator components to the latest. 63 -> 66

#### Test
Data generator and pipeline validation components have been published with the latest env version into test registry.
- [ ] [Run](https://ml.azure.com/runs/zen_bottle_57452hlbms?wsid=/subscriptions/75703df0-38f9-4e2e-8328-45f6fc810286/resourcegroups/rg-sasumai/workspaces/sasum-westus3-ws&tid=7f292395-a08f-4cc0-b3d0-a400b023b0d2)