### PR TITLE
Upgraded the validation_tigger_import env version

### DIFF
--- a/assets/training/model_management/components/import_model/spec.yaml
+++ b/assets/training/model_management/components/import_model/spec.yaml
@@ -219,7 +219,7 @@ outputs:
 
 jobs:
   validation_trigger_import:
-    component: azureml:validation_trigger_import:0.0.14
+    component: azureml:validation_trigger_import:0.0.15
     compute: ${{parent.inputs.compute}}
     resources:
       instance_type: '${{parent.inputs.instance_type}}'

--- a/assets/training/model_management/components/validation_trigger_import/spec.yaml
+++ b/assets/training/model_management/components/validation_trigger_import/spec.yaml
@@ -4,7 +4,7 @@ type: command
 name: validation_trigger_import
 display_name: Validation Trigger Import model
 description: Component for enabling validation of import pipeline.
-version: 0.0.14
+version: 0.0.15
 
 # Pipeline inputs
 inputs:
@@ -181,7 +181,7 @@ outputs:
 
 is_deterministic: True
 
-environment: azureml://registries/azureml/environments/python-sdk-v2/versions/23
+environment: azureml://registries/azureml/environments/python-sdk-v2/versions/25
 code: ../../src
 command: python run_model_validate.py --validation-info ${{outputs.validation_info}}
 


### PR DESCRIPTION
1. This PR focuses on updating the environment version for the `validation_trigger_import` component.
2. This issue was detected during this build failure : https://github.com/Azure/azureml-examples/actions/runs/12786552346
3. The validation_trigger_import component was making use of an older version of the `azureml/curated/python-sdk-v2` which points to version 23.
4. This version needed to be updated to latest version 25.
5. Attaching the below latest version image

<img width="479" alt="image" src="https://github.com/user-attachments/assets/67df9c8a-81bd-4fc0-9e66-860606931866" />


