### PR TITLE
Fix model monitoring CI test failures due to conflicts with uploaded artifact names

### DIFF
--- a/.github/workflows/model-monitoring-ci.yml
+++ b/.github/workflows/model-monitoring-ci.yml
@@ -135,13 +135,16 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ env.pytest_report_folder }}
-          path: ${{ env.pytest_report_folder }}
+          name: ${{ env.pytest_report_folder }}-${{ matrix.group }}
+          path: ${{ env.pytest_report_folder }}-${{ matrix.group }}
   report:
       name: Publish test results
       if: always()
       runs-on: ubuntu-latest
       needs: run-momo-tests
+      strategy:
+        matrix:
+          group: [1, 2, 3, 4, 5, 6]
 
       permissions:
         # Required for EnricoMi/publish-unit-test-result-action
@@ -154,13 +157,13 @@ jobs:
           id: download-artifact
           uses: actions/download-artifact@v4
           with:
-            name: ${{ env.pytest_report_folder }}
-            path: ${{ env.pytest_report_folder }}
+            name: ${{ env.pytest_report_folder }}-${{ matrix.group }}
+            path: ${{ env.pytest_report_folder }}-${{ matrix.group }}
           continue-on-error: true
 
         - name: Publish test results
           if: steps.download-artifact.outputs.download-path != ''
           uses: EnricoMi/publish-unit-test-result-action@v2
           with:
-            check_name: Test Results for ${{ github.workflow }}
-            junit_files: ${{ env.pytest_report_folder }}/**/*.xml
+            check_name: Test Results for ${{ github.workflow }} - Group ${{ matrix.group }}
+            junit_files: ${{ env.pytest_report_folder }}-${{ matrix.group }}/**/*.xml

--- a/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_drift_compute_metrics
 display_name: Data Drift - Compute Metrics
 description: Compute data drift metrics given a baseline and a deployment's model data input.
-version: 0.3.29
+version: 0.3.30
 is_deterministic: true
 
 code: ../../src
@@ -69,6 +69,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --production_dataset ${{inputs.production_dataset}}

--- a/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_drift_signal_monitor
 display_name: Data Drift - Signal Monitor
 description: Computes the data drift between a baseline and production data assets.
-version: 0.3.50
+version: 0.3.51
 is_deterministic: true
 
 inputs:
@@ -63,7 +63,7 @@ outputs:
 jobs:
   compute_feature_importances:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.27
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.28
     inputs:
       baseline_data:
         type: mltable
@@ -82,7 +82,7 @@ jobs:
       type: aml_token
   feature_selection:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.24
+    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.25
     inputs:
       input_data_1:
         type: mltable
@@ -103,7 +103,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.29
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.30
     inputs:
       production_dataset:
         type: mltable
@@ -130,7 +130,7 @@ jobs:
       type: aml_token
   compute_histogram_buckets:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.24
     inputs:
       input_data_1:
         type: mltable
@@ -150,7 +150,7 @@ jobs:
       type: aml_token
   compute_baseline_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.24
     inputs:
       input_data:
         type: mltable
@@ -170,7 +170,7 @@ jobs:
       type: aml_token
   compute_target_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.24
     inputs:
       input_data:
         type: mltable
@@ -190,7 +190,7 @@ jobs:
       type: aml_token
   output_signal_metrics:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.29
     inputs:
       signal_metrics:
         type: mltable
@@ -218,7 +218,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.29
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/data_quality/data_quality_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_quality_compute_metrics
 display_name:  Data Quality - Compute Metrics
 description: Compute data quality metrics leveraged by the data quality monitor.
-version: 0.3.28
+version: 0.3.29
 is_deterministic: true
 
 inputs:
@@ -59,6 +59,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --input_data ${{inputs.input_data}}

--- a/assets/model_monitoring/components/data_quality/data_quality_metrics_joiner/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_metrics_joiner/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_quality_metrics_joiner
 display_name:  Data Quality - Metrics Joiner
 description: Join baseline and target data quality metrics into a single output.
-version: 0.3.21
+version: 0.3.22
 is_deterministic: true
 
 inputs:
