### PR TITLE
Create new local model versions for models with perf issues

### DIFF
--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-cuda-gpu/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-1.5b/onnx/cuda/cuda-int4-rtn-block-32
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-1.5b/onnx/cuda/cuda-int4-kquant-block-128-mixed/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-cuda-gpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-cuda-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'CUDAExecutionProvider'
-    fileSizeBytes: 1073741824
-    vRamFootprintBytes: 1362861314
+    fileSizeBytes: 1535450808
+    vRamFootprintBytes: 1535670046

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-cuda-gpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-qwen-1.5b-cuda-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-1.5b
-  directoryPath: cuda-int4-rtn-block-32
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-cpu/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-1.5b/onnx/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-1.5b/onnx/cpu_and_mobile/cpu-int4-kquant-block-128-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-cpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-qwen-1.5b-generic-cpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-1.5b
-  directoryPath: cpu-int4-rtn-block-32-acc-level-4
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-cpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-cpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 1964944541
-    vRamFootprintBytes: 1965162961
+    fileSizeBytes: 2061584302
+    vRamFootprintBytes: 2061807165

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-1.5b/onnx/directml/directml-int4-rtn-block-32-acc-level-4
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-1.5b/onnx/webgpu/webgpu-int4-kquant-block-32-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-1.5b/onnx/webgpu/webgpu-int4-kquant-block-32-mixed-acc-level-4/v2
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-1.5b/onnx/webgpu/webgpu-int4-kquant-block-32-mixed-acc-level-4/v1
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/spec.yaml
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-1.5b
-  directoryPath: v2
+  directoryPath: v1
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'WebGPUExecutionProvider'
-    fileSizeBytes: 1362648117
-    vRamFootprintBytes: 1362929128
+    fileSizeBytes: 1610612736
+    vRamFootprintBytes: 1610930124

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-qwen-1.5b-generic-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-1.5b
-  directoryPath: directml-int4-rtn-block-32-acc-level-4
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-1.5b
+  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-1.5b
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-1.5B/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-1.5b
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-1.5b
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-cuda-gpu/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-7b/onnx/cuda/cuda-int4-rtn-block-32
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-7b/onnx/cuda/cuda-int4-kquant-block-128-mixed/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-cuda-gpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-cuda-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'CUDAExecutionProvider'
-    fileSizeBytes: 5096273664
-    vRamFootprintBytes: 5096487731
+    fileSizeBytes: 5669356830
+    vRamFootprintBytes: 5669577287

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-cuda-gpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-qwen-7b-cuda-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-7b
-  directoryPath: cuda-int4-rtn-block-32
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-cpu/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-7b/onnx/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-7b/onnx/cpu_and_mobile/cpu-int4-kquant-block-128-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-cpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-cpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 6667944735
-    vRamFootprintBytes: 6668163013
+    fileSizeBytes: 6904159928
+    vRamFootprintBytes: 6904383723

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-cpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-qwen-7b-generic-cpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-7b
-  directoryPath: cpu-int4-rtn-block-32-acc-level-4
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-gpu/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-7b/onnx/directml/directml-int4-rtn-block-32-acc-level-4
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-7b/onnx/webgpu/webgpu-int4-kquant-block-32-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-gpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'WebGPUExecutionProvider'
-    fileSizeBytes: 5096273664
-    vRamFootprintBytes: 5096556544
+    fileSizeBytes: 5991479377
+    vRamFootprintBytes: 5991798210

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-gpu/spec.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-qwen-7b-generic-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-7b
-  directoryPath: directml-int4-rtn-block-32-acc-level-4
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-7b
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-7b
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/DeepSeek-R1-Distill-Qwen-7B/model.yaml
+++ b/assets/models/system/DeepSeek-R1-Distill-Qwen-7B/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-7b
+  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-7b
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/Phi-4-reasoning-cuda-gpu/spec.yaml
+++ b/assets/models/system/Phi-4-reasoning-cuda-gpu/spec.yaml
@@ -16,7 +16,7 @@ tags:
 type: custom_model
 variantInfo:
   parents:
-  - assetId: azureml://registries/azureml/models/Phi-4-reasoning/versions/7
+  - assetId: azureml://registries/azureml/models/Phi-4-reasoning/versions/1
   variantMetadata:
     modelType: 'ONNX'
     quantization: ['RTN']

--- a/assets/models/system/Phi-4-reasoning-generic-cpu/spec.yaml
+++ b/assets/models/system/Phi-4-reasoning-generic-cpu/spec.yaml
@@ -16,7 +16,7 @@ tags:
 type: custom_model
 variantInfo:
   parents:
-  - assetId: azureml://registries/azureml/models/Phi-4-reasoning/versions/7
+  - assetId: azureml://registries/azureml/models/Phi-4-reasoning/versions/1
   variantMetadata:
     modelType: 'ONNX'
     quantization: ['RTN']

