### PR TITLE
fix vulnerabilities of torch, urllib3 and mlflow on rai tabular, text and vision environments

### DIFF
--- a/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
@@ -45,6 +45,10 @@ RUN pip install 'cryptography>=43.0.1'
 # TODO: remove rai-core-flask pin with next raiwidgets release
 RUN pip install 'rai-core-flask==0.7.6'
 
+# to resolve vulnerability mlflow (GHSA-wxj7-3fx5-pp9m) for mlflow < 3.1.0
+# from azureml-mlflow package
+RUN pip install 'mlflow>=3.1.0'
+
 # To resolve vulnerability issue
 RUN pip install 'gunicorn>=22.0.0'
 RUN pip install 'Werkzeug>=3.0.3'

--- a/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-text/context/Dockerfile
@@ -41,6 +41,10 @@ RUN pip install 'cryptography>=43.0.1'
 # see issue https://github.com/huggingface/datasets/issues/6182
 RUN pip install git+https://github.com/huggingface/evaluate.git
 
+# to resolve vulnerability mlflow (GHSA-wxj7-3fx5-pp9m) for mlflow < 3.1.0
+# from azureml-mlflow package
+RUN pip install 'mlflow>=3.1.0'
+
 # To resolve vulnerability issue
 RUN pip install 'Werkzeug>=3.0.3'
 RUN pip install 'tqdm>=4.66.3'

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -34,9 +34,6 @@ RUN pip install 'responsibleai~=0.36.0' \
 RUN pip install 'azureml-mlflow=={{latest-pypi-version}}' \
                 'azureml-rai-utils==0.0.6'
 
-RUN pip install 'azureml-dataset-runtime=={{latest-pypi-version}}' \
-                'azureml-automl-dnn-vision=={{latest-pypi-version}}'
-
 RUN pip install 'scikit-learn>=1.5.1' \
                 'interpret-community==0.31.0' \
                 'Pillow>=10.3.0' \
@@ -61,11 +58,7 @@ RUN pip install 'Werkzeug>=3.0.3' \
 # To resolve GHSA-2586-f3p4-hq84 vulnerability issue for lightgbm<4.6.0
 # from azureml-automl-dnn-vision package
 RUN pip install 'lightgbm>=4.6.0'
-# To resolve GHSA-53q9-r3pm-6pq6 vulnerability issue for torch < 2.6.0
-# and  urllib3 (GHSA-pq67-6m6q-mj2v) for urllib3 < 2.5.0
-# from azureml-automl-dnn-vision package
-RUN pip install 'torch>=2.6.0'
-RUN pip install 'urllib3>=2.5.0'
+
 # to resolve vulnerability mlflow (GHSA-wxj7-3fx5-pp9m) for mlflow < 3.1.0
 # from azureml-mlflow package
 RUN pip install 'mlflow>=3.1.0'

--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -61,8 +61,14 @@ RUN pip install 'Werkzeug>=3.0.3' \
 # To resolve GHSA-2586-f3p4-hq84 vulnerability issue for lightgbm<4.6.0
 # from azureml-automl-dnn-vision package
 RUN pip install 'lightgbm>=4.6.0'
-# To resolve CVE-2024-5480 vulnerability issue for torch < 2.2.2
-RUN pip install 'torch>=2.2.2'
+# To resolve GHSA-53q9-r3pm-6pq6 vulnerability issue for torch < 2.6.0
+# and  urllib3 (GHSA-pq67-6m6q-mj2v) for urllib3 < 2.5.0
+# from azureml-automl-dnn-vision package
+RUN pip install 'torch>=2.6.0'
+RUN pip install 'urllib3>=2.5.0'
+# to resolve vulnerability mlflow (GHSA-wxj7-3fx5-pp9m) for mlflow < 3.1.0
+# from azureml-mlflow package
+RUN pip install 'mlflow>=3.1.0'
 # To resolve GHSA-jh2j-j4j9-crg3 vulnerability issue
 RUN pip install 'opencv-python-headless==4.8.1.78'
 RUN pip install 'setuptools>=78.1.1'

--- a/assets/responsibleai/environments/responsibleai-vision/tests/requirements.txt
+++ b/assets/responsibleai/environments/responsibleai-vision/tests/requirements.txt
@@ -2,3 +2,5 @@ azure-ai-ml==1.25.0
 azure-identity==1.20.0
 azureml-core>=1.58.0
 marshmallow==3.19.0
+azureml-dataset-runtime
+azureml-automl-dnn-vision

--- a/assets/responsibleai/environments/responsibleai-vision/tests/responsibleai_vision_sample_test.py
+++ b/assets/responsibleai/environments/responsibleai-vision/tests/responsibleai_vision_sample_test.py
@@ -12,7 +12,7 @@ from azure.identity import AzureCliCredential
 
 BUILD_CONTEXT = Path("../context")
 JOB_SOURCE_CODE = "src"
-TIMEOUT_MINUTES = os.environ.get("timeout_minutes", 60)
+TIMEOUT_MINUTES = os.environ.get("timeout_minutes", 120)
 STD_LOG = Path("artifacts/user_logs/std_log.txt")
 
 


### PR DESCRIPTION
fix vulnerabilities in rai tabular, text and vision environments. 
* Python (Pip) Security Update for mlflow ([GHSA-wxj7-3fx5-pp9m](https://github.com/advisories/GHSA-wxj7-3fx5-pp9m)):
     * Due to dependency constraint mlflow-skinny<3.0.0 from azureml-mlflow==1.60.0.post1 (latest version).
     * Impacted: rai-tabular, rai-text and rai-vision
* Python (Pip) Security Update for urllib3 ([GHSA-48p4-8xcf-vxj5](https://github.com/advisories/GHSA-48p4-8xcf-vxj5)): 
    * urllib3 was downgraded from 2.5.0 to 1.26.20 due to the constraint urllib3<2.0.0 imposed by azureml-automl-runtime~=1.60.0, which is a dependency of the Azure ML AutoML DNN Vision package.
    * Impacted: rai-vision
*   Python (Pip) Security Update for torch ([GHSA-53q9-r3pm-6pq6](https://github.com/advisories/GHSA-53q9-r3pm-6pq6)): 
    * torch was downgraded from 2.6.0 to 2.2.2 due to the exact version constraint torch==2.2.2 imposed by azureml-automl-dnn-vision==1.60.0. 
    * Impacted: rai-vision 
