### PR TITLE
Update RAI tabular image to ubuntu 22.04

### DIFF
--- a/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
@@ -1,23 +1,21 @@
-FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu20.04:{{latest-image-tag}}
-
-ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/responsibleai-tabular
+FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:{{latest-image-tag}}
 
 # Install wkhtmltopdf for pdf rendering from html
 RUN apt-get -y update && apt-get -y install wkhtmltopdf
 
-# Prepend path to AzureML conda environment
-ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
+WORKDIR /
+ENV CONDA_PREFIX=/azureml-envs/responsibleai-tabular
+ENV CONDA_DEFAULT_ENV=$CONDA_PREFIX
 
 # Create conda environment
 COPY conda_dependencies.yaml .
-RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
-    rm conda_dependencies.yaml && \
-    conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
-    conda clean -a -y
+RUN conda env create -p $CONDA_PREFIX -f conda_dependencies.yaml -q && \
+    rm conda_dependencies.yaml
+
+# Prepend path to AzureML conda environment
+ENV PATH=$CONDA_PREFIX/bin:$PATH
 
 RUN conda list
-# Conda install and pip install could happen side by side. Remove crypytography with vulnerability from conda
-RUN conda remove cryptography
 
 RUN pip install --pre 'azure-ai-ml' 'azure-storage-blob<=12.13.0' 'numpy<1.24.0'
 
@@ -52,7 +50,13 @@ RUN pip install 'gunicorn>=22.0.0'
 RUN pip install 'Werkzeug>=3.0.3'
 RUN pip install 'tqdm>=4.66.3'
 
+# clean conda and pip caches
+RUN conda run -p $CONDA_PREFIX pip cache purge && \
+    conda clean -a -y
+
+RUN rm -rf ~/.cache/pip
+
 RUN pip freeze
 
 # This is needed for mpi to locate libpython
-ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH $CONDA_PREFIX/lib:$LD_LIBRARY_PATH

--- a/assets/responsibleai/environments/responsibleai-tabular/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/conda_dependencies.yaml
@@ -1,7 +1,6 @@
 name: responsibleai-tabular
 channels:
   - conda-forge
-  - defaults
   - anaconda
 dependencies:
   - python=3.9

--- a/assets/responsibleai/environments/responsibleai-tabular/tests/requirements.txt
+++ b/assets/responsibleai/environments/responsibleai-tabular/tests/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-ml~=1.0.0
-azure.identity==1.10.0
-azureml-core~=1.53.0
+azure-ai-ml==1.25.0
+azure-identity==1.20.0
+azureml-core>=1.58.0
 azureml-mlflow

--- a/assets/responsibleai/environments/responsibleai-tabular/tests/responsibleai_sample_test.py
+++ b/assets/responsibleai/environments/responsibleai-tabular/tests/responsibleai_sample_test.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from azure.ai.ml import MLClient
 from azure.ai.ml import command, Input
-from azure.ai.ml._restclient.models import JobStatus
+from azure.ai.ml.operations._run_history_constants import JobStatus
 from azure.ai.ml.entities import Environment, BuildContext
 from azure.ai.ml import automl
 from azure.ai.ml.constants import AssetTypes

--- a/assets/responsibleai/environments/responsibleai-text/tests/requirements.txt
+++ b/assets/responsibleai/environments/responsibleai-text/tests/requirements.txt
@@ -1,3 +1,3 @@
 azure-ai-ml==1.25.0
-azure.identity==1.20.0
+azure-identity==1.20.0
 azureml-core>=1.58.0


### PR DESCRIPTION
Update RAI tabular image to ubuntu 22.04 based on e2e validated changes from merged PR in RAI-vNext-Preview repository: https://github.com/Azure/RAI-vNext-Preview/pull/220

Copilot summary:
This pull request includes several changes to the `Dockerfile` and `conda_dependencies.yaml` for the `responsibleai-tabular` environment. The main focus is on updating the base image, environment variable handling, and cleaning up dependencies.

### Dockerfile updates:
* Updated the base image from `ubuntu20.04` to `ubuntu22.04` to ensure compatibility with newer dependencies.
* Modified environment variable handling to use `CONDA_PREFIX` and `CONDA_DEFAULT_ENV` instead of `AZUREML_CONDA_ENVIRONMENT_PATH`.
* Added steps to clean conda and pip caches to reduce image size and potential conflicts.

### Conda dependencies update:
* Removed the `defaults` channel from `conda_dependencies.yaml` to streamline the dependency resolution process.