### PR TITLE
Fix Phi-4-mini-instruct-generic-gpu version metadata

### DIFF
--- a/assets/models/system/phi-4-mini-instruct-generic-gpu/spec.yaml
+++ b/assets/models/system/phi-4-mini-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-instruct-generic-gpu
-version: v2
+version: 2
 path: ./
 tags:
   foundryLocal: ""


### PR DESCRIPTION
Phi-4-mini-instruct-generic-gpu version metadata was "v2" instead of "2", causing an error when trying to release new version.