### PR TITLE
Pin huggingface-hub package in IC and OD/IS environments

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/requirements.txt
@@ -10,5 +10,6 @@ transformers==4.39.3
 accelerate==0.29.3
 optimum==1.19.0
 diffusers==0.27.2
+huggingface-hub==0.25.2
 setuptools>=71.1.0
 mlflow==2.12.1

--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/requirements.txt
@@ -10,5 +10,6 @@ transformers==4.38.2
 accelerate==0.27.2
 optimum==1.17.1
 diffusers==0.24.0
+huggingface-hub==0.25.2
 openmim==0.3.9
 setuptools>=71.1.0


### PR DESCRIPTION
The previous IC and OD/IS environment releases picked up a recent bug (https://github.com/easydiffusion/easydiffusion/issues/1851) that crashes vision + multimodal code. This PR works around the issue by pinning the affected package, huggingface_hub, to a known working version.

Tested by checking the offending import statement in the docker image.
