### PR TITLE
Fix input column names for OD/IS components

### DIFF
--- a/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
@@ -263,7 +263,8 @@ jobs:
       compute_model_import: ${{parent.inputs.compute_model_import}}
       compute_finetune: ${{parent.inputs.compute_finetune}}
       task_name: ${{parent.inputs.task_type}}
-      user_column_names: image_url, label
+      label_column_name: label
+      user_column_names: image_url,label
       task_specific_extra_params: '"model_family=HuggingFaceImage;model_name=${{parent.inputs.model_name}};metric_for_best_model=${{parent.inputs.primary_metric}};number_of_epochs=${{parent.inputs.number_of_epochs}}"'
 
   framework_selector:

--- a/assets/training/finetune_acft_image/components/pipeline_components/diffusers_text_to_image/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/diffusers_text_to_image/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.9
+version: 0.0.10
 name: diffusers_text_to_image_dreambooth_pipeline
 display_name: Text to Image Dreambooth Finetuning Diffusers Pipeline
 description: Pipeline component for text to image dreambooth training using diffusers library and transformers models.

--- a/assets/training/finetune_acft_image/components/pipeline_components/hf_classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/hf_classification/spec.yaml
@@ -359,13 +359,13 @@ inputs:
     type: string
     default: label
     optional: true
-    description: Label column name in provided test dataset, for example "label".
+    description: Label column name to be ignored by model for prediction purposes, for example "label".
 
   input_column_names:
     type: string
     default: image_url
     optional: true
-    description: Input column names in provided test dataset, for example column1. Add comma delimited values in case of multiple input columns, for example column1,column2.
+    description: Input column names provided to model for prediction, for example column1. Add comma delimited values in case of multiple input columns, for example column1,column2.
 
   evaluation_config:
     type: uri_file
@@ -406,8 +406,8 @@ jobs:
       process_count_per_instance: ${{parent.inputs.process_count_per_instance}}
       compute_model_evaluation: ${{parent.inputs.compute_model_evaluation}}
       task_name: ${{parent.inputs.task_name}}
