### PR TITLE
Pin OAI sdk version to 1.77

### DIFF
--- a/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
+++ b/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
@@ -2,7 +2,7 @@ azure-ai-evaluation==1.6.0
 azureml-mlflow=={{latest-pypi-version}}
 azure-ai-ml=={{latest-pypi-version}}
 
-openai=={{latest-pypi-version}}
+openai==1.77.0
 opentelemetry-api==1.31.0
 opentelemetry-sdk==1.31.0
 azure-monitor-query=={{latest-pypi-version}}


### PR DESCRIPTION
currently, the latest azure sdk version (1.16.0) conflicts with the latest open ai version (1.78.1)
to fix this, we'll pin the open ai sdk version to 1.77.0