### PR TITLE
[BugFix]: Validate for type in transformers image classification and …

### DIFF
--- a/assets/training/finetune_acft_image/components/finetune/hf_classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/hf_classification/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
-version: 0.0.21
+version: 0.0.22
 name: transformers_image_classification_finetune
 display_name: Image Classification HuggingFace Transformers Model Finetune
 description: Component to finetune HuggingFace transformers models for image classification.
@@ -340,7 +340,7 @@ command: >-
   $[[--precision ${{inputs.precision}}]]
   $[[--label_smoothing_factor ${{inputs.label_smoothing_factor}}]]
   $[[--seed ${{inputs.random_seed}}]]
-  $[[--evaluation_strategy ${{inputs.evaluation_strategy}}]]
+  $[[--eval_strategy ${{inputs.evaluation_strategy}}]]
   $[[--eval_steps ${{inputs.evaluation_steps}}]]
   $[[--logging_strategy ${{inputs.logging_strategy}}]]
   $[[--logging_steps ${{inputs.logging_steps}}]]

--- a/assets/training/finetune_acft_image/components/pipeline_components/hf_classification/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/hf_classification/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.24
+version: 0.0.25
 name: transformers_image_classification_pipeline
 display_name: Image Classification HuggingFace Transformers Pipeline
 description: Pipeline component for image classification using HuggingFace transformers models.
@@ -385,10 +385,6 @@ outputs:
   pytorch_model_folder:
     type: custom_model
     description: Output dir to save the finetune model as torch model.
-  # ######################### Compute metrics Component ######################### #
-  evaluation_result:
-    type: uri_folder
-    description: Test Data Evaluation Results
 
 jobs:
   finetune_common_validation:
@@ -428,7 +424,7 @@ jobs:
 
   image_classification_finetune:
     type: command
-    component: azureml:transformers_image_classification_finetune:0.0.21
+    component: azureml:transformers_image_classification_finetune:0.0.22
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch

--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/requirements.txt
@@ -7,7 +7,7 @@ requests
 datasets==2.19.0
 transformers==4.48.0
 accelerate==0.29.3
-optimum==1.23.3
+optimum==1.24.0
 diffusers==0.27.2
 huggingface-hub==0.25.2
 setuptools>=71.1.0

--- a/assets/training/finetune_acft_image/src/finetune/finetune.py
+++ b/assets/training/finetune_acft_image/src/finetune/finetune.py
@@ -424,7 +424,7 @@ def get_parser():
 
     # # evaluation
     parser.add_argument(
-        "--evaluation_strategy",
+        "--eval_strategy",
         type=str,
         choices=(
             IntervalStrategy.NO,
@@ -883,7 +883,21 @@ def main():
     """Driver function."""
     parser = get_parser()
     args, _ = parser.parse_known_args()
+    # Validate argument types without modifying args
+    for action in parser._actions:
+        arg_name = action.dest
+        expected_type = action.type
+        arg_value = getattr(args, arg_name, None)
 
+        if expected_type and arg_value is not None:
+            try:
+                # Attempt to cast the argument to the expected type without modifying args
+                expected_type(arg_value)
+            except (ValueError, TypeError):
+                error_msg = f"Argument '{arg_name}' expects type {expected_type.__name__}, but got value '{arg_value}'"
+                raise ACFTValidationException._with_error(
+                    AzureMLError.create(ACFTUserError, pii_safe_message=error_msg)
+                )
     print(f"Deepspeed Version: {deepspeed.__version__}")
 
     if args.task_name in [Tasks.HF_SD_TEXT_TO_IMAGE]:


### PR DESCRIPTION
…optimum upgrade compat changes

e2e test run : <a href="https://ml.azure.com/experiments/id/3cfa7d04-03b8-4d43-a540-b8d6f93e43b4/runs/d970e478-50c9-4fab-aa21-a0f02465c2ae?wsid=/subscriptions/dbd697c3-ef40-488f-83e6-5ad4dfb78f9b/resourceGroups/rdondera/providers/Microsoft.MachineLearningServices/workspaces/validatr&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" target="_blank">Image Classification HuggingFace Transformers Model Finetune
 </a>

1. Optimum in latest version has renamed evaluation_strategy to eval_strategy
2. pre-validation in all arguments to be in its required dtype