### PR TITLE
[Enhancement]: Run without  validation data and fix ev2 enum issue fo…

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/components/grpo/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/grpo/chat_completion/spec.yaml
@@ -35,15 +35,6 @@ inputs:
     description: output folder of model import component containing model artifacts and a metadata file.
     mode: rw_mount
 
-  # apply_lora:
-  #   type: string
-  #   enum:
-  #   - "true"
-  #   - "false"
-  #   default: "true"
-  #   optional: true
-  #   description: If "true" enables LoRA fine tuning.
-
   beta:
     type: number
     default: 0.00
@@ -67,12 +58,6 @@ inputs:
     optional: false
     description: Path to a custom DeepSpeed configuration file in JSON format
     mode: ro_mount
-
-  do_eval:
-    type: boolean
-    default: false
-    optional: true
-    description: Whether to run evaluation on the validation set or not. Will be set to True if eval_strategy is different from "disable"
 
   epsilon:
     type: number
@@ -307,7 +292,6 @@ command: >-
   $[[--bf16 'true']]
   $[[--use_vllm 'true']]
   $[[--gradient_checkpointing 'true']]
-  $[[--do_eval '${{inputs.do_eval}}']]
   $[[--eval_on_start 'false']]
   $[[--eval_strategy '${{inputs.eval_strategy}}']]
   $[[--hub_private_repo 'false']]

--- a/assets/training/finetune_acft_hf_nlp/components/grpo/chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/grpo/chat_completion/spec.yaml
@@ -35,14 +35,14 @@ inputs:
     description: output folder of model import component containing model artifacts and a metadata file.
     mode: rw_mount
 
-  apply_lora:
-    type: string
-    enum:
-    - "true"
-    - "false"
-    default: "true"
-    optional: true
-    description: If "true" enables LoRA fine tuning.
+  # apply_lora:
+  #   type: string
+  #   enum:
+  #   - "true"
+  #   - "false"
+  #   default: "true"
+  #   optional: true
+  #   description: If "true" enables LoRA fine tuning.
 
   beta:
     type: number
@@ -72,7 +72,7 @@ inputs:
     type: boolean
     default: false
     optional: true
-    description: Whether to run evaluation on the validation set or not. Will be set to True if eval_strategy is different from "no"
+    description: Whether to run evaluation on the validation set or not. Will be set to True if eval_strategy is different from "disable"
 
   epsilon:
     type: number
@@ -89,12 +89,12 @@ inputs:
   eval_strategy:
     type: string
     enum:
-    - "no"
-    - "steps"
-    - "epoch"
-    default: no
+    - disable
+    - steps
+    - epoch
+    default: disable
     optional: true
-    description: Evaluation strategy to use during training. Options are 'no', 'steps', or 'epoch'.
+    description: Evaluation strategy to use during training. Options are "disable", "steps", or "epoch".
 
   gradient_accumulation_steps:
     type: integer
@@ -318,5 +318,3 @@ command: >-
   $[[--save_steps '${{inputs.save_steps}}']]
   $[[--save_total_limit '${{inputs.save_total_limit}}']]
   $[[--report_to 'azure_ml']]
-  $[[--use_peft ${{inputs.apply_lora}}]]
-

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/grpo_chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/grpo_chat_completion/spec.yaml
@@ -53,14 +53,6 @@ inputs:
     mode: rw_mount
 
   #Finetune parameters
-  # apply_lora:
-  #   type: string
-  #   enum:
-  #   - "true"
-  #   - "false"
-  #   default: "true"
-  #   optional: true
-  #   description: If "true" enables lora.
 
   dataset_name:
     type: string
@@ -214,12 +206,6 @@ inputs:
     description: Path to a custom DeepSpeed configuration file in JSON format
     mode: ro_mount
 
-  do_eval:
-    type: boolean
-    default: false
-    optional: true
-    description: Whether to run evaluation on the validation set or not. Will be set to True if eval_strategy is different from "disable"
-
   max_prompt_length:
     type: integer
     default: 512
@@ -340,7 +326,6 @@ jobs:
       dataset_train_split: '${{parent.inputs.dataset_train_split}}'
       dataset_validation_split: '${{parent.inputs.dataset_validation_split}}'
       deepspeed_config: '${{parent.inputs.deepspeed_config}}'
-      do_eval: '${{parent.inputs.do_eval}}'
       epsilon: '${{parent.inputs.epsilon}}'
       eval_steps: '${{parent.inputs.eval_steps}}'
       eval_strategy: '${{parent.inputs.eval_strategy}}'

--- a/assets/training/finetune_acft_hf_nlp/components/pipeline_components/grpo_chat_completion/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/components/pipeline_components/grpo_chat_completion/spec.yaml
@@ -53,14 +53,14 @@ inputs:
     mode: rw_mount
 
   #Finetune parameters
