### PR TITLE
Update gsq component to azure-ai-evaluation sdk

### DIFF
--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
@@ -113,16 +113,16 @@ conf:
     dependencies:
       - python=3.10
       - pip:
-          - azure-cli-core~=2.62.0
-          - promptflow-evals==0.3.1
-          - openai~=1.11.1
+          - azure-cli-core~=2.66.0
+          - azure-ai-evaluation~=1.0.1
+          - azure-ai-ml~=1.22.4
+          - openai~=1.56.2
           - json5==0.9.11
           - mltable~=1.6.1
-          - promptflow[azure]~=1.13.0
-          - promptflow-tools~=1.4.0
           - keyrings.alt~=5.0.0
           - azureml-mlflow~=1.56.0
-          - mlflow~=2.14.3
+          - protobuf<5.29.0
+          - mlflow~=2.17.2
           - azureml-fsspec~=1.3.1
           - fsspec~=2023.4.0
           - pyopenssl<23.0.0

--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
@@ -69,15 +69,15 @@ conf:
     dependencies:
       - python=3.10
       - pip:
-        - azure-cli-core~=2.62.0
-        - promptflow-evals==0.3.1
-        - openai~=1.11.1
+        - azure-cli-core~=2.66.0
+        - azure-ai-evaluation~=1.0.1
+        - azure-ai-ml~=1.22.4
+        - openai~=1.56.2
         - json5==0.9.11
         - mltable~=1.6.1
-        - promptflow[azure]~=1.13.0
-        - promptflow-tools~=1.4.0
         - keyrings.alt~=5.0.0
-        - mlflow~=2.14.3
+        - mlflow~=2.17.2
+        - protobuf<5.29.0
         - azureml-fsspec~=1.3.1
         - fsspec~=2023.4.0
     name: momo-gsq-spark

--- a/assets/model_monitoring/components/tests/gsq-requirements.txt
+++ b/assets/model_monitoring/components/tests/gsq-requirements.txt
@@ -1,15 +1,16 @@
-azure-ai-ml==1.13.0
-promptflow-evals==0.3.1
-azure-cli-core~=2.62.0
-azure-identity~=1.12.0
+azure-ai-ml~=1.22.4
+azure-ai-evaluation~=1.0.1
+azure-cli-core~=2.66.0
+azure-identity~=1.19.0
 # apparently this is still needed for some azureml paths, see:
 # assets/model_monitoring/components/src/model_data_collector_preprocessor/store_url.py
-azureml-core~=1.56.0
-mlflow~=2.14.3
+azureml-core~=1.58.0
+mlflow~=2.17.2
+protobuf<5.29.0
 fsspec~=2023.4.0
 azureml-fsspec==1.3.1
 mltable~=1.6.1
-openai~=1.12.0
+openai~=1.56.2
 pandas~=2.0.3
 ruamel.yaml==0.17.21
 scipy~=1.10.0


### PR DESCRIPTION
Update gsq component to azure-ai-evaluation sdk instead of promptflow-evals.
This is so that we can upgrade to the latest package and also to resolve recent errors in production due to dependency conflicts:
https://github.com/Azure/azureml-assets/actions/runs/12107541987/job/33754555073?pr=3632
![image](https://github.com/user-attachments/assets/c297c434-a958-4143-97e3-e42e38092bab)

Copilot generated summary:

This pull request includes changes to update dependencies and refactor imports in the model monitoring components for generation safety and quality.

Dependency updates:

* [`assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml`](diffhunk://#diff-4f585c94b42af767cb3d2a3c89b0c45c3ce3f521fe461520a84cb5a38386dce5L117-L122): Replaced `promptflow-evals` and `promptflow[azure]` dependencies with `azure-ai-evaluation`.
* [`assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml`](diffhunk://#diff-e2137c017041a72116c30037bcf11bf4e00c425d35be9c10d941a5daf0908facL73-L78): Replaced `promptflow-evals` and `promptflow[azure]` dependencies with `azure-ai-evaluation`.
* [`assets/model_monitoring/components/tests/gsq-requirements.txt`](diffhunk://#diff-abcd5c830a54167aae7a9a613ed0917d5f26ef17569c7df7863702afd0092632L2-R2): Updated `promptflow-evals` dependency to `azure-ai-evaluation`.

Import refactoring:

* [`assets/model_monitoring/components/src/generation_safety_quality/annotation_compute_histogram/run.py`](diffhunk://#diff-fc312ce9848984d76b756f6eeac9ba9e473786d7079d3d520636ca805a0616a1L24-R26): Updated imports to use `azure.ai.evaluation` instead of `promptflow.evals`.