### PR TITLE
Fix RAI Vision liburiparser1 and libzvbi0t64 image vulnerabilities

### DIFF
--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update
 RUN apt-get install -y python3-opencv
 RUN apt-get remove -y libavutil58 libswresample4 libavformat60
 RUN apt-get remove -y libavcodec60 libswscale7 libpmix2 libcjson1
+RUN apt-get remove -y liburiparser1 libzvbi0t64
 
 WORKDIR /
 ENV CONDA_PREFIX=/azureml-envs/responsibleai-vision

--- a/assets/responsibleai/tabular/components/causal/spec.yaml
+++ b/assets/responsibleai/tabular/components/causal/spec.yaml
@@ -58,7 +58,7 @@ outputs:
 
 code: ../src/
 
-environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/14
+environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/18
 
 command: >-
   python create_causal.py

--- a/assets/responsibleai/tabular/components/counterfactual/spec.yaml
+++ b/assets/responsibleai/tabular/components/counterfactual/spec.yaml
@@ -38,7 +38,7 @@ outputs:
 
 code: ../src/
 
-environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/14
+environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/18
 
 command: >-
   python create_counterfactual.py

--- a/assets/responsibleai/tabular/components/error_analysis/spec.yaml
+++ b/assets/responsibleai/tabular/components/error_analysis/spec.yaml
@@ -27,7 +27,7 @@ outputs:
 
 code: ../src/
 
-environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/14
+environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/18
 
 command: >-
   python create_error_analysis.py

--- a/assets/responsibleai/tabular/components/explanation/spec.yaml
+++ b/assets/responsibleai/tabular/components/explanation/spec.yaml
@@ -17,7 +17,7 @@ outputs:
 
 code: ../src/
 
-environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/14
+environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/18
 
 command: >-
   python create_explanation.py

--- a/assets/responsibleai/tabular/components/insight_create/spec.yaml
+++ b/assets/responsibleai/tabular/components/insight_create/spec.yaml
@@ -44,7 +44,7 @@ outputs:
   rai_insights_dashboard:
     type: path
 code: ../src/
-environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/14
+environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/18
 command: >-
   python create_rai_insights.py
   --title '${{inputs.title}}'

--- a/assets/responsibleai/tabular/components/insight_gather/spec.yaml
+++ b/assets/responsibleai/tabular/components/insight_gather/spec.yaml
@@ -27,7 +27,7 @@ outputs:
   ux_json:
     type: path
 
-environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/14
+environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/18
 
 code: ../src/
 

--- a/assets/responsibleai/tabular/components/score_card/spec.yaml
+++ b/assets/responsibleai/tabular/components/score_card/spec.yaml
@@ -17,7 +17,7 @@ outputs:
   scorecard:
     type: path
 
-environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/14
+environment: azureml://registries/azureml/environments/responsibleai-tabular/versions/18
 
 code: ../src/
 

--- a/assets/responsibleai/text/components/rai_text_insights/spec.yaml
+++ b/assets/responsibleai/text/components/rai_text_insights/spec.yaml
@@ -69,7 +69,7 @@ outputs:
     type: path
     description: Json file to which UX is serialized to for viewing in static AzureML Studio UI
 code: ../src
-environment: azureml://registries/azureml/environments/responsibleai-text/versions/16
+environment: azureml://registries/azureml/environments/responsibleai-text/versions/17
 command: >-
   python ./rai_text_insights.py
   --task_type ${{inputs.task_type}}

--- a/assets/responsibleai/vision/components/rai_vision_insights/spec.yaml
+++ b/assets/responsibleai/vision/components/rai_vision_insights/spec.yaml
@@ -116,7 +116,7 @@ outputs:
     type: path
     description: Json file to which UX is serialized to for viewing in static AzureML Studio UI
 code: ../src
-environment: azureml://registries/azureml/environments/responsibleai-vision/versions/19
+environment: azureml://registries/azureml/environments/responsibleai-vision/versions/21
 command: >-
   python ./rai_vision_insights.py
   --task_type ${{inputs.task_type}}


### PR DESCRIPTION
Fix RAI Vision liburiparser1 and libzvbi0t64 image vulnerabilities

Vulnerabilities:
https://ubuntu.com/security/notices/USN-7367-1 
https://ubuntu.com/security/notices/USN-7356-1 

Tested and verified in internal responsibleai repository.