### PR TITLE
Allow customers to specify additional train/evaluation files

### DIFF
--- a/assets/training/finetune_acft_image/components/finetune/medimage_insight/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_insight/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: medimgage_embedding_finetune
-version: 0.0.2
+version: 0.0.3
 
 type: command
 
@@ -31,6 +31,18 @@ inputs:
     type: uri_file
     optional: false
     description: Path to the evaluation text TSV file.
+    mode: ro_mount
+
+  eval_train_image_tsv:
+    type: uri_file
+    optional: true
+    description: Optional path used for the evaluation task. If not specified, will use the training path.
+    mode: ro_mount
+
+  eval_train_text_tsv:
+    type: uri_file
+    optional: true
+    description: Optional path used for the evaluation task. If not specified, will use the training path.
     mode: ro_mount
 
   image_tsv:
@@ -75,6 +87,8 @@ command: >-
   --mlflow_model_folder '${{inputs.mlflow_model_path}}'
   --eval_image_tsv "${{inputs.eval_image_tsv}}"
   --eval_text_tsv "${{inputs.eval_text_tsv}}"
+  $[[--eval_train_image_tsv "${{inputs.eval_train_image_tsv}}"]]
+  $[[--eval_train_text_tsv "${{inputs.eval_train_text_tsv}}"]]
   --image_tsv "${{inputs.image_tsv}}"
   --text_tsv "${{inputs.text_tsv}}"
   --label_file "${{inputs.label_file}}"

--- a/assets/training/finetune_acft_image/components/pipeline_components/medimage_insight_ft/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/medimage_insight_ft/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: medimage_insight_ft_pipeline
-version: 0.0.2
+version: 0.0.3
 type: pipeline
 display_name: Medimage Insight Finetune Pipeline
 description: Pipeline Component to finetune MedImageInsight Model.
@@ -22,6 +22,18 @@ inputs:
     type: uri_file
     optional: false
     description: Path to the evaluation text TSV file.
+    mode: ro_mount
+
+  eval_train_image_tsv:
+    type: uri_file
+    optional: true
+    description: Optional path used for the evaluation task. If not specified, will use the training path.
+    mode: ro_mount
+
+  eval_train_text_tsv:
+    type: uri_file
+    optional: true
+    description: Optional path used for the evaluation task. If not specified, will use the training path.
     mode: ro_mount
 
   image_tsv:
@@ -96,7 +108,7 @@ outputs:
 jobs:
   medical_image_embedding_model_finetune:
     type: command
-    component: azureml:medimgage_embedding_finetune:0.0.2
+    component: azureml:medimgage_embedding_finetune:0.0.3
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'
@@ -108,6 +120,8 @@ jobs:
       mlflow_model_path: '${{parent.inputs.mlflow_embedding_model_path}}'
       eval_image_tsv: '${{parent.inputs.eval_image_tsv}}'
       eval_text_tsv: '${{parent.inputs.eval_text_tsv}}'
+      eval_train_image_tsv: '${{parent.inputs.eval_train_image_tsv}}'
+      eval_train_text_tsv: '${{parent.inputs.eval_train_text_tsv}}'
       image_tsv: '${{parent.inputs.image_tsv}}'
       text_tsv: '${{parent.inputs.text_tsv}}'
       label_file: '${{parent.inputs.label_file}}'

--- a/assets/training/finetune_acft_image/src/medimage_insight_embedding_finetune/medimage_embedding_finetune.py
+++ b/assets/training/finetune_acft_image/src/medimage_insight_embedding_finetune/medimage_embedding_finetune.py
@@ -26,6 +26,8 @@ CHECKPOINT_PATH = "artifacts/checkpoints/vision_model/medimageinsigt-v1.0.0.pt"
 LANG_ENCODER_PATH = "artifacts/checkpoints/language_model/clip_tokenizer_4.16.2"
 EVAL_IMAGE_TSV = 'EVAL_IMAGE_TSV'
 EVAL_TEXT_TSV = 'EVAL_TEXT_TSV'
