### PR TITLE
[BugFix]: Phi-3 with lora FT fails at model conversion due to issue i…

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -17,7 +17,7 @@ sacrebleu==2.4.0
 bitsandbytes==0.43.3
 einops==0.7.0
 aiohttp==3.10.5
-peft==0.8.2
+peft==0.9.0
 deepspeed==0.13.3
 trl==0.8.1
 tiktoken==0.6.0


### PR DESCRIPTION
An issue in peft library cases the issue in our pipeline if apply lora is true for phi-3 models. Details like bug re-creation and test run are as follows : 

<h3>Bug creation and fix runs </h3>
<ul><li><a href="https://ml.azure.com/experiments/id/776fcb0f-b31f-4b03-a33d-eb9b0d61889f/runs/eeb55e83-24ea-44de-a406-8d97b4a8e2f9?wsid=%2fsubscriptions%2fba7979f7-d040-49c9-af1a-7414402bf622%2fresourceGroups%2ffinetunedev_rg%2fproviders%2fMicrosoft.MachineLearningServices%2fworkspaces%2ffinetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" target="_blank"> Issue recreated</a></li><li><a href="https://ml.azure.com/experiments/id/776fcb0f-b31f-4b03-a33d-eb9b0d61889f/runs/1760dbc4-a1ec-4bfc-af58-b66ff728a6b5?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" target="_blank"> Run after bug fix , check environment</a></li>
<li><a href="https://github.com/huggingface/peft/commit/3967fcc8ea477cfeb61bae86922a2b9e9c3446a3" target="_blank">The peft bug which causes this issue</a></li></ul>