-      label_column_name: '${{parent.inputs.label_column_name}}'
-      user_column_names: '${{parent.inputs.input_column_names}}, ${{parent.inputs.label_column_name}}'
+      label_column_name: label
+      user_column_names: image_url,label
       test_batch_size: ${{parent.inputs.test_batch_size}}
       device: auto
       evaluation_config: ${{parent.inputs.evaluation_config}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.22
+version: 0.0.23
 name: image_instance_segmentation_pipeline
 display_name: Image Instance Segmentation Pipeline
 description: Pipeline component for image instance segmentation.
@@ -300,7 +300,7 @@ jobs:
 
   finetune_common_validation:
     type: command
-    component: azureml:finetune_common_validation:0.0.5
+    component: azureml:finetune_common_validation:0.0.6
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       train_mltable_path: ${{parent.inputs.training_data}}
@@ -308,12 +308,13 @@ jobs:
       compute_model_import: ${{parent.inputs.compute_model_import}}
       compute_finetune: ${{parent.inputs.compute_finetune}}
       task_name: ${{parent.inputs.task_type}}
-      user_column_names: image_url, label
+      label_column_name: label
+      user_column_names: image_url,label
       task_specific_extra_params: '"model_family=MmDetectionImage;model_name=${{parent.inputs.model_name}};metric_for_best_model=${{parent.inputs.primary_metric}};number_of_epochs=${{parent.inputs.number_of_epochs}}"'
 
   framework_selector:
     type: command
-    component: azureml:image_framework_selector:0.0.17
+    component: azureml:image_framework_selector:0.0.18
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       task_type: ${{parent.inputs.task_type}}
@@ -369,7 +370,7 @@ jobs:
 
   mm_detection_model_import:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.18
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.19
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       model_family: 'MmDetectionImage'
@@ -379,7 +380,7 @@ jobs:
 
   mm_detection_finetune:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.18
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.19
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch
@@ -423,7 +424,7 @@ jobs:
 
   output_selector:
     type: command
-    component: azureml:image_model_output_selector:0.0.16
+    component: azureml:image_model_output_selector:0.0.17
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       mlflow_model_t: ${{parent.jobs.image_instance_segmentation_runtime_component.outputs.mlflow_model_folder}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.22
+version: 0.0.23
 name: mmdetection_image_objectdetection_instancesegmentation_pipeline
 display_name: Image Object Detection and Instance Segmentation MMDetection Pipeline
 description: Pipeline component for image object detection and instance segmentation using MMDetection models.
@@ -357,13 +357,13 @@ inputs:
     type: string
     default: label
     optional: true
-    description: Label column name in provided test dataset, for example "label".
+    description: Label column name to be ignored by model for prediction purposes, for example "label".
 
   input_column_names:
     type: string
-    default: image_url
+    default: image,image_meta_info,text_prompt
     optional: true
-    description: Input column names in provided test dataset, for example column1. Add comma delimited values in case of multiple input columns, for example column1,column2.
+    description: Input column names provided to model for prediction, for example column1. Add comma delimited values in case of multiple input columns, for example column1,column2.
 
   evaluation_config:
     type: uri_file
@@ -391,7 +391,7 @@ outputs:
 jobs:
   finetune_common_validation:
     type: command
-    component: azureml:finetune_common_validation:0.0.5
+    component: azureml:finetune_common_validation:0.0.6
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       mlflow_model_path: ${{parent.inputs.mlflow_model}}
@@ -404,8 +404,8 @@ jobs:
       process_count_per_instance: ${{parent.inputs.process_count_per_instance}}
       compute_model_evaluation: ${{parent.inputs.compute_model_evaluation}}
       task_name: ${{parent.inputs.task_name}}
-      label_column_name: '${{parent.inputs.label_column_name}}'
-      user_column_names: '${{parent.inputs.input_column_names}}, ${{parent.inputs.label_column_name}}'
+      label_column_name: label
+      user_column_names: image_url,label
       test_batch_size: ${{parent.inputs.test_batch_size}}
       device: auto
       evaluation_config: ${{parent.inputs.evaluation_config}}
@@ -414,7 +414,7 @@ jobs:
 
   image_od_is_model_import:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.18
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.19
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       model_family: ${{parent.inputs.model_family}}
@@ -426,7 +426,7 @@ jobs:
 
   image_od_is_finetune:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.18
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.19
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch
@@ -482,7 +482,7 @@ jobs:
 
   model_prediction:
     type: command
-    component: azureml:model_prediction:0.0.28
+    component: azureml:model_prediction:0.0.34
     compute: '${{parent.inputs.compute_model_evaluation}}'
     inputs:
       task: '${{parent.inputs.task_name}}'
@@ -497,7 +497,7 @@ jobs:
 
   compute_metrics:
     type: command
-    component: azureml:compute_metrics:0.0.28
+    component: azureml:compute_metrics:0.0.33
     compute: '${{parent.inputs.compute_model_evaluation}}'
     inputs:
       task: '${{parent.inputs.task_name}}'

--- a/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.22
+version: 0.0.23
 name: image_object_detection_pipeline
 display_name: Image Object Detection Pipeline
 description: Pipeline component for image object detection.
@@ -325,7 +325,7 @@ jobs:
 
   finetune_common_validation:
     type: command
-    component: azureml:finetune_common_validation:0.0.5
+    component: azureml:finetune_common_validation:0.0.6
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       train_mltable_path: ${{parent.inputs.training_data}}
@@ -333,12 +333,13 @@ jobs:
       compute_model_import: ${{parent.inputs.compute_model_import}}
       compute_finetune: ${{parent.inputs.compute_finetune}}
       task_name: ${{parent.inputs.task_type}}
-      user_column_names: image_url, label
+      label_column_name: label
+      user_column_names: image_url,label
       task_specific_extra_params: '"model_family=MmDetectionImage;model_name=${{parent.inputs.model_name}};metric_for_best_model=${{parent.inputs.primary_metric}};number_of_epochs=${{parent.inputs.number_of_epochs}}"'
 
   framework_selector:
     type: command
-    component: azureml:image_framework_selector:0.0.17
+    component: azureml:image_framework_selector:0.0.18
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       task_type: ${{parent.inputs.task_type}}
@@ -396,7 +397,7 @@ jobs:
 
   mm_detection_model_import:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.18
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.19
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       model_family: 'MmDetectionImage'
@@ -406,7 +407,7 @@ jobs:
 
   mm_detection_finetune:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.18
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.19
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch
@@ -450,7 +451,7 @@ jobs:
 
   output_selector:
     type: command
-    component: azureml:image_model_output_selector:0.0.16
+    component: azureml:image_model_output_selector:0.0.17
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       mlflow_model_t: ${{parent.jobs.image_object_detection_runtime_component.outputs.mlflow_model_folder}}


### PR DESCRIPTION
Separate input column names used in finetuning validation from those used in model prediction.

Tacked on: increment the version of diffusion finetuning pipeline for release purposes.

Tested by: runs delayed due to errors registering new components in automl-images-dev.
