### PR TITLE
Add IHV Qwen2.5-1.5B-Instruct NPU test models to azureml registry

### DIFF
--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/asset.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/description.md
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of Qwen2.5-1.5B-Instruct to enable local inference on Intel NPUs. This model uses post-training quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of the Qwen2.5-1.5B-Instruct for local inference on Intel NPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Qwen2.5-1.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct) for details.

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/fl-perf-improvements/qwen2.5-1.5b-instruct/onnx/npu/qwen2.5-1.5b-instruct-openvino-npu
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/spec.yaml
@@ -1,0 +1,30 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen2.5-1.5b-instruct-openvino-npu
+version: 1
+path: ./
+tags:
+  foundryLocal: "test"
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct/blob/main/LICENSE>."
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: chat-completion
+  maxOutputTokens: 2048
+  alias: qwen2.5-1.5b
+  directoryPath: qwen2.5-1.5b-instruct-openvino-npu
+  promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen2.5-1.5b-instruct/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['PTQ']
+    device: 'npu'
+    executionProvider: 'OpenVINOExecutionProvider'

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/asset.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/description.md
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of Qwen2.5-1.5B-Instruct to enable local inference on Qualcomm NPUs. This model uses post-training quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of the Qwen2.5-1.5B-Instruct for local inference on Qualcomm NPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Qwen2.5-1.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct) for details.

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/fl-perf-improvements/qwen2.5-1.5b-instruct/onnx/npu/qwen2.5-1.5b-instruct-qnn-npu
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/spec.yaml
@@ -1,0 +1,30 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen2.5-1.5b-instruct-qnn-npu
+version: 1
+path: ./
+tags:
+  foundryLocal: "test"
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct/blob/main/LICENSE>."
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: chat-completion
+  maxOutputTokens: 2048
+  alias: qwen2.5-1.5b
+  directoryPath: qwen2.5-1.5b-instruct-qnn-npu
+  promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen2.5-1.5b-instruct/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['PTQ']
+    device: 'npu'
+    executionProvider: 'QNNExecutionProvider'

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-vitis-npu/asset.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-vitis-npu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-vitis-npu/description.md
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-vitis-npu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of Qwen2.5-1.5B-Instruct to enable local inference on AMD NPUs. This model uses post-training quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of the Qwen2.5-1.5B-Instruct for local inference on AMD NPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Qwen2.5-1.5B-Instruct](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct) for details.

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-vitis-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-vitis-npu/model.yaml
@@ -1,0 +1,9 @@
+path:
+  container_name: models
+  container_path: foundrylocal/fl-perf-improvements/qwen2.5-1.5b-instruct/onnx/npu/qwen2.5-1.5b-instruct-vitis-npu
+
+  storage_name: automlcesdkdataresources
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-vitis-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-vitis-npu/spec.yaml
@@ -1,0 +1,30 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen2.5-1.5b-instruct-vitis-npu
+version: 1
+path: ./
+tags:
+  foundryLocal: "test"
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct/blob/main/LICENSE>."
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: chat-completion
+  maxOutputTokens: 2048
+  alias: qwen2.5-1.5b
+  directoryPath: qwen2.5-1.5b-instruct-vitis-npu
+  promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: ""
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen2.5-1.5b-instruct/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['PTQ']
+    device: 'npu'
+    executionProvider: 'VitisAIExecutionProvider'


### PR DESCRIPTION
Add IHV Qwen2.5-1.5B-Instruct NPU test models for all variants in blob storage to azureml registry.

1. qwen2.5-1.5b-instruct-vitis-npu
2. qwen2.5-1.5b-instruct-openvino-npu
3. qwen2.5-1.5b-instruct-qnn-npu