### PR TITLE
[Update]: Corrections in pipeline version 3 for nlp multiclass and mu…

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/nlp_multiclass/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/nlp_multiclass/spec.yaml
@@ -271,4 +271,13 @@ jobs:
       preprocess_output: ${{parent.jobs.preprocess.outputs.output_dir}}
     outputs:
       pytorch_model_folder: ${{parent.outputs.pytorch_model_folder_finetune}}
+  text_classification_model_converter:
+    type: command
+    component: azureml:ft_nlp_model_converter:0.0.66
+    compute: ${{parent.inputs.compute_finetune}}
+    resources:
+      instance_type: ${{parent.inputs.instance_type_finetune}}
+    inputs:
+      model_path: ${{parent.jobs.finetune.outputs.pytorch_model_folder}}
+    outputs:
       mlflow_model_folder: ${{parent.outputs.mlflow_model_folder_finetune}}

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/nlp_multilabel/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/nlp_multilabel/spec.yaml
@@ -271,4 +271,13 @@ jobs:
       preprocess_output: ${{parent.jobs.preprocess.outputs.output_dir}}
     outputs:
       pytorch_model_folder: ${{parent.outputs.pytorch_model_folder_finetune}}
+  text_classification_model_converter:
+    type: command
+    component: azureml:ft_nlp_model_converter:0.0.66
+    compute: ${{parent.inputs.compute_finetune}}
+    resources:
+      instance_type: ${{parent.inputs.instance_type_finetune}}
+    inputs:
+      model_path: ${{parent.jobs.finetune.outputs.pytorch_model_folder}}
+    outputs:
       mlflow_model_folder: ${{parent.outputs.mlflow_model_folder_finetune}}

--- a/assets/training/finetune_acft_hf_nlp/components/preprocess/nlp_multiclass/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/preprocess/nlp_multiclass/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: nlp_multiclass_datapreprocessing
-version: 0.0.2
+version: 0.0.3
 type: command
 
 is_deterministic: True


### PR DESCRIPTION
…ltilabel


Version 3 of pipelines would fail to be created because the finetune version ( 66 ) used in the pipelines doesn't have mlflow model output. But pipeline tries to fetch this. This is corrected in this PR.