### PR TITLE
Create data_mapping for every evaluator passed in evaluator_configuration

### DIFF
--- a/assets/evaluation_on_cloud/environments/evaluations-built-in/context/evaluate_on_data.py
+++ b/assets/evaluation_on_cloud/environments/evaluations-built-in/context/evaluate_on_data.py
@@ -73,8 +73,7 @@ def get_evaluator_config(command_line_args):
     evaluators_o = json.loads(command_line_args.evaluators)
     for evaluator_name, evaluator in evaluators_o.items():
         if evaluator["DataMapping"]:
-            data_mapping["column_mapping"] = evaluator["DataMapping"]
-            evaluator_config[evaluator_name] = data_mapping
+            evaluator_config[evaluator_name] = {"column_mapping": evaluator["DataMapping"]}
     return evaluator_config
 
 

--- a/assets/evaluation_on_cloud/environments/evaluations-built-in/context/evaluate_on_data.py
+++ b/assets/evaluation_on_cloud/environments/evaluations-built-in/context/evaluate_on_data.py
@@ -69,7 +69,6 @@ def initialize_evaluators(command_line_args):
 def get_evaluator_config(command_line_args):
     """Get evaluator configuration from user input."""
     evaluator_config = {}
-    data_mapping = {}
     evaluators_o = json.loads(command_line_args.evaluators)
     for evaluator_name, evaluator in evaluators_o.items():
         if evaluator["DataMapping"]:


### PR DESCRIPTION
data_mapping dictionary was being reused across all evaluator configurations passed causing the evaluation to fail where data_mapping was different.