### PR TITLE
Don't copy conda yaml to finetuned model

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
+++ b/assets/training/finetune_acft_hf_nlp/src/model_converter/model_converter_adapters.py
@@ -296,14 +296,16 @@ class Pytorch_to_OSS_MlFlow_ModelConverter(ModelConverter, PyTorch_to_MlFlow_Mod
         # Temp Fix:
         # specific check for t5 text-classification, translation, summarization so that base model
         # dependencies doesn't get pass and use transformers version 4.44.0 from infer dependencies
-        if not self.is_t5_finetune(model.config.model_type):
-            conda_file_path = Path(self.ft_pytorch_model_path, MLFlowHFFlavourConstants.CONDA_YAML_FILE)
-            if conda_file_path.is_file():
-                self.mlflow_save_model_kwargs.update({"conda_env": str(conda_file_path)})
-                logger.info(
-                    f"Found {MLFlowHFFlavourConstants.CONDA_YAML_FILE} from base model. "
-                    "Using it for saving Mlflow model."
-                )
+        # Fix: 1/23/2025 : To make sure the old models also use the latest transformers version
+        # if not self.is_t5_finetune(model.config.model_type):
+        #     conda_file_path = Path(self.ft_pytorch_model_path, MLFlowHFFlavourConstants.CONDA_YAML_FILE)
+        #     if conda_file_path.is_file():
+        #         self.mlflow_save_model_kwargs.update({"conda_env": str(conda_file_path)})
+        #         logger.info(
+        #             f"Found {MLFlowHFFlavourConstants.CONDA_YAML_FILE} from base model. "
+        #             "Using it for saving Mlflow model."
+        #         )
+
 
         # saving oss mlflow model
         model_pipeline = pipeline(task=self.mlflow_task_type, model=model, tokenizer=tokenizer, config=model.config)


### PR DESCRIPTION
To make sure the ft'd models use the correct transformers don't copy the base model dependencies to the ft model.
Repro Run (with fix): [distilgpt2-classification-dri-bug-fix - Azure AI | Machine Learning Studio](https://ml.azure.com/experiments/id/a894b8f8-36a3-4a77-b375-072212a2916e/runs/4f021a60-318f-4863-8a88-31ba346af685?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47&pipelineChildMetrics=true)
Run (bug): [gpt2-classification-dri-bug-fix - Azure AI | Machine Learning Studio](https://ml.azure.com/experiments/id/a894b8f8-36a3-4a77-b375-072212a2916e/runs/65a089ac-8e80-4dd8-b796-cdf3b2275fef?wsid=/subscriptions/ba7979f7-d040-49c9-af1a-7414402bf622/resourceGroups/finetunedev_rg/providers/Microsoft.MachineLearningServices/workspaces/finetunedev_westeurope&tid=72f988bf-86f1-41af-91ab-2d7cd011db47&pipelineChildMetrics=true)