### PR TITLE
To update libssh, git

### DIFF
--- a/assets/common/environments/python-sdk-v2/context/Dockerfile
+++ b/assets/common/environments/python-sdk-v2/context/Dockerfile
@@ -20,3 +20,4 @@ RUN conda env create -p $CONDA_PREFIX -f conda_dependencies.yaml -q --solver=cla
         
 ## Vulnerability fix
 RUN pip install tqdm requests==2.32.4
+


### PR DESCRIPTION
Resolved vulnerabilities related to libssh, git, and git-man by updating the respective libraries
<img width="1497" height="520" alt="image" src="https://github.com/user-attachments/assets/8ee83ba1-67af-46d1-b5c9-6c9f6a241b6d" />

Scan results
<img width="739" height="219" alt="image" src="https://github.com/user-attachments/assets/8a058639-0fb9-487f-8e73-3b492dc15e6a" />
