### PR TITLE
Fix import error for `libstdc++.so.6` when loading sklearn model for forecasting

### DIFF
--- a/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
+++ b/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
@@ -19,3 +19,6 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
     conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
     conda clean -a -y
 # dummy number to change when needing to force rebuild without changing the definition: 2
+
+# Avoid ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$AZUREML_CONDA_ENVIRONMENT_PATH


### PR DESCRIPTION
This PR fixes the following error:

```ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found```

by appending the `AZUREML_CONDA_ENVIRONMENT_PATH` to the `LD_LIBRARY_PATH` environment variable, which allows the system to look in this directory when searching for dynamic libraries needed by executables. 