### PR TITLE
Upgrade forecasting components

### DIFF
--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: automl_hts_inference
 display_name: AutoML Hierarchical Timeseries Forecasting - Inference
 description: Enables inference for hts components.
-version: 0.0.6
+version: 0.0.7
 is_deterministic: false
 
 inputs:
@@ -74,7 +74,7 @@ outputs:
 jobs:
   automl_hts_inference_setup: 
     type: command
-    component: azureml:automl_hts_inference_setup_step:0.0.6
+    component: azureml:automl_hts_inference_setup_step:0.0.7
     inputs:
       raw_Data: ${{parent.inputs.raw_data}}
       enable_event_logger:  True
@@ -97,7 +97,7 @@ jobs:
     compute: ${{parent.inputs.compute_name}}
   automl_hts_model_inference: 
     type: parallel
-    component: azureml:automl_hts_prs_inference_step:0.0.6
+    component: azureml:automl_hts_prs_inference_step:0.0.7
     inputs:
       partitioned_data: ${{parent.jobs.automl_hts_inference_setup.outputs.processed_data}}
       metadata: ${{parent.jobs.automl_hts_inference_setup.outputs.metadata}}
@@ -121,7 +121,7 @@ jobs:
     compute: ${{parent.inputs.compute_name}}
   automl_hts_inference_collect_step: 
     type: command
-    component: azureml:automl_hts_inference_collect_step:0.0.6
+    component: azureml:automl_hts_inference_collect_step:0.0.7
     inputs:
       setup_metadata: ${{parent.jobs.automl_hts_inference_setup.outputs.metadata}}
       input_metadata: ${{parent.jobs.automl_hts_model_inference.outputs.output_metadata}}

--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_collect/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_collect/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_hts_inference_collect_step
-version: 0.0.6
+version: 0.0.7
 display_name: AutoML HTS - Inference Collect
 type: command
 

--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_setup/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_inference_setup/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_hts_inference_setup_step
-version: 0.0.6
+version: 0.0.7
 display_name: AutoML HTS - Inference Setup
 type: command
 

--- a/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_prs_inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-inference/components/automl_hts_prs_inference/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
 type: parallel
-version: 0.0.6
+version: 0.0.7
 
 name: automl_hts_prs_inference_step
 display_name: AutoML HTS - Inference Step

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_data_agg/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_data_agg/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/parallelComponent.schema.json
 type: parallel
-version: 0.0.6
+version: 0.0.7
 
 name: automl_hts_data_aggregation_step
 display_name: AutoML HTS - Training Data Aggregation

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_prs_train/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_prs_train/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/parallelComponent.schema.json
 type: parallel
-version: 0.0.6
+version: 0.0.7
 
 name: automl_hts_automl_training_step
 display_name: AutoML HTS - AutoML Training

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: automl_hts_training
 display_name: AutoML Hierarchical Timeseries Forecasting - Training
 description: Enables AutoML Training for hts components.
-version: 0.0.6
+version: 0.0.7
 is_deterministic: false
 
 inputs:
@@ -40,7 +40,7 @@ outputs:
 jobs:
   automl_hts_train_setup_step: 
     type: command
-    component: azureml:automl_hts_training_setup_step:0.0.6
+    component: azureml:automl_hts_training_setup_step:0.0.7
     inputs:
       raw_Data: ${{parent.inputs.raw_data}}
       automl_config: ${{parent.inputs.automl_config}}
@@ -56,7 +56,7 @@ jobs:
     compute: ${{parent.inputs.compute_name}}
   automl_hts_data_aggregation_step: 
     type: parallel
-    component: azureml:automl_hts_data_aggregation_step:0.0.6
+    component: azureml:automl_hts_data_aggregation_step:0.0.7
     inputs:
       partitioned_data: ${{parent.jobs.automl_hts_train_setup_step.outputs.processed_data}}
       metadata: ${{parent.jobs.automl_hts_train_setup_step.outputs.metadata}}
@@ -80,7 +80,7 @@ jobs:
     compute: ${{parent.inputs.compute_name}}
   automl_hts_automl_training_step: 
     type: parallel
-    component: azureml:automl_hts_automl_training_step:0.0.6
+    component: azureml:automl_hts_automl_training_step:0.0.7
     inputs:
       aggregated_data: ${{parent.jobs.automl_hts_data_aggregation_step.outputs.aggregated_data}}
       data_agg_metadata: ${{parent.jobs.automl_hts_data_aggregation_step.outputs.output_metadata}}
@@ -104,7 +104,7 @@ jobs:
     compute: ${{parent.inputs.compute_name}}
   automl_hts_train_collect_step: 
     type: command
-    component: azureml:automl_hts_training_collect_step:0.0.6
+    component: azureml:automl_hts_training_collect_step:0.0.7
     inputs:
       setup_metadata: ${{parent.jobs.automl_hts_train_setup_step.outputs.metadata}}
       input_metadata: ${{parent.jobs.automl_hts_automl_training_step.outputs.output_metadata}}

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_collect/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_collect/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_hts_training_collect_step
-version: 0.0.6
+version: 0.0.7
 display_name: AutoML HTS - Collection Training Results
 type: command
 

--- a/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_setup/spec.yaml
+++ b/assets/training/forecasting_demand/automl-hts-train/components/automl_hts_train_setup/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_hts_training_setup_step
-version: 0.0.6
+version: 0.0.7
 display_name: AutoML HTS - Training Setup
 type: command
 

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_prs_train/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_prs_train/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/parallelComponent.schema.js
 
 name: automl_many_models_training_step
 display_name: AutoML Many Models - AutoML Training
