### PR TITLE
component changes for phi 3.5

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
+++ b/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
@@ -1281,7 +1281,7 @@ def finetune(args: Namespace):
                 mlflow_ml_configs_dir,
                 ml_config_dir
             )
-            logger.info(f"Copied ml_configs folder to output dir.")
+            logger.info("Copied ml_configs folder to output dir.")
 
 
 def can_apply_ort(args: Namespace, logger):

--- a/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
+++ b/assets/training/finetune_acft_hf_nlp/src/finetune/finetune.py
@@ -1273,6 +1273,16 @@ def finetune(args: Namespace):
             shutil.copy(str(conda_file_path), args.output_dir)
             logger.info(f"Copied {MLFlowHFFlavourConstants.CONDA_YAML_FILE} file to output dir.")
 
+        # copy inference config files
+        mlflow_ml_configs_dir = Path(args.model_selector_output, "ml_configs")
+        ml_config_dir = Path(args.output_dir, "ml_configs")
+        if mlflow_ml_configs_dir.is_dir():
+            shutil.copytree(
+                mlflow_ml_configs_dir,
+                ml_config_dir
+            )
+            logger.info(f"Copied ml_configs folder to output dir.")
+
 
 def can_apply_ort(args: Namespace, logger):
     """Can ORT be enabled."""

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -87,6 +87,16 @@ class ModelConverter(ABC):
             )
             logger.info(f"Copied {SaveFileConstants.ACFT_CONFIG_SAVE_PATH} file.")
 
+    def copy_ml_configs(self, src_model_path: str, dst_model_path: str):
+        """Copy ml_configs folder to mlflow model artifacts."""
+        ml_configs_path = Path(src_model_path, "ml_configs")
+        dst_model_path = Path(dst_model_path, "ml_configs")
+        if ml_configs_path.is_dir():
+            shutil.copytree(
+                ml_configs_path,
+                dst_model_path
+            )
+        logger.info(f"Copied ml_configs folder.")
 
 class PyTorch_to_MlFlow_ModelConverter:
     """Mixin class to convert pytorch to hftransformers/oss flavour mlflow model."""
@@ -224,6 +234,7 @@ class Pytorch_to_HFTransformers_MlFlow_ModelConverter(ModelConverter, PyTorch_to
         self.download_license_file(self.model_name, self.ft_pytorch_model_path, self.mlflow_model_save_path)
         self.add_model_signature()
         self.copy_finetune_config(self.ft_pytorch_model_path, self.mlflow_model_save_path)
+        self.copy_ml_configs(self.ft_pytorch_model_path, self.mlflow_model_save_path)
         copy_tokenizer_files_to_model_folder(self.mlflow_model_save_path, self.component_args.task_name)
 
         logger.info("Saved MLFlow model using HFTransformers flavour.")

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -327,6 +327,7 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         self.download_license_file(self.model_name, self.ft_pytorch_model_path, self.mlflow_model_save_path)
         self.add_model_signature()
         self.copy_finetune_config(self.ft_pytorch_model_path, self.mlflow_model_save_path)
+        self.copy_ml_configs(self.ft_pytorch_model_path, self.mlflow_model_save_path)
 
         # Temp fix for t5 text-classification, translation, summarization
         if self.is_t5_finetune(model.config.model_type):

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -96,7 +96,8 @@ class ModelConverter(ABC):
                 ml_configs_path,
                 dst_model_path
             )
-        logger.info(f"Copied ml_configs folder.")
+        logger.info("Copied ml_configs folder.")
+
 
 class PyTorch_to_MlFlow_ModelConverter:
     """Mixin class to convert pytorch to hftransformers/oss flavour mlflow model."""

--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -388,6 +388,16 @@ def main():
             shutil.copy(str(conda_file_path), args.output_dir)
             logger.info(f"Copied {MLFlowHFFlavourConstants.CONDA_YAML_FILE} file to output dir.")
 
+        # copy inference config files
+        mlflow_ml_configs_dir = Path(args.mlflow_model_path, MLFlowHFFlavourConstants.ML_CONFIGS_DIR)
+        ml_config_dir = Path(args.output_dir, MLFlowHFFlavourConstants.ML_CONFIGS_DIR)
+        if mlflow_ml_configs_dir.is_dir():
+            shutil.copytree(
+                mlflow_ml_configs_dir,
+                ml_config_dir
+            )
+            logger.info(f"Copied ml_configs folder to output dir.")
+
 
 if __name__ == "__main__":
     main()

--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -396,7 +396,7 @@ def main():
                 mlflow_ml_configs_dir,
                 ml_config_dir
             )
-            logger.info(f"Copied ml_configs folder to output dir.")
+            logger.info("Copied ml_configs folder to output dir.")
 
 
 if __name__ == "__main__":

--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -389,8 +389,8 @@ def main():
             logger.info(f"Copied {MLFlowHFFlavourConstants.CONDA_YAML_FILE} file to output dir.")
 
         # copy inference config files
-        mlflow_ml_configs_dir = Path(args.mlflow_model_path, MLFlowHFFlavourConstants.ML_CONFIGS_DIR)
-        ml_config_dir = Path(args.output_dir, MLFlowHFFlavourConstants.ML_CONFIGS_DIR)
+        mlflow_ml_configs_dir = Path(args.mlflow_model_path, "ml_configs")
+        ml_config_dir = Path(args.output_dir, "ml_configs")
         if mlflow_ml_configs_dir.is_dir():
             shutil.copytree(
                 mlflow_ml_configs_dir,


### PR DESCRIPTION
Copy ml_configs folder from base model artifacts to finetuned model output (folder is introduced in phi 3.5 models)
phi3.5-moe:  https://ml.azure.com/registries/azureml/models/Phi-3.5-MoE-instruct/version/2?tid=72f988bf-86f1-41af-91ab-2d7cd011db47#artifacts

Testing

- phi3.5-moe: https://ml.azure.com/experiments/id/3d8ad77d-6c3b-4337-8777-4d340f542908/runs/a4e5cd18-46fa-4a99-8d96-b8e479e8b639?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
- phi3.5-mini: https://ml.azure.com/experiments/id/3d8ad77d-6c3b-4337-8777-4d340f542908/runs/88990ba3-3e78-4c4c-bbc8-06ed16537ae9?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
- model with no ml_configs folder for sanity (phi3-mini-128k):  https://ml.azure.com/experiments/id/3d8ad77d-6c3b-4337-8777-4d340f542908/runs/0e1eddb6-93c6-4a8d-a667-45b7456741ff?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#