### PR TITLE
Update RAI vision and text images to ubuntu 22.04

### DIFF
--- a/.github/workflows/assets-test.yaml
+++ b/.github/workflows/assets-test.yaml
@@ -154,21 +154,33 @@ jobs:
             sleep $sleep_timer
           done &
 
+      - name: Sets ASSET_CONFIG_NAME
+        id: env
+        env:
+          name: "${{ matrix.asset_config_path }}"
+        # replace all '/' in asset path, not just first one, and write to $GITHUB_ENV
+        run: |
+          echo "ASSET_CONFIG_NAME=${name//\//-}" >> $GITHUB_ENV
+
       - name: Test asset
-        run: python -u $scripts_test_dir/test_assets.py -i "${{ matrix.asset_config_path }}" -a $asset_config_filename -p $scripts_test_dir/requirements.txt -r $GITHUB_WORKSPACE/$pytest_reports
+        run: python -u $scripts_test_dir/test_assets.py -i "${{ matrix.asset_config_path }}" -a $asset_config_filename -p $scripts_test_dir/requirements.txt -r $GITHUB_WORKSPACE/$pytest_reports-"${{ env.ASSET_CONFIG_NAME }}"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ env.pytest_reports }}
-          path: ${{ env.pytest_reports }}
+          name: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}
+          path: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}
 
   report:
     name: Publish test results
     if: always()
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - test
+      - setup
+    strategy:
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     permissions:
       # Required for EnricoMi/publish-unit-test-result-action
@@ -177,12 +189,20 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Sets ASSET_CONFIG_NAME
+        id: env
+        env:
+          name: "${{ matrix.asset_config_path }}"
+        # replace all '/' in asset path, not just first one, and write to $GITHUB_ENV
+        run: |
+          echo "ASSET_CONFIG_NAME=${name//\//-}" >> $GITHUB_ENV
+
       - name: Download test results
         id: download-artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.pytest_reports }}
-          path: ${{ env.pytest_reports }}
+          name: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}
+          path: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}
         continue-on-error: true
 
       - name: Publish test results
@@ -190,4 +210,4 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           check_name: Test Results for ${{ github.workflow }}
-          junit_files: ${{ env.pytest_reports }}/**/*.xml
+          junit_files: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}/**/*.xml

--- a/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
@@ -1,20 +1,18 @@
-FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:{{latest-image-tag}}
 
-ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-text
-
-# Prepend path to AzureML conda environment
-ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
+WORKDIR /
+ENV CONDA_PREFIX=/azureml-envs/responsibleai-text
+ENV CONDA_DEFAULT_ENV=$CONDA_PREFIX
 
 # Create conda environment
 COPY conda_dependencies.yaml .
-RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
-    rm conda_dependencies.yaml && \
-    conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
-    conda clean -a -y
+RUN conda env create -p $CONDA_PREFIX -f conda_dependencies.yaml -q && \
+    rm conda_dependencies.yaml
+
+# Prepend path to AzureML conda environment
+ENV PATH=$CONDA_PREFIX/bin:$PATH
 
 RUN conda list
-# Conda install and pip install could happen side by side. Remove crypytography with vulnerability from conda
-RUN conda remove cryptography
 
 RUN pip install --pre 'azure-ai-ml' 'azure-storage-blob<=12.13.0' 'numpy==1.26.2'
 
@@ -48,7 +46,13 @@ RUN pip install git+https://github.com/huggingface/evaluate.git
 RUN pip install 'Werkzeug>=3.0.3'
 RUN pip install 'tqdm>=4.66.3'
 
+# clean conda and pip caches
+RUN conda run -p $CONDA_PREFIX pip cache purge && \
+    conda clean -a -y
+
+RUN rm -rf ~/.cache/pip
+
 RUN pip freeze
 
 # This is needed for mpi to locate libpython
-ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH $CONDA_PREFIX/lib:$LD_LIBRARY_PATH

--- a/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-text/context/conda_dependencies.yaml
@@ -1,7 +1,6 @@
 name: responsibleai-text
 channels:
   - conda-forge
-  - defaults
   - huggingface
   - anaconda
   - pytorch

--- a/assets/responsibleai/environments/responsibleai-text/tests/requirements.txt
+++ b/assets/responsibleai/environments/responsibleai-text/tests/requirements.txt
@@ -1,3 +1,3 @@
-azure-ai-ml==1.22.4
-azure.identity==1.19.0
+azure-ai-ml==1.25.0
+azure.identity==1.20.0
 azureml-core>=1.58.0

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -1,25 +1,24 @@
-FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:{{latest-image-tag}}
+
 # Install OpenCV native dependencies
 RUN apt-get update
 RUN apt-get install -y python3-opencv
 RUN apt-get remove -y libavutil56 libswresample3 libavformat58
-RUN apt-get remove -y libavcodec58 libswscale5 libopenexr24 libpmix2
+RUN apt-get remove -y libavcodec58 libswscale5 libpmix2
 
-ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-vision
-
-# Prepend path to AzureML conda environment
-ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
+WORKDIR /
+ENV CONDA_PREFIX=/azureml-envs/responsibleai-vision
+ENV CONDA_DEFAULT_ENV=$CONDA_PREFIX
 
 # Create conda environment
 COPY conda_dependencies.yaml .
-RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
-    rm conda_dependencies.yaml && \
-    conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
-    conda clean -a -y
+RUN conda env create -p $CONDA_PREFIX -f conda_dependencies.yaml -q && \
+    rm conda_dependencies.yaml
+
+# Prepend path to AzureML conda environment
+ENV PATH=$CONDA_PREFIX/bin:$PATH
 
 RUN conda list
-# Conda install and pip install could happen side by side. Remove crypytography with vulnerability from conda
-RUN conda remove cryptography
 
 RUN pip install --pre 'azure-ai-ml' 'azure-storage-blob<=12.13.0'
 
@@ -38,8 +37,7 @@ RUN pip install 'azureml-core=={{latest-pypi-version}}' \
 RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
                 'azureml-automl-dnn-vision=={{latest-pypi-version}}'
 
-RUN pip install 'shap==0.41.0' \
-                'scikit-learn>=1.5.1' \
+RUN pip install 'scikit-learn>=1.5.1' \
                 'interpret-community==0.31.0' \
                 'Pillow>=10.3.0' \
                 'setuptools>=65.5.1' \
@@ -47,6 +45,8 @@ RUN pip install 'shap==0.41.0' \
                 'scipy==1.10.0' \
                 'statsmodels==0.14.0' \
                 'gunicorn>=22.0.0'
+
+RUN pip install 'shap==0.46.0'
 
 # azureml-dataset-runtime[fuse] upper bound for pyarrow is 11.0.0
 # so we install pyarrow in extra step to avoid conflict
@@ -62,10 +62,16 @@ RUN pip install 'Werkzeug>=3.0.3' \
 
 # To resolve CVE-2024-5480 vulnerability issue for torch < 2.2.2
 RUN pip install 'torch>=2.2.2'
-# To resolve vulnerability issue
+# To resolve GHSA-jh2j-j4j9-crg3 vulnerability issue
 RUN pip install 'opencv-python-headless==4.8.1.78'
+
+# clean conda and pip caches
+RUN conda run -p $CONDA_PREFIX pip cache purge && \
+    conda clean -a -y
+
+RUN rm -rf ~/.cache/pip
 
 RUN pip freeze
 
 # This is needed for mpi to locate libpython
-ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH $CONDA_PREFIX/lib:$LD_LIBRARY_PATH

--- a/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
@@ -1,7 +1,6 @@
 name: responsibleai-vision
 channels:
   - conda-forge
-  - defaults
   - anaconda
   - pytorch
 dependencies:

--- a/assets/responsibleai/environments/responsibleai-vision/tests/requirements.txt
+++ b/assets/responsibleai/environments/responsibleai-vision/tests/requirements.txt
@@ -1,3 +1,3 @@
-azure-ai-ml==1.22.4
-azure.identity==1.19.0
+azure-ai-ml==1.25.0
+azure-identity==1.20.0
 azureml-core>=1.58.0


### PR DESCRIPTION
Update RAI vision and text images to ubuntu 22.04

This also fixes the assets-test github yaml to support running multiple tests of assets in one PR. It looks like actions/upload-artifact was upgraded from v3 to v4 recently leading to such test failures. v4 version does not support uploading files with the same name. I used a unique asset path (replacing / with -) to continue to support this workflow.

Copilot summary:
This pull request includes updates to the Dockerfiles and conda dependencies for the responsible AI environments, focusing on upgrading the base image, cleaning up environment variables, and improving package management.

### Dockerfile and Environment Updates:

* Upgraded base image from `ubuntu20.04` to `ubuntu22.04` in both `responsibleai-text` and `responsibleai-vision` Dockerfiles. [[1]](diffhunk://#diff-59bdebe358573c1a07c8b0b547b47734da15a9d8dbf718e6b2dfad83d93781beL1-L17) [[2]](diffhunk://#diff-63e8d3e23a82c973cac28e2ccdeaffb75572227077da3e55339d9c9e9696d976L1-L22)
* Consolidated environment variables and paths by replacing `AZUREML_CONDA_ENVIRONMENT_PATH` with `CONDA_PREFIX` and `CONDA_DEFAULT_ENV`. [[1]](diffhunk://#diff-59bdebe358573c1a07c8b0b547b47734da15a9d8dbf718e6b2dfad83d93781beL1-L17) [[2]](diffhunk://#diff-63e8d3e23a82c973cac28e2ccdeaffb75572227077da3e55339d9c9e9696d976L1-L22)
* Added steps to clean conda and pip caches to reduce image size and improve security. [[1]](diffhunk://#diff-59bdebe358573c1a07c8b0b547b47734da15a9d8dbf718e6b2dfad83d93781beR49-R58) [[2]](diffhunk://#diff-63e8d3e23a82c973cac28e2ccdeaffb75572227077da3e55339d9c9e9696d976L65-R77)

### Package Management:

* Updated `shap` package version from `0.41.0` to `0.46.0` in the `responsibleai-vision` Dockerfile.
* Removed the `defaults` channel from `conda_dependencies.yaml` files for both environments to streamline package sources. [[1]](diffhunk://#diff-a1cdf5393e174aba61839d6def829422fd274422f5a1bc9945046704b2c0ed19L4) [[2]](diffhunk://#diff-b055aa561250a9f59cadee20932c81f7939c81c232f6bc724aab4d5e44706e3fL4)