### PR TITLE
Update model versions - Phi-3 - Updated FMI base image v57

### DIFF
--- a/assets/models/system/phi-3-medium-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-medium-128k-instruct/spec.yaml
@@ -68,4 +68,4 @@ tags:
     save_total_limit: 1
     max_seq_length: 4096
   benchmark: "quality"
-version: 5
+version: 6

--- a/assets/models/system/phi-3-medium-4k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-medium-4k-instruct/spec.yaml
@@ -71,4 +71,4 @@ tags:
     save_total_limit: 1
     max_seq_length: 4096
   benchmark: "quality"
-version: 4
+version: 5

--- a/assets/models/system/phi-3-mini-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-mini-128k-instruct/spec.yaml
@@ -70,4 +70,4 @@ tags:
     logging_steps: 10
     save_total_limit: 1
   benchmark: "quality"
-version: 11
+version: 12

--- a/assets/models/system/phi-3-mini-4k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-mini-4k-instruct/spec.yaml
@@ -76,4 +76,4 @@ tags:
     logging_steps: 10
     save_total_limit: 1
   benchmark: "quality"
-version: 13
+version: 14

--- a/assets/models/system/phi-3-small-8k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-small-8k-instruct/spec.yaml
@@ -64,4 +64,4 @@ tags:
     save_total_limit: 1
     max_seq_length: 4096
   benchmark: "quality"
-version: 4
+version: 5


### PR DESCRIPTION
- phi-3-medium-4k-instruct
- phi-3-medium-128k-instruct
- phi-3-small-8k-instruct
- phi-3-mini-4k-instruct
- phi-3-mini-128k-instruct