### PR TITLE
Update RAI vision image to ubuntu 24.04 to fix opencv vulnerabilities

### DIFF
--- a/assets/responsibleai/environments/responsibleai-tabular/spec.yaml
+++ b/assets/responsibleai/environments/responsibleai-tabular/spec.yaml
@@ -13,6 +13,6 @@ build:
 os_type: linux
 
 tags:
-  OS: Ubuntu20.04
+  OS: Ubuntu22.04
   Training: ""
   Preview: ""

--- a/assets/responsibleai/environments/responsibleai-text/spec.yaml
+++ b/assets/responsibleai/environments/responsibleai-text/spec.yaml
@@ -13,6 +13,6 @@ build:
 os_type: linux
 
 tags:
-  OS: Ubuntu20.04
+  OS: Ubuntu22.04
   Training: ""
   Preview: ""

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azureml/openmpi4.1.0-ubuntu22.04:{{latest-image-tag}}
+FROM mcr.microsoft.com/azureml/openmpi5.0-ubuntu24.04:{{latest-image-tag}}
 
 # Install OpenCV native dependencies
 RUN apt-get update
@@ -59,7 +59,9 @@ RUN pip install 'cryptography>=43.0.1'
 RUN pip install 'Werkzeug>=3.0.3' \
                 'tqdm>=4.66.3' \
                 'onnx>=1.17.0'
-
+# To resolve GHSA-2586-f3p4-hq84 vulnerability issue for lightgbm<4.6.0
+# from azureml-automl-dnn-vision package
+RUN pip install 'lightgbm>=4.6.0'
 # To resolve CVE-2024-5480 vulnerability issue for torch < 2.2.2
 RUN pip install 'torch>=2.2.2'
 # To resolve GHSA-jh2j-j4j9-crg3 vulnerability issue

--- a/assets/responsibleai/environments/responsibleai-vision/spec.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision/spec.yaml
@@ -13,6 +13,6 @@ build:
 os_type: linux
 
 tags:
-  OS: Ubuntu20.04
+  OS: Ubuntu24.04
   Training: ""
   Preview: ""


### PR DESCRIPTION
Update RAI vision image to ubuntu 24.04 to fix opencv vulnerabilities

Also updates lightgbm to >4.6.0 to fix GHSA-2586-f3p4-hq84. Updates OS tags for tabular and text to ubuntu 22.04 and vision to ubuntu 24.04.

Copilot summary:
This pull request includes several updates to the `responsibleai` environments, focusing on updating the operating system versions and addressing vulnerabilities in dependencies.

Operating system updates:

* [`assets/responsibleai/environments/responsibleai-tabular/spec.yaml`](diffhunk://#diff-f9299ddfe13c32354a70f2cfa0e080a7c8260c20146131de0c0bfa73e6f18c6fL16-R16): Updated OS tag from Ubuntu20.04 to Ubuntu22.04.
* [`assets/responsibleai/environments/responsibleai-text/spec.yaml`](diffhunk://#diff-8d8e393b8bdb4d53cc622c28c9b63939408da4ce33364900df792b98b67570e4L16-R16): Updated OS tag from Ubuntu20.04 to Ubuntu22.04.
* [`assets/responsibleai/environments/responsibleai-vision/spec.yaml`](diffhunk://#diff-1d291114d87ff20bf098db381d8bf8fb91c08229a4b76c77be38906c06e571ebL16-R16): Updated OS tag from Ubuntu20.04 to Ubuntu24.04.

Dependency updates:

* [`assets/responsibleai/environments/responsibleai-vision/context/Dockerfile`](diffhunk://#diff-63e8d3e23a82c973cac28e2ccdeaffb75572227077da3e55339d9c9e9696d976L1-R1): Changed base image from `openmpi4.1.0-ubuntu22.04` to `openmpi5.0-ubuntu24.04`.
* [`assets/responsibleai/environments/responsibleai-vision/context/Dockerfile`](diffhunk://#diff-63e8d3e23a82c973cac28e2ccdeaffb75572227077da3e55339d9c9e9696d976L62-R64): Added installation of `lightgbm>=4.6.0` to resolve GHSA-2586-f3p4-hq84 vulnerability issue.