### PR TITLE
Upgrade `compute_metrics` component to latest environment

### DIFF
--- a/assets/training/model_evaluation/components/compute_metrics/spec.yaml
+++ b/assets/training/model_evaluation/components/compute_metrics/spec.yaml
@@ -3,7 +3,7 @@ name: compute_metrics
 display_name: Compute Metrics
 description: Calculate model performance metrics, given ground truth and prediction data.
 
-version: 0.0.31
+version: 0.0.32
 type: command
 tags:
   type: evaluation
@@ -77,7 +77,7 @@ outputs:
 
 is_deterministic: True
 code: ../../src
-environment: azureml://registries/azureml/environments/model-evaluation/versions/32
+environment: azureml://registries/azureml/environments/model-evaluation/versions/34
 
 command: >-
   python compute_metrics.py


### PR DESCRIPTION
Need to use the `azureml-metrics` package version with image generation evaluation functionality.

Tested by running evaluation for SD on MSCOCO: https://ml.azure.com/experiments/id/281951e9-fe7b-49b2-91ea-2416f08e5714/runs/yellow_rabbit_9qs4fhj4r7?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/benchmarking&tid=72f988bf-86f1-41af-91ab-2d7cd011db47# .
