### PR TITLE
Fix opencv-python-headless, opencv-python (GHSA-qr4w-53vh-m672) and cryptography vulnerability

### DIFF
--- a/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
@@ -42,7 +42,7 @@ RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
 RUN pip install 'pyarrow>=14.0.1'
 
 # To resolve vulnerability issue regarding crytography
-RUN pip install 'cryptography>=42.0.4'
+RUN pip install 'cryptography>=43.0.1'
 
 # TODO: remove rai-core-flask pin with next raiwidgets release
 RUN pip install 'rai-core-flask==0.7.6'

--- a/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
@@ -32,7 +32,7 @@ RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
 RUN pip install 'pyarrow>=14.0.1'
 
 # To resolve vulnerability issue regarding crytography
-RUN pip install 'cryptography>=42.0.4'
+RUN pip install 'cryptography>=43.0.1'
 
 # Install huggingface evaluate package from source
 # see issue https://github.com/huggingface/datasets/issues/6182

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -46,7 +46,7 @@ RUN pip install 'shap==0.41.0' \
 RUN pip install 'pyarrow>=14.0.1'
 
 # To resolve vulnerability issue regarding crytography
-RUN pip install 'cryptography>=42.0.4'
+RUN pip install 'cryptography>=43.0.1'
 
 # To resolve vulnerability issue
 RUN pip install 'Werkzeug>=3.0.3' \

--- a/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
@@ -20,10 +20,11 @@ dependencies:
     - itsdangerous<=2.1.2
     - vision_explanation_methods
     - responsibleai-vision==0.3.8
-    - opencv-python==4.4.0.46
+    - opencv-python==4.8.1.78
     - mltable==1.5.0
     - fastai
     - ipython<8.13
     - typing-extensions>=4.8.0
     - gevent-websocket
     - torch>=2.2.2
+    - opencv-python-headless


### PR DESCRIPTION
opencv-python  https://github.com/advisories/GHSA-qr4w-53vh-m672
opencv-python-headless https://github.com/advisories/GHSA-jh2j-j4j9-crg3
cryptography  https://github.com/advisories/GHSA-h4gh-qq45-vh27