@@ -48,6 +48,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --baseline_metrics ${{inputs.baseline_metrics}}

--- a/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: data_quality_signal_monitor
 display_name: Data Quality - Signal Monitor
 description: Computes the data quality of a target dataset with reference to a baseline.
-version: 0.3.48
+version: 0.3.49
 is_deterministic: true
 
 inputs:
@@ -63,7 +63,7 @@ outputs:
 jobs:
   compute_feature_importances:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.27
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.28
     inputs:
       baseline_data:
         type: mltable
@@ -82,7 +82,7 @@ jobs:
       type: aml_token
   feature_selection:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.24
+    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.25
     inputs:
       input_data_1:
         type: mltable
@@ -103,7 +103,7 @@ jobs:
       type: aml_token
   compute_baseline_data_statistics:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_data_statistics/versions/0.3.23
+    component: azureml://registries/azureml/components/data_quality_data_statistics/versions/0.3.24
     inputs:
       baseline_data:
         type: mltable
@@ -120,7 +120,7 @@ jobs:
       type: aml_token
   compute_baseline_data_quality:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.28
+    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.29
     inputs:
       input_data:
         type: mltable
@@ -145,7 +145,7 @@ jobs:
       type: aml_token
   compute_target_data_quality:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.28
+    component: azureml://registries/azureml/components/data_quality_compute_metrics/versions/0.3.29
     inputs:
       input_data:
         type: mltable
@@ -168,7 +168,7 @@ jobs:
       type: aml_token
   join_data_quality_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_quality_metrics_joiner/versions/0.3.21
+    component: azureml://registries/azureml/components/data_quality_metrics_joiner/versions/0.3.22
     inputs:
       baseline_metrics:
         type: mltable
@@ -188,7 +188,7 @@ jobs:
       type: aml_token
   output_signal_metrics:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.29
     inputs:
       signal_metrics:
         type: mltable
@@ -210,7 +210,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.29
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/data_quality/data_quality_statistics/spec.yaml
+++ b/assets/model_monitoring/components/data_quality/data_quality_statistics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: data_quality_data_statistics
 display_name: Data Quality - Data Statistics
 description: Compute data statistics leveraged by the data quality monitor.
-version: 0.3.23
+version: 0.3.24
 is_deterministic: true
 
 inputs:
@@ -47,6 +47,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --baseline_data ${{inputs.baseline_data}}

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_compute_metrics/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/SparkComponent.json
 type: spark
 
 name: feature_attribution_drift_compute_metrics
-version: 0.3.24
+version: 0.3.25
 display_name: Feature Attribution Drift - Compute Metrics
 is_deterministic: true
 description: Feature attribution drift using model monitoring.
@@ -47,6 +47,7 @@ conf:
         - fsspec~=2023.4.0
         - interpret-community[mimic]~=0.31.0
         - protobuf~=3.20
+        - numpy<2.0.0
     name: interpret-spark
 args: >-
   --baseline_data ${{inputs.baseline_data}}

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: feature_attribution_drift_signal_monitor
 display_name: Feature Attribution Drift - Signal Monitor
 description: Computes the feature attribution between a baseline and production data assets.
-version: 0.3.40
+version: 0.3.41
 is_deterministic: true
 
 inputs:
@@ -44,7 +44,7 @@ outputs:
 jobs:
   compute_baseline_explanations:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.27
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.28
     inputs:
       baseline_data:
         type: mltable
@@ -63,7 +63,7 @@ jobs:
       type: aml_token
   compute_production_explanations:
     type: spark
-    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.27
+    component: azureml://registries/azureml/components/feature_importance_metrics/versions/0.3.28
     inputs:
       baseline_data:
         type: mltable
@@ -82,7 +82,7 @@ jobs:
       type: aml_token
   compute_feature_attribution:
     type: spark
-    component: azureml://registries/azureml/components/feature_attribution_drift_compute_metrics/versions/0.3.24
+    component: azureml://registries/azureml/components/feature_attribution_drift_compute_metrics/versions/0.3.25
     inputs:
       production_data:
         type: mltable
