### PR TITLE
Fix qwen2.5-0.5b-instruct OV + Vitis models

### DIFF
--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-openvino-npu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen2.5-0.5b-instruct-openvino-npu
 version: 1
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-vitis-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-vitis-npu/spec.yaml
@@ -1,9 +1,9 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-0.5b-instruct-vitis-npu
-version: 1
+version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct/blob/main/LICENSE>."
   author: Microsoft


### PR DESCRIPTION
Model had an extra file that caused issues when integrating with Foundry Local. Up-versioning to remove this file and increasing version such that the models no longer have `test` tag since they're ready to publish.