### PR TITLE
chore: remove optional field to force validation output

### DIFF
--- a/assets/training/distillation/components/data_generation/spec.yaml
+++ b/assets/training/distillation/components/data_generation/spec.yaml
@@ -101,7 +101,6 @@ inputs:
   # Output of validation component.
   validation_output:
     type: uri_file
-    optional: true
     description: Validation status.
     mode: rw_mount
     


### PR DESCRIPTION
### Description
We want to ensure that the data generation component is not triggered without the validation component running. This PR removed the validation output optional flag to ensure the output from validation component is enforced. 

#### Test Run
- [Run](https://ml.azure.com/runs/happy_guitar_h7gk2sjkrz?wsid=/subscriptions/75703df0-38f9-4e2e-8328-45f6fc810286/resourcegroups/rg-sasumai/workspaces/sasum-westus3-ws&tid=7f292395-a08f-4cc0-b3d0-a400b023b0d2)