### PR TITLE
Upgrade a lot of environments for image components

### DIFF
--- a/assets/training/finetune_acft_common/components/validation/spec.yaml
+++ b/assets/training/finetune_acft_common/components/validation/spec.yaml
@@ -1,14 +1,14 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
-version: 0.0.6
+version: 0.0.7
 name: finetune_common_validation
 display_name: Common Validation Component
 description: Component to validate the finetune job against Validation Service
 
 is_deterministic: True
 
-environment: azureml://registries/azureml/environments/acpt-pytorch-2.2-cuda12.1/versions/18
+environment: azureml://registries/azureml/environments/acpt-pytorch-2.2-cuda12.1/versions/23
 
 code: ../../src/validation
 

--- a/assets/training/finetune_acft_hf_nlp/environments/data_import/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/data_import/context/Dockerfile
@@ -1,5 +1,5 @@
 # openmpi image
-FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:{{latest-image-tag}}
 
 USER root
 

--- a/assets/training/finetune_acft_image/components/framework_selector/spec.yaml
+++ b/assets/training/finetune_acft_image/components/framework_selector/spec.yaml
@@ -1,14 +1,14 @@
 $schema: https://azuremlschemas.azureedge.net/development/commandComponent.schema.json
 type: command
 
-version: 0.0.18
+version: 0.0.19
 name: image_framework_selector
 display_name: Framework Selector for Image Tasks
 description: Framework selector control flow component for image tasks
 
 is_deterministic: true
 
-environment: azureml://registries/azureml/environments/acpt-automl-image-framework-selector-gpu/versions/43
+environment: azureml://registries/azureml/environments/acpt-automl-image-framework-selector-gpu/versions/44
 
 code: ../../src/framework_selector
 

--- a/assets/training/finetune_acft_image/components/model_output_selector/spec.yaml
+++ b/assets/training/finetune_acft_image/components/model_output_selector/spec.yaml
@@ -1,14 +1,14 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
-version: 0.0.17
+version: 0.0.18
 name: image_model_output_selector
 display_name: Model output selector for image components
 description: Model output selector control flow component for image tasks
 
 is_deterministic: true
 
-environment: azureml://registries/azureml/environments/acpt-automl-image-framework-selector-gpu/versions/43
+environment: azureml://registries/azureml/environments/acpt-automl-image-framework-selector-gpu/versions/44
 
 code: ../../src/model_output_selector
 

--- a/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
@@ -372,7 +372,7 @@ jobs:
 
   output_selector:
     type: command
