### PR TITLE
rai eval ui dag flow v8

### DIFF
--- a/assets/promptflow/models/rai-eval-ui-dag-flow/model.yaml
+++ b/assets/promptflow/models/rai-eval-ui-dag-flow/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: rai-eval-flows
-  container_path: models/rai_eval_ui_dag_flow/v7
+  container_path: models/rai_eval_ui_dag_flow/v8
   storage_name: amlraipfmodels
   type: azureblob
 publish:

--- a/assets/promptflow/models/rai-eval-ui-dag-flow/spec.yaml
+++ b/assets/promptflow/models/rai-eval-ui-dag-flow/spec.yaml
@@ -9,4 +9,4 @@ properties:
   azureml.promptflow.description: Compute the quality and safety of the answer for the given question based on the ground_truth and the context
   inference-min-sku-spec: 2|0|14|28
   inference-recommended-sku: Standard_DS3_v2
-version: 7
+version: 8


### PR DESCRIPTION
Update the rai eval ui dag flow model to reference version 8, which has been recently added.