### PR TITLE
Add Qwen3-Embedding models (0.6B and 8B) to Foundry Local catalog

### DIFF
--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/asset.yaml
@@ -1,0 +1,4 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
+name: qwen3-embedding-0.6b-cuda-gpu
+version: 1
+directory: ./qwen3-embedding-0.6b-cuda-gpu

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/asset.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
-name: qwen3-embedding-0.6b-cuda-gpu
-version: 1
-directory: ./qwen3-embedding-0.6b-cuda-gpu
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/description.md
@@ -7,6 +7,7 @@ This is the GPU (NVIDIA CUDA)-optimized variant of qwen3-embedding-0.6b, a text 
 - **Parameters**: 0.6 billion
 - **Context Length**: 32K tokens
 - **Embedding Dimension**: Up to 1024
+- **Quantization**: KLD Gradient quantization
 - **Target Device**: GPU (NVIDIA CUDA)
 - **Execution Provider**: CUDAExecutionProvider
 - **Supported Languages**: 100+

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/description.md
@@ -1,0 +1,28 @@
+# Qwen3 Embedding 0.6B Cuda Gpu
+
+This is the GPU (NVIDIA CUDA)-optimized variant of qwen3-embedding-0.6b, a text embedding model from the Qwen3 family developed by Alibaba Cloud and optimized by Microsoft.
+
+## Model Details
+- **Model Type**: Text Embedding (ONNX)
+- **Parameters**: 0.6 billion
+- **Context Length**: 32K tokens
+- **Embedding Dimension**: Up to 1024
+- **Target Device**: GPU (NVIDIA CUDA)
+- **Execution Provider**: CUDAExecutionProvider
+- **Supported Languages**: 100+
+
+## Intended Use
+This model is optimized for local execution on devices with GPU (NVIDIA CUDA) hardware acceleration using Foundry Local.
+
+## Capabilities
+- Text retrieval and semantic search
+- Code retrieval
+- Text classification and clustering
+- Bitext mining
+- Multilingual and cross-lingual retrieval
+
+## License
+This model is licensed under Apache 2.0. See [license details](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE).
+
+## Source
+- HuggingFace: [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B)

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/model.yaml
@@ -1,0 +1,8 @@
+storage:
+  container_name: models
+  container_path: foundrylocal/models/qwen3-embedding-0.6b/onnx/cuda/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/model.yaml
@@ -1,4 +1,4 @@
-storage:
+path:
   container_name: models
   container_path: foundrylocal/models/qwen3-embedding-0.6b/onnx/cuda/v1
   storage_name: foundrylocalmodels

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "1.1.0"
+  minFLVersion: "0.0.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-0.6b-cuda-gpu
 version: 1
 path: ./
 tags:
-  foundryLocal: ""
+  foundryLocal: "test"
   license: "Apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
   author: Microsoft
@@ -12,12 +12,22 @@ tags:
   task: embedding
   maxOutputTokens: 0
   alias: qwen3-embedding-0.6b
+  directoryPath: v1
   promptTemplate: ""
-  directoryPath: qwen3-embedding-0.6b-cuda-gpu
-  baseName: qwen3-embedding-0.6b
   supportsToolCalling: "false"
   toolCallStart: ""
   toolCallEnd: ""
+  toolRegisterStart: ""
+  toolRegisterEnd: ""
+  toolResponseStart: ""
+  toolResponseEnd: ""
+  capabilities: "embedding"
+  supportsReasoning: "false"
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 32768
+  minFLVersion: "1.1.0"
+  disable-maap: "true"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
@@ -4,23 +4,17 @@ version: 1
 path: ./
 tags:
   foundryLocal: "test"
-  license: "Apache-2.0"
+  license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
-  task: embedding
-  maxOutputTokens: 0
+  task: embeddings
+  maxOutputTokens: 1
   alias: qwen3-embedding-0.6b
   directoryPath: v1
   promptTemplate: ""
   supportsToolCalling: "false"
