### PR TITLE
Resolve versions in dependencies of oss_distillation_pipeline

### DIFF
--- a/assets/training/distillation/components/data_generation/spec.yaml
+++ b/assets/training/distillation/components/data_generation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: oss_distillation_generate_data
-version: 0.0.6
+version: 0.0.5
 type: command
 
 is_deterministic: True

--- a/assets/training/distillation/components/pipeline/spec.yaml
+++ b/assets/training/distillation/components/pipeline/spec.yaml
@@ -257,7 +257,7 @@ jobs:
 
   oss_distillation_generate_data:
     type: command
-    component: azureml:oss_distillation_generate_data:0.0.4
+    component: azureml:oss_distillation_generate_data:0.0.5
     compute: '${{parent.inputs.compute_data_generation}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_data_generation}}'

--- a/assets/training/distillation/components/pipeline_validation/spec.yaml
+++ b/assets/training/distillation/components/pipeline_validation/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: oss_distillation_validate_pipeline
-version: 0.0.2
+version: 0.0.1
 type: command
 
 is_deterministic: true


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/08eee58f-0e8c-4792-9630-b2ae309aaffb)
oss_distillation_validate_pipeline will be 0.0.1 as its just getting created.