### PR TITLE
removing model filter import due to bug

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -93,13 +93,13 @@ def get_model_asset_id() -> str:
 
 def validate_huggingface_id(huggingface_id: str) -> None:
     """Validate the huggingface_id using Hfapi. Raise exception if the huggingface id is invalid."""
-    from huggingface_hub import HfApi, ModelFilter
+    from huggingface_hub import HfApi
     hf_api = HfApi()  # by default endpoint points to https://huggingface.co
 
     try:
         model_infos = [
             info
-            for info in hf_api.list_models(filter=ModelFilter(model_name=huggingface_id))
+            for info in hf_api.list_models(model_name=huggingface_id)
             if info.modelId == huggingface_id
         ]
     except ConnectionError:


### PR DESCRIPTION
**Repro Run**: [text_classification_pipeline - Azure AI | Machine Learning Studio](https://ml.azure.com/runs/d3007eac-3a9f-4883-b1f0-3afc89213c1f?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)

**Error:** 
File "/mnt/azureml/cr/j/1132c5b99d8c436aaa930fba13b5dca4/exe/wd/model_selector.py", line 96, in validate_huggingface_id
    from huggingface_hub import HfApi, ModelFilter
ImportError: cannot import name 'ModelFilter' from 'huggingface_hub' (/opt/conda/envs/ptca/lib/python3.10/site-packages/huggingface_hub/__init__.py)

**Successful run:** [run](https://ml.azure.com/experiments/id/5316da7e-57a6-494d-ac8d-223f932e5f85/runs/c1a6f184-c383-4382-8d94-fbf372c82bcd?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)

similar code in [common_utils.py](https://github.com/Azure/azureml-assets/blob/main/assets/training/model_management/src/azureml/model/mgmt/utils/common_utils.py)
![{CBEA2DB5-9262-4022-A9F1-EB9954EE1A11}](https://github.com/user-attachments/assets/11a80213-dd07-4543-8a31-cba67f3a5f74)

