### PR TITLE
[Update]: Updates in nlp preprocess and model converter for using lat…

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/model_converter/common/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: ft_nlp_model_converter
-version: 0.0.65
+version: 0.0.66
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/nlp_multilabel/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/nlp_multilabel/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: nlp_multilabel_datapreprocessing
-version: 0.0.2
+version: 0.0.3
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_utils.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_utils.py
@@ -45,6 +45,8 @@ ACFT_TASKS_HUGGINGFACE_MODELS_MAPPING = {
     Tasks.QUESTION_ANSWERING: AutoModelForQuestionAnswering,
     Tasks.TEXT_GENERATION: AutoModelForCausalLM,
     Tasks.CHAT_COMPLETION: AutoModelForCausalLM,
+    Tasks.NLP_MULTICLASS: AutoModelForSequenceClassification,
+    Tasks.NLP_MULTILABEL: AutoModelForSequenceClassification
 }
 
 

--- a/assets/training/finetune_acft_hf_nlp/src/preprocess/preprocess.py
+++ b/assets/training/finetune_acft_hf_nlp/src/preprocess/preprocess.py
@@ -55,7 +55,7 @@ def str2bool(arg):
 
 def default_missing_path(arg_str: str, default: Any = None):
     """If path of the arg is missing, reset the value to default. Use this type with paths."""
-    if isinstance(arg_str, str) and not Path(arg_str).is_file():
+    if isinstance(arg_str, str) and not Path(arg_str).exists():
         return default
     return arg_str
 
@@ -309,8 +309,6 @@ def main():
     parser = get_parser()
     # unknown args are the command line strings that could not be parsed by the argparser
     parsed_args, unparsed_args = parser.parse_known_args()
-    logger.info(f"Component Args: {parsed_args}")
-
     set_logging_parameters(
         task_type=parsed_args.task_name,
         acft_custom_dimensions={
@@ -321,7 +319,7 @@ def main():
         azureml_pkg_denylist_logging_patterns=LOGS_TO_BE_FILTERED_IN_APPINSIGHTS,
         log_level=logging.INFO,
     )
-
+    logger.info(f"Component Args: {parsed_args}")
     pre_process(parsed_args, unparsed_args)
 
 


### PR DESCRIPTION
…est FT components

<p><b> There changes are part of fixing NLP noteboos in CI/CD. At some point from the nlp classification finetune component the mlflow_model output was removed and standalone conversion component was introduced. AutoML nlp components need to digest this change in case we start using latest FT component. </b>. Need to update model converter because it'll be used for NLP multiclass and multilabel classification tasks. In these preprocess tasks the train input will be a folder rather than a file, changing validation accordingly. </p>

<ul>
  <li><a href="https://ml.azure.com/experiments/id/f5fe6654-1e62-4d45-b97b-a2cf2bf5f397/runs/olive_knee_284059rpmx?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" target="_blank">Fixed MultiClass fixed Run</a></li>
  <li><a href="https://ml.azure.com/experiments/id/0b16d944-ab17-44d4-8223-5b4cdf1ecfb6/runs/mango_leaf_h2pp8krkrc_HD_0?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourcegroups/finetunedev_rg/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" target="_blank">NLP Multi-Label fixed Run</a></li>
</ul>