### PR TITLE
Update promptTemplate and parameterSchema tags for some local models

### DIFF
--- a/assets/models/system/Phi-4-cuda-gpu/spec.yaml
+++ b/assets/models/system/Phi-4-cuda-gpu/spec.yaml
@@ -13,7 +13,7 @@ tags:
   maxOutputTokens: 2048
   alias: phi-4
   directoryPath: cuda-int4-rtn-block-32
-  promptTemplate: "{\"system\": \"<|im_start|>system<|im_sep|>{Content}<|im_end|>\", \"user\": \"<|im_start|>user<|im_sep|>{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant<|im_sep|>{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user<|im_sep|>{Content}<|im_end|><|im_start|>assistant<|im_sep|>\"}"
+  promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|end|>\", \"user\": \"<|user|>\\n{Content}<|end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|end|>\", \"prompt\": \"<|user|>\\n{Content}<|end|>\\n<|assistant|>\"}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/Phi-4-cuda-gpu/spec.yaml
+++ b/assets/models/system/Phi-4-cuda-gpu/spec.yaml
@@ -13,7 +13,7 @@ tags:
   maxOutputTokens: 2048
   alias: phi-4
   directoryPath: cuda-int4-rtn-block-32
-  promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|end|>\", \"user\": \"<|user|>\\n{Content}<|end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|end|>\", \"prompt\": \"<|user|>\\n{Content}<|end|>\\n<|assistant|>\"}"
+  promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|im_end|>\", \"user\": \"<|user|>\\n{Content}<|im_end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|im_end|>\", \"prompt\": \"<|user|>\\n{Content}<|im_end|>\\n<|assistant|>\"}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/Phi-4-generic-cpu/spec.yaml
+++ b/assets/models/system/Phi-4-generic-cpu/spec.yaml
@@ -13,7 +13,7 @@ tags:
   maxOutputTokens: 2048
   alias: phi-4
   directoryPath: cpu-int4-rtn-block-32-acc-level-4
-  promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|end|>\", \"user\": \"<|user|>\\n{Content}<|end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|end|>\", \"prompt\": \"<|user|>\\n{Content}<|end|>\\n<|assistant|>\"}"
+  promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|im_end|>\", \"user\": \"<|user|>\\n{Content}<|im_end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|im_end|>\", \"prompt\": \"<|user|>\\n{Content}<|im_end|>\\n<|assistant|>\"}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/Phi-4-generic-cpu/spec.yaml
+++ b/assets/models/system/Phi-4-generic-cpu/spec.yaml
@@ -13,7 +13,7 @@ tags:
   maxOutputTokens: 2048
   alias: phi-4
   directoryPath: cpu-int4-rtn-block-32-acc-level-4
-  promptTemplate: "{\"system\": \"<|im_start|>system<|im_sep|>{Content}<|im_end|>\", \"user\": \"<|im_start|>user<|im_sep|>{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant<|im_sep|>{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user<|im_sep|>{Content}<|im_end|><|im_start|>assistant<|im_sep|>\"}"
+  promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|end|>\", \"user\": \"<|user|>\\n{Content}<|end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|end|>\", \"prompt\": \"<|user|>\\n{Content}<|end|>\\n<|assistant|>\"}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/Phi-4-generic-gpu/spec.yaml
+++ b/assets/models/system/Phi-4-generic-gpu/spec.yaml
@@ -13,7 +13,7 @@ tags:
   maxOutputTokens: 2048
   alias: phi-4
   directoryPath: directml-int4-rtn-block-32-acc-level-4
-  promptTemplate: "{\"system\": \"<|im_start|>system<|im_sep|>{Content}<|im_end|>\", \"user\": \"<|im_start|>user<|im_sep|>{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant<|im_sep|>{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user<|im_sep|>{Content}<|im_end|><|im_start|>assistant<|im_sep|>\"}"
+  promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|end|>\", \"user\": \"<|user|>\\n{Content}<|end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|end|>\", \"prompt\": \"<|user|>\\n{Content}<|end|>\\n<|assistant|>\"}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/Phi-4-generic-gpu/spec.yaml
+++ b/assets/models/system/Phi-4-generic-gpu/spec.yaml
@@ -13,7 +13,7 @@ tags:
   maxOutputTokens: 2048
   alias: phi-4
   directoryPath: directml-int4-rtn-block-32-acc-level-4
-  promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|end|>\", \"user\": \"<|user|>\\n{Content}<|end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|end|>\", \"prompt\": \"<|user|>\\n{Content}<|end|>\\n<|assistant|>\"}"
+  promptTemplate: "{\"system\": \"<|system|>\\n{Content}<|im_end|>\", \"user\": \"<|user|>\\n{Content}<|im_end|>\", \"assistant\": \"<|assistant|>\\n{Content}<|im_end|>\", \"prompt\": \"<|user|>\\n{Content}<|im_end|>\\n<|assistant|>\"}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/qwen2.5-0.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/system/qwen2.5-0.5b-instruct-cuda-gpu/spec.yaml
@@ -14,6 +14,7 @@ tags:
   alias: qwen2.5-0.5b
   directoryPath: cuda-int4-rtn-block-32
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.8}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/qwen2.5-0.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/system/qwen2.5-0.5b-instruct-generic-cpu/spec.yaml
@@ -14,6 +14,7 @@ tags:
   alias: qwen2.5-0.5b
   directoryPath: cpu-int4-rtn-block-32-acc-level-4
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 0.7}, {\"name\": \"top_p\", \"default\": 0.8}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/qwen2.5-0.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/system/qwen2.5-0.5b-instruct-generic-gpu/spec.yaml
@@ -14,6 +14,7 @@ tags:
   alias: qwen2.5-0.5b
   directoryPath: directml-int4-awq-block-128
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.8}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/qwen2.5-coder-0.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/system/qwen2.5-coder-0.5b-instruct-cuda-gpu/spec.yaml
@@ -14,6 +14,7 @@ tags:
   alias: qwen2.5-coder-0.5b
   directoryPath: cuda-int4-rtn-block-32
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.9}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/qwen2.5-coder-0.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/system/qwen2.5-coder-0.5b-instruct-generic-cpu/spec.yaml
@@ -14,6 +14,7 @@ tags:
   alias: qwen2.5-coder-0.5b
   directoryPath: cpu-int4-rtn-block-32-acc-level-4
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.9}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/system/qwen2.5-coder-0.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/system/qwen2.5-coder-0.5b-instruct-generic-gpu/spec.yaml
@@ -14,6 +14,7 @@ tags:
   alias: qwen2.5-coder-0.5b
   directoryPath: webgpu-int4-rtn-block-32-acc-level-4
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.9}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
 type: custom_model
 variantInfo:
   parents:


### PR DESCRIPTION
Phi-4 model `promptTemplate` tags must be updated to match Phi-3 `promptTemplate` tags.

Qwen 0.5b models need `parameterSchema` tags w/ specific values.