-    component: azureml:image_model_output_selector:0.0.17
+    component: azureml:image_model_output_selector:0.0.18
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       mlflow_model_t: ${{parent.jobs.image_classification_runtime_component.outputs.mlflow_model_folder}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.21
+version: 0.0.22
 name: image_classification_pipeline
 display_name: Image Classification Pipeline
 description: Pipeline component for image classification.
@@ -255,7 +255,7 @@ jobs:
 
   finetune_common_validation:
     type: command
-    component: azureml:finetune_common_validation:0.0.6
+    component: azureml:finetune_common_validation:0.0.7
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       train_mltable_path: ${{parent.inputs.training_data}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/classification/spec.yaml
@@ -269,7 +269,7 @@ jobs:
 
   framework_selector:
     type: command
-    component: azureml:image_framework_selector:0.0.18
+    component: azureml:image_framework_selector:0.0.19
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       task_type: 'image-classification'

--- a/assets/training/finetune_acft_image/components/pipeline_components/hf_classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/hf_classification/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.21
+version: 0.0.22
 name: transformers_image_classification_pipeline
 display_name: Image Classification HuggingFace Transformers Pipeline
 description: Pipeline component for image classification using HuggingFace transformers models.
@@ -393,7 +393,7 @@ outputs:
 jobs:
   finetune_common_validation:
     type: command
-    component: azureml:finetune_common_validation:0.0.6
+    component: azureml:finetune_common_validation:0.0.7
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       mlflow_model_path: ${{parent.inputs.mlflow_model}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/hf_classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/hf_classification/spec.yaml
@@ -483,7 +483,7 @@ jobs:
 
   model_prediction:
     type: command
-    component: azureml:model_prediction:0.0.34
+    component: azureml:model_prediction:0.0.35
     compute: '${{parent.inputs.compute_model_evaluation}}'
     inputs:
       task: '${{parent.inputs.task_name}}'
@@ -498,7 +498,7 @@ jobs:
 
   compute_metrics:
     type: command
-    component: azureml:compute_metrics:0.0.33
+    component: azureml:compute_metrics:0.0.35
     compute: '${{parent.inputs.compute_model_evaluation}}'
     inputs:
       task: '${{parent.inputs.task_name}}'

--- a/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
@@ -314,7 +314,7 @@ jobs:
 
   framework_selector:
     type: command
-    component: azureml:image_framework_selector:0.0.18
+    component: azureml:image_framework_selector:0.0.19
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       task_type: ${{parent.inputs.task_type}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
@@ -424,7 +424,7 @@ jobs:
 
   output_selector:
     type: command
-    component: azureml:image_model_output_selector:0.0.17
+    component: azureml:image_model_output_selector:0.0.18
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       mlflow_model_t: ${{parent.jobs.image_instance_segmentation_runtime_component.outputs.mlflow_model_folder}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.23
+version: 0.0.24
 name: image_instance_segmentation_pipeline
 display_name: Image Instance Segmentation Pipeline
 description: Pipeline component for image instance segmentation.
@@ -300,7 +300,7 @@ jobs:
 
   finetune_common_validation:
     type: command
-    component: azureml:finetune_common_validation:0.0.6
+    component: azureml:finetune_common_validation:0.0.7
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       train_mltable_path: ${{parent.inputs.training_data}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.23
+version: 0.0.24
 name: mmdetection_image_objectdetection_instancesegmentation_pipeline
 display_name: Image Object Detection and Instance Segmentation MMDetection Pipeline
 description: Pipeline component for image object detection and instance segmentation using MMDetection models.
@@ -391,7 +391,7 @@ outputs:
 jobs:
   finetune_common_validation:
     type: command
-    component: azureml:finetune_common_validation:0.0.6
+    component: azureml:finetune_common_validation:0.0.7
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       mlflow_model_path: ${{parent.inputs.mlflow_model}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
@@ -482,7 +482,7 @@ jobs:
 
   model_prediction:
     type: command
-    component: azureml:model_prediction:0.0.34
+    component: azureml:model_prediction:0.0.35
     compute: '${{parent.inputs.compute_model_evaluation}}'
     inputs:
       task: '${{parent.inputs.task_name}}'
@@ -497,7 +497,7 @@ jobs:
 
   compute_metrics:
     type: command
-    component: azureml:compute_metrics:0.0.33
+    component: azureml:compute_metrics:0.0.35
     compute: '${{parent.inputs.compute_model_evaluation}}'
     inputs:
       task: '${{parent.inputs.task_name}}'

--- a/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
@@ -339,7 +339,7 @@ jobs:
 
   framework_selector:
     type: command
-    component: azureml:image_framework_selector:0.0.18
+    component: azureml:image_framework_selector:0.0.19
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       task_type: ${{parent.inputs.task_type}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
@@ -451,7 +451,7 @@ jobs:
 
   output_selector:
     type: command
-    component: azureml:image_model_output_selector:0.0.17
+    component: azureml:image_model_output_selector:0.0.18
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       mlflow_model_t: ${{parent.jobs.image_object_detection_runtime_component.outputs.mlflow_model_folder}}

--- a/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.23
+version: 0.0.24
 name: image_object_detection_pipeline
 display_name: Image Object Detection Pipeline
 description: Pipeline component for image object detection.
@@ -325,7 +325,7 @@ jobs:
 
   finetune_common_validation:
     type: command
-    component: azureml:finetune_common_validation:0.0.6
+    component: azureml:finetune_common_validation:0.0.7
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       train_mltable_path: ${{parent.inputs.training_data}}


### PR DESCRIPTION
The current environment for the common validation component for vision has reached EOL. Ideally, environments would not expire every two months and if they did, we would have an automatic way to update the definitions of the dependent components. This PR is a mere patch.

Same thing for image_framework_selector and image_model_output_selector.

Tested by running in the cloud:
a. MC: https://ml.azure.com/experiments/id/3cfa7d04-03b8-4d43-a540-b8d6f93e43b4/runs/great_wing_8c9cvwlmn7?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/validatr&tid=72f988bf-86f1-41af-91ab-2d7cd011db47
b. OD: https://ml.azure.com/experiments/id/1a564b75-73f8-4579-a20c-cbe9564cc731/runs/busy_deer_r13zv4w97f?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/validatr&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
c. IS: https://ml.azure.com/experiments/id/096ae769-8375-4b60-8e38-8cd185bf97a5/runs/plucky_panda_5zgm10gz2x?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/validatr&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
d. MC, dpv2: https://ml.azure.com/experiments/id/744ce829-14af-4c0a-8a8a-74ad1f5de729/runs/honest_loquat_5ywpyg29rb_HD_0?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/validatr&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
e. OD, dpv2: https://ml.azure.com/experiments/id/b80967d0-0c6e-4bb7-93a4-2df18bbe424e/runs/modest_parang_c7x4tb1p7r_HD_0?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/validatr&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