-  toolCallStart: ""
-  toolCallEnd: ""
-  toolRegisterStart: ""
-  toolRegisterEnd: ""
-  toolResponseStart: ""
-  toolResponseEnd: ""
   capabilities: "embedding"
   supportsReasoning: "false"
   reasoningStart: ""

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
@@ -1,0 +1,31 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3-embedding-0.6b-cuda-gpu
+version: 1
+path: ./
+tags:
+  foundryLocal: ""
+  license: "Apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: embedding
+  maxOutputTokens: 0
+  alias: qwen3-embedding-0.6b
+  promptTemplate: ""
+  directoryPath: qwen3-embedding-0.6b-cuda-gpu
+  baseName: qwen3-embedding-0.6b
+  supportsToolCalling: "false"
+  toolCallStart: ""
+  toolCallEnd: ""
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3-embedding-0.6b/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'gpu'
+    executionProvider: 'CUDAExecutionProvider'
+    fileSizeBytes: 501754600
+    vRamFootprintBytes: 501754600

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/asset.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
-name: qwen3-embedding-0.6b-generic-cpu
-version: 1
-directory: ./qwen3-embedding-0.6b-generic-cpu
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/asset.yaml
@@ -1,0 +1,4 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
+name: qwen3-embedding-0.6b-generic-cpu
+version: 1
+directory: ./qwen3-embedding-0.6b-generic-cpu

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/description.md
@@ -1,0 +1,28 @@
+# Qwen3 Embedding 0.6B Generic Cpu
+
+This is the CPU-optimized variant of qwen3-embedding-0.6b, a text embedding model from the Qwen3 family developed by Alibaba Cloud and optimized by Microsoft.
+
+## Model Details
+- **Model Type**: Text Embedding (ONNX)
+- **Parameters**: 0.6 billion
+- **Context Length**: 32K tokens
+- **Embedding Dimension**: Up to 1024
+- **Target Device**: CPU
+- **Execution Provider**: CPUExecutionProvider
+- **Supported Languages**: 100+
+
+## Intended Use
+This model is optimized for local execution on devices with CPU hardware acceleration using Foundry Local.
+
+## Capabilities
+- Text retrieval and semantic search
+- Code retrieval
+- Text classification and clustering
+- Bitext mining
+- Multilingual and cross-lingual retrieval
+
+## License
+This model is licensed under Apache 2.0. See [license details](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE).
+
+## Source
+- HuggingFace: [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B)

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/description.md
@@ -7,6 +7,7 @@ This is the CPU-optimized variant of qwen3-embedding-0.6b, a text embedding mode
 - **Parameters**: 0.6 billion
 - **Context Length**: 32K tokens
 - **Embedding Dimension**: Up to 1024
+- **Quantization**: KLD Gradient quantization
 - **Target Device**: CPU
 - **Execution Provider**: CPUExecutionProvider
 - **Supported Languages**: 100+

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/model.yaml
@@ -1,0 +1,8 @@
+storage:
+  container_name: models
+  container_path: foundrylocal/models/qwen3-embedding-0.6b/onnx/cpu_and_mobile/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/model.yaml
@@ -1,4 +1,4 @@
-storage:
+path:
   container_name: models
   container_path: foundrylocal/models/qwen3-embedding-0.6b/onnx/cpu_and_mobile/v1
   storage_name: foundrylocalmodels

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "1.1.0"
+  minFLVersion: "0.0.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-0.6b-generic-cpu
 version: 1
 path: ./
 tags:
-  foundryLocal: ""
+  foundryLocal: "test"
   license: "Apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
   author: Microsoft
@@ -12,12 +12,22 @@ tags:
   task: embedding
   maxOutputTokens: 0
   alias: qwen3-embedding-0.6b
+  directoryPath: v1
   promptTemplate: ""
-  directoryPath: qwen3-embedding-0.6b-generic-cpu
-  baseName: qwen3-embedding-0.6b
   supportsToolCalling: "false"
   toolCallStart: ""
   toolCallEnd: ""
+  toolRegisterStart: ""
+  toolRegisterEnd: ""
+  toolResponseStart: ""
+  toolResponseEnd: ""
+  capabilities: "embedding"
+  supportsReasoning: "false"
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 32768
+  minFLVersion: "1.1.0"
+  disable-maap: "true"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
@@ -4,23 +4,17 @@ version: 1
 path: ./
 tags:
   foundryLocal: "test"
-  license: "Apache-2.0"
+  license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
-  task: embedding
-  maxOutputTokens: 0
+  task: embeddings
+  maxOutputTokens: 1
   alias: qwen3-embedding-0.6b
   directoryPath: v1
   promptTemplate: ""
   supportsToolCalling: "false"
