### PR TITLE
Update vision component with latest env 

### DIFF
--- a/assets/responsibleai/vision/components/rai_vision_insights/spec.yaml
+++ b/assets/responsibleai/vision/components/rai_vision_insights/spec.yaml
@@ -116,7 +116,7 @@ outputs:
     type: path
     description: Json file to which UX is serialized to for viewing in static AzureML Studio UI
 code: ../src
-environment: azureml://registries/azureml/environments/responsibleai-vision/versions/6
+environment: azureml://registries/azureml/environments/responsibleai-vision/versions/7
 command: >-
   python ./rai_vision_insights.py
   --task_type ${{inputs.task_type}}

--- a/assets/responsibleai/vision/jobs/fetch_fridge_model.yml
+++ b/assets/responsibleai/vision/jobs/fetch_fridge_model.yml
@@ -16,7 +16,7 @@ outputs:
   model_output_path:
     type: path
 code: ./src_fridge/
-environment: azureml://registries/azureml/environments/responsibleai-vision/versions/6
+environment: azureml://registries/azureml/environments/responsibleai-vision/versions/7
 command: >-
   python ./fetch_image_model.py
   --model_base_name ${{inputs.model_base_name}}


### PR DESCRIPTION
updated the vision image version in vision component, but didn't bump up the comp version, as there are a previous PR that bumped up the version and didn't get released
https://github.com/Azure/azureml-assets/pull/3397/files
current env version
![image](https://github.com/user-attachments/assets/dd9200ee-73b3-4f0b-83bb-571f1758eed7)

current comp version
![image](https://github.com/user-attachments/assets/2d12dde4-5ef3-4174-bd72-4696c47f560a)