@@ -101,7 +101,7 @@ jobs:
       type: aml_token
   output_signal_metrics:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.29
     inputs:
       signal_metrics:
         type: mltable
@@ -122,7 +122,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.29
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/feature_attribution_drift/feature_importance_metrics/spec.yaml
+++ b/assets/model_monitoring/components/feature_attribution_drift/feature_importance_metrics/spec.yaml
@@ -2,7 +2,7 @@ $schema: http://azureml/sdk-2-0/SparkComponent.json
 type: spark
 
 name: feature_importance_metrics
-version: 0.3.27
+version: 0.3.28
 display_name: Feature importance
 is_deterministic: true
 description: Feature importance for model monitoring.
@@ -54,6 +54,7 @@ conf:
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
         - protobuf~=3.20
+        - numpy<2.0.0
     name: interpret-spark
 args: >-
   --baseline_data ${{inputs.baseline_data}}

--- a/assets/model_monitoring/components/genai_token_statistics/genai_token_statistics_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/genai_token_statistics/genai_token_statistics_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: genai_token_statistics_compute_metrics
 display_name:  GenAI Token Statistics - Compute Metrics
 description: Compute token statistics metrics.
-version: 0.0.17
+version: 0.0.18
 is_deterministic: true
 
 inputs:
@@ -47,6 +47,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --production_dataset ${{inputs.production_dataset}}

--- a/assets/model_monitoring/components/genai_token_statistics/genai_token_statistics_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/genai_token_statistics/genai_token_statistics_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: genai_token_statistics_signal_monitor
 display_name: GenAI Token Statistics - Signal Monitor
 description: Computes the token and cost metrics over LLM outputs.
-version: 0.0.17
+version: 0.0.18
 is_deterministic: true
 inputs:
   monitor_name:
@@ -30,7 +30,7 @@ outputs:
 jobs:
   compute_metrics:
     type: spark
-    component: azureml://registries/azureml/components/genai_token_statistics_compute_metrics/versions/0.0.17
+    component: azureml://registries/azureml/components/genai_token_statistics_compute_metrics/versions/0.0.18
     inputs:
       production_dataset:
         type: mltable
@@ -49,7 +49,7 @@ jobs:
       type: aml_token
   output_signal_metrics: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.31
+    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.32
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_histogram/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_histogram
 display_name: Annotation - Compute Histogram
 description: Compute annotation histogram given a deployment's model data input.
-version: 0.4.32
+version: 0.4.33
 is_deterministic: false
 inputs:
   production_dataset:

--- a/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/annotation_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_annotation_compute_metrics
 display_name: Annotation - Compute Metrics
 description: Compute annotation metrics given a deployment's model data input.
-version: 0.4.25
+version: 0.4.26
 is_deterministic: True
 inputs:
   annotation_histogram: 

--- a/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/generation_safety_quality_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: generation_safety_quality_signal_monitor
 display_name: Generation Safety & Quality - Signal Monitor
 description: Computes the content generation safety metrics over LLM outputs.
-version: 0.5.23
+version: 0.5.24
 is_deterministic: true
 inputs:
   monitor_name:
@@ -109,7 +109,7 @@ outputs:
 jobs:
   input_schema_adaptor:
     type: spark
-    component: azureml://registries/azureml/components/gsq_input_schema_adaptor/versions/0.0.20
+    component: azureml://registries/azureml/components/gsq_input_schema_adaptor/versions/0.0.21
     inputs:
       production_dataset:
         type: mltable
@@ -124,7 +124,7 @@ jobs:
       type: aml_token
   compute_histogram:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.32
+    component: azureml://registries/azureml/components/gsq_annotation_compute_histogram/versions/0.4.33
     inputs:
       production_dataset:
         type: mltable
@@ -167,7 +167,7 @@ jobs:
       type: aml_token
   compute_metrics:
     type: spark
-    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.25
+    component: azureml://registries/azureml/components/gsq_annotation_compute_metrics/versions/0.4.26
     inputs:
       annotation_histogram:
         type: mltable
