### PR TITLE
Add CPU accuracy level 4 local models

### DIFF
--- a/assets/models/system/Mistral-7B-Instruct-v0-2-generic-cpu/model.yaml
+++ b/assets/models/system/Mistral-7B-Instruct-v0-2-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/onnx-models/mistral-7b-instruct-v0.2/onnx/cpu_and_mobile/mistral-7b-instruct-v0.2-cpu-int4-rtn-block-32
+  container_path: foundrylocal/onnx-models/mistral-7b-instruct-v0.2/onnx/cpu_and_mobile/mistral-7b-instruct-v0.2-cpu-int4-rtn-block-32-acc-level-4
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/phi-3-mini-128k-instruct-generic-cpu/model.yaml
+++ b/assets/models/system/phi-3-mini-128k-instruct-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/onnx-models/phi-3-mini-128k-instruct/onnx/cpu_and_mobile/phi-3-mini-128k-instruct-cpu-int4-rtn-block-32
+  container_path: foundrylocal/foundry-local-missing/phi-3-mini-128k-instruct/onnx/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:

--- a/assets/models/system/phi-3-mini-4k-instruct-generic-cpu/model.yaml
+++ b/assets/models/system/phi-3-mini-4k-instruct-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/onnx-models/phi-3-mini-4k-instruct/onnx/cpu_and_mobile/phi-3-mini-4k-instruct-cpu-int4-rtn-block-32
+  container_path: foundrylocal/foundry-local-missing/phi-3-mini-4k-instruct/onnx/cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4
   storage_name: automlcesdkdataresources
   type: azureblob
 publish:


### PR DESCRIPTION
Switch to CPU models w/ `accuracy_level=4` for the following local models to improve speed:

1. Mistral-7B-Instruct-v0.2
2. Phi-3-128k-Instruct
3. Phi-3-4k-Instruct