### PR TITLE
FMI Version 58 release with deepspeed version upgrade to fix vulnerability

### DIFF
--- a/assets/training/model_management/environments/foundation-model-inference/context/Dockerfile
+++ b/assets/training/model_management/environments/foundation-model-inference/context/Dockerfile
@@ -47,7 +47,7 @@ RUN pip install git+https://github.com/stanford-futuredata/megablocks.git@5897cd
 # RUN pip install -e ./ --no-cache-dir
 
 # When copied to assets repo, change to install from public pypi
-RUN pip install llm-optimized-inference==0.2.15 --no-cache-dir
+RUN pip install llm-optimized-inference==0.2.16 --no-cache-dir
 
 RUN pip uninstall transformers -y
 RUN pip uninstall -y vllm


### PR DESCRIPTION
This release contains FMI Version 58 release which fixes the deepspeed vulnerability. We have upgrade deepspeed version from 0.14.4 to 0.15.1 and deepspeed-mii from 2.6.0 to 3.0.0