@@ -189,7 +189,7 @@ jobs:
       type: aml_token
   output_signal_metrics: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.31
+    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.32
     inputs:
       signal_metrics:
         type: mltable
@@ -211,7 +211,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.29
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/generation_safety_quality/input_schema_adaptor/spec.yaml
+++ b/assets/model_monitoring/components/generation_safety_quality/input_schema_adaptor/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: gsq_input_schema_adaptor
 display_name: Input Schema Adaptor
 description: Adapt data to fit into GSQ component.
-version: 0.0.20
+version: 0.0.21
 is_deterministic: True
 inputs:
   production_dataset:
@@ -38,6 +38,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 
 code: ../../src

--- a/assets/model_monitoring/components/model_monitor/genai_mdc_preprocessor/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/genai_mdc_preprocessor/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: genai_mdc_preprocessor
 display_name: GenAI MDC - Preprocessor
 description: Filters the raw span log based on the window provided, and aggregates it to trace level.
-version: 0.0.24
+version: 0.0.25
 is_deterministic: true
 
 code: ../../src
@@ -51,6 +51,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --data_window_end ${{inputs.data_window_end}}

--- a/assets/model_monitoring/components/model_monitor/model_data_collector_preprocessor/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_data_collector_preprocessor/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_data_collector_preprocessor
 display_name: Model Data Collector - Preprocessor
 description: Filters the data based on the window provided.
-version: 0.4.25
+version: 0.4.26
 is_deterministic: true
 
 code: ../../src
@@ -48,6 +48,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --data_window_end ${{inputs.data_window_end}}

--- a/assets/model_monitoring/components/model_monitor/model_monitor_azmon_metric_publisher/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_azmon_metric_publisher/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_azmon_metric_publisher
 display_name: Model Monitor - Azure Monitor Metric Publisher
 description: Azure Monitor Publisher for the computed model monitor metrics.
-version: 0.3.27
+version: 0.3.28
 is_deterministic: true
 
 code: ../../src/
@@ -51,6 +51,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 
 args: >-

--- a/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_compute_histogram
 display_name: Model Monitor - Compute Histogram
 description: Compute a histogram given an input data and associated histogram buckets.
-version: 0.3.23
+version: 0.3.24
 is_deterministic: true
 
 code: ../../src
@@ -50,6 +50,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --input_data ${{inputs.input_data}}

--- a/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram_buckets/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_compute_histogram_buckets/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_compute_histogram_buckets
 display_name: Model Monitor - Compute Histogram Buckets
 description: Compute histogram buckets given up to two datasets.
-version: 0.3.23
+version: 0.3.24
 is_deterministic: true
 
 code: ../../src
@@ -51,6 +51,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --input_data_1 ${{inputs.input_data_1}} 

--- a/assets/model_monitoring/components/model_monitor/model_monitor_create_manifest/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_create_manifest/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_create_manifest
 display_name: Model Monitor - Create Manifest
 description: Creates the model monitor metric manifest.
-version: 0.3.20
+version: 0.3.21
 is_deterministic: true
 
 code: ../../src/
@@ -77,6 +77,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --signal_outputs_1 ${{inputs.signal_outputs_1}} $[[--signal_outputs_2 ${{inputs.signal_outputs_2}}]] $[[--signal_outputs_3 ${{inputs.signal_outputs_3}}]] $[[--signal_outputs_4 ${{inputs.signal_outputs_4}}]] $[[--signal_outputs_5 ${{inputs.signal_outputs_5}}]] $[[--signal_outputs_6 ${{inputs.signal_outputs_6}}]] $[[--signal_outputs_7 ${{inputs.signal_outputs_7}}]] $[[--signal_outputs_8 ${{inputs.signal_outputs_8}}]] $[[--signal_outputs_9 ${{inputs.signal_outputs_9}}]] $[[--signal_outputs_10 ${{inputs.signal_outputs_10}}]] --model_monitor_metrics_output ${{outputs.model_monitor_metrics_output}}

