### PR TITLE
Updating RAI Vision Image with updated opencv-python-headless version

### DIFF
--- a/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
@@ -27,4 +27,4 @@ dependencies:
     - typing-extensions>=4.8.0
     - gevent-websocket
     - torch>=2.2.2
-    - opencv-python-headless
+    - opencv-python-headless==4.8.1.78


### PR DESCRIPTION
To resolve image vulnerability and align opencv and opencv headless to same version