### PR TITLE
Remove preview tags from GA built-in evaluators

### DIFF
--- a/assets/promptflow/evaluators/models/bleu-score-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/bleu-score-evaluator/spec.yaml
@@ -6,5 +6,4 @@ properties:
   is-evaluator: true
   show-artifact: true
   _default-display-file: ./BleuScoreEvaluator/_bleu.py
-tags:
 version: 3

--- a/assets/promptflow/evaluators/models/bleu-score-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/bleu-score-evaluator/spec.yaml
@@ -7,5 +7,4 @@ properties:
   show-artifact: true
   _default-display-file: ./BleuScoreEvaluator/_bleu.py
 tags:
-  Preview: ""
 version: 3

--- a/assets/promptflow/evaluators/models/coherence-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/coherence-evaluator/spec.yaml
@@ -7,6 +7,5 @@ properties:
   show-artifact: true
   _default-display-file: ./coherence.prompty
 tags:
-  Preview: ""
   hiddenlayerscanned: ""
 version: 4

--- a/assets/promptflow/evaluators/models/f1score-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/f1score-evaluator/spec.yaml
@@ -7,6 +7,5 @@ properties:
   show-artifact: true
   _default-display-file: ./F1ScoreEvaluator/_f1_score.py
 tags:
-  Preview: ""
   hiddenlayerscanned: ""
 version: 3

--- a/assets/promptflow/evaluators/models/fluency-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/fluency-evaluator/spec.yaml
@@ -7,6 +7,5 @@ properties:
   show-artifact: true
   _default-display-file: ./fluency.prompty
 tags:
-  Preview: ""
   hiddenlayerscanned: ""
 version: 4

--- a/assets/promptflow/evaluators/models/gleu-score-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/gleu-score-evaluator/spec.yaml
@@ -7,5 +7,4 @@ properties:
   show-artifact: true
   _default-display-file: ./GleuScoreEvaluator/_gleu.py
 tags:
-  Preview: ""
 version: 3

--- a/assets/promptflow/evaluators/models/gleu-score-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/gleu-score-evaluator/spec.yaml
@@ -6,5 +6,4 @@ properties:
   is-evaluator: true
   show-artifact: true
   _default-display-file: ./GleuScoreEvaluator/_gleu.py
-tags:
 version: 3

--- a/assets/promptflow/evaluators/models/groundedness-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/groundedness-evaluator/spec.yaml
@@ -7,6 +7,5 @@ properties:
   show-artifact: true
   _default-display-file: ./groundedness_without_query.prompty
 tags:
-  Preview: ""
   hiddenlayerscanned: ""
 version: 4

--- a/assets/promptflow/evaluators/models/meteor-score-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/meteor-score-evaluator/spec.yaml
@@ -7,5 +7,4 @@ properties:
   show-artifact: true
   _default-display-file: ./MeteorScoreEvaluator/_meteor.py
 tags:
-  Preview: ""
 version: 3

--- a/assets/promptflow/evaluators/models/meteor-score-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/meteor-score-evaluator/spec.yaml
@@ -6,5 +6,4 @@ properties:
   is-evaluator: true
   show-artifact: true
   _default-display-file: ./MeteorScoreEvaluator/_meteor.py
-tags:
 version: 3

--- a/assets/promptflow/evaluators/models/relevance-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/relevance-evaluator/spec.yaml
@@ -7,6 +7,5 @@ properties:
   show-artifact: true
   _default-display-file: ./relevance.prompty
 tags:
-  Preview: ""
   hiddenlayerscanned: ""
 version: 4

--- a/assets/promptflow/evaluators/models/retrieval-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/retrieval-evaluator/spec.yaml
@@ -7,6 +7,5 @@ properties:
   show-artifact: true
   _default-display-file: ./retrieval.prompty
 tags:
-  Preview: ""
   hiddenlayerscanned: ""
 version: 1

--- a/assets/promptflow/evaluators/models/rouge-score-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/rouge-score-evaluator/spec.yaml
@@ -6,5 +6,4 @@ properties:
   is-evaluator: true
   show-artifact: true
   _default-display-file: ./RougeScoreEvaluator/_rouge.py
-tags:
 version: 3

--- a/assets/promptflow/evaluators/models/rouge-score-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/rouge-score-evaluator/spec.yaml
@@ -7,5 +7,4 @@ properties:
   show-artifact: true
   _default-display-file: ./RougeScoreEvaluator/_rouge.py
 tags:
-  Preview: ""
 version: 3

--- a/assets/promptflow/evaluators/models/similarity-evaluator/spec.yaml
+++ b/assets/promptflow/evaluators/models/similarity-evaluator/spec.yaml
@@ -7,6 +7,5 @@ properties:
   show-artifact: true
   _default-display-file: ./SimilarityEvaluator/similarity.prompty
 tags:
-  Preview: ""
   hiddenlayerscanned: ""
 version: 3


### PR DESCRIPTION
This PR removes the "Preview" tag from the following evaluator models:

- Bleu
- Coherence
- F1Score
- Fluency
- GleuScore
- Groundedness
- MeteorScore
- Relevance
- Retrieval
- RougeScore
- Similarity