--- a/assets/model_monitoring/components/model_monitor/model_monitor_data_joiner/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_data_joiner/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_data_joiner
 display_name: Model Monitor - Data Joiner
 description: Joins two data assets on the given columns for model monitor.
-version: 0.3.23
+version: 0.3.24
 is_deterministic: true
 
 code: ../../src/
@@ -48,6 +48,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --left_input_data ${{inputs.left_input_data}}

--- a/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_evaluate_metrics_threshold/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_evaluate_metrics_threshold
 display_name: Model Monitor - Evaluate Metrics Threshold
 description: Evaluate signal metrics against the threshold provided in the monitoring signal.
-version: 0.3.28
+version: 0.3.29
 is_deterministic: true
 
 code: ../../src
@@ -42,6 +42,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --metrics_to_evaluate ${{inputs.signal_metrics}} --signal_name ${{inputs.signal_name}} $[[--notification_emails ${{inputs.notification_emails}}]]

--- a/assets/model_monitoring/components/model_monitor/model_monitor_feature_selector/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_feature_selector/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_feature_selector
 display_name: Model Monitor - Feature Selector
 description: Selects features to compute signal metrics on.
-version: 0.3.24
+version: 0.3.25
 is_deterministic: true
 
 code: ../../src
@@ -53,6 +53,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --input_data_1 ${{inputs.input_data_1}}

--- a/assets/model_monitoring/components/model_monitor/model_monitor_metric_outputter/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_metric_outputter/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_metric_outputter
 display_name: Model Monitor - Metric Outputter
 description: Output the computed model monitor metrics.
-version: 0.3.31
+version: 0.3.32
 is_deterministic: true
 
 code: ../../src/
@@ -53,6 +53,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --monitor_name ${{inputs.monitor_name}} --signal_name ${{inputs.signal_name}} --signal_type ${{inputs.signal_type}} --signal_metrics ${{inputs.signal_metrics}} --metric_timestamp ${{inputs.metric_timestamp}} --signal_output ${{outputs.signal_output}} $[[--samples_index ${{inputs.samples_index}}]]

--- a/assets/model_monitoring/components/model_monitor/model_monitor_output_metrics/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor/model_monitor_output_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_output_metrics
 display_name: Model Monitor - Output Metrics
 description: Output the computed model monitor metrics to the default datastore.
-version: 0.3.28
+version: 0.3.29
 is_deterministic: true
 
 code: ../../src/
@@ -61,6 +61,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --signal_name ${{inputs.signal_name}} 

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_correlation_test/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_correlation_test/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: action_analyzer_correlation_test
 display_name: Action Analyzer - Correlation Test
 description: Perform correlation test on different groups to generate actions.
-version: 0.0.17
+version: 0.0.18
 is_deterministic: True
 inputs:
   data_with_action_metric_score:
@@ -36,6 +36,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 code: ../../src
 

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_identify_problem_traffic/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_identify_problem_traffic/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: action_analyzer_identify_problem_traffic
 display_name: Action Analyzer - Identify Problem Traffic 
 description: Separate bad queries into different groups.
-version: 0.0.20
+version: 0.0.21
 is_deterministic: True
 inputs:
   signal_output:
@@ -61,6 +61,7 @@ conf:
         - bertopic[flair]
         - nbformat
         - openAI
+        - numpy<2.0.0
 code: ../../src
 
 entry:

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_metrics_calculation/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_metrics_calculation/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: action_analyzer_metrics_calculation
 display_name: Action Analyzer - Metrics Calculation
 description: Calculate futher metrics for generating actions.
-version: 0.0.17
+version: 0.0.18
 is_deterministic: True
 inputs:
   data_with_groups:
@@ -45,6 +45,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 code: ../../src
 

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_output_actions/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/action_analyzer_output_actions/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: action_analyzer_output_actions
 display_name: Action Analyzer - Output Actions
 description: Merge and output actions.
-version: 0.0.20
+version: 0.0.21
 is_deterministic: True
 inputs:
   action_data:
@@ -44,6 +44,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 code: ../../src
 

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/model_monitor_action_analyzer/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/model_monitor_action_analyzer/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: model_monitor_action_analyzer
 display_name: Model Monitor - Action Analyzer
 description: Generate and output actions to the default datastore.
