### PR TITLE
[vFix]: Ubuntu upgrade to 22.04 and mflow upgrade

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -1,5 +1,5 @@
 # PTCA image
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu118-py310-torch222:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
+FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch222:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
 RUN apt-get -y update

--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/requirements.txt
@@ -12,4 +12,4 @@ optimum==1.19.0
 diffusers==0.27.2
 huggingface-hub==0.25.2
 setuptools>=71.1.0
-mlflow==2.12.1
+mlflow==2.16.0

--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
@@ -1,5 +1,5 @@
 # PTCA image
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu118-py310-torch222:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
+FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch222:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
 RUN apt-get -y update

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -1,5 +1,5 @@
 # PTCA image
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu118-py310-torch222:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
+FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch222:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
 RUN apt-get -y update

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
@@ -1,5 +1,5 @@
 # PTCA image
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2004-cu118-py310-torch222:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
+FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch222:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 RUN apt-get -y update
 


### PR DESCRIPTION
For image vulnerability upgrades : 
<hr>
<h2> Workspace image builds</h2>
<ul>
  <li><a href="https://ml.azure.com/environments/acft-transformers-image-gpu-vFix/version/1?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47" target="_blank">acft-transformers-image-gpu</a></li>
  <li><a href="https://ml.azure.com/environments/acft-transformers-image-gpu-vFix/version/1?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47" target="_blank">acft-transformers-image-gpu</a></li>
  <li><a href="https://ml.azure.com/environments/acft-mmtracking-video-gpu/version/1?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47" target="_blank">acft-mmtracking-video-gpu</a></li>
  <li><a href="https://ml.azure.com/environments/acft-mmdetection-image-gpu-vFix/version/1?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47" target="_blank">acft-mmdetection-image-gpu</a></li>
</ul>
