### PR TITLE
Mlflow version upgrade for Microsoft-Phi-1-5

### DIFF
--- a/assets/models/system/microsoft-phi-1-5/model.yaml
+++ b/assets/models/system/microsoft-phi-1-5/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/microsoft-phi-1-5/1699277210/mlflow_model_folder
+  container_path: huggingface/microsoft-phi-1-5/1726802472/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/microsoft-phi-1-5/spec.yaml
+++ b/assets/models/system/microsoft-phi-1-5/spec.yaml
@@ -37,4 +37,4 @@ tags:
   - Standard_ND40rs_v2
   - Standard_ND96asr_v4
 
-version: 8
+version: 9


### PR DESCRIPTION
Error Encountered:

raise PydanticUserError(
pydantic.errors.PydanticUserError: If you use `@root_validator` with pre=False (the default) you MUST specify `skip_on_failure=True`. Note that `@root_validator` is deprecated and should be replaced with `@model_validator`.


Fix:

For microsoft-phi-1-5 model 
- Updated the mlflow version to latest (from 2.6.0 to 2.12.2) and resolved the conflicting dependencies.
- Updated the azureml-evaluate-mlflow (from 0.0.26 to 0.0.60) and resolved the conflicting dependencies.

Test evidences attached in the comment below.

Artifacts Reference:

![Screenshot 2024-09-20 150200](https://github.com/user-attachments/assets/fd0e43d1-bd89-4f66-aa8a-617804e66749)

Testing done over a deployment:

![Screenshot 2024-09-20 150709](https://github.com/user-attachments/assets/49004a22-d7f5-4c7a-b001-4ae401e33e15)