-version: 0.0.21
+version: 0.0.22
 is_deterministic: true
 inputs:
   signal_output:
@@ -52,7 +52,7 @@ outputs:
 jobs:
   identify_problem_traffic:
     type: spark
-    component: azureml://registries/azureml/components/action_analyzer_identify_problem_traffic/versions/0.0.20
+    component: azureml://registries/azureml/components/action_analyzer_identify_problem_traffic/versions/0.0.21
     inputs:
       signal_output: 
         type: uri_folder
@@ -74,7 +74,7 @@ jobs:
       type: aml_token
   metrics_calculation:
     type: spark
-    component: azureml://registries/azureml/components/action_analyzer_metrics_calculation/versions/0.0.17
+    component: azureml://registries/azureml/components/action_analyzer_metrics_calculation/versions/0.0.18
     inputs:
       data_with_groups:
         type: mltable
@@ -91,7 +91,7 @@ jobs:
       type: aml_token
   correlation_test:
     type: spark
-    component: azureml://registries/azureml/components/action_analyzer_correlation_test/versions/0.0.17
+    component: azureml://registries/azureml/components/action_analyzer_correlation_test/versions/0.0.18
     inputs:
       data_with_action_metric_score:
         type: mltable
@@ -106,7 +106,7 @@ jobs:
       type: aml_token
   output_actions:
     type: spark
-    component: azureml://registries/azureml/components/action_analyzer_output_actions/versions/0.0.20
+    component: azureml://registries/azureml/components/action_analyzer_output_actions/versions/0.0.21
     inputs:
       action_data:
         type: mltable

--- a/assets/model_monitoring/components/model_monitor_action_analyzer/model_monitor_action_detector/spec.yaml
+++ b/assets/model_monitoring/components/model_monitor_action_analyzer/model_monitor_action_detector/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_monitor_action_detector
 display_name: Model Monitor - Action Detector
 description: Generate and output actions
-version: 0.0.13
+version: 0.0.14
 is_deterministic: true
 inputs:
   signal_output:
@@ -63,6 +63,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec~=1.0.0
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 code: ../../src
 

--- a/assets/model_monitoring/components/model_performance/model_performance_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/model_performance/model_performance_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: model_performance_compute_metrics
 display_name: Model Performance - Compute Metrics
 description: Compute model performance metrics leveraged by the model performance monitor.
-version: 0.0.22
+version: 0.0.23
 is_deterministic: true
 
 code: ../../src
@@ -74,6 +74,7 @@ conf:
         - fsspec~=2023.4.0
         - azureml-metrics[tabular]~=0.0.42
         - setuptools[core]
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --task ${{inputs.task}}

--- a/assets/model_monitoring/components/model_performance/model_performance_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/model_performance/model_performance_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: model_performance_signal_monitor
 display_name: Model Performance - Signal Monitor
 description: Computes the model performance
-version: 0.0.24
+version: 0.0.25
 is_deterministic: true
 inputs:
   task:
@@ -57,7 +57,7 @@ outputs:
 jobs:
   compute_metrics:
     type: spark
-    component: azureml://registries/azureml/components/model_performance_compute_metrics/versions/0.0.22
+    component: azureml://registries/azureml/components/model_performance_compute_metrics/versions/0.0.23
     inputs:
       task: ${{parent.inputs.task}}
       baseline_data_target_column: ${{parent.inputs.baseline_data_target_column}}
@@ -78,7 +78,7 @@ jobs:
       type: aml_token
   output_signal_metrics: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.31
+    component: azureml://registries/azureml/components/model_monitor_metric_outputter/versions/0.3.32
     inputs:
       signal_metrics:
         type: mltable
@@ -99,7 +99,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.29
     inputs:
       signal_metrics:
         type: mltable

--- a/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
+++ b/assets/model_monitoring/components/prediction_drift/prediction_drift_signal_monitor/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: prediction_drift_signal_monitor
 display_name: Prediction Drift - Signal Monitor
 description: Computes the prediction drift between a baseline and a target data assets.