-  apply_lora:
-    type: string
-    enum:
-    - "true"
-    - "false"
-    default: "true"
-    optional: true
-    description: If "true" enables lora.
+  # apply_lora:
+  #   type: string
+  #   enum:
+  #   - "true"
+  #   - "false"
+  #   default: "true"
+  #   optional: true
+  #   description: If "true" enables lora.
 
   dataset_name:
     type: string
@@ -89,12 +89,12 @@ inputs:
   eval_strategy:
     type: string
     enum:
-    - "no"
-    - "steps"
-    - "epoch"
-    default: "no"
+    - disable
+    - steps
+    - epoch
+    default: disable
     optional: true
-    description: Evaluation strategy to use during training. Options are 'no', 'steps', or 'epoch'.
+    description: Evaluation strategy to use during training. Options are 'disable', 'steps', or 'epoch'.
 
   num_iterations:
     type: integer
@@ -218,7 +218,7 @@ inputs:
     type: boolean
     default: false
     optional: true
-    description: Whether to run evaluation on the validation set or not. Will be set to True if eval_strategy is different from "no"
+    description: Whether to run evaluation on the validation set or not. Will be set to True if eval_strategy is different from "disable"
 
   max_prompt_length:
     type: integer
@@ -334,7 +334,6 @@ jobs:
       instance_type: '${{parent.inputs.instance_type_finetune}}'
       shm_size: '${{parent.inputs.shm_size_finetune}}'
     inputs:
-      apply_lora: '${{parent.inputs.apply_lora}}'
       beta: '${{parent.inputs.beta}}'
       dataset_name: '${{parent.inputs.dataset_name}}'
       dataset_prompt_column: '${{parent.inputs.dataset_prompt_column}}'

--- a/assets/training/finetune_acft_hf_nlp/src/grpo/reasoning_train.py
+++ b/assets/training/finetune_acft_hf_nlp/src/grpo/reasoning_train.py
@@ -91,6 +91,7 @@ class GRPOScriptArguments(ScriptArguments):
 @dataclass
 class ExtendedGRPOConfig(GRPOConfig):
     """Extend the base GRPOConfig to add eval_strategy options."""
+
     eval_strategy: str = field(
         default="no",
         metadata={
@@ -99,6 +100,14 @@ class ExtendedGRPOConfig(GRPOConfig):
     )
 
     def __post_init__(self):
+        """Perform post-initialization tasks for training configuration.
+
+        Converts eval_strategy from "disable" to "no" to comply with
+        the ev2 release pipeline constraints. Then, attempts to invoke
+        the superclass’s __post_init__ method to complete any additional
+        initialization (e.g., setting up distributed_state), suppressing
+        errors if the method is not defined.
+        """
         # Convert 'disable' option to 'no'
         # Need this since ev2 release pipeline doesn't allow 'no' as option
         if self.eval_strategy == "disable":

--- a/assets/training/finetune_acft_hf_nlp/src/grpo/reasoning_train.py
+++ b/assets/training/finetune_acft_hf_nlp/src/grpo/reasoning_train.py
@@ -110,7 +110,6 @@ class ExtendedGRPOConfig(GRPOConfig):
             pass
 
 
-
 def get_tokenizer(model_args: ModelConfig) -> PreTrainedTokenizer:
     """Return the tokenizer for the model.
 


### PR DESCRIPTION
…r "no"
<h1> Reason for changes </h1>
<p>
When the assets are created in registries such as azureml-staging, they use different sdk / script to create which causes failure if "no" is present as one of the enum value in spec file. 
Hence I stopped the older release and made a workaround to not use "no" in spec file. 
</p>
<p>
Also lora is disabled for now, until we have verifiable results on its ability to ingest training data in GRPO context.
</p>
<p>
When user chooses to not run evaluations in training run, he should be able to continue to train with just training data. This scenario is tested now.
</p>
<h1> Required Test runs </h1>
<hr>
	<ul> <li><a href="https://ml.azure.com/experiments/id/c45283c0-d73c-4f32-b67d-e744294a012a/runs/b831a45e-2c7d-4f81-8790-a01ec4e93736?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/rtanase/providers/Microsoft.MachineLearningServices/workspaces/rtanase&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#">should work with no eval data when evals is disabled </a></li>
<li><a href="https://ml.azure.com/experiments/id/c45283c0-d73c-4f32-b67d-e744294a012a/runs/e4a5c5cb-6aff-4bf3-86a2-0f47ed450cf3?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/rtanase/providers/Microsoft.MachineLearningServices/workspaces/rtanase&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#" >working run when validation data is given but eval strategy disabled  </a></li></ul>
<hr>
<a href="https://ml.azure.com/experiments/id/c45283c0-d73c-4f32-b67d-e744294a012a/runs/11d5ba07-0964-4340-bec3-eae959398307?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourceGroups/rtanase/providers/Microsoft.MachineLearningServices/workspaces/rtanase&tid=72f988bf-86f1-41af-91ab-2d7cd011db47#">test after addressing comments</a>
