### PR TITLE
Update qa_data_generation with new curated environment

### DIFF
--- a/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
+++ b/assets/large_language_models/rag/components/qa_data_generation/spec.yaml
@@ -4,7 +4,7 @@ type: command
 tags:
     Preview: ""
 
-version: 0.0.75
+version: 0.0.76
 name: llm_rag_qa_data_generation
 display_name: LLM - Generate QnA Test Data
 is_deterministic: true
@@ -57,7 +57,7 @@ outputs:
     type: uri_folder
     description: "csv or jsonl file containing the question, answer, context, and metadata sets"
 
-environment: azureml:llm-rag@latest
+environment: azureml:llm-rag-embeddings@latest
 code: '../src'  # nothing used from here
 
 command: >-


### PR DESCRIPTION
Attempt to deprecated llm-rag curated environment to reduce maintenance cost and effort.
llm-rag-embeddings is a superset of llm-rag, it should be fine to change the environment to llm-rag-embeddings.

qa_data_generation is the ONLY component that is using it.

