### PR TITLE
Update model versions

### DIFF
--- a/assets/models/system/phi-3-vision-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-vision-128k-instruct/spec.yaml
@@ -24,4 +24,4 @@ tags:
     ]
   inference_supported_envs:
     - vllm
-version: 3
+version: 2

--- a/assets/models/system/snowflake-artic-instruct/spec.yaml
+++ b/assets/models/system/snowflake-artic-instruct/spec.yaml
@@ -20,4 +20,4 @@ tags:
     ]
   inference_supported_envs:
     - vllm
-version: 1
+version: 2

--- a/assets/models/system/stabilityai-stable-diffusion-xl-refiner-1-0/spec.yaml
+++ b/assets/models/system/stabilityai-stable-diffusion-xl-refiner-1-0/spec.yaml
@@ -25,4 +25,4 @@ tags:
       Standard_ND96amsr_A100_v4,
       Standard_ND96asr_v4
     ]
-version: 4
+version: 5


### PR DESCRIPTION
Intended to fix errors related to model versions during pipeline deployment. Examples:

##[error]Failed to update metadata for model : stabilityai-stable-diffusion-xl-refiner-1-0 : Value of property inference-min-sku-spec for model stabilityai-stable-diffusion-xl-refiner-1-0 cannot be replaced to 6|1|112|736 without increasing the version.

Asset azureml://registries/azureml/models/Phi-3-vision-128k-instruct/versions/3 was deleted at 08/16/2024 16:27:49 +00:00, it cannot be recreated. Please try again with a different version.

See https://ev2portal.azure.net/#/Rollout/azureml-msftkube-shell/788dac33-b1e6-4eae-88a7-b290e1b37512?RolloutInfra=Prod for a pipeline with these errors.