### PR TITLE
Update assets test artifacts upload logic to publish all test results in one step

### DIFF
--- a/.github/workflows/assets-test.yaml
+++ b/.github/workflows/assets-test.yaml
@@ -154,23 +154,15 @@ jobs:
             sleep $sleep_timer
           done &
 
-      - name: Sets ASSET_CONFIG_NAME
-        id: env
-        env:
-          name: "${{ matrix.asset_config_path }}"
-        # replace all '/' in asset path, not just first one, and write to $GITHUB_ENV
-        run: |
-          echo "ASSET_CONFIG_NAME=${name//\//-}" >> $GITHUB_ENV
-
       - name: Test asset
-        run: python -u $scripts_test_dir/test_assets.py -i "${{ matrix.asset_config_path }}" -a $asset_config_filename -p $scripts_test_dir/requirements.txt -r $GITHUB_WORKSPACE/$pytest_reports-"${{ env.ASSET_CONFIG_NAME }}"
+        run: python -u $scripts_test_dir/test_assets.py -i "${{ matrix.asset_config_path }}" -a $asset_config_filename -p $scripts_test_dir/requirements.txt -r $GITHUB_WORKSPACE/$pytest_reports-"${{ strategy.job-index }}"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}
-          path: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}
+          name: ${{ env.pytest_reports }}-${{ strategy.job-index }}
+          path: ${{ env.pytest_reports }}-${{ strategy.job-index }}
 
   report:
     name: Publish test results
@@ -179,8 +171,6 @@ jobs:
     needs:
       - test
       - setup
-    strategy:
-      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     permissions:
       # Required for EnricoMi/publish-unit-test-result-action
@@ -189,20 +179,13 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Sets ASSET_CONFIG_NAME
-        id: env
-        env:
-          name: "${{ matrix.asset_config_path }}"
-        # replace all '/' in asset path, not just first one, and write to $GITHUB_ENV
-        run: |
-          echo "ASSET_CONFIG_NAME=${name//\//-}" >> $GITHUB_ENV
-
-      - name: Download test results
+      - name: Download all test results
         id: download-artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}
-          path: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}
+          path: ${{ env.pytest_reports }}
+          pattern: ${{ env.pytest_reports }}-*
+          merge-multiple: true
         continue-on-error: true
 
       - name: Publish test results
@@ -210,4 +193,4 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           check_name: Test Results for ${{ github.workflow }}
-          junit_files: ${{ env.pytest_reports }}-${{ env.ASSET_CONFIG_NAME }}/**/*.xml
+          junit_files: ${{ env.pytest_reports }}/**/*.xml


### PR DESCRIPTION
With merged PR:

[Update RAI vision and text images to ubuntu 22.04 by imatiach-msft · Pull Request #3870 · Azure/azureml-assets](https://github.com/Azure/azureml-assets/pull/3870)

I updated the "Publish test results" step to publish for each test since it was failing when run on PRs with more than one asset updated.

As part of this I added the matrix:
```
    strategy:
      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
```
Now the name for this step changes depending on the number of assets tested and it will include asset_config_path, like:

![image](https://github.com/user-attachments/assets/76dbb0ce-836f-41f2-9c1f-b4a0b3b5c1e3)

"Publish test results" is set as mandatory, which is causing builds to show as missing one step:

![image](https://github.com/user-attachments/assets/8811f132-58b0-4ab6-8707-86c55312f269)

one solution would be to remove it from mandatory list. However, it looks like the publish step is just overwriting the results every time, and it might be better to publish all test results files in a folder for all tested assets:

![image](https://github.com/user-attachments/assets/a67a4d08-10c7-4144-8d1c-e09ad2db594f)

Note how this only displays one test suite but it would be better to display all of them.

I am also seeing errors on PRs that have no test for asset updates:

![image](https://github.com/user-attachments/assets/6a3130e5-4b8e-4450-ae51-82ac05d34c40)

This PR attempts to update this logic, so that all test results are uploaded and then published in one step.
In addition, it goes back to just one "Publish test results" step and removes the matrix, so it will appear on all PRs again (hence no config change would be needed).