### PR TITLE
update eci asset to v3

### DIFF
--- a/assets/promptflow/evaluators/models/eci-evaluator/model.yaml
+++ b/assets/promptflow/evaluators/models/eci-evaluator/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: rai-eval-flows
-  container_path: models/evaluators/_ECIEvaluator/v1/evaluator
+  container_path: models/evaluators/_ECIEvaluator/v3/evaluator
   storage_name: amlraipfmodels
   type: azureblob
 publish:


### PR DESCRIPTION
Updates the reference for the ECI evaluator to point to version 3 of the model. Version 2 is skipped because that was a faulty test version.