### PR TITLE
Removed finetune config for facebook-dinov2-base-imagenet1k-1-layer model.

### DIFF
--- a/assets/models/system/facebook-dinov2-base-imagenet1k-1-layer/spec.yaml
+++ b/assets/models/system/facebook-dinov2-base-imagenet1k-1-layer/spec.yaml
@@ -4,11 +4,6 @@ path: ./
 properties:
   SharedComputeCapacityEnabled: true
   SHA: 3ec10e6c76362191b61260300fe1d6173a8dd7e1
-  finetuning-tasks: image-classification
-  finetune-min-sku-spec: 4|1|28|176
-  finetune-recommended-sku: Standard_NC4as_T4_v3, Standard_NC6s_v3, Standard_NC8as_T4_v3, Standard_NC12s_v3,
-    Standard_NC16as_T4_v3, Standard_NC24s_v3, Standard_NC64as_T4_v3, Standard_NC96ads_A100_v4,
-    Standard_ND96asr_v4, Standard_ND96amsr_A100_v4, Standard_ND40rs_v2
   evaluation-min-sku-spec: 4|1|28|176
   evaluation-recommended-sku: Standard_NC4as_T4_v3, Standard_NC6s_v3, Standard_NC8as_T4_v3, Standard_NC12s_v3,
     Standard_NC16as_T4_v3, Standard_NC24s_v3, Standard_NC64as_T4_v3, Standard_NC96ads_A100_v4,
@@ -105,18 +100,4 @@ tags:
       Standard_ND96amsr_A100_v4,
       Standard_ND40rs_v2
     ]
-  finetune_compute_allow_list:
-    [
-      Standard_NC4as_T4_v3,
-      Standard_NC6s_v3,
-      Standard_NC8as_T4_v3,
-      Standard_NC12s_v3,
-      Standard_NC16as_T4_v3,
-      Standard_NC24s_v3,
-      Standard_NC64as_T4_v3,
-      Standard_NC96ads_A100_v4,
-      Standard_ND96asr_v4,
-      Standard_ND96amsr_A100_v4,
-      Standard_ND40rs_v2
-    ]
-version: 1
+version: 2


### PR DESCRIPTION
The option to execute finetune operation for model `facebook-dinov2-base-imagenet1k-1-layer` is disabled from UI. But the finetune task is still available as filter over model catalog.

This PR is to remove finetune config from `spec.yaml` file for model `facebook-dinov2-base-imagenet1k-1-layer`.