### PR TITLE
[VulnerabilityFix]: Upgrade  Werkzeug to 3.1.3 in acpt_image_framewor…

### DIFF
--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/requirements.txt
@@ -6,3 +6,4 @@ azureml-mlflow
 azureml-core
 requests
 setuptools>=71.1.0
+Werkzeug==3.1.3


### PR DESCRIPTION
…k_selector

Fixing vulnerability with Werkzeup upgrade to 3.1.3.
<hr>
<h2> Test build </h2>
<ul>
  <li><a href="https://ml.azure.com/environments/acpt-automl-image-framework-selector/version/3?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47" target="_blank">New Version Image build with change</a></li>
  <li><a href="https://github.com/advisories/GHSA-f9vj-2wh5-fj8j" target="_blank">Vulnerability Details</a></li>
</ul>