### PR TITLE
Fix security vulnerabilities in Docker environments

### DIFF
--- a/assets/training/aoai/proxy_components/environments/context/Dockerfile
+++ b/assets/training/aoai/proxy_components/environments/context/Dockerfile
@@ -1,6 +1,28 @@
 FROM mcr.microsoft.com/azureml/openmpi5.0-ubuntu24.04:{{latest-image-tag}}
 
 RUN apt-get update && apt-get -y upgrade
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.22.6ubuntu6.5 \
+    dpkg=1.22.6ubuntu6.5 \
+    libdpkg-perl=1.22.6ubuntu6.5
+
+# Fix GNU C Library vulnerability (USN-7760-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.39-0ubuntu8.6 \
+    libc6-dev=2.39-0ubuntu8.6 \
+    libc-dev-bin=2.39-0ubuntu8.6 \
+    libc6=2.39-0ubuntu8.6
+
+# Fix PAM vulnerability (USN-7761-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libpam-runtime=1.5.3-5ubuntu5.5 \
+    libpam0g=1.5.3-5ubuntu5.5 \
+    libpam-modules-bin=1.5.3-5ubuntu5.5 \
+    libpam-modules=1.5.3-5ubuntu5.5
+
 RUN pip install --upgrade pip
 
 COPY requirements.txt .

--- a/assets/training/automl/environments/ai-ml-automl-dnn-forecasting-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-forecasting-gpu/context/Dockerfile
@@ -31,6 +31,25 @@ apt-get install -y --only-upgrade \
     libpam-modules-bin \
     libpam-runtime
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         cmake \

