### PR TITLE
Update local models to add tool calling support

### DIFF
--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-cuda-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<|tool_call|>"
   toolCallEnd: "<|/tool_call|>"
+  toolRegisterStart: "<|tool|>"
+  toolRegisterEnd: "<|/tool|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-reasoning-cuda-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-cuda-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: phi-4-mini-reasoning
   directoryPath: v1
   promptTemplate: "{\"system\": \"<|system|>Your name is Phi, an AI math expert developed by Microsoft. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<|tool_call|>"
+  toolCallEnd: "<|/tool_call|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-cpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<|tool_call|>"
   toolCallEnd: "<|/tool_call|>"
+  toolRegisterStart: "<|tool|>"
+  toolRegisterEnd: "<|/tool|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-reasoning-generic-cpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-cpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: phi-4-mini-reasoning
   directoryPath: v1
   promptTemplate: "{\"system\": \"<|system|>Your name is Phi, an AI math expert developed by Microsoft. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<|tool_call|>"
+  toolCallEnd: "<|/tool_call|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<|tool_call|>"
   toolCallEnd: "<|/tool_call|>"
+  toolRegisterStart: "<|tool|>"
+  toolRegisterEnd: "<|/tool|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-reasoning-generic-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-generic-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: phi-4-mini-reasoning
   directoryPath: v1
   promptTemplate: "{\"system\": \"<|system|>Your name is Phi, an AI math expert developed by Microsoft. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<|tool_call|>"
+  toolCallEnd: "<|/tool_call|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-qnn-npu/spec.yaml
@@ -14,9 +14,6 @@ tags:
   alias: phi-4-mini-reasoning
   directoryPath: v1
   promptTemplate: "{\"system\": \"<|system|>Your name is Phi, an AI math expert developed by Microsoft. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
-  supportsToolCalling: ""
-  toolCallStart: "<|tool_call|>"
-  toolCallEnd: "<|/tool_call|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-qnn-npu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: phi-4-mini-reasoning
   directoryPath: v1
   promptTemplate: "{\"system\": \"<|system|>Your name is Phi, an AI math expert developed by Microsoft. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<|tool_call|>"
+  toolCallEnd: "<|/tool_call|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/phi-4-mini-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-cuda-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<|tool_call|>"
   toolCallEnd: "<|/tool_call|>"
+  toolRegisterStart: "<|tool|>"
+  toolRegisterEnd: "<|/tool|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/phi-4-mini-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-cuda-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: phi-4-mini
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|system|>{Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<|tool_call|>"
+  toolCallEnd: "<|/tool_call|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/phi-4-mini-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-instruct-cuda-gpu
-version: 3
+version: 4
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/phi-4-mini-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-generic-cpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<|tool_call|>"
   toolCallEnd: "<|/tool_call|>"
+  toolRegisterStart: "<|tool|>"
+  toolRegisterEnd: "<|/tool|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/phi-4-mini-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-generic-cpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: phi-4-mini
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|system|>{Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<|tool_call|>"
+  toolCallEnd: "<|/tool_call|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/phi-4-mini-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-instruct-generic-cpu
-version: 3
+version: 4
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/phi-4-mini-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-generic-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<|tool_call|>"
   toolCallEnd: "<|/tool_call|>"
+  toolRegisterStart: "<|tool|>"
+  toolRegisterEnd: "<|/tool|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/phi-4-mini-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-instruct-generic-gpu
-version: 3
+version: 4
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/phi-4-mini-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-generic-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: phi-4-mini
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|system|>{Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<|tool_call|>"
+  toolCallEnd: "<|/tool_call|>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-0.5b-instruct-cuda-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-cuda-gpu/spec.yaml
@@ -18,6 +18,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-cuda-gpu/spec.yaml
@@ -15,6 +15,9 @@ tags:
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.8}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-0.5b-instruct-generic-cpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-cpu/spec.yaml
@@ -15,6 +15,9 @@ tags:
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 0.7}, {\"name\": \"top_p\", \"default\": 0.8}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-cpu/spec.yaml
@@ -18,6 +18,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-0.5b-instruct-generic-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-gpu/spec.yaml
@@ -18,6 +18,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-generic-gpu/spec.yaml
@@ -15,6 +15,9 @@ tags:
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.8}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-cuda-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-cuda-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-1.5b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-1.5b-instruct-cuda-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-cpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-1.5b-instruct-generic-cpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-cpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-1.5b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-1.5b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-1.5b-instruct-generic-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-14b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-14b-instruct-cuda-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-14b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-14b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-14b-instruct-cuda-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-14b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-14b-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-14b-instruct-cuda-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-cpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-14b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-14b-instruct-generic-cpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-cpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-14b-instruct-generic-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-14b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-14b-instruct-generic-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-cuda-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-7b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-7b-instruct-cuda-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-cuda-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-cpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-7b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-7b-instruct-generic-cpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-cpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-7b-instruct-generic-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-7b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-generic-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-cuda-gpu/spec.yaml
@@ -15,6 +15,9 @@ tags:
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.9}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-0.5b-instruct-cuda-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-cuda-gpu/spec.yaml
@@ -18,6 +18,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-cpu/spec.yaml
@@ -15,6 +15,9 @@ tags:
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.9}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-0.5b-instruct-generic-cpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-cpu/spec.yaml
@@ -18,6 +18,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-0.5b-instruct-generic-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-gpu/spec.yaml
@@ -15,6 +15,9 @@ tags:
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.9}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-generic-gpu/spec.yaml
@@ -18,6 +18,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-1.5b-instruct-cuda-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-cuda-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-coder-1.5b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-cuda-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-1.5b-instruct-generic-cpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-cpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-coder-1.5b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-cpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-1.5b-instruct-generic-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-coder-1.5b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-generic-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-cuda-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-14b-instruct-cuda-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-cuda-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-coder-14b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-cpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-14b-instruct-generic-cpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-cpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-coder-14b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-coder-14b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-14b-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-14b-instruct-generic-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-cuda-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-7b-instruct-cuda-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-cuda-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-coder-7b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-cuda-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-7b-instruct-generic-cpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-cpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-coder-7b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-cpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-7b-instruct-generic-gpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: ""

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-gpu/spec.yaml
@@ -14,6 +14,9 @@ tags:
   alias: qwen2.5-coder-7b
   directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-generic-gpu/spec.yaml
@@ -17,6 +17,8 @@ tags:
   supportsToolCalling: ""
   toolCallStart: "<tool_call>"
   toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
 type: custom_model
 variantInfo:
   parents:


### PR DESCRIPTION
Update the following models to add metadata for `supportsToolCalling`, `toolCallStart`, `toolCallEnd`, `toolRegisterStart`, and `toolRegisterEnd` in the `tags` section of the `spec.yaml` files:
- Phi-4-mini-reasoning
- phi-4-mini-instruct
- qwen2.5-0.5b-instruct
- qwen2.5-1.5b-instruct
- qwen2.5-7b-instruct
- qwen2.5-14b-instruct
- qwen2.5-coder-0.5b-instruct
- qwen2.5-coder-1.5b-instruct
- qwen2.5-coder-7b-instruct
- qwen2.5-coder-14b-instruct