-  toolCallStart: ""
-  toolCallEnd: ""
-  toolRegisterStart: ""
-  toolRegisterEnd: ""
-  toolResponseStart: ""
-  toolResponseEnd: ""
   capabilities: "embedding"
   supportsReasoning: "false"
   reasoningStart: ""

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
@@ -1,0 +1,31 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3-embedding-0.6b-generic-cpu
+version: 1
+path: ./
+tags:
+  foundryLocal: ""
+  license: "Apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: embedding
+  maxOutputTokens: 0
+  alias: qwen3-embedding-0.6b
+  promptTemplate: ""
+  directoryPath: qwen3-embedding-0.6b-generic-cpu
+  baseName: qwen3-embedding-0.6b
+  supportsToolCalling: "false"
+  toolCallStart: ""
+  toolCallEnd: ""
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3-embedding-0.6b/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'cpu'
+    executionProvider: 'CPUExecutionProvider'
+    fileSizeBytes: 519582264
+    vRamFootprintBytes: 519582264

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/asset.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
-name: qwen3-embedding-0.6b-webgpu-gpu
-version: 1
-directory: ./qwen3-embedding-0.6b-webgpu-gpu
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/asset.yaml
@@ -1,0 +1,4 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
+name: qwen3-embedding-0.6b-webgpu-gpu
+version: 1
+directory: ./qwen3-embedding-0.6b-webgpu-gpu

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/description.md
@@ -1,0 +1,28 @@
+# Qwen3 Embedding 0.6B Webgpu Gpu
+
+This is the GPU (WebGPU)-optimized variant of qwen3-embedding-0.6b, a text embedding model from the Qwen3 family developed by Alibaba Cloud and optimized by Microsoft.
+
+## Model Details
+- **Model Type**: Text Embedding (ONNX)
+- **Parameters**: 0.6 billion
+- **Context Length**: 32K tokens
+- **Embedding Dimension**: Up to 1024
+- **Target Device**: GPU (WebGPU)
+- **Execution Provider**: WebGPUExecutionProvider
+- **Supported Languages**: 100+
+
+## Intended Use
+This model is optimized for local execution on devices with GPU (WebGPU) hardware acceleration using Foundry Local.
+
+## Capabilities
+- Text retrieval and semantic search
+- Code retrieval
+- Text classification and clustering
+- Bitext mining
+- Multilingual and cross-lingual retrieval
+
+## License
+This model is licensed under Apache 2.0. See [license details](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE).
+
+## Source
+- HuggingFace: [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B)

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/description.md
@@ -7,6 +7,7 @@ This is the GPU (WebGPU)-optimized variant of qwen3-embedding-0.6b, a text embed
 - **Parameters**: 0.6 billion
 - **Context Length**: 32K tokens
 - **Embedding Dimension**: Up to 1024
+- **Quantization**: KLD Gradient quantization
 - **Target Device**: GPU (WebGPU)
 - **Execution Provider**: WebGPUExecutionProvider
 - **Supported Languages**: 100+

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/model.yaml
@@ -1,0 +1,8 @@
+storage:
+  container_name: models
+  container_path: foundrylocal/models/qwen3-embedding-0.6b/onnx/webgpu/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/model.yaml
@@ -1,4 +1,4 @@
-storage:
+path:
   container_name: models
   container_path: foundrylocal/models/qwen3-embedding-0.6b/onnx/webgpu/v1
   storage_name: foundrylocalmodels

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "1.1.0"
+  minFLVersion: "0.0.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-0.6b-webgpu-gpu
 version: 1
 path: ./
 tags:
-  foundryLocal: ""
+  foundryLocal: "test"
   license: "Apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
   author: Microsoft
@@ -12,12 +12,22 @@ tags:
   task: embedding
   maxOutputTokens: 0
   alias: qwen3-embedding-0.6b
+  directoryPath: v1
   promptTemplate: ""
-  directoryPath: qwen3-embedding-0.6b-webgpu-gpu
-  baseName: qwen3-embedding-0.6b
   supportsToolCalling: "false"
   toolCallStart: ""
   toolCallEnd: ""
+  toolRegisterStart: ""
+  toolRegisterEnd: ""
+  toolResponseStart: ""
+  toolResponseEnd: ""
+  capabilities: "embedding"
+  supportsReasoning: "false"
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 32768
+  minFLVersion: "1.1.0"
+  disable-maap: "true"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/spec.yaml
@@ -4,23 +4,17 @@ version: 1
 path: ./
 tags:
   foundryLocal: "test"
