### PR TITLE
update ui flow model to version 11

### DIFF
--- a/assets/promptflow/models/rai-eval-ui-dag-flow/model.yaml
+++ b/assets/promptflow/models/rai-eval-ui-dag-flow/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: rai-eval-flows
-  container_path: models/rai_eval_ui_dag_flow/v10
+  container_path: models/rai_eval_ui_dag_flow/v11
   storage_name: amlraipfmodels
   type: azureblob
 publish:

--- a/assets/promptflow/models/rai-eval-ui-dag-flow/spec.yaml
+++ b/assets/promptflow/models/rai-eval-ui-dag-flow/spec.yaml
@@ -9,4 +9,4 @@ properties:
   azureml.promptflow.description: Compute the quality and safety of the answer for the given question based on the ground_truth and the context
   inference-min-sku-spec: 2|0|14|28
   inference-recommended-sku: Standard_DS3_v2
-version: 10
+version: 11


### PR DESCRIPTION
Update the ui flow model to version 11.

Version 11 re-introduces the new evaluators that were added in version 9, but rolled back in version 10. This version fixes the "fail without groundedness pro" bug that forced the version 10 rollback.