### PR TITLE
[BugFix]: Add actionable error message so that user can fix mistake

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -324,6 +324,17 @@ def main():
     model_name = model_selector_args.get("model_name", ModelSelectorConstants.MODEL_NAME_NOT_FOUND)
     logger.info(f"Model name - {model_name}")
     logger.info(f"Task name: {getattr(args, 'task_name', None)}")
+    # Validate port for right model type
+    if args.pytorch_model_path and Path(args.pytorch_model_path, MLFlowHFFlavourConstants.MISC_CONFIG_FILE).is_file():
+        raise ACFTValidationException._with_error(
+                AzureMLError.create(
+                    ACFTUserError,
+                    pii_safe_message=(
+                        "MLFLOW model is connected to pytorch_model_path, "
+                        "it needs to be connected to mlflow_model_path"
+                    )
+                )
+            )
 
     # load ft config and update ACFT config
     # finetune_config_dict = load_finetune_config(args)


### PR DESCRIPTION
This pull request addresses an issue where users encounter an OSError during model conversion by adding more informative error messages.
The issue happens if connection to port is not right.

<hr>
<h3> Tests after review </h3>
<ul><li><a href="https://ml.azure.com/experiments/id/776fcb0f-b31f-4b03-a33d-eb9b0d61889f/runs/5bc3f525-9db1-4bea-93d1-64f41df4ea13?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" target="_blank">Updated Run</a></li><li><a href="https://ml.azure.com/experiments/id/776fcb0f-b31f-4b03-a33d-eb9b0d61889f/runs/5996f55a-331a-4e4e-a079-0ee9b2c74a47?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91" target="_blank">Right Port</a></li></ul>