-  license: "Apache-2.0"
+  license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
-  task: embedding
-  maxOutputTokens: 0
+  task: embeddings
+  maxOutputTokens: 1
   alias: qwen3-embedding-0.6b
   directoryPath: v1
   promptTemplate: ""
   supportsToolCalling: "false"
-  toolCallStart: ""
-  toolCallEnd: ""
-  toolRegisterStart: ""
-  toolRegisterEnd: ""
-  toolResponseStart: ""
-  toolResponseEnd: ""
   capabilities: "embedding"
   supportsReasoning: "false"
   reasoningStart: ""

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-webgpu-gpu/spec.yaml
@@ -1,0 +1,31 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3-embedding-0.6b-webgpu-gpu
+version: 1
+path: ./
+tags:
+  foundryLocal: ""
+  license: "Apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: embedding
+  maxOutputTokens: 0
+  alias: qwen3-embedding-0.6b
+  promptTemplate: ""
+  directoryPath: qwen3-embedding-0.6b-webgpu-gpu
+  baseName: qwen3-embedding-0.6b
+  supportsToolCalling: "false"
+  toolCallStart: ""
+  toolCallEnd: ""
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3-embedding-0.6b/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'gpu'
+    executionProvider: 'WebGPUExecutionProvider'
+    fileSizeBytes: 540924753
+    vRamFootprintBytes: 540924753

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b/asset.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
-name: qwen3-embedding-0.6b
-version: 1
-directory: ./qwen3-embedding-0.6b
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b/asset.yaml
@@ -1,0 +1,4 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
+name: qwen3-embedding-0.6b
+version: 1
+directory: ./qwen3-embedding-0.6b

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b/description.md
@@ -1,0 +1,21 @@
+# Qwen3 Embedding 0.6B
+
+This is the parent model entry for qwen3-embedding-0.6b in the Foundry Local catalog.
+
+## Model Details
+- **Model Type**: Text Embedding
+- **Architecture**: Transformer (Qwen3)
+- **Parameters**: 0.6 billion
+- **Context Length**: 32K tokens
+- **Embedding Dimension**: Up to 1024
+- **Supported Languages**: 100+
+
+## Overview
+
+The Qwen3 Embedding model series is designed for text embedding and ranking tasks. Building upon the Qwen3 foundation models, it provides state-of-the-art performance across text retrieval, code retrieval, text classification, text clustering, and bitext mining tasks.
+
+## License
+This model is licensed under Apache 2.0. See [license details](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B).
+
+## Source
+- HuggingFace: [Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B)

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b/model.yaml
@@ -1,0 +1,8 @@
+storage:
+  container_name: models
+  container_path: foundrylocal/models/qwen3-embedding-0.6b
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b/model.yaml
@@ -1,4 +1,4 @@
-storage:
+path:
   container_name: models
   container_path: foundrylocal/models/qwen3-embedding-0.6b
   storage_name: foundrylocalmodels

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b/spec.yaml
@@ -1,0 +1,7 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3-embedding-0.6b
+version: 1
+path: ./
+tags:
+  foundryLocal: ""
+type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b/spec.yaml
@@ -3,5 +3,5 @@ name: qwen3-embedding-0.6b
 version: 1
 path: ./
 tags:
-  foundryLocal: ""
+  foundryLocal: "test"
 type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/asset.yaml
