### PR TITLE
Update the path of libstdc++.so in env var

### DIFF
--- a/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
+++ b/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
@@ -21,4 +21,4 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
 # dummy number to change when needing to force rebuild without changing the definition: 2
 
 # Avoid ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$AZUREML_CONDA_ENVIRONMENT_PATH
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$AZUREML_CONDA_ENVIRONMENT_PATH/lib


### PR DESCRIPTION
The current env is leading to failure because it is unable to find `libstdc++.so`. This PR updates the env variable so that the required item can be found. This issue started happening in the latest env, this wasn't an issue in the last released env.