### PR TITLE
[BugFix]: GPT 4o input type system error fix

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_selector/model_selector.py
@@ -316,6 +316,19 @@ def main():
         log_level=logging.INFO,
     )
 
+    # Validated custom model type
+    if args.mlflow_model_path and \
+       not Path(args.mlflow_model_path, MLFlowHFFlavourConstants.MISC_CONFIG_FILE).is_file():
+        raise ACFTValidationException._with_error(
+                    AzureMLError.create(
+                        ACFTUserError,
+                        pii_safe_message=(
+                            "MLmodel file is not found, If this is a custom model "
+                            "it needs to be connected to pytorch_model_path"
+                        )
+                    )
+            )
+
     # Adding flavor map to args
     setattr(args, "flavor_map", FLAVOR_MAP)
 


### PR DESCRIPTION
GPT 4o of any custom model if connected to mlflow model type we'll see a system error of MLmodel file is missing. Adding validation of if early with User Error raised.

<h3> Tests and Runs <h3> 
<p>
<a href="https://ml.azure.com/experiments/id/a2667362-dd95-4bb1-a1fc-83c3d47707cf/runs/84bc7290-35f8-4b33-a5c0-14a6cc49efc5?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" target="_blank">Bug re-created  </a>
<hr>
<a href="https://ml.azure.com/runs/555f2283-156e-4ede-a372-5244409a233e?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" target="_blank">Bug with patch </a>
<hr>
<a href="https://ml.azure.com/runs/78936ec1-0faf-476e-af99-5f599e239f63?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#">gpt-40-with right connection </a>

</p>