@@ -1,0 +1,4 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
+name: qwen3-embedding-8b-cuda-gpu
+version: 1
+directory: ./qwen3-embedding-8b-cuda-gpu

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/asset.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
-name: qwen3-embedding-8b-cuda-gpu
-version: 1
-directory: ./qwen3-embedding-8b-cuda-gpu
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/description.md
@@ -1,0 +1,28 @@
+# Qwen3 Embedding 8B Cuda Gpu
+
+This is the GPU (NVIDIA CUDA)-optimized variant of qwen3-embedding-8b, a text embedding model from the Qwen3 family developed by Alibaba Cloud and optimized by Microsoft.
+
+## Model Details
+- **Model Type**: Text Embedding (ONNX)
+- **Parameters**: 8 billion
+- **Context Length**: 32K tokens
+- **Embedding Dimension**: Up to 4096
+- **Target Device**: GPU (NVIDIA CUDA)
+- **Execution Provider**: CUDAExecutionProvider
+- **Supported Languages**: 100+
+
+## Intended Use
+This model is optimized for local execution on devices with GPU (NVIDIA CUDA) hardware acceleration using Foundry Local.
+
+## Capabilities
+- Text retrieval and semantic search
+- Code retrieval
+- Text classification and clustering
+- Bitext mining
+- Multilingual and cross-lingual retrieval
+
+## License
+This model is licensed under Apache 2.0. See [license details](https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE).
+
+## Source
+- HuggingFace: [Qwen3-Embedding-8B](https://huggingface.co/Qwen/Qwen3-Embedding-8B)

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/description.md
@@ -7,6 +7,7 @@ This is the GPU (NVIDIA CUDA)-optimized variant of qwen3-embedding-8b, a text em
 - **Parameters**: 8 billion
 - **Context Length**: 32K tokens
 - **Embedding Dimension**: Up to 4096
+- **Quantization**: KLD Gradient quantization
 - **Target Device**: GPU (NVIDIA CUDA)
 - **Execution Provider**: CUDAExecutionProvider
 - **Supported Languages**: 100+

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/model.yaml
@@ -1,4 +1,4 @@
-storage:
+path:
   container_name: models
   container_path: foundrylocal/models/qwen3-embedding-8b/onnx/cuda/v1
   storage_name: foundrylocalmodels

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/model.yaml
@@ -1,0 +1,8 @@
+storage:
+  container_name: models
+  container_path: foundrylocal/models/qwen3-embedding-8b/onnx/cuda/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
@@ -4,23 +4,17 @@ version: 1
 path: ./
 tags:
   foundryLocal: "test"
-  license: "Apache-2.0"
+  license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
-  task: embedding
-  maxOutputTokens: 0
+  task: embeddings
+  maxOutputTokens: 1
   alias: qwen3-embedding-8b
   directoryPath: v1
   promptTemplate: ""
   supportsToolCalling: "false"
-  toolCallStart: ""
-  toolCallEnd: ""
-  toolRegisterStart: ""
-  toolRegisterEnd: ""
-  toolResponseStart: ""
-  toolResponseEnd: ""
   capabilities: "embedding"
   supportsReasoning: "false"
   reasoningStart: ""

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "1.1.0"
+  minFLVersion: "0.0.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-8b-cuda-gpu
 version: 1
 path: ./
 tags:
-  foundryLocal: ""
+  foundryLocal: "test"
   license: "Apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
   author: Microsoft
@@ -12,12 +12,22 @@ tags:
   task: embedding
   maxOutputTokens: 0
   alias: qwen3-embedding-8b
+  directoryPath: v1
   promptTemplate: ""
-  directoryPath: qwen3-embedding-8b-cuda-gpu
-  baseName: qwen3-embedding-8b
   supportsToolCalling: "false"
   toolCallStart: ""
   toolCallEnd: ""
+  toolRegisterStart: ""
+  toolRegisterEnd: ""
+  toolResponseStart: ""
+  toolResponseEnd: ""
+  capabilities: "embedding"
+  supportsReasoning: "false"
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 32768
+  minFLVersion: "1.1.0"
+  disable-maap: "true"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
@@ -1,0 +1,31 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3-embedding-8b-cuda-gpu
+version: 1
+path: ./
+tags:
+  foundryLocal: ""
+  license: "Apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: embedding
+  maxOutputTokens: 0
+  alias: qwen3-embedding-8b
+  promptTemplate: ""
+  directoryPath: qwen3-embedding-8b-cuda-gpu
+  baseName: qwen3-embedding-8b
+  supportsToolCalling: "false"
+  toolCallStart: ""
+  toolCallEnd: ""
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3-embedding-8b/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'gpu'
+    executionProvider: 'CUDAExecutionProvider'
+    fileSizeBytes: 5914497024
+    vRamFootprintBytes: 5914982491

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/asset.yaml
@@ -1,0 +1,4 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
+name: qwen3-embedding-8b-generic-cpu
+version: 1
+directory: ./qwen3-embedding-8b-generic-cpu

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/asset.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
-name: qwen3-embedding-8b-generic-cpu
-version: 1
-directory: ./qwen3-embedding-8b-generic-cpu
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/description.md
@@ -7,6 +7,7 @@ This is the CPU-optimized variant of qwen3-embedding-8b, a text embedding model 
 - **Parameters**: 8 billion
 - **Context Length**: 32K tokens
 - **Embedding Dimension**: Up to 4096
+- **Quantization**: KLD Gradient quantization
 - **Target Device**: CPU
 - **Execution Provider**: CPUExecutionProvider
 - **Supported Languages**: 100+

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/description.md
@@ -1,0 +1,28 @@
+# Qwen3 Embedding 8B Generic Cpu
+
+This is the CPU-optimized variant of qwen3-embedding-8b, a text embedding model from the Qwen3 family developed by Alibaba Cloud and optimized by Microsoft.
+
+## Model Details
+- **Model Type**: Text Embedding (ONNX)
+- **Parameters**: 8 billion
+- **Context Length**: 32K tokens
+- **Embedding Dimension**: Up to 4096
+- **Target Device**: CPU
+- **Execution Provider**: CPUExecutionProvider
+- **Supported Languages**: 100+
+
+## Intended Use
+This model is optimized for local execution on devices with CPU hardware acceleration using Foundry Local.
+
+## Capabilities
+- Text retrieval and semantic search
+- Code retrieval
+- Text classification and clustering
+- Bitext mining
+- Multilingual and cross-lingual retrieval
+
+## License
+This model is licensed under Apache 2.0. See [license details](https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE).
+
+## Source
+- HuggingFace: [Qwen3-Embedding-8B](https://huggingface.co/Qwen/Qwen3-Embedding-8B)

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/model.yaml
@@ -1,0 +1,8 @@
+storage:
+  container_name: models
+  container_path: foundrylocal/models/qwen3-embedding-8b/onnx/cpu_and_mobile/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/model.yaml
@@ -1,4 +1,4 @@
-storage:
+path:
   container_name: models
   container_path: foundrylocal/models/qwen3-embedding-8b/onnx/cpu_and_mobile/v1
   storage_name: foundrylocalmodels

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
@@ -4,23 +4,17 @@ version: 1
 path: ./
 tags:
   foundryLocal: "test"
-  license: "Apache-2.0"
+  license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
-  task: embedding
-  maxOutputTokens: 0
+  task: embeddings
+  maxOutputTokens: 1
   alias: qwen3-embedding-8b
   directoryPath: v1
   promptTemplate: ""
   supportsToolCalling: "false"
-  toolCallStart: ""
-  toolCallEnd: ""
-  toolRegisterStart: ""
-  toolRegisterEnd: ""
-  toolResponseStart: ""
-  toolResponseEnd: ""
   capabilities: "embedding"
   supportsReasoning: "false"
   reasoningStart: ""

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "1.1.0"
+  minFLVersion: "0.0.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-8b-generic-cpu
 version: 1
 path: ./
 tags:
-  foundryLocal: ""
+  foundryLocal: "test"
   license: "Apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
   author: Microsoft
@@ -12,12 +12,22 @@ tags:
   task: embedding
   maxOutputTokens: 0
   alias: qwen3-embedding-8b
+  directoryPath: v1
   promptTemplate: ""
-  directoryPath: qwen3-embedding-8b-generic-cpu
-  baseName: qwen3-embedding-8b
   supportsToolCalling: "false"
   toolCallStart: ""
   toolCallEnd: ""
+  toolRegisterStart: ""
+  toolRegisterEnd: ""
+  toolResponseStart: ""
+  toolResponseEnd: ""
+  capabilities: "embedding"
+  supportsReasoning: "false"
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 32768
+  minFLVersion: "1.1.0"
+  disable-maap: "true"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
@@ -1,0 +1,31 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3-embedding-8b-generic-cpu
+version: 1
+path: ./
+tags:
+  foundryLocal: ""
+  license: "Apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: embedding
+  maxOutputTokens: 0
+  alias: qwen3-embedding-8b
+  promptTemplate: ""
+  directoryPath: qwen3-embedding-8b-generic-cpu
+  baseName: qwen3-embedding-8b
+  supportsToolCalling: "false"
+  toolCallStart: ""
+  toolCallEnd: ""
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3-embedding-8b/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'cpu'
+    executionProvider: 'CPUExecutionProvider'
+    fileSizeBytes: 6053498880
+    vRamFootprintBytes: 6053984812

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/asset.yaml
@@ -1,0 +1,4 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
+name: qwen3-embedding-8b-webgpu-gpu
+version: 1
+directory: ./qwen3-embedding-8b-webgpu-gpu

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/asset.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
-name: qwen3-embedding-8b-webgpu-gpu
-version: 1
-directory: ./qwen3-embedding-8b-webgpu-gpu
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/description.md
@@ -7,6 +7,7 @@ This is the GPU (WebGPU)-optimized variant of qwen3-embedding-8b, a text embeddi
 - **Parameters**: 8 billion
 - **Context Length**: 32K tokens
 - **Embedding Dimension**: Up to 4096
+- **Quantization**: KLD Gradient quantization
 - **Target Device**: GPU (WebGPU)
 - **Execution Provider**: WebGPUExecutionProvider
 - **Supported Languages**: 100+

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/description.md
@@ -1,0 +1,28 @@
+# Qwen3 Embedding 8B Webgpu Gpu
+
+This is the GPU (WebGPU)-optimized variant of qwen3-embedding-8b, a text embedding model from the Qwen3 family developed by Alibaba Cloud and optimized by Microsoft.
+
+## Model Details
+- **Model Type**: Text Embedding (ONNX)
+- **Parameters**: 8 billion
+- **Context Length**: 32K tokens
+- **Embedding Dimension**: Up to 4096
+- **Target Device**: GPU (WebGPU)
+- **Execution Provider**: WebGPUExecutionProvider
+- **Supported Languages**: 100+
+
+## Intended Use
+This model is optimized for local execution on devices with GPU (WebGPU) hardware acceleration using Foundry Local.
+
+## Capabilities
+- Text retrieval and semantic search
+- Code retrieval
+- Text classification and clustering
+- Bitext mining
+- Multilingual and cross-lingual retrieval
+
+## License
+This model is licensed under Apache 2.0. See [license details](https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE).
+
+## Source
+- HuggingFace: [Qwen3-Embedding-8B](https://huggingface.co/Qwen/Qwen3-Embedding-8B)

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/model.yaml
@@ -1,4 +1,4 @@
-storage:
+path:
   container_name: models
   container_path: foundrylocal/models/qwen3-embedding-8b/onnx/webgpu/v1
   storage_name: foundrylocalmodels

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/model.yaml
@@ -1,0 +1,8 @@
+storage:
+  container_name: models
+  container_path: foundrylocal/models/qwen3-embedding-8b/onnx/webgpu/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/spec.yaml
@@ -4,23 +4,17 @@ version: 1
 path: ./
 tags:
   foundryLocal: "test"
-  license: "Apache-2.0"
+  license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
-  task: embedding
-  maxOutputTokens: 0
+  task: embeddings
+  maxOutputTokens: 1
   alias: qwen3-embedding-8b
   directoryPath: v1
   promptTemplate: ""
   supportsToolCalling: "false"
-  toolCallStart: ""
-  toolCallEnd: ""
-  toolRegisterStart: ""
-  toolRegisterEnd: ""
-  toolResponseStart: ""
-  toolResponseEnd: ""
   capabilities: "embedding"
   supportsReasoning: "false"
   reasoningStart: ""

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "1.1.0"
+  minFLVersion: "0.0.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/spec.yaml
@@ -1,0 +1,31 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3-embedding-8b-webgpu-gpu
+version: 1
+path: ./
+tags:
+  foundryLocal: ""
+  license: "Apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: embedding
+  maxOutputTokens: 0
+  alias: qwen3-embedding-8b
+  promptTemplate: ""
+  directoryPath: qwen3-embedding-8b-webgpu-gpu
+  baseName: qwen3-embedding-8b
+  supportsToolCalling: "false"
+  toolCallStart: ""
+  toolCallEnd: ""
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3-embedding-8b/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'gpu'
+    executionProvider: 'WebGPUExecutionProvider'
+    fileSizeBytes: 6441209856
+    vRamFootprintBytes: 6441696945

--- a/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-webgpu-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-8b-webgpu-gpu
 version: 1
 path: ./
 tags:
-  foundryLocal: ""
+  foundryLocal: "test"
   license: "Apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
   author: Microsoft
@@ -12,12 +12,22 @@ tags:
   task: embedding
   maxOutputTokens: 0
   alias: qwen3-embedding-8b
+  directoryPath: v1
   promptTemplate: ""
-  directoryPath: qwen3-embedding-8b-webgpu-gpu
-  baseName: qwen3-embedding-8b
   supportsToolCalling: "false"
   toolCallStart: ""
   toolCallEnd: ""
+  toolRegisterStart: ""
+  toolRegisterEnd: ""
+  toolResponseStart: ""
+  toolResponseEnd: ""
+  capabilities: "embedding"
+  supportsReasoning: "false"
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 32768
+  minFLVersion: "1.1.0"
+  disable-maap: "true"
 type: custom_model
 variantInfo:
   parents:

--- a/assets/models/foundrylocal/qwen3-embedding-8b/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b/asset.yaml
@@ -1,0 +1,4 @@
+$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
+name: qwen3-embedding-8b
+version: 1
+directory: ./qwen3-embedding-8b

--- a/assets/models/foundrylocal/qwen3-embedding-8b/asset.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b/asset.yaml
@@ -1,4 +1,4 @@
-$schema: https://azuremlschemas.azureedge.net/latest/asset.schema.json
-name: qwen3-embedding-8b
-version: 1
-directory: ./qwen3-embedding-8b
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3-embedding-8b/description.md
+++ b/assets/models/foundrylocal/qwen3-embedding-8b/description.md
@@ -1,0 +1,21 @@
+# Qwen3 Embedding 8B
+
+This is the parent model entry for qwen3-embedding-8b in the Foundry Local catalog.
+
+## Model Details
+- **Model Type**: Text Embedding
+- **Architecture**: Transformer (Qwen3)
+- **Parameters**: 8 billion
+- **Context Length**: 32K tokens
+- **Embedding Dimension**: Up to 4096
+- **Supported Languages**: 100+
+
+## Overview
+
+The Qwen3 Embedding model series is designed for text embedding and ranking tasks. Building upon the Qwen3 foundation models, it provides state-of-the-art performance across text retrieval, code retrieval, text classification, text clustering, and bitext mining tasks.
+
+## License
+This model is licensed under Apache 2.0. See [license details](https://huggingface.co/Qwen/Qwen3-Embedding-8B).
+
+## Source
+- HuggingFace: [Qwen3-Embedding-8B](https://huggingface.co/Qwen/Qwen3-Embedding-8B)

--- a/assets/models/foundrylocal/qwen3-embedding-8b/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b/model.yaml
@@ -1,0 +1,8 @@
+storage:
+  container_name: models
+  container_path: foundrylocal/models/qwen3-embedding-8b
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-8b/model.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b/model.yaml
@@ -1,4 +1,4 @@
-storage:
+path:
   container_name: models
   container_path: foundrylocal/models/qwen3-embedding-8b
   storage_name: foundrylocalmodels

--- a/assets/models/foundrylocal/qwen3-embedding-8b/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b/spec.yaml
@@ -3,5 +3,5 @@ name: qwen3-embedding-8b
 version: 1
 path: ./
 tags:
-  foundryLocal: ""
+  foundryLocal: "test"
 type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-8b/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b/spec.yaml
@@ -1,0 +1,7 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3-embedding-8b
+version: 1
+path: ./
+tags:
+  foundryLocal: ""
+type: custom_model


### PR DESCRIPTION
## Summary

Add Qwen3-Embedding-0.6B and Qwen3-Embedding-8B embedding models to the Foundry Local public catalog.

## Models Added

| Model | Variants | License |
|-------|----------|---------|
| Qwen3-Embedding-0.6B | CPU, CUDA, WebGPU | Apache-2.0 |
| Qwen3-Embedding-8B | CPU, CUDA, WebGPU | Apache-2.0 |

**8 model entries** (2 parents + 6 variants), **32 files** total (asset.yaml, description.md, model.yaml, spec.yaml per model).

## Details

- **Task type**: `embedding` (first embedding models in the catalog)
- **Quantization**: INT4 via Olive ModelBuilder (RTN), matching existing catalog convention
- **Context length**: 32,768 tokens
- **Blob storage**: `foundrylocalmodels/models/foundrylocal/models/`
- **Source**: [Qwen/Qwen3-Embedding-0.6B](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B), [Qwen/Qwen3-Embedding-8B](https://huggingface.co/Qwen/Qwen3-Embedding-8B)
- **Olive recipes**: microsoft/olive-recipes#355
- **SDK embedding support**: microsoft/Foundry-Local#639
