### PR TITLE
Added support for model_framework options for import_model component

### DIFF
--- a/assets/training/model_management/components/convert_model_to_mlflow/spec.yaml
+++ b/assets/training/model_management/components/convert_model_to_mlflow/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 
 name: convert_model_to_mlflow
-version: 0.0.32
+version: 0.0.33
 type: command
 
 is_deterministic: True

--- a/assets/training/model_management/components/import_model/spec.yaml
+++ b/assets/training/model_management/components/import_model/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: import_model
 display_name: Import model
 description: Import a model into a workspace or a registry
-version: 0.0.38
+version: 0.0.39
 
 # Pipeline inputs
 inputs:
@@ -46,6 +46,17 @@ inputs:
     default: HFTransformersV2
     optional: false
     description: Flavor of MLFlow to which model the model is converted to.
+
+  model_framework:
+    type: string
+    enum:
+      - Huggingface
+      - MMLab
+      - llava
+      - AutoML
+    default: Huggingface
+    optional: false
+    description: Framework from which model is imported from.
 
   vllm_enabled:
     type: boolean
@@ -260,7 +271,7 @@ jobs:
         type: uri_folder
 
   convert_model_to_mlflow:
-    component: azureml:convert_model_to_mlflow:0.0.32
+    component: azureml:convert_model_to_mlflow:0.0.33
     compute: ${{parent.inputs.compute}}
     resources:
       instance_type: '${{parent.inputs.instance_type}}'
@@ -271,6 +282,7 @@ jobs:
       model_flavor: ${{parent.inputs.model_flavor}}
       vllm_enabled: ${{parent.inputs.vllm_enabled}}
       license_file_path: ${{parent.inputs.license_file_path}}
+      model_framework: ${{parent.inputs.model_framework}}
       model_download_metadata: ${{parent.jobs.download_model.outputs.model_download_metadata}}
       model_path: ${{parent.jobs.download_model.outputs.model_output}}
       hf_config_args: ${{parent.inputs.hf_config_args}}


### PR DESCRIPTION
Added model_framework parameter for the import_model component which can take one of the values from Huggingface,  MMLab, llava, AutoML. This will add support for framework models other than Huggingface as well.

import-model component validation: link [here](https://ml.azure.com/runs/8b63704a-006d-4d9b-a1df-005870b0d65f?wsid=/subscriptions/66a54950-50a7-4b7e-b0c5-66ce29be6486/resourceGroups/foundationmodeltest_rg/providers/Microsoft.MachineLearningServices/workspaces/foundation-model-workspace&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#)

![import_model_validation](https://github.com/user-attachments/assets/79bcfa54-cdae-4867-b222-53a7769c9e0b)