-version: 0.4.26
+version: 0.4.27
 is_deterministic: true
 
 inputs:
@@ -57,7 +57,7 @@ outputs:
 jobs:
   feature_selection:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.24
+    component: azureml://registries/azureml/components/model_monitor_feature_selector/versions/0.3.25
     inputs:
       input_data_1:
         type: mltable
@@ -77,7 +77,7 @@ jobs:
       type: aml_token
   compute_drift_metrics:
     type: spark
-    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.29
+    component: azureml://registries/azureml/components/data_drift_compute_metrics/versions/0.3.30
     inputs:
       production_dataset:
         type: mltable
@@ -104,7 +104,7 @@ jobs:
       type: aml_token
   compute_histogram_buckets:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram_buckets/versions/0.3.24
     inputs:
       input_data_1:
         type: mltable
@@ -124,7 +124,7 @@ jobs:
       type: aml_token
   compute_baseline_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.24
     inputs:
       input_data:
         type: mltable
@@ -144,7 +144,7 @@ jobs:
       type: aml_token
   compute_target_histogram:
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.23
+    component: azureml://registries/azureml/components/model_monitor_compute_histogram/versions/0.3.24
     inputs:
       input_data:
         type: mltable
@@ -164,7 +164,7 @@ jobs:
       type: aml_token
   output_signal_metrics: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_output_metrics/versions/0.3.29
     inputs:
       signal_metrics:
         type: mltable
@@ -191,7 +191,7 @@ jobs:
       type: aml_token
   evaluate_metric_thresholds: 
     type: spark
-    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.28
+    component: azureml://registries/azureml/components/model_monitor_evaluate_metrics_threshold/versions/0.3.29
     inputs:
       signal_metrics: 
         type: mltable

--- a/assets/model_monitoring/components/token_statistics/token_statistics_compute_metrics/spec.yaml
+++ b/assets/model_monitoring/components/token_statistics/token_statistics_compute_metrics/spec.yaml
@@ -4,7 +4,7 @@ type: spark
 name: token_statistics_compute_metrics
 display_name:  Token Statistics - Compute Metrics
 description: Compute token statistics metrics.
-version: 0.0.19
+version: 0.0.20
 is_deterministic: true
 
 inputs:
@@ -42,6 +42,7 @@ conf:
         - mltable~=1.3.0
         - azureml-fsspec
         - fsspec~=2023.4.0
+        - numpy<2.0.0
     name: momo-base-spark
 args: >-
   --token_dataset ${{inputs.token_dataset}}


