### PR TITLE
Openai-whisper-large deployment failing fix

### DIFF
--- a/assets/models/system/openai-whisper-large/model.yaml
+++ b/assets/models/system/openai-whisper-large/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/openai-whisper-large/1703152412/mlflow_model_folder
+  container_path: huggingface/openai-whisper-large/20240913/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/openai-whisper-large/spec.yaml
+++ b/assets/models/system/openai-whisper-large/spec.yaml
@@ -52,4 +52,4 @@ tags:
   SharedComputeCapacityEnabled: ""
   hiddenlayerscanned: ""
   task: automatic-speech-recognition
-version: 15
+version: 16


### PR DESCRIPTION
Issue Trace:
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
mlflow 2.6.0 requires gunicorn<22; platform_system != "Windows", but you have gunicorn 22.0.0 which is incompatible.

Resolution:
Upgrade azureml-evaluate-mlflow to the latest version (upgraded from 0.0.32 to 0.0.60)
On doing above step, upgrade pip conflicts for the other dependencies to the compatible versions. 

Test evidences attached in the comment below. 