### PR TITLE
[vfix]: update torch in base image and docker runs for other environm…

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch260:{{latest-image-tag}}
+FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest-image-tag}}
 
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/azureml-automl-dnn-vision-gpu
 # Prepend path to AzureML conda environment
@@ -105,8 +105,8 @@ RUN /opt/conda/bin/pip install --upgrade 'urllib3==2.5.0' || true
 RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'urllib3==2.5.0' || true
 RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --upgrade 'urllib3==2.5.0' || true
 
-RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --force-reinstall 'torch==2.7.1rc1' torchvision==0.22.1 || true
-RUN /opt/conda/envs/ptca/bin/pip install --force-reinstall 'torch==2.7.1rc1' torchvision==0.22.1 || true
+RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --force-reinstall 'torch==2.7.1' torchvision==0.22.1 
+RUN /opt/conda/envs/ptca/bin/pip install --force-reinstall 'torch==2.7.1' torchvision==0.22.1 
 
 
 # end pip install

--- a/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
@@ -104,11 +104,10 @@ RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'pillow==11.3.0'
 RUN /opt/conda/bin/pip install --upgrade 'urllib3==2.5.0'
 RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'urllib3==2.5.0'
 RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --upgrade 'urllib3==2.5.0'
-RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --upgrade 'mlflow==3.1.4'
 
 RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --force-reinstall 'torch==2.7.1' torchvision==0.22.1 
 RUN /opt/conda/envs/ptca/bin/pip install --force-reinstall 'torch==2.7.1' torchvision==0.22.1 
-
+RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --upgrade 'mlflow==3.1.4'
 
 # end pip install
 ENV LD_LIBRARY_PATH $AZUREML_CONDA_ENVIRONMENT_PATH/lib:$LD_LIBRARY_PATH

--- a/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
@@ -104,6 +104,7 @@ RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'pillow==11.3.0'
 RUN /opt/conda/bin/pip install --upgrade 'urllib3==2.5.0'
 RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'urllib3==2.5.0'
 RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --upgrade 'urllib3==2.5.0'
+RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --upgrade 'mlflow==3.1.4'
 
 RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --force-reinstall 'torch==2.7.1' torchvision==0.22.1 
 RUN /opt/conda/envs/ptca/bin/pip install --force-reinstall 'torch==2.7.1' torchvision==0.22.1 

--- a/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
@@ -96,14 +96,14 @@ RUN pip install cryptography>=42.0.5 \
                 aiohttp>=3.12.14
 
 # Patch for pillow vulnerability
-RUN /azureml-envs/azureml-automl-dnn-text-gpu/bin/pip install --upgrade 'pillow==11.3.0' || true
-RUN /opt/conda/bin/pip install --upgrade 'pillow==11.3.0' || true
-RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'pillow==11.3.0' || true
+RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --upgrade 'pillow==11.3.0'
+RUN /opt/conda/bin/pip install --upgrade 'pillow==11.3.0' 
+RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'pillow==11.3.0'
                 
 # Upgrade torch, requests, urllib3 in the system Python for fixing vulnerability
-RUN /opt/conda/bin/pip install --upgrade 'urllib3==2.5.0' || true
-RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'urllib3==2.5.0' || true
-RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --upgrade 'urllib3==2.5.0' || true
+RUN /opt/conda/bin/pip install --upgrade 'urllib3==2.5.0'
+RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'urllib3==2.5.0'
+RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --upgrade 'urllib3==2.5.0'
 
 RUN /azureml-envs/azureml-automl-dnn-vision-gpu/bin/pip install --force-reinstall 'torch==2.7.1' torchvision==0.22.1 
 RUN /opt/conda/envs/ptca/bin/pip install --force-reinstall 'torch==2.7.1' torchvision==0.22.1 


### PR DESCRIPTION
…ents

Git advisory : https://github.com/advisories/GHSA-3749-ghw9-m3mg

- Advisory suggests to move to torch 2.7.1-rc1 but there is no pypi version with that exact string. 
- Looking deeper into advisory references. The commit which fixes the issue is preset in torch 2.7.1
- For the commit goto : https://github.com/pytorch/pytorch/issues/149274