### PR DESCRIPTION
Fixes test failures in model monitoring CI during "upload test results" step due to name conflict:
![image](https://github.com/user-attachments/assets/e62fb379-f7e0-4504-b876-4676bf3f48ce)

With updated v4 version of `actions/upload-artifact` name conflicts are no longer automatically overwritten. This is resolved by updating the artifact names which are now unique by appending the matrix group number to the artifact name.

In addition, fixing numpy errors by pinning numpy<2.0.0 and updating the versions on all components, which fixes the e2e test failures.

Copilot summary:
This pull request includes updates to various YAML specification files and CI workflow configurations to enhance the model monitoring components and ensure compatibility with the latest dependencies. The most important changes involve updating component versions and adding a new dependency.

### CI Workflow Enhancements:
* [`.github/workflows/model-monitoring-ci.yml`](diffhunk://#diff-23161e1727a12f2b2ce755d64b586e47fad8b3b3ba73e1eff59bf857aefb21a7L138-R147): Added a matrix strategy for grouping test results and modified artifact names to include the matrix group. [[1]](diffhunk://#diff-23161e1727a12f2b2ce755d64b586e47fad8b3b3ba73e1eff59bf857aefb21a7L138-R147) [[2]](diffhunk://#diff-23161e1727a12f2b2ce755d64b586e47fad8b3b3ba73e1eff59bf857aefb21a7L157-R169)

### Component Version Updates:
* [`assets/model_monitoring/components/data_drift/data_drift_compute_metrics/spec.yaml`](diffhunk://#diff-86affa5c56d6b05201073b67a214c3ce356d41c7b8df42ec04fd946600cd731bL7-R7): Updated version from `0.3.29` to `0.3.30`.
* [`assets/model_monitoring/components/data_drift/data_drift_signal_monitor/spec.yaml`](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L7-R7): Updated multiple component versions to the latest available. [[1]](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L7-R7) [[2]](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L66-R66) [[3]](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L85-R85) [[4]](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L106-R106) [[5]](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L133-R133) [[6]](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L153-R153) [[7]](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L173-R173) [[8]](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L193-R193) [[9]](diffhunk://#diff-9845970428817310efa54b26e7c1456a1d011f8e28327bfc6455120f6167e0d0L221-R221)
* [`assets/model_monitoring/components/data_quality/data_quality_compute_metrics/spec.yaml`](diffhunk://#diff-761a04d7e18da6eb15dc98ca5da02b8201ea0633144de5647e43737a84ef98fcL7-R7): Updated version from `0.3.28` to `0.3.29`.
* [`assets/model_monitoring/components/data_quality/data_quality_signal_monitor/spec.yaml`](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL7-R7): Updated multiple component versions to the latest available. [[1]](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL7-R7) [[2]](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL66-R66) [[3]](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL85-R85) [[4]](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL106-R106) [[5]](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL123-R123) [[6]](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL148-R148) [[7]](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL171-R171) [[8]](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL191-R191) [[9]](diffhunk://#diff-d2432f9e9b3c4768bd1bde18920cca082abc9eb7e6d6cb28ee14fb0496bf698dL213-R213)
* [`assets/model_monitoring/components/data_quality/data_quality_statistics/spec.yaml`](diffhunk://#diff-b53089d76791671b7ebe0ed283a12d5eba28c743a711d06f6c666b87e4e043a5L7-R7): Updated version from `0.3.23` to `0.3.24`.
* [`assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_compute_metrics/spec.yaml`](diffhunk://#diff-73c7e19fe9890c0c4ac51c4c7561bf68020b145f1a469332f64d726d0d04b96eL5-R5): Updated version from `0.3.24` to `0.3.25`.
* [`assets/model_monitoring/components/feature_attribution_drift/feature_attribution_drift_signal_monitor/spec.yaml`](diffhunk://#diff-6947eebbe5e4512815f6cfa8b62466298ab58ce4bdf154b8438d4df9ce2cdc0aL7-R7): Updated multiple component versions to the latest available. [[1]](diffhunk://#diff-6947eebbe5e4512815f6cfa8b62466298ab58ce4bdf154b8438d4df9ce2cdc0aL7-R7) [[2]](diffhunk://#diff-6947eebbe5e4512815f6cfa8b62466298ab58ce4bdf154b8438d4df9ce2cdc0aL47-R47) [[3]](diffhunk://#diff-6947eebbe5e4512815f6cfa8b62466298ab58ce4bdf154b8438d4df9ce2cdc0aL66-R66) [[4]](diffhunk://#diff-6947eebbe5e4512815f6cfa8b62466298ab58ce4bdf154b8438d4df9ce2cdc0aL85-R85)

### Dependency Updates:
* Added `numpy<2.0.0` to the `conf` section in several component specification files to ensure compatibility with existing code. [[1]](diffhunk://#diff-86affa5c56d6b05201073b67a214c3ce356d41c7b8df42ec04fd946600cd731bR72) [[2]](diffhunk://#diff-761a04d7e18da6eb15dc98ca5da02b8201ea0633144de5647e43737a84ef98fcR62) [[3]](diffhunk://#diff-04d242609781aeafe51794db69a53a05e9e7a8eed29d143df1f9ed540999e5eeR51) [[4]](diffhunk://#diff-b53089d76791671b7ebe0ed283a12d5eba28c743a711d06f6c666b87e4e043a5R50) [[5]](diffhunk://#diff-73c7e19fe9890c0c4ac51c4c7561bf68020b145f1a469332f64d726d0d04b96eR50)