### PR TITLE
Update Phi-3-mini-4k-instruct version

### DIFF
--- a/assets/models/system/phi-3-mini-4k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-mini-4k-instruct/spec.yaml
@@ -76,4 +76,4 @@ tags:
     logging_steps: 10
     save_total_limit: 1
   benchmark: "quality"
-version: 12
+version: 13


### PR DESCRIPTION
Intended to fix error due to previous deletion of v12.