### PR TITLE
Mlflow version upgrade for Deci-DeciCoder-1b model

### DIFF
--- a/assets/models/system/Deci-DeciCoder-1b/model.yaml
+++ b/assets/models/system/Deci-DeciCoder-1b/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/Deci-DeciCoder-1b/1702510317/mlflow_model_folder
+  container_path: huggingface/Deci-DeciCoder-1b/1728322144/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/Deci-DeciCoder-1b/spec.yaml
+++ b/assets/models/system/Deci-DeciCoder-1b/spec.yaml
@@ -30,4 +30,4 @@ tags:
   author: "Deci AI"
   huggingface_model_id: Deci/DeciCoder-1b
   datasets: bigcode/starcoderdata
-version: 4
+version: 5


### PR DESCRIPTION

![Screenshot 2024-10-08 223730](https://github.com/user-attachments/assets/cc85bc43-72f0-481c-9aba-bbf3f92ecfc4)
Mlflow version upgrade for Deci-DeciCoder-1b model. This version upgrade was required as model deployment was failing due to pydantic validation error.

- mlflow==2.12.2
- mlflow-skinny==2.12.2
- azureml-core==1.56.0
- azureml-mlflow==1.56.0
- Pillow==10.0.1
- azureml-evaluate-mlflow==0.0.60


