### PR TITLE
Add EVALUATIONSUITE to AssetType and GENERIC_ASSET_TYPES

### DIFF
--- a/scripts/azureml-assets/CHANGELOG.md
+++ b/scripts/azureml-assets/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.17.3 (2026-04-23)
+### 🚀 New Features
+- Add EvaluationSuite to asset types and GENERIC_ASSET_TYPES
+
 ## 1.17.2 (2026-04-17)
 ### 🚀 New Features
 - [#4939](https://github.com/Azure/azureml-assets/pull/4939) Add HumanEvaluationTemplate AssetType

--- a/scripts/azureml-assets/azureml/assets/config.py
+++ b/scripts/azureml-assets/azureml/assets/config.py
@@ -48,6 +48,7 @@ class AssetType(Enum):
     AGENTMANIFEST = 'agentmanifest'
     APPTEMPLATE = 'apptemplate'
     HUMANEVALUATIONTEMPLATE = 'humanevaluationtemplate'
+    EVALUATIONSUITE = 'evaluationsuite'
 
 
 class ComponentType(Enum):
@@ -142,7 +143,8 @@ EXCLUDE_PREFIX = "!"
 FULL_ASSET_NAME_DELIMITER = "/"
 FULL_ASSET_NAME_TEMPLATE = "{type}/{name}/{version}"
 GENERIC_ASSET_TYPES = [AssetType.EVALUATIONRESULT, AssetType.PROMPT, AssetType.AGENTBLUEPRINT, AssetType.EVALUATOR,
-                       AssetType.APPTEMPLATE, AssetType.BENCHMARKSPEC, AssetType.HUMANEVALUATIONTEMPLATE]
+                       AssetType.APPTEMPLATE, AssetType.BENCHMARKSPEC, AssetType.HUMANEVALUATIONTEMPLATE,
+                       AssetType.EVALUATIONSUITE]
 OTHER_ASSET_TYPES = [AssetType.AGENTMANIFEST]
 PARTIAL_ASSET_NAME_TEMPLATE = "{type}/{name}"
 PUBLISH_LOCATION_HOSTNAMES = {PublishLocation.MCR: 'mcr.microsoft.com'}

--- a/scripts/azureml-assets/setup.py
+++ b/scripts/azureml-assets/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
    name="azureml-assets",
-   version="1.17.2",
+   version="1.17.3",
    description="Utilities for publishing assets to Azure Machine Learning system registries.",
    author="Microsoft Corp",
    packages=find_packages(),


### PR DESCRIPTION
Register EvaluationSuite as a new generic asset type. This enables evaluation suites to be stored as workspace-scoped generic assets following the same pattern as evaluators, prompts, and agent blueprints.