### PR TITLE
updated env versions for medimage insight components

### DIFF
--- a/assets/training/finetune_acft_image/components/finetune/medimage_insight/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_insight/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: medimgage_embedding_finetune
-version: 0.0.3
+version: 0.0.4
 
 type: command
 
@@ -8,7 +8,7 @@ is_deterministic: True
 
 display_name: Medical Image Insight Embedding Finetune
 description: Component to finetune the model using the medical image data
-environment : azureml://registries/azureml/environments/acft-medimageinsight-embedding/versions/1
+environment : azureml://registries/azureml/environments/acft-medimageinsight-embedding/versions/8
 code: ../../../src/medimage_insight_embedding_finetune
 
 distribution:

--- a/assets/training/finetune_acft_image/components/model_converters/medimage_embed_adapter_merge/spec.yaml
+++ b/assets/training/finetune_acft_image/components/model_converters/medimage_embed_adapter_merge/spec.yaml
@@ -1,14 +1,14 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
-version: 0.0.2
+version: 0.0.3
 name: medimage_embedding_adapter_merge
 display_name: Package Classification Model
 description: Integrate labels and generates classification model
 
 is_deterministic: True
 
-environment : azureml://registries/azureml/environments/acft-medimageinsight-embedding-generator/versions/1
+environment : azureml://registries/azureml/environments/acft-medimageinsight-embedding-generator/versions/9
 
 code: ../../../src/model_converters/medimage_embed_adapter_merge
 

--- a/assets/training/finetune_acft_image/components/pipeline_components/medimage_insight_ft/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/medimage_insight_ft/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 name: medimage_insight_ft_pipeline
-version: 0.0.3
+version: 0.0.4
 type: pipeline
 display_name: Medimage Insight Finetune Pipeline
 description: Pipeline Component to finetune MedImageInsight Model.
@@ -108,7 +108,7 @@ outputs:
 jobs:
   medical_image_embedding_model_finetune:
     type: command
-    component: azureml:medimgage_embedding_finetune:0.0.3
+    component: azureml:medimgage_embedding_finetune:0.0.4
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'
@@ -131,7 +131,7 @@ jobs:
       mlflow_model_folder: '${{parent.outputs.embedding_mlflow_model}}'
   medimage_embedding_adapter_merge:
     type: command
-    component: azureml:medimage_embedding_adapter_merge:0.0.2
+    component: azureml:medimage_embedding_adapter_merge:0.0.3
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
       instance_type: '${{parent.inputs.instance_type_finetune}}'


### PR DESCRIPTION
Updated environment versions for the medimage insight components to ensure compatibility with the latest versions of the AzureML environments.
Updated versions for acft-medimageinsight-embedding environment to version 8 and acft-medimageinsight-embedding-generator environment to version 9

Successful finetuning run using the new components: 
https://ml.azure.com/experiments/id/fbed6833-3441-4b56-8df0-f4397933bf27/runs/aba1d261-7edd-43f4-8f84-12d5e8aa933a?wsid=/subscriptions/1b12b3fb-e309-4f14-b551-1affe9e4ac57/resourcegroups/daniele-dev-rg/workspaces/daniele-dev-ml-workspace&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#