--- a/assets/training/automl/environments/ai-ml-automl-dnn-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-gpu/context/Dockerfile
@@ -2,6 +2,27 @@ FROM mcr.microsoft.com/azureml/openmpi5.0-cuda12.4-ubuntu22.04:{{latest-image-ta
 
 USER root
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
+
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/azureml-automl-dnn-gpu
 # Prepend path to AzureML conda environment
 ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
@@ -2,6 +2,27 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu124-py310-torch260:{{latest
 
 USER root:root
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
+
 # Update system package index and upgrade Python 3.10 packages to required versions
 RUN apt-get update && \
     apt-get install -y --only-upgrade \

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
@@ -12,6 +12,27 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 
 # Inference requirements
 COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20250310.v1 /artifacts /var/
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 RUN apt-get update && \
     apt-get install -y --only-upgrade \
         libpython3.10-stdlib \

--- a/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
@@ -12,6 +12,27 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 
 # Inference requirements
 COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20250310.v1 /artifacts /var/
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 RUN apt-get update && \
     apt-get install -y --only-upgrade \
         libpython3.10-stdlib \

--- a/assets/training/automl/environments/ai-ml-automl-dnn/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn/context/Dockerfile
@@ -13,6 +13,37 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 ENV ENABLE_METADATA=true
 
 # Upgrade system-level packages to fix known vulnerabilities (systemd, python3.12, pam)
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1) for Ubuntu 24.04
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.22.6ubuntu6.5 \
+    dpkg=1.22.6ubuntu6.5 \
+    libdpkg-perl=1.22.6ubuntu6.5
+
+# Fix GNU C Library vulnerability (USN-7760-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.39-0ubuntu8.6 \
+    libc6-dev=2.39-0ubuntu8.6 \
+    libc-dev-bin=2.39-0ubuntu8.6 \
+    libc6=2.39-0ubuntu8.6
+
+# Fix libxml2 vulnerability (USN-7743-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.14+dfsg-1.3ubuntu3.5
+
+# Fix PAM vulnerability (USN-7761-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libpam-runtime=1.5.3-5ubuntu5.5 \
+    libpam0g=1.5.3-5ubuntu5.5 \
+    libpam-modules-bin=1.5.3-5ubuntu5.5 \
+    libpam-modules=1.5.3-5ubuntu5.5
+
+# Fix SQLite vulnerability (USN-7751-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libsqlite3-0=3.45.1-1ubuntu2.5
+
 RUN apt-get update && \
     apt-get install -y --only-upgrade \
         systemd-dev \

--- a/assets/training/automl/environments/ai-ml-automl-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-gpu/context/Dockerfile
@@ -2,6 +2,27 @@ FROM mcr.microsoft.com/azureml/openmpi5.0-cuda12.4-ubuntu22.04:{{latest-image-ta
 
 USER root
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
+
 ENV AZUREML_CONDA_ENVIRONMENT_PATH /azureml-envs/azureml-automl-dnn-gpu
 # Prepend path to AzureML conda environment
 ENV PATH $AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH

--- a/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
@@ -13,6 +13,37 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 ENV ENABLE_METADATA=true
 
 # System package security upgrades
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1) for Ubuntu 24.04
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.22.6ubuntu6.5 \
+    dpkg=1.22.6ubuntu6.5 \
+    libdpkg-perl=1.22.6ubuntu6.5
+
+# Fix GNU C Library vulnerability (USN-7760-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.39-0ubuntu8.6 \
+    libc6-dev=2.39-0ubuntu8.6 \
+    libc-dev-bin=2.39-0ubuntu8.6 \
+    libc6=2.39-0ubuntu8.6
+
+# Fix libxml2 vulnerability (USN-7743-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.14+dfsg-1.3ubuntu3.5
+
+# Fix PAM vulnerability (USN-7761-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libpam-runtime=1.5.3-5ubuntu5.5 \
+    libpam0g=1.5.3-5ubuntu5.5 \
+    libpam-modules-bin=1.5.3-5ubuntu5.5 \
+    libpam-modules=1.5.3-5ubuntu5.5
+
+# Fix SQLite vulnerability (USN-7751-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libsqlite3-0=3.45.1-1ubuntu2.5
+
 RUN apt-get update && \
     apt-get install -y --only-upgrade \
         libpam0g \

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
@@ -3,6 +3,26 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch271:{{latest
 
 USER root
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 RUN pip install --upgrade pip
 
 COPY requirements.txt .

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -4,6 +4,26 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch271:{{latest
 USER root
 
 RUN apt-get update && apt-get -y upgrade
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 RUN pip install --upgrade pip
 
 COPY requirements.txt .

--- a/assets/training/finetune_acft_hf_nlp/environments/data_import/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/data_import/context/Dockerfile
@@ -5,6 +5,32 @@ USER root
 
 # sudo is expected by Singularity inside the image
 RUN apt-get update && ACCEPT_EULA=Y apt-get -y upgrade && apt-get install sudo
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.22.6ubuntu6.5 \
+    dpkg=1.22.6ubuntu6.5 \
+    libdpkg-perl=1.22.6ubuntu6.5
+
+# Fix GNU C Library vulnerability (USN-7760-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.39-0ubuntu8.6 \
+    libc6-dev=2.39-0ubuntu8.6 \
+    libc-dev-bin=2.39-0ubuntu8.6 \
+    libc6=2.39-0ubuntu8.6
+
+# Fix libxml2 vulnerability (USN-7743-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.14+dfsg-1.3ubuntu3.5
+
+# Fix PAM vulnerability (USN-7761-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libpam-runtime=1.5.3-5ubuntu5.5 \
+    libpam0g=1.5.3-5ubuntu5.5 \
+    libpam-modules-bin=1.5.3-5ubuntu5.5 \
+    libpam-modules=1.5.3-5ubuntu5.5
+
 RUN pip install --upgrade pip
 
 COPY requirements.txt .

--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -4,6 +4,25 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest
 USER root
 RUN apt-get -y update && apt-get install -y expat
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
@@ -4,6 +4,25 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest
 USER root
 RUN apt-get -y update
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 # Install unzip
 RUN apt-get -y install unzip
 

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
@@ -3,6 +3,25 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest
 
 USER root
 RUN apt-get -y update
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
     
 # Install unzip
 RUN apt-get -y install unzip

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
@@ -4,6 +4,25 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest
 USER root
 RUN apt-get -y update
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 # Install unzip
 RUN apt-get -y install unzip
 

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
@@ -3,6 +3,25 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch28x:{{latest
 USER root
 RUN apt-get -y update
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 COPY requirements.txt .
 
 RUN pip install -r requirements.txt

--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
@@ -4,6 +4,25 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest
 USER root
 RUN apt-get -y update && apt-get install -y libglib2.0-0
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -4,6 +4,25 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest
 USER root
 RUN apt-get -y update && apt-get install -y expat
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
@@ -3,6 +3,25 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest
 
 RUN apt-get -y update && apt-get install -y expat
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 # Install required packages
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
@@ -4,6 +4,25 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest
 USER root
 RUN apt-get -y update && apt-get install -y expat
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir

--- a/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
+++ b/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
@@ -12,6 +12,27 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 
 ENV ENABLE_METADATA=true
 # Upgrade critical system and python packages
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 RUN apt-get update && \
     apt-get install -y --only-upgrade \
         systemd \

--- a/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
@@ -22,6 +22,27 @@ RUN /opt/conda/envs/ptca/bin/pip install --upgrade \
 
 # Inference requirements
 COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20230419.v1 /artifacts /var/
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         libcurl4 \

--- a/assets/training/general/environments/lightgbm-3.3/context/Dockerfile
+++ b/assets/training/general/environments/lightgbm-3.3/context/Dockerfile
@@ -10,6 +10,37 @@ ENV PATH=$CONDA_PREFIX/bin:$PATH
 ENV LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 
 # Update package lists and reinstall system OpenSSL & OpenSSH
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1) for Ubuntu 24.04
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.22.6ubuntu6.5 \
+    dpkg=1.22.6ubuntu6.5 \
+    libdpkg-perl=1.22.6ubuntu6.5
+
+# Fix GNU C Library vulnerability (USN-7760-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.39-0ubuntu8.6 \
+    libc6-dev=2.39-0ubuntu8.6 \
+    libc-dev-bin=2.39-0ubuntu8.6 \
+    libc6=2.39-0ubuntu8.6
+
+# Fix libxml2 vulnerability (USN-7743-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.14+dfsg-1.3ubuntu3.5
+
+# Fix PAM vulnerability (USN-7761-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libpam-runtime=1.5.3-5ubuntu5.5 \
+    libpam0g=1.5.3-5ubuntu5.5 \
+    libpam-modules-bin=1.5.3-5ubuntu5.5 \
+    libpam-modules=1.5.3-5ubuntu5.5
+
+# Fix SQLite vulnerability (USN-7751-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libsqlite3-0=3.45.1-1ubuntu2.5
+
 RUN apt-get update && \
     apt-get install --reinstall -y openssl libssl-dev openssh-server && \
     apt-get clean && \

--- a/assets/training/general/environments/sklearn-1.5/context/Dockerfile
+++ b/assets/training/general/environments/sklearn-1.5/context/Dockerfile
@@ -10,6 +10,37 @@ ENV PATH=$CONDA_PREFIX/bin:$PATH
 ENV LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 
 # Update package lists and reinstall system OpenSSL & OpenSSH
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1) for Ubuntu 24.04
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.22.6ubuntu6.5 \
+    dpkg=1.22.6ubuntu6.5 \
+    libdpkg-perl=1.22.6ubuntu6.5
+
+# Fix GNU C Library vulnerability (USN-7760-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.39-0ubuntu8.6 \
+    libc6-dev=2.39-0ubuntu8.6 \
+    libc-dev-bin=2.39-0ubuntu8.6 \
+    libc6=2.39-0ubuntu8.6
+
+# Fix libxml2 vulnerability (USN-7743-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.14+dfsg-1.3ubuntu3.5
+
+# Fix PAM vulnerability (USN-7761-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libpam-runtime=1.5.3-5ubuntu5.5 \
+    libpam0g=1.5.3-5ubuntu5.5 \
+    libpam-modules-bin=1.5.3-5ubuntu5.5 \
+    libpam-modules=1.5.3-5ubuntu5.5
+
+# Fix SQLite vulnerability (USN-7751-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \
+    libsqlite3-0=3.45.1-1ubuntu2.5
+
 RUN apt-get update && \
     apt-get install --reinstall -y openssl libssl-dev openssh-server && \
     apt-get clean && \

--- a/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
+++ b/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
@@ -14,6 +14,48 @@ FROM nvcr.io/nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
 
 USER root:root
 
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
+# Fix GCC vulnerability (USN-7700-1)
+RUN apt-get install -y --only-upgrade \
+    cpp-11=11.4.0-1ubuntu1~22.04.2 \
+    libtsan0=11.4.0-1ubuntu1~22.04.2 \
+    libstdc++-11-dev=11.4.0-1ubuntu1~22.04.2 \
+    gcc-11=11.4.0-1ubuntu1~22.04.2 \
+    libgcc-11-dev=11.4.0-1ubuntu1~22.04.2 \
+    g++-11=11.4.0-1ubuntu1~22.04.2 \
+    libasan6=11.4.0-1ubuntu1~22.04.2 \
+    gcc-11-base=11.4.0-1ubuntu1~22.04.2 \
+    libquadmath0=12.3.0-1ubuntu1~22.04.2 \
+    libstdc++6=12.3.0-1ubuntu1~22.04.2 \
+    libatomic1=12.3.0-1ubuntu1~22.04.2 \
+    liblsan0=12.3.0-1ubuntu1~22.04.2 \
+    libubsan1=12.3.0-1ubuntu1~22.04.2 \
+    libcc1-0=12.3.0-1ubuntu1~22.04.2 \
+    libgcc-s1=12.3.0-1ubuntu1~22.04.2 \
+    libgomp1=12.3.0-1ubuntu1~22.04.2 \
+    gcc-12-base=12.3.0-1ubuntu1~22.04.2 \
+    libitm1=12.3.0-1ubuntu1~22.04.2
+
+
 ARG IMAGE_NAME=None
 ARG BUILD_NUMBER=None
 

--- a/assets/training/vision/environments/automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/vision/environments/automl-dnn-vision-gpu/context/Dockerfile
@@ -13,6 +13,27 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 
 # Inference requirements
 COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20250310.v1 /artifacts /var/
+
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade \
+    dpkg-dev=1.21.1ubuntu2.6 \
+    dpkg=1.21.1ubuntu2.6 \
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \
+    libc-bin=2.35-0ubuntu3.11 \
+    libc6-dev=2.35-0ubuntu3.11 \
+    libc-dev-bin=2.35-0ubuntu3.11 \
+    locales=2.35-0ubuntu3.11 \
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         libcurl4 \

--- a/fix_vulnerabilities.py
+++ b/fix_vulnerabilities.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+Script to fix security vulnerabilities across multiple Docker environments.
+This script addresses USN-7768-1 (dpkg), USN-7760-1 (GNU C Library), 
+USN-7743-1 (libxml2), USN-7761-1 (PAM), USN-7751-1 (SQLite), and USN-7700-1 (GCC).
+"""
+
+import os
+import re
+from pathlib import Path
+
+# Define vulnerability fixes for different Ubuntu versions
+UBUNTU_22_04_FIXES = """
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1)
+RUN apt-get update && \\
+    apt-get install -y --only-upgrade \\
+    dpkg-dev=1.21.1ubuntu2.6 \\
+    dpkg=1.21.1ubuntu2.6 \\
+    libdpkg-perl=1.21.1ubuntu2.6
+
+# Fix GNU C Library vulnerability (USN-7760-1)
+RUN apt-get install -y --only-upgrade \\
+    libc-bin=2.35-0ubuntu3.11 \\
+    libc6-dev=2.35-0ubuntu3.11 \\
+    libc-dev-bin=2.35-0ubuntu3.11 \\
+    locales=2.35-0ubuntu3.11 \\
+    libc6=2.35-0ubuntu3.11
+
+# Fix libxml2 vulnerability (USN-7743-1)
+RUN apt-get install -y --only-upgrade \\
+    libxml2=2.9.13+dfsg-1ubuntu0.9
+"""
+
+UBUNTU_24_04_FIXES = """
+# --- Security Vulnerability Fixes ---
+# Fix dpkg vulnerability (USN-7768-1) for Ubuntu 24.04
+RUN apt-get update && \\
+    apt-get install -y --only-upgrade \\
+    dpkg-dev=1.22.6ubuntu6.5 \\
+    dpkg=1.22.6ubuntu6.5 \\
+    libdpkg-perl=1.22.6ubuntu6.5
+
+# Fix GNU C Library vulnerability (USN-7760-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \\
+    libc-bin=2.39-0ubuntu8.6 \\
+    libc6-dev=2.39-0ubuntu8.6 \\
+    libc-dev-bin=2.39-0ubuntu8.6 \\
+    libc6=2.39-0ubuntu8.6
+
+# Fix libxml2 vulnerability (USN-7743-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \\
+    libxml2=2.9.14+dfsg-1.3ubuntu3.5
+
+# Fix PAM vulnerability (USN-7761-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \\
+    libpam-runtime=1.5.3-5ubuntu5.5 \\
+    libpam0g=1.5.3-5ubuntu5.5 \\
+    libpam-modules-bin=1.5.3-5ubuntu5.5 \\
+    libpam-modules=1.5.3-5ubuntu5.5
+
+# Fix SQLite vulnerability (USN-7751-1) for Ubuntu 24.04
+RUN apt-get install -y --only-upgrade \\
+    libsqlite3-0=3.45.1-1ubuntu2.5
+"""
+
+GCC_FIXES = """
+# Fix GCC vulnerability (USN-7700-1)
+RUN apt-get install -y --only-upgrade \\
+    cpp-11=11.4.0-1ubuntu1~22.04.2 \\
+    libtsan0=11.4.0-1ubuntu1~22.04.2 \\
+    libstdc++-11-dev=11.4.0-1ubuntu1~22.04.2 \\
+    gcc-11=11.4.0-1ubuntu1~22.04.2 \\
+    libgcc-11-dev=11.4.0-1ubuntu1~22.04.2 \\
+    g++-11=11.4.0-1ubuntu1~22.04.2 \\
+    libasan6=11.4.0-1ubuntu1~22.04.2 \\
+    gcc-11-base=11.4.0-1ubuntu1~22.04.2 \\
+    libquadmath0=12.3.0-1ubuntu1~22.04.2 \\
+    libstdc++6=12.3.0-1ubuntu1~22.04.2 \\
+    libatomic1=12.3.0-1ubuntu1~22.04.2 \\
+    liblsan0=12.3.0-1ubuntu1~22.04.2 \\
+    libubsan1=12.3.0-1ubuntu1~22.04.2 \\
+    libcc1-0=12.3.0-1ubuntu1~22.04.2 \\
+    libgcc-s1=12.3.0-1ubuntu1~22.04.2 \\
+    libgomp1=12.3.0-1ubuntu1~22.04.2 \\
+    gcc-12-base=12.3.0-1ubuntu1~22.04.2 \\
+    libitm1=12.3.0-1ubuntu1~22.04.2
+"""
+
+# Map of environment names to their expected Ubuntu versions
+ENVIRONMENT_VERSIONS = {
+    # Ubuntu 22.04 environments
+    'acft-group-relative-policy-optimization': '22.04',
+    'acft-hf-nlp-gpu': '22.04',
+    'acft-medimageinsight-adapter-finetune': '22.04',
+    'acft-medimageinsight-embedding': '22.04',
+    'acft-medimageinsight-embedding-generator': '22.04',
+    'acft-medimageparse-finetune': '22.04',
+    'acft-mmdetection-image-gpu': '22.04',
+    'acft-mmtracking-video-gpu': '22.04',
+    'acft-multimodal-gpu': '22.04',
+    'acft-transformers-image-gpu': '22.04',
+    'acpt-automl-image-framework-selector-gpu': '22.04',
+    'acpt-pytorch-2.2-cuda12.1': '22.04',
+    'ai-ml-automl-dnn-forecasting-gpu': '22.04',
+    'ai-ml-automl-dnn-gpu': '22.04',
+    'ai-ml-automl-dnn-text-gpu': '22.04',
+    'ai-ml-automl-dnn-text-gpu-ptca': '22.04',
+    'ai-ml-automl-dnn-vision-gpu': '22.04',
+    'ai-ml-automl-gpu': '22.04',
+    'automl-dnn-vision-gpu': '22.04',
+    'automl-gpu': '22.04',
+    'tensorflow-2.16-cuda12': '22.04',
+    
+    # Ubuntu 24.04 environments
+    'acft-hf-nlp-data-import': '24.04',
+    'ai-ml-automl': '24.04',
+    'ai-ml-automl-dnn': '24.04',
+    'aoai-data-upload-finetune': '24.04',
+    'lightgbm-3.3': '24.04',
+    'sklearn-1.5': '24.04',
+}
+
+def find_dockerfiles():
+    """Find all Dockerfile paths in the workspace."""
+    base_path = Path("e:/azureml-assets")
+    dockerfiles = []
+    for dockerfile_path in base_path.rglob("**/context/Dockerfile"):
+        if dockerfile_path.exists():
+            dockerfiles.append(dockerfile_path)
+    return dockerfiles
+
+def detect_ubuntu_version(dockerfile_content):
+    """Detect Ubuntu version from Dockerfile content."""
+    if 'ubuntu2204' in dockerfile_content.lower() or 'ubuntu22.04' in dockerfile_content.lower():
+        return '22.04'
+    elif 'ubuntu2404' in dockerfile_content.lower() or 'ubuntu24.04' in dockerfile_content.lower():
+        return '24.04'
+    elif 'ubuntu18.04' in dockerfile_content.lower() or 'ubuntu1804' in dockerfile_content.lower():
+        return '18.04'
+    return None
+
+def apply_security_fixes(dockerfile_path):
+    """Apply security fixes to a Dockerfile."""
+    with open(dockerfile_path, 'r') as f:
+        content = f.read()
+    
+    # Skip if already has security fixes
+    if "Security Vulnerability Fixes" in content:
+        print(f"Skipping {dockerfile_path} - already has security fixes")
+        return False
+    
+    # Skip test files
+    if "/test/" in str(dockerfile_path):
+        print(f"Skipping test file {dockerfile_path}")
+        return False
+    
+    # Detect Ubuntu version
+    ubuntu_version = detect_ubuntu_version(content)
+    if not ubuntu_version:
+        print(f"Could not detect Ubuntu version for {dockerfile_path}")
+        return False
+    
+    # Choose appropriate fixes
+    if ubuntu_version == '22.04':
+        fixes = UBUNTU_22_04_FIXES
+        # Add GCC fixes for tensorflow-2.16-cuda12
+        if 'tensorflow-2.16-cuda12' in str(dockerfile_path):
+            fixes += GCC_FIXES
+    elif ubuntu_version == '24.04':
+        fixes = UBUNTU_24_04_FIXES
+    else:
+        print(f"Unsupported Ubuntu version {ubuntu_version} for {dockerfile_path}")
+        return False
+    
+    # Find insertion point - after FROM and USER statements
+    lines = content.split('\n')
+    insert_index = 0
+    
+    for i, line in enumerate(lines):
+        if line.strip().startswith('FROM '):
+            insert_index = i + 1
+        elif line.strip().startswith('USER root'):
+            insert_index = i + 1
+            break
+        elif line.strip().startswith('RUN apt-get update'):
+            insert_index = i
+            break
+    
+    # Insert security fixes
+    lines.insert(insert_index, fixes)
+    
+    # Write back to file
+    with open(dockerfile_path, 'w') as f:
+        f.write('\n'.join(lines))
+    
+    print(f"Applied security fixes to {dockerfile_path}")
+    return True
+
+def main():
+    """Main function to apply security fixes to all Dockerfiles."""
+    dockerfiles = find_dockerfiles()
+    
+    # Filter to only environments mentioned in the vulnerability report
+    vulnerable_envs = [
+        'acft-group-relative-policy-optimization',
+        'acft-hf-nlp-data-import', 
+        'acft-hf-nlp-gpu',
+        'acft-medimageinsight-adapter-finetune',
+        'acft-medimageinsight-embedding',
+        'acft-medimageinsight-embedding-generator',
+        'acft-medimageparse-finetune',
+        'acft-mmdetection-image-gpu',
+        'acft-mmtracking-video-gpu', 
+        'acft-multimodal-gpu',
+        'acft-transformers-image-gpu',
+        'acpt-automl-image-framework-selector-gpu',
+        'acpt-pytorch-2.2-cuda12.1',
+        'ai-ml-automl',
+        'ai-ml-automl-dnn',
+        'ai-ml-automl-dnn-forecasting-gpu',
+        'ai-ml-automl-dnn-gpu',
+        'ai-ml-automl-dnn-text-gpu',
+        'ai-ml-automl-dnn-text-gpu-ptca',
+        'ai-ml-automl-dnn-vision-gpu',
+        'ai-ml-automl-gpu',
+        'aoai-data-upload-finetune',
+        'automl-dnn-vision-gpu',
+        'automl-gpu',
+        'lightgbm-3.3',
+        'sklearn-1.5',
+        'tensorflow-2.16-cuda12'
+    ]
+    
+    updated_count = 0
+    
+    for dockerfile in dockerfiles:
+        dockerfile_str = str(dockerfile)
+        
+        # Check if this Dockerfile is for a vulnerable environment
+        is_vulnerable = False
+        for env_name in vulnerable_envs:
+            if env_name in dockerfile_str:
+                is_vulnerable = True
+                break
+        
+        if is_vulnerable:
+            if apply_security_fixes(dockerfile):
+                updated_count += 1
+    
+    print(f"\nApplied security fixes to {updated_count} Dockerfiles")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This commit addresses multiple Ubuntu Security Notifications (USNs):
- USN-7768-1: dpkg vulnerability fixes
- USN-7760-1: GNU C Library (libc) vulnerability fixes
- USN-7743-1: libxml2 vulnerability fixes
- USN-7761-1: PAM vulnerability fixes
- USN-7751-1: SQLite vulnerability fixes
- USN-7700-1: GCC vulnerability fixes

Updated packages to required versions across 25+ environment Dockerfiles:

Ubuntu 22.04 environments:
- dpkg, dpkg-dev, libdpkg-perl: upgraded to 1.21.1ubuntu2.6
- libc-bin, libc6, libc6-dev, libc-dev-bin, locales: upgraded to 2.35-0ubuntu3.11
- libxml2: upgraded to 2.9.13+dfsg-1ubuntu0.9

Ubuntu 24.04 environments:
- dpkg, dpkg-dev, libdpkg-perl: upgraded to 1.22.6ubuntu6.5
- libc-bin, libc6, libc6-dev, libc-dev-bin: upgraded to 2.39-0ubuntu8.6
- libxml2: upgraded to 2.9.14+dfsg-1.3ubuntu3.5
- PAM packages: upgraded to 1.5.3-5ubuntu5.5
- SQLite: upgraded to 3.45.1-1ubuntu2.5

Affected environments include:
- All AutoML environments (ai-ml-automl-*)
- ACFT environments (acft-*, acpt-*)
- Training environments (tensorflow, pytorch, sklearn, lightgbm)
- Inference and multimodal environments

Also included fix_vulnerabilities.py script for systematic application of security patches.