### PR TITLE
pin torch version 2.7.1-rc1 in rai-vision image

### DIFF
--- a/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-vision/context/Dockerfile
@@ -66,7 +66,7 @@ RUN pip install 'lightgbm>=4.6.0'
 # To resolve GHSA-53q9-r3pm-6pq6 vulnerability issue for torch < 2.6.0
 # and  urllib3 (GHSA-pq67-6m6q-mj2v) for urllib3 < 2.5.0
 # from azureml-automl-dnn-vision package
-RUN pip install 'torch>=2.6.0'
+RUN pip install 'torch>=2.7.1-rc1'
 RUN pip install 'urllib3>=2.5.0'
 # to resolve vulnerability mlflow (GHSA-wxj7-3fx5-pp9m) for mlflow < 3.1.0
 # from azureml-mlflow package

--- a/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-vision/context/conda_dependencies.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.9
   - pip
   - numpy==1.26.2
-  - pytorch>=2.2.2
+  - pytorch>=2.7.1-rc1
   - torchvision
   - captum
   - cpuonly


### PR DESCRIPTION
* [Python (Pip) Security Update for torch (GHSA-3749-ghw9-m3mg)](https://github.com/advisories/ghsa-3749-ghw9-m3mg): pin torch version 2.7.1-rc1