### PR TITLE
[Responsible AI] Remove torch from responsibleai-vision docker file as it already present in conda_dependencies.yaml

### DIFF
--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -53,8 +53,6 @@ RUN pip install 'Werkzeug>=3.0.3' \
                 'tqdm>=4.66.3' \
                 'onnx>=1.16.0'
 
-# To resolve CVE-2024-5480 vulnerability issue for torch < 2.2.2
-RUN pip install 'torch>=2.2.2'
 # To resolve vulnerability issue
 RUN pip install 'opencv-python-headless==4.8.1.78'
 


### PR DESCRIPTION
Remove torch from responsibleai-vision docker file as it already present in conda_dependencies.yaml