### PR TITLE
[BugFix]: Phi-3.5-mini-instruct fails to fine tune with lora

### DIFF
--- a/assets/models/system/phi-3.5-mini-128k-instruct/model.yaml
+++ b/assets/models/system/phi-3.5-mini-128k-instruct/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: huggingface/phi-3.5-mini-128k-instruct/20240808/mlflow_model_folder
+  container_path: huggingface/phi-3.5-mini-128k-instruct/20241107/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/phi-3.5-mini-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3.5-mini-128k-instruct/spec.yaml
@@ -70,4 +70,4 @@ tags:
     logging_strategy: "steps"
     logging_steps: 10
     save_total_limit: 1
-version: 4
+version: 5


### PR DESCRIPTION
<p>use re-entrant is made false to fix "<b>Parameter at index 63 with name base_model.model.model.layers.31.self_attn.qkv_proj.lora_B.default.weight has been marked as ready twice.</b>" in finetune config of modal.</p><hr><ul>
  <li><a href="https://ml.azure.com/experiments/id/ead0803e-e7e6-4afc-8e9d-fe8ffcdf6a90/runs/d8f22a6e-2696-4825-9c90-4035567f604f?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47&pipelineChildMetrics=true" target="_blank">Bug Recreated</a></li>
  <li><a href="https://ml.azure.com/experiments/id/ead0803e-e7e6-4afc-8e9d-fe8ffcdf6a90/runs/3812fb1a-55d8-495b-9543-8e993ea96e16?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47&pipelineChildMetrics=true" target="_blank">Fixed Run</a></li>
  <li><a href="https://ml.azure.com/experiments/id/ead0803e-e7e6-4afc-8e9d-fe8ffcdf6a90/runs/0c13db9f-b3ba-48da-ac64-4453ecf6c50a?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47&pipelineChildMetrics=true" target="_blank">MaaS Pipeline Sanity Run</a></li>
</ul>