### PR TITLE
Update opencv-python-headless version in RAI vision image

### DIFF
--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -55,6 +55,8 @@ RUN pip install 'Werkzeug>=3.0.3' \
 
 # To resolve CVE-2024-5480 vulnerability issue for torch < 2.2.2
 RUN pip install 'torch>=2.2.2'
+# To resolve vulnerability issue
+RUN pip install 'opencv-python-headless==4.8.1.78'
 
 RUN pip freeze
 


### PR DESCRIPTION
There was a pr for 
[Updating RAI Vision Image with updated opencv-python-headless version](https://github.com/Azure/azureml-assets/commit/519a9092ab6b330a6184765416ab14aad4522074)

but it does not work, suspect it got override by automl dependency installed later, so pinned in Dockerfile