### PR TITLE
Upgrade mlflow version from 2.12.1 to 2.15.0 for mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco model

### DIFF
--- a/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/model.yaml
+++ b/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: finetuning-image-models
-  container_path: mmdetection-3.x-mlflow/mask-rcnn_swin-t-p4-w7_fpn_1x_coco/1718170194/mlflow_model_folder
+  container_path: mmdetection-3.x-mlflow/mask-rcnn_swin-t-p4-w7_fpn_1x_coco/1732881371/mlflow_model_folder
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/spec.yaml
+++ b/assets/models/system/mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco/spec.yaml
@@ -113,4 +113,4 @@ tags:
       Standard_ND96amsr_A100_v4,
       Standard_ND40rs_v2
     ]
-version: 15
+version: 16


### PR DESCRIPTION
Upgrade mlflow version from 2.12.1 to 2.15.0 for mmd-3x-mask-rcnn_swin-t-p4-w7_fpn_1x_coco model to fix deployment and inferencing.