--- a/assets/models/system/deepseek-r1-distill-llama-8b-cuda-gpu/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-llama-8b/onnx/cuda/cuda-int4-rtn-block-32
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-llama-8b/onnx/cuda/cuda-int4-kquant-block-128-mixed/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/deepseek-r1-distill-llama-8b-cuda-gpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b-cuda-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'CUDAExecutionProvider'
-    fileSizeBytes: 5304284610
-    vRamFootprintBytes: 5304515348
+    fileSizeBytes: 5927054868
+    vRamFootprintBytes: 5927293839

--- a/assets/models/system/deepseek-r1-distill-llama-8b-cuda-gpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-llama-8b-cuda-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-8b
-  directoryPath: cuda-int4-rtn-block-32
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/deepseek-r1-distill-llama-8b-generic-cpu/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-llama-8b/onnx/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-llama-8b/onnx/cpu_and_mobile/cpu-int4-kquant-block-128-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/deepseek-r1-distill-llama-8b-generic-cpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-llama-8b-generic-cpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-8b
-  directoryPath: cpu-int4-rtn-block-32-acc-level-4
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/deepseek-r1-distill-llama-8b-generic-cpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b-generic-cpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 6861210255
-    vRamFootprintBytes: 6861445345
+    fileSizeBytes: 7126964711
+    vRamFootprintBytes: 7126988563

--- a/assets/models/system/deepseek-r1-distill-llama-8b-generic-gpu/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-llama-8b/onnx/directml/directml-int4-rtn-block-32-acc-level-4
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-llama-8b/onnx/webgpu/webgpu-int4-kquant-block-32-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/deepseek-r1-distill-llama-8b-generic-gpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-llama-8b-generic-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-8b
-  directoryPath: directml-int4-rtn-block-32-acc-level-4
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/deepseek-r1-distill-llama-8b-generic-gpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b-generic-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'WebGPUExecutionProvider'
-    fileSizeBytes: 5304284610
-    vRamFootprintBytes: 5304568647
+    fileSizeBytes: 6216965160
+    vRamFootprintBytes: 6217290792

--- a/assets/models/system/deepseek-r1-distill-llama-8b/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-llama-8b
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-llama-8b
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/deepseek-r1-distill-llama-8b/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-llama-8b/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-llama-8b
+  container_path: foundrylocal/foundry-local/deepseek-r1-distill-llama-8b
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/deepseek-r1-distill-qwen-14b-cuda-gpu/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-14b/onnx/cuda/cuda-int4-rtn-block-32
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-14b/onnx/cuda/cuda-int4-kquant-block-128-mixed/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/deepseek-r1-distill-qwen-14b-cuda-gpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b-cuda-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'CUDAExecutionProvider'
-    fileSizeBytes: 9459665469
-    vRamFootprintBytes: 9460030894
+    fileSizeBytes: 10554882129
+    vRamFootprintBytes: 10555257559

--- a/assets/models/system/deepseek-r1-distill-qwen-14b-cuda-gpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-qwen-14b-cuda-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-14b
-  directoryPath: cuda-int4-rtn-block-32
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/deepseek-r1-distill-qwen-14b-generic-cpu/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-14b/onnx/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-14b/onnx/cpu_and_mobile/cpu-int4-kquant-block-128-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/deepseek-r1-distill-qwen-14b-generic-cpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b-generic-cpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 11929271664
-    vRamFootprintBytes: 11929644103
+    fileSizeBytes: 12358768394
+    vRamFootprintBytes: 12359149537

--- a/assets/models/system/deepseek-r1-distill-qwen-14b-generic-cpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-qwen-14b-generic-cpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-14b
-  directoryPath: cpu-int4-rtn-block-32-acc-level-4
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/deepseek-r1-distill-qwen-14b-generic-gpu/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-14b/onnx/directml/directml-int4-rtn-block-32-acc-level-4
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-14b/onnx/webgpu/webgpu-int4-kquant-block-32-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/deepseek-r1-distill-qwen-14b-generic-gpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b-generic-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'WebGPUExecutionProvider'
-    fileSizeBytes: 9459665469
-    vRamFootprintBytes: 9460148039
+    fileSizeBytes: 11027328532
+    vRamFootprintBytes: 11027872808

--- a/assets/models/system/deepseek-r1-distill-qwen-14b-generic-gpu/spec.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: deepseek-r1-distill-qwen-14b-generic-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-14b
-  directoryPath: directml-int4-rtn-block-32-acc-level-4
+  directoryPath: v2
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/deepseek-r1-distill-qwen-14b/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-14b
+  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-14b
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/deepseek-r1-distill-qwen-14b/model.yaml
+++ b/assets/models/system/deepseek-r1-distill-qwen-14b/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/fl-perf-improvements/deepseek-r1-distill-qwen-14b
+  container_path: foundrylocal/foundry-local/deepseek-r1-distill-qwen-14b
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/phi-4-mini-instruct-cuda-gpu/model.yaml
+++ b/assets/models/system/phi-4-mini-instruct-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/onnx-models/phi-4-mini-instruct/onnx/cuda/cuda-int4-int8
+  container_path: foundrylocal/fl-perf-improvements/phi-4-mini-instruct/onnx/cuda/cuda-int4-kquant-block-128-mixed/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/phi-4-mini-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/system/phi-4-mini-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-instruct-cuda-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: phi-4-mini
-  directoryPath: cuda-int4-int8
+  directoryPath: v2
   promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|end|>\", \"user\": \"<|user|>\\n{Content}<|end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|end|>\", \"prompt\": \"<|user|>\\n{Content}<|end|>\\n<|assistant|>\", \"tool_spec\": \"<|tool|>\\n{Content}<|end|>\", \"tool\": \"<|tool_response|>\\n{Content}<|end|>\", \"tool_prompt\": \"<|tool_response|>\\n{Content}<|end|>\\n<|assistant|>\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/phi-4-mini-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/system/phi-4-mini-instruct-cuda-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'CUDAExecutionProvider'
