### PR TITLE
fix mlflow, urllib3 and torch in rai-vision image

### DIFF
--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -61,8 +61,16 @@ RUN pip install 'Werkzeug>=3.0.3' \
 # To resolve GHSA-2586-f3p4-hq84 vulnerability issue for lightgbm<4.6.0
 # from azureml-automl-dnn-vision package
 RUN pip install 'lightgbm>=4.6.0'
-# To resolve CVE-2024-5480 vulnerability issue for torch < 2.2.2
-RUN pip install 'torch>=2.2.2'
+
+# To resolve GHSA-53q9-r3pm-6pq6 vulnerability issue for torch < 2.6.0
+# and  urllib3 (GHSA-pq67-6m6q-mj2v) for urllib3 < 2.5.0
+# from azureml-automl-dnn-vision package
+RUN pip install 'torch>=2.6.0'
+RUN pip install 'urllib3>=2.5.0'
+# to resolve vulnerability mlflow (GHSA-wxj7-3fx5-pp9m) for mlflow < 3.1.0
+# from azureml-mlflow package
+RUN pip install 'mlflow>=3.1.0'
+
 # To resolve GHSA-jh2j-j4j9-crg3 vulnerability issue
 RUN pip install 'opencv-python-headless==4.8.1.78'
 RUN pip install 'setuptools>=78.1.1'


### PR DESCRIPTION
fix vulnerabilities in rai-vision image:
* Python (Pip) Security Update for mlflow ([GHSA-wxj7-3fx5-pp9m](https://github.com/advisories/GHSA-wxj7-3fx5-pp9m)):
Due to dependency constraint mlflow-skinny<3.0.0 from azureml-mlflow==1.60.0.post1 (latest version).

* Python (Pip) Security Update for urllib3 ([GHSA-48p4-8xcf-vxj5](https://github.com/advisories/GHSA-48p4-8xcf-vxj5)):
urllib3 was downgraded from 2.5.0 to 1.26.20 due to the constraint urllib3<2.0.0 imposed by azureml-automl-runtime~=1.60.0, which is a dependency of the Azure ML AutoML DNN Vision package.
* Python (Pip) Security Update for torch ([GHSA-53q9-r3pm-6pq6](https://github.com/advisories/GHSA-53q9-r3pm-6pq6)):
torch was downgraded from 2.6.0 to 2.2.2 due to the exact version constraint torch==2.2.2 imposed by azureml-automl-dnn-vision==1.60.0.