### PR TITLE
Update Phi-4 license to MIT

### DIFF
--- a/assets/models/system/Phi-4/spec.yaml
+++ b/assets/models/system/Phi-4/spec.yaml
@@ -20,7 +20,7 @@ tags:
   keywords: "Conversation"
   inference_supported_envs:
     - vllm
-  license: MSRLA
+  license: MIT
   task: chat-completion
   displayName: "Phi-4"
   summary: "Phi-4 14B, a highly capable model for low latency scenarios."


### PR DESCRIPTION
Phi-4 is now under license MIT.