-    fileSizeBytes: 4101693767
-    vRamFootprintBytes: 4127970082
+    fileSizeBytes: 3865470566
+    vRamFootprintBytes: 3892090994

--- a/assets/models/system/phi-4-mini-instruct-generic-cpu/model.yaml
+++ b/assets/models/system/phi-4-mini-instruct-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/onnx-models/phi-4-mini-instruct/onnx/cpu_and_mobile/cpu-int4-int8
+  container_path: foundrylocal/fl-perf-improvements/phi-4-mini-instruct/onnx/cpu_and_mobile/cpu-int4-kquant-block-128-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/phi-4-mini-instruct-generic-cpu/spec.yaml
+++ b/assets/models/system/phi-4-mini-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-instruct-generic-cpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: phi-4-mini
-  directoryPath: cpu-int4-int8
+  directoryPath: v2
   promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|end|>\", \"user\": \"<|user|>\\n{Content}<|end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|end|>\", \"prompt\": \"<|user|>\\n{Content}<|end|>\\n<|assistant|>\", \"tool_spec\": \"<|tool|>\\n{Content}<|end|>\", \"tool\": \"<|tool_response|>\\n{Content}<|end|>\", \"tool_prompt\": \"<|tool_response|>\\n{Content}<|end|>\\n<|assistant|>\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/phi-4-mini-instruct-generic-cpu/spec.yaml
+++ b/assets/models/system/phi-4-mini-instruct-generic-cpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 5572720066
-    vRamFootprintBytes: 5625235751
+    fileSizeBytes: 5153960755
+    vRamFootprintBytes: 5206105439

--- a/assets/models/system/phi-4-mini-instruct-generic-gpu/model.yaml
+++ b/assets/models/system/phi-4-mini-instruct-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/foundry-local-missing/phi-4-mini-instruct/onnx/webgpu/webgpu-int4-rtn-block-32-acc-level-4
+  container_path: foundrylocal/fl-perf-improvements/phi-4-mini-instruct/onnx/webgpu/webgpu-int4-kquant-block-32-mixed-acc-level-4/v2
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/phi-4-mini-instruct-generic-gpu/spec.yaml
+++ b/assets/models/system/phi-4-mini-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-instruct-generic-gpu
-version: 1
+version: v2
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: phi-4-mini
-  directoryPath: webgpu-int4-rtn-block-32-acc-level-4
+  directoryPath: v2
   promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|end|>\", \"user\": \"<|user|>\\n{Content}<|end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|end|>\", \"prompt\": \"<|user|>\\n{Content}<|end|>\\n<|assistant|>\", \"tool_spec\": \"<|tool|>\\n{Content}<|end|>\", \"tool\": \"<|tool_response|>\\n{Content}<|end|>\", \"tool_prompt\": \"<|tool_response|>\\n{Content}<|end|>\\n<|assistant|>\"}"
 type: custom_model
 variantInfo:

--- a/assets/models/system/phi-4-mini-instruct-generic-gpu/spec.yaml
+++ b/assets/models/system/phi-4-mini-instruct-generic-gpu/spec.yaml
@@ -23,5 +23,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'WebGPUExecutionProvider'
-    fileSizeBytes: 3382286745
-    vRamFootprintBytes: 3408532602
+    fileSizeBytes: 3994319585
+    vRamFootprintBytes: 4020946899

--- a/assets/models/system/qwen2.5-coder-1.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/system/qwen2.5-coder-1.5b-instruct-generic-gpu/spec.yaml
@@ -1,5 +1,5 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
-name: qwen2.5-coder-1.5b-generic-gpu
+name: qwen2.5-coder-1.5b-instruct-generic-gpu
 version: 1
 path: ./
 tags:


### PR DESCRIPTION
Summary of changes:

1. Publish new models with improved perf (`deepseek-r1-distill-llama-8b`, `deepseek-r1-distill-qwen-1.5b`, `deepseek-r1-distill-qwen-14b`, `deepseek-r1-distill-qwen-7b`, `phi-4-mini-instruct`)
2. Fix issue with Qwen2.5-coder-1.5b generic GPU variant naming (missing `instruct`)
3. Fix issue with Phi-4-reasoning parent assetId (wrong version)