### PR TITLE
AI studio security update 2024.10, add AzureML SDK v2 and fix LangChain version lock

### DIFF
--- a/assets/aistudio/environments/ai_studio_dev/context/requirements.txt
+++ b/assets/aistudio/environments/ai_studio_dev/context/requirements.txt
@@ -1,18 +1,13 @@
 # Install Python SDK
-ipykernel
+azure-ai-ml
 openai>1.0
-# Promptflow
-promptflow[azure]>=1.11.0
-promptflow-evals
-promptflow-rag
-keyrings.alt
 # hardcoded the version of azureml-mlflow here for faster Docker image building speed
 azureml-mlflow==1.57.0
 # copilot dependencies
-langchain==0.1.17
-langchain-openai==0.1.6
+keyrings.alt
+ipykernel
+langchain
+langchain-openai
 semantic-kernel
 pytest
 keyring
-# # inference server dependencies (moved to Docker file)
-# azureml-inference-server-http


### PR DESCRIPTION
1. Security patch 2024.10
2. Add AzureML SDK v2
3. Remove version lock for LangChain