+EVAL_TRAIN_IMAGE_TSV = 'EVAL_TRAIN_IMAGE_TSV'
+EVAL_TRAIN_TEXT_TSV = 'EVAL_TRAIN_TEXT_TSV'
 IMAGE_TSV = 'IMAGE_TSV'
 TEXT_TSV = 'TEXT_TSV'
 LABEL_FILE = 'LABEL_FILE'
@@ -265,6 +267,20 @@ def get_parser() -> argparse.ArgumentParser:
         help='Path to evaluation text TSV file.'
     )
     parser.add_argument(
+        '--eval_train_image_tsv',
+        type=str,
+        help='Optional path used for the evaluation task. If not specified, will use the training path.',
+        default="",
+        required=False
+    )
+    parser.add_argument(
+        '--eval_train_text_tsv',
+        type=str,
+        help='Optional path used for the evaluation task. If not specified, will use the training path.',
+        default="",
+        required=False
+    )
+    parser.add_argument(
         '--image_tsv',
         type=str,
         help='Path to training image TSV file.'
@@ -369,6 +385,12 @@ def load_opt_command(cmdline_args: argparse.Namespace) -> Tuple[Dict[str, Any], 
     image_tsv = copy_tsv(cmdline_args[IMAGE_TSV], opt[SAVE_DIR])
     text_tsv = copy_tsv(cmdline_args[TEXT_TSV], opt[SAVE_DIR])
     label_file = copy_tsv(cmdline_args[LABEL_FILE], opt[SAVE_DIR])
+    eval_train_image_tsv = image_tsv
+    eval_train_text_tsv = text_tsv
+    if cmdline_args.get(EVAL_TRAIN_IMAGE_TSV):
+        eval_train_image_tsv = copy_tsv(cmdline_args[EVAL_TRAIN_IMAGE_TSV], opt[SAVE_DIR])
+    if cmdline_args.get(EVAL_TRAIN_TEXT_TSV):
+        eval_train_text_tsv = copy_tsv(cmdline_args[EVAL_TRAIN_TEXT_TSV], opt[SAVE_DIR])
 
     if DATASET in opt and ROOT in opt[DATASET]:
         opt[DATASET]["TRAIN_TSV_LIST"] = [image_tsv, text_tsv]
@@ -379,8 +401,8 @@ def load_opt_command(cmdline_args: argparse.Namespace) -> Tuple[Dict[str, Any], 
         if key.startswith('EVALDATASET_'):
             opt[key][EVAL_IMAGE_TSV] = eval_image_tsv
             opt[key][EVAL_TEXT_TSV] = eval_text_tsv
-            opt[key][IMAGE_TSV] = image_tsv
-            opt[key][TEXT_TSV] = text_tsv
+            opt[key][IMAGE_TSV] = eval_train_image_tsv
+            opt[key][TEXT_TSV] = eval_train_text_tsv
             opt[key][LABEL_FILE] = label_file
 
     opt[USER_DIR] = os.path.dirname(mv.__file__)


### PR DESCRIPTION
Evaluation tasks in MI2 only support classification
If a customer wants to finetune MI2 using multi-label data (captions), they need to be able to specify a different dataset for the evaluation portion of their data.
This change allows us to support 2 optional files in the pipeline that will be used for this evaluation.

Example run with 6 files (captions)
https://ml.azure.com/runs/good_tree_4s7wtc126d?wsid=/subscriptions/1b12b3fb-e309-4f14-b551-1affe9e4ac57/resourcegroups/mablonde-ai-studio-test/workspaces/hubless&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#

And a standard classification run (to verify no regressions):
https://ml.azure.com/runs/neat_ticket_2ncmgmxtcf?wsid=/subscriptions/1b12b3fb-e309-4f14-b551-1affe9e4ac57/resourcegroups/mablonde-ai-studio-test/workspaces/hubless&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#
