### PR TITLE
Update deci versions

### DIFF
--- a/assets/models/system/Deci-DeciCoder-1b/spec.yaml
+++ b/assets/models/system/Deci-DeciCoder-1b/spec.yaml
@@ -31,4 +31,4 @@ tags:
   author: "Deci AI"
   huggingface_model_id: Deci/DeciCoder-1b
   datasets: bigcode/starcoderdata
-version: 3
+version: 4

--- a/assets/models/system/Deci-DeciLM-7B-instruct/spec.yaml
+++ b/assets/models/system/Deci-DeciLM-7B-instruct/spec.yaml
@@ -31,4 +31,4 @@ tags:
   author: "Deci AI"
   huggingface_model_id: Deci/DeciLM-7B-instruct
   datasets: Open-Orca/SlimOrca
-version: 3
+version: 4

--- a/assets/models/system/Deci-DeciLM-7B/spec.yaml
+++ b/assets/models/system/Deci-DeciLM-7B/spec.yaml
@@ -30,4 +30,4 @@ tags:
   license: apache-2.0
   author: "Deci AI"
   huggingface_model_id: Deci/DeciLM-7B
-version: 3
+version: 4


### PR DESCRIPTION
To fix deployment error of the form:

Failed to update metadata for model : Deci-DeciCoder-1b : Value of property inference-min-sku-spec for model Deci-DeciCoder-1b cannot be replaced to 12|2|224|1474 without increasing the version.