### PR TITLE
Revert versions to match PROD

### DIFF
--- a/assets/models/system/phi-3.5-mini-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3.5-mini-128k-instruct/spec.yaml
@@ -80,4 +80,4 @@ tags:
     logging_steps: 10
     save_total_limit: 1
   benchmark: "quality"
-version: 7
+version: 6

--- a/assets/models/system/phi-3.5-moe-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3.5-moe-128k-instruct/spec.yaml
@@ -77,4 +77,4 @@ tags:
     logging_steps: 10
     save_total_limit: 1
   benchmark: "quality"
-version: 6
+version: 5


### PR DESCRIPTION
Looks like we have this version upgraded in the repo but never released to PROD and been long time. This prevents anybody from updating the tags on the models or any metadata and seems like next release is going to take time