-version: 0.0.6
+version: 0.0.7
 is_deterministic: false
 
 type: parallel

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: automl_many_models_training
 display_name: AutoML - Many Models Training
 description: Enables AutoML many models training.
-version: 0.0.6
+version: 0.0.7
 is_deterministic: false
 
 inputs:
@@ -44,7 +44,7 @@ outputs:
 jobs:
   automl_many_models_training_setup_step: 
     type: command
-    component: azureml:automl_many_models_training_setup_step:0.0.6
+    component: azureml:automl_many_models_training_setup_step:0.0.7
     inputs:
       raw_Data: ${{parent.inputs.raw_data}}
       automl_config: ${{parent.inputs.automl_config}}
@@ -61,7 +61,7 @@ jobs:
     compute: ${{parent.inputs.compute_name}}
   automl_many_models_training_step: 
     type: parallel
-    component: azureml:automl_many_models_training_step:0.0.6
+    component: azureml:automl_many_models_training_step:0.0.7
     inputs:
       partitioned_data: ${{parent.jobs.automl_many_models_training_setup_step.outputs.processed_data}}
       metadata: ${{parent.jobs.automl_many_models_training_setup_step.outputs.metadata}}
@@ -84,7 +84,7 @@ jobs:
     compute: ${{parent.inputs.compute_name}}
   automl_many_models_training_collect_step: 
     type: command
-    component: azureml:automl_many_models_training_collection_step:0.0.6
+    component: azureml:automl_many_models_training_collection_step:0.0.7
     inputs:
       setup_metadata: ${{parent.jobs.automl_many_models_training_setup_step.outputs.metadata}}
       input_metadata: ${{parent.jobs.automl_many_models_training_step.outputs.output_metadata}}

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_collect/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_collect/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_many_models_training_collection_step
-version: 0.0.6
+version: 0.0.7
 display_name: AutoML Many Models - Collection Training Results
 is_deterministic: false
 type: command

--- a/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_setup/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/automl_many_model_training_setup/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_many_models_training_setup_step
-version: 0.0.6
+version: 0.0.7
 display_name: AutoML Many Models - Training Setup Step
 is_deterministic: false
 type: command

--- a/assets/training/forecasting_demand/automl-many-models-train/components/spark_partition/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many-models-train/components/spark_partition/spec.yaml
@@ -3,7 +3,7 @@ name: automl_tabular_data_partitioning
 type: spark
 display_name: AutoML - Tabular Data Partitioning
 description: Enables dataset partitioning for AutoML many models and hierarchical timeseries solution accelerators using spark.
-version: 0.0.6
+version: 0.0.7
 is_deterministic: false
 
 code: ../../src/spark_partition/

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_model_inferencing/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_model_inferencing/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: automl_many_models_inference
 display_name: AutoML Many Models - Inference
 description: Inference components for AutoML many model.
-version: 0.0.6
+version: 0.0.7
 is_deterministic: false
 
 inputs:
@@ -93,7 +93,7 @@ outputs:
 jobs:
   automl_many_models_inference_setup_step: 
     type: command
-    component: azureml:automl_many_models_inference_setup_step:0.0.6
+    component: azureml:automl_many_models_inference_setup_step:0.0.7
     inputs:
       raw_Data: ${{parent.inputs.raw_data}}
       enable_event_logger: True
@@ -120,7 +120,7 @@ jobs:
     compute: ${{parent.inputs.compute_name}}
   automl_many_models_inferencing_step: 
     type: parallel
-    component: azureml:automl_many_models_inference_step:0.0.6
+    component: azureml:automl_many_models_inference_step:0.0.7
     inputs:
       partitioned_data: ${{parent.jobs.automl_many_models_inference_setup_step.outputs.processed_data}}
       metadata: ${{parent.jobs.automl_many_models_inference_setup_step.outputs.metadata}}
@@ -145,7 +145,7 @@ jobs:
     compute: ${{parent.inputs.compute_name}}
   automl_many_models_inference_collect_step: 
     type: command
-    component: azureml:automl_many_models_inference_collect_step:0.0.6
+    component: azureml:automl_many_models_inference_collect_step:0.0.7
     inputs:
       setup_metadata: ${{parent.jobs.automl_many_models_inference_setup_step.outputs.metadata}}
       input_metadata: ${{parent.jobs.automl_many_models_inferencing_step.outputs.output_metadata}}

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_collect_inf/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_collect_inf/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_many_models_inference_collect_step
-version: 0.0.6
+version: 0.0.7
 display_name: AutoML Many Models - Collection Inference Results
 is_deterministic: false
 type: command

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_prs_inferencing/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_prs_inferencing/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/pipelineJob.schema.json
 
 name: automl_many_models_inference_step
 display_name: AutoML Many Models - Inference Step
-version: 0.0.6
+version: 0.0.7
 is_deterministic: false
 
 type: parallel

--- a/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_setup_inf/spec.yaml
+++ b/assets/training/forecasting_demand/automl-many_models-inference/components/automl_many_models_setup_inf/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: automl_many_models_inference_setup_step
-version: 0.0.6
+version: 0.0.7
 display_name: AutoML Many Models - Inference Setup Step
 is_deterministic: false
 type: command

--- a/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.jso
 name: automl_forecasting_inference
 display_name: AutoML Forecasting Inference
 description: Inference component for AutoML Forecasting.
-version: 0.0.9
+version: 0.0.10
 type: command
 
 inputs:


### PR DESCRIPTION
Bump up the forecasting components' version to use latest env. Environment does not require any change since it uses latest tag.