### PR TITLE
Fix issues with mmdetection docker image (10/24)

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
@@ -9,9 +9,14 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
 # # # Install mmdet
+# Temporary workaround for https://github.com/open-mmlab/mim/issues/244
+RUN pip install pip==24.0
 # # Note that MMDet installs pycocotools
 # Note: mmdet should be installed via mim to access the model zoo config folder.
 RUN mim install mmdet==3.3.0
+# Temporary workaround for https://github.com/open-mmlab/mmdetection/issues/11668 (when mmdet updated, remove lines below)
+RUN mim install mmcv==2.2.0 -f https://download.openmmlab.com/mmcv/dist/cu118/torch2.2/index.html --no-cache-dir
+RUN sed -i 's/2.2.0/2.3.0/' /opt/conda/envs/ptca/lib/python3.10/site-packages/mmdet/__init__.py
 
 # Vulnerability Fix
 RUN pip install gunicorn==22.0.0


### PR DESCRIPTION
Work around the two issues with the mmdetection framework current as of 10/24:
a. https://github.com/open-mmlab/mim/issues/244 -> mim incompatibility with latest pip
b. https://github.com/open-mmlab/mmdetection/issues/11668 -> overly restrictive mmcv dependency specification in mmdet

When these two issues are resolved, the hacks/workarounds should be removed from the Dockerfile.

Tested by running detection and segmentation jobs in the cloud: 
a. https://ml.azure.com/experiments/id/1a564b75-73f8-4579-a20c-cbe9564cc731/runs/patient_jackal_j1ndbfxt13?wsid=%2Fsubscriptions%2Fdbd697c3-ef40-488f-83e6-5ad4dfb78f9b%2FresourceGroups%2Frdondera%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Fvalidatr&tid=72f988bf-86f1-41af-91ab-2d7cd011db47&reloadCount=1#
b. https://ml.azure.com/experiments/id/096ae769-8375-4b60-8e38-8cd185bf97a5/runs/funny_whistle_9rwtdfy2dw?wsid=%2Fsubscriptions%2Fdbd697c3-ef40-488f-83e6-5ad4dfb78f9b%2FresourceGroups%2Frdondera%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Fvalidatr&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
