### PR TITLE
Fix AIME 2025 missing link and bump FrontierScience versions

### DIFF
--- a/assets/benchmarkspecs/builtin/frontierscience/spec.yaml
+++ b/assets/benchmarkspecs/builtin/frontierscience/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.frontierscience"
-version: 1
+version: 2
 display_name: "FrontierScience Benchmark"
 description: "FrontierScience is a benchmark for evaluating model reasoning accuracy on challenging science olympiad problems spanning multiple scientific disciplines including biology, chemistry, physics, and mathematics."
 benchmarkType: "builtin"
@@ -38,7 +38,7 @@ dataset:
     dataset_source: "https://huggingface.co/datasets/openai/frontierscience"
   source:
     provider: "mlregistry"
-    sourceDatasetId: "azureml://registries/azureml/data/frontierscience/versions/2"
+    sourceDatasetId: "azureml://registries/azureml/data/frontierscience/versions/3"
     sourceFormat: "csv"
     properties:
       file_name: "frontierscience.csv"

--- a/assets/benchmarkspecs/builtin/inspect_ai_aime2025/spec.yaml
+++ b/assets/benchmarkspecs/builtin/inspect_ai_aime2025/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.inspect_ai.aime2025"
-version: 1
+version: 2
 display_name: "AIME 2025 Benchmark (inspect_ai)"
 description: "American Invitational Mathematics Examination 2025. Tests advanced mathematical reasoning with competition-level problems. Evaluated using the inspect_ai framework."
 benchmarkType: "builtin"
@@ -20,6 +20,7 @@ dataset:
   properties:
     domain: "math"
     source_paper: "https://artofproblemsolving.com/wiki/index.php/2025_AIME"
+    dataset_source: "https://huggingface.co/datasets/math-ai/aime25"
   source:
     provider: "mlregistry"
     sourceDatasetId: "azureml://registries/azureml/data/aime2025/versions/1"

--- a/assets/pipelines/data/global_dataset/generic_csv/frontierscience/asset.yaml
+++ b/assets/pipelines/data/global_dataset/generic_csv/frontierscience/asset.yaml
@@ -1,5 +1,5 @@
 name: frontierscience
-version: 2
+version: 3
 type: data
 spec: spec.yaml
 extra_config: storage.yaml


### PR DESCRIPTION
## Changes

### AIME 2025
- Add missing `dataset_source` URL (`https://huggingface.co/datasets/math-ai/aime25`) to fix missing external link icon in Foundry UI
- Bump benchmarkspec version 1 → 2

### FrontierScience
- Bump dataset version 2 → 3 and benchmarkspec version 1 → 2 to trigger re-release
- Update `sourceDatasetId` to reference dataset v3
- Fixes registry replication failure where FrontierScience was only available in westus