### PR TITLE
Publish a new finetuned qwen3-0.6b model into Foundry Local

### DIFF
--- a/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/description.md
+++ b/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of Qwen3-0.6B-MTT-Finetuned to enable local inference on CPUs. This model uses DiscQuant mixed-precision quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of the Qwen3-0.6B-MTT-Finetuned for local inference on CPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Qwen3-0.6B](https://huggingface.co/Qwen/Qwen3-0.6B) for details.

--- a/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/qwen3-0.6b-pp-finetuned-mtt/onnx/cpu_and_mobile/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-0.6b-pp-finetuned-mtt-generic-cpu
 version: 1
 path: ./
 tags:
-  foundryLocal: "pp_finetuned_mtt"
+  foundryLocal: "pp_finetuned"
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-0.6B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/spec.yaml
@@ -1,0 +1,41 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3-0.6b-pp-finetuned-mtt-generic-cpu
+version: 1
+path: ./
+tags:
+  foundryLocal: "pp_finetuned_mtt"
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-0.6B/blob/main/LICENSE>."
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: chat-completion
+  maxOutputTokens: 2048
+  alias: qwen3-0.6b-pp-finetuned-mtt
+  directoryPath: v1
+  promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: "true"
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
+  toolResponseStart: "<tool_response>"
+  toolResponseEnd: "</tool_response>"
+  capabilities: "reasoning,tool-calling"
+  supportsReasoning: "true"
+  reasoningStart: "<think>"
+  reasoningEnd: "</think>"
+  contextLength: 40960
+  minFLVersion: "0.0.0"
+  disable-maap: true
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3-0.6b/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'cpu'
+    executionProvider: 'CPUExecutionProvider'
+    fileSizeBytes: 529864172
+    vRamFootprintBytes: 529864172

--- a/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-0.6b-pp-finetuned-mtt-generic-cpu/spec.yaml
@@ -27,7 +27,7 @@ tags:
   reasoningEnd: "</think>"
   contextLength: 40960
   minFLVersion: "0.0.0"
-  disable-maap: true
+  disable-maap: "true"
 type: custom_model
 variantInfo:
   parents:


### PR DESCRIPTION
This PR to publish a qwen3-0.6b finetuned by Foundry Local Android customer. The model is fully tested locally and will be archived once it's published to Catalog.