### PR TITLE
[vFix] : Upgrade mlflow for vFix in aoai-data-upload-finetune

### DIFF
--- a/assets/training/aoai/proxy_components/environments/context/requirements.txt
+++ b/assets/training/aoai/proxy_components/environments/context/requirements.txt
@@ -1,6 +1,6 @@
 azure-ai-ml==1.14.0
 openai==1.28.0
-mlflow==2.12.2
+mlflow==2.16.0
 pandas==2.2.0
 azureml-mlflow==1.56.0
 azure-mgmt-cognitiveservices==13.5.0


### PR DESCRIPTION
<h2>Vulnerability fix for aoai-data-upload-finetune image </h2> <p> Upgrade of mlflow to 2.16.0 </p>
<hr>
<h3>Workspace build </h3>
<ul>
  <li><a href="https://ml.azure.com/environments/aoai-data-upload-finetune-vFix/version/1?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47" target="_blank">WorkspceBuild</a></li>
</ul>