### PR TITLE
Upgrade ubuntu base image for acft-hf-nlp-data-import Env to 22.04

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/data_import/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/data_import/context/Dockerfile
@@ -1,5 +1,5 @@
 # openmpi image
-FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:{{latest-image-tag}}
 
 USER root
 


### PR DESCRIPTION
Sanity runs are [here](https://ml.azure.com/experiments/id/faf98e2f-9d7a-4c32-bd02-1a544d3d282e?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/hyperdrive-service-static-rg/providers/Microsoft.MachineLearningServices/workspaces/train-finetune-dev-eastus&tid=72f988bf-86f1-41af-91ab-2d7cd011db47)