### PR TITLE
Install langchain via extra requirement

### DIFF
--- a/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag/context/conda_dependencies.yaml
@@ -8,7 +8,7 @@ dependencies:
 - scikit-learn
 - pip:
     # RAG package
-  - azureml-rag[azure,cognitive_search,data_generation,pinecone,milvus,azure_cosmos_mongo_vcore,azure_cosmos_nosql]==0.2.36
+  - azureml-rag[azure,langchain,cognitive_search,data_generation,pinecone,milvus,azure_cosmos_mongo_vcore,azure_cosmos_nosql]==0.2.36
     # Azure
   - azure-ai-formrecognizer==3.3.1
   - azure-identity=={{latest-pypi-version}}
@@ -29,7 +29,6 @@ dependencies:
   - datasets~=2.10.1
   - faiss-cpu~=1.7.3
   - inference-schema>=1.8.0
-  - langchain<0.3
   - lxml
   - markdown
   - mlflow-skinny==2.3.2

--- a/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/conda_dependencies.yaml
@@ -7,7 +7,7 @@ dependencies:
 - pip=24.0
 - pip:
     # RAG package
-  - azureml-rag[azure,faiss,cognitive_search,document_parsing,data_generation,pinecone,milvus,azure_cosmos_mongo_vcore,azure_cosmos_nosql]==0.2.36
+  - azureml-rag[azure,faiss,langchain,cognitive_search,document_parsing,data_generation,pinecone,milvus,azure_cosmos_mongo_vcore,azure_cosmos_nosql]==0.2.36
     # Azure AI
   - azure-ai-formrecognizer==3.3.1
     # Azure
@@ -30,7 +30,6 @@ dependencies:
   - faiss-cpu~=1.7.3
   - GitPython>=3.1
   - inference-schema>=1.8.0
-  - langchain<0.3
   - lxml
   - markdown
   - mlflow>=2.6.0


### PR DESCRIPTION
Current llm-rag-embeddings doesn't have langchain-community package, which is causing failure in FAISS dataingestion pipeline.

This PR will install langchain and its dependency via azureml-rag[langchain] extension.