### PR TITLE
Fix irrelevant system error thrown in compute feature importances on LightGBM model training failure

### DIFF
--- a/assets/model_monitoring/components/src/feature_importance_metrics/compute_feature_importance.py
+++ b/assets/model_monitoring/components/src/feature_importance_metrics/compute_feature_importance.py
@@ -29,6 +29,8 @@ from feature_importance_metrics.feature_importance_utilities import (
 
 CONTINUOUS_ERR = ('The target column is continuous. ' +
                   'Please specify the task type as regression.')
+CONTINUOUS_SYSTEM_ERR_VARIANTS = ["Unknown label type: 'continuous'",
+                                  "Unknown label type: continuous"]
 
 
 def parse_args():
@@ -97,8 +99,9 @@ def create_lightgbm_model(X, y, task_type):
     try:
         model = lgbm.fit(X, y)
     except ValueError as e:
+        e_str = str(e)
         # Depending on lightgbm version this error message can be slightly different
-        if "Unknown label type: 'continuous'" or "Unknown label type: continuous" in str(e):
+        if any(variant in e_str for variant in CONTINUOUS_SYSTEM_ERR_VARIANTS):
             raise InvalidInputError(CONTINUOUS_ERR)
         raise e
     log_time_and_message(f"Created lightgbm model using task_type: {task_type}")


### PR DESCRIPTION
Fix irrelevant system error thrown in compute feature importances on LightGBM model training failure.
Resolve customer ICM where incorrect error message was displayed due to faulty logic added in PR https://github.com/Azure/azureml-assets/pull/2929:

![image](https://github.com/user-attachments/assets/c1aaa423-52e3-49c3-8740-213492527bdf)

The logic it should instead be equivalent to:
```
if "Unknown label type: 'continuous'" in str(e) or "Unknown label type: continuous" in str(e):
```
NOT the current format which always falls into the if as true due to string not being checked:
``` 
if "Unknown label type: 'continuous'" or "Unknown label type: continuous" in str(e):
```

The underlying customer error was:
```ValueError: Series.dtypes must be int, float or bool```
but it was re-raised as the CONTINUOUS_ERR incorrectly.

Copilot summary:
This pull request includes changes to the `compute_feature_importance.py` file to improve error handling for continuous target columns when creating a LightGBM model. The most important changes include the introduction of a new error variant list and the modification of the error handling logic in the `create_lightgbm_model` function.

Error handling improvements:

* [`assets/model_monitoring/components/src/feature_importance_metrics/compute_feature_importance.py`](diffhunk://#diff-722964c327cbff02d1ff2dfa4cb1875410468efc9643ec8c336aae7abda69415R32-R33): Added `CONTINUOUS_SYSTEM_ERR_VARIANTS` list to handle different error message formats for continuous target columns.
* [`assets/model_monitoring/components/src/feature_importance_metrics/compute_feature_importance.py`](diffhunk://#diff-722964c327cbff02d1ff2dfa4cb1875410468efc9643ec8c336aae7abda69415R102-R104): Updated the error handling in `create_lightgbm_model` to check against `CONTINUOUS_SYSTEM_ERR_VARIANTS` using the `any` function.