### PR TITLE
Rename trace to turn in evaluation level

### DIFF
--- a/assets/evaluators/builtin/customer_satisfaction/evaluator/_customer_satisfaction.py
+++ b/assets/evaluators/builtin/customer_satisfaction/evaluator/_customer_satisfaction.py
@@ -56,11 +56,11 @@ class EvaluationLevel(str, Enum):
     """Supported evaluation levels for CustomerSatisfactionEvaluator.
 
     - ``CONVERSATION``: Force conversation-level evaluation using the multi-turn path.
-    - ``TRACE``: Force trace-level evaluation using the single-turn query/response path.
+    - ``TURN``: Force turn-level evaluation using the single-turn query/response path.
     """
 
     CONVERSATION = "conversation"
-    TRACE = "trace"
+    TURN = "turn"
 
 
 def _merge_query_response_messages(query: List[dict], response: List[dict]) -> List[dict]:
@@ -928,8 +928,8 @@ class CustomerSatisfactionEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :type threshold: int
         :keyword evaluation_level: Force a specific evaluation level for this invocation. When ``None``
             (default), the level is auto-detected from input shape (``messages`` -> conversation,
-            ``query``/``response`` -> trace). Set to ``EvaluationLevel.CONVERSATION`` or
-            ``EvaluationLevel.TRACE`` to override auto-detection.
+            ``query``/``response`` -> turn). Set to ``EvaluationLevel.CONVERSATION`` or
+            ``EvaluationLevel.TURN`` to override auto-detection.
         :type evaluation_level: Optional[Union[EvaluationLevel, str]]
         :keyword kwargs: Additional keyword arguments.
         """
@@ -1082,7 +1082,7 @@ class CustomerSatisfactionEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         """
         if self._evaluation_level == EvaluationLevel.CONVERSATION:
             return True
-        if self._evaluation_level == EvaluationLevel.TRACE:
+        if self._evaluation_level == EvaluationLevel.TURN:
             return False
         # Auto-detect (_evaluation_level is None)
         return eval_input.get("messages") is not None
@@ -1104,7 +1104,7 @@ class CustomerSatisfactionEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                 query, response = _wrap_string_messages(query, response)
             if isinstance(query, list) and isinstance(response, list):
                 kwargs["messages"] = _merge_query_response_messages(query, response)
-        elif self._evaluation_level == EvaluationLevel.TRACE and kwargs.get("messages"):
+        elif self._evaluation_level == EvaluationLevel.TURN and kwargs.get("messages"):
             if any(m.get("role") == MessageRole.USER for m in kwargs["messages"]):
                 query_messages, response_messages = _split_messages_at_latest_user(kwargs["messages"])
                 kwargs["query"] = query_messages
@@ -1118,7 +1118,7 @@ class CustomerSatisfactionEvaluator(PromptyEvaluatorBase[Union[str, float]]):
     async def _do_eval(self, eval_input: Dict) -> Dict[str, Union[float, str]]:  # type: ignore[override]
         """Do Customer Satisfaction evaluation.
 
-        Routes to conversation-level or trace-level evaluation based on
+        Routes to conversation-level or turn-level evaluation based on
         ``_evaluation_level`` (if set)
         or auto-detects from input shape (default).
 

--- a/assets/evaluators/builtin/customer_satisfaction/spec.yaml
+++ b/assets/evaluators/builtin/customer_satisfaction/spec.yaml
@@ -10,7 +10,7 @@ tags:
   provider: "Microsoft"
   preview: "true"
   is_continuous_scenario: "true"
-  supportedEvaluationLevels: ["conversation", "trace"]
+  supportedEvaluationLevels: ["conversation", "turn"]
 initParameterSchema:
   type: "object"
   properties:

--- a/assets/evaluators/builtin/customer_satisfaction/spec.yaml
+++ b/assets/evaluators/builtin/customer_satisfaction/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.customer_satisfaction"
-version: 4
+version: 5
 displayName: "Customer-Satisfaction-Evaluator"
 description: "Evaluates the predicted customer satisfaction level of an AI agent interaction on a 1-5 Likert scale. This evaluator assesses whether the agent's response would likely result in a satisfied customer based on helpfulness, completeness, tone, and resolution of the user's needs. Useful for measuring customer support quality, chatbot effectiveness, and overall user experience."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
+++ b/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
@@ -54,11 +54,11 @@ class EvaluationLevel(str, Enum):
     """Supported evaluation levels for TaskCompletionEvaluator.
 
     - ``CONVERSATION``: Force conversation-level evaluation using the multi-turn path.
-    - ``TRACE``: Force trace-level evaluation using the single-turn query/response path.
+    - ``TURN``: Force turn-level evaluation using the single-turn query/response path.
     """
 
     CONVERSATION = "conversation"
-    TRACE = "trace"
+    TURN = "turn"
 
 
 def _merge_query_response_messages(query: List[dict], response: List[dict]) -> List[dict]:
@@ -1013,8 +1013,8 @@ class TaskCompletionEvaluator(PromptyEvaluatorBase[Union[str, int]]):
         :type credential: Optional[TokenCredential]
         :keyword evaluation_level: Force a specific evaluation level for this invocation. When ``None``
             (default), the level is auto-detected from input shape (``messages`` -> conversation,
-            ``query``/``response`` -> trace). Set to ``EvaluationLevel.CONVERSATION`` or
-            ``EvaluationLevel.TRACE`` to override auto-detection.
+            ``query``/``response`` -> turn). Set to ``EvaluationLevel.CONVERSATION`` or
+            ``EvaluationLevel.TURN`` to override auto-detection.
         :type evaluation_level: Optional[Union[EvaluationLevel, str]]
         :keyword kwargs: Additional keyword arguments.
         """
@@ -1201,7 +1201,7 @@ class TaskCompletionEvaluator(PromptyEvaluatorBase[Union[str, int]]):
         """
         if self._evaluation_level == EvaluationLevel.CONVERSATION:
             return True
-        if self._evaluation_level == EvaluationLevel.TRACE:
+        if self._evaluation_level == EvaluationLevel.TURN:
             return False
         # Auto-detect (_evaluation_level is None)
         return eval_input.get("messages") is not None
@@ -1242,7 +1242,7 @@ class TaskCompletionEvaluator(PromptyEvaluatorBase[Union[str, int]]):
                 query, response = _wrap_string_messages(query, response)
             if isinstance(query, list) and isinstance(response, list):
                 kwargs["messages"] = _merge_query_response_messages(query, response)
-        elif self._evaluation_level == EvaluationLevel.TRACE and kwargs.get("messages"):
+        elif self._evaluation_level == EvaluationLevel.TURN and kwargs.get("messages"):
             if any(m.get("role") == MessageRole.USER for m in kwargs["messages"]):
                 query_messages, response_messages = _split_messages_at_latest_user(kwargs["messages"])
                 kwargs["query"] = query_messages
@@ -1256,7 +1256,7 @@ class TaskCompletionEvaluator(PromptyEvaluatorBase[Union[str, int]]):
     async def _do_eval(self, eval_input: Dict) -> Dict[str, Union[int, str]]:  # type: ignore[override]
         """Do Task Completion evaluation.
 
-        Routes to conversation-level or trace-level evaluation based on
+        Routes to conversation-level or turn-level evaluation based on
         ``_evaluation_level`` (if set)
         or auto-detects from input shape (default).
 

--- a/assets/evaluators/builtin/task_completion/spec.yaml
+++ b/assets/evaluators/builtin/task_completion/spec.yaml
@@ -9,7 +9,7 @@ categories: ["agents"]
 tags:
   is_continuous_scenario: "true"
   provider: "Microsoft"
-supportedEvaluationLevels: ["conversation", "trace"]
+supportedEvaluationLevels: ["conversation", "turn"]
 initParameterSchema:
   type: "object"
   properties:

--- a/assets/evaluators/builtin/task_completion/spec.yaml
+++ b/assets/evaluators/builtin/task_completion/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.task_completion"
-version: 9
+version: 10
 displayName: "Task-Completion-Evaluator-(Preview)"
 description: "Evaluates whether an AI agent successfully completed the requested task end to end by analyzing the conversation history and agent response to determine if all task requirements were met, ignoring rule adherence or intent understanding. This evaluator is useful for assessing agent effectiveness in task-oriented scenarios, workflow automation, and goal-oriented AI interactions."
 evaluatorType: "builtin"

--- a/assets/evaluators/tests/test_evaluators_behavior/test_task_completion_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_task_completion_evaluator_behavior.py
@@ -540,10 +540,10 @@ class TestTaskCompletionEvaluationLevel:
         evaluator._flow.assert_not_called()
         assert "task_completion" in result
 
-    def test_forced_trace_with_query_response(self):
-        """Forced trace level works with query/response."""
+    def test_forced_turn_with_query_response(self):
+        """Forced turn level works with query/response."""
         evaluator = _create_mocked_evaluator_with_level(
-            evaluation_level=EvaluationLevel.TRACE
+            evaluation_level=EvaluationLevel.TURN
         )
         result = evaluator(query="Plan a trip.", response="Here's your itinerary.")
         evaluator._flow.assert_called_once()
@@ -565,10 +565,10 @@ class TestTaskCompletionEvaluationLevel:
         assert "Done! Your flight is booked. Confirmation sent." in merged_messages
         assert "task_completion" in result
 
-    def test_forced_trace_with_messages_converts(self):
-        """Forced trace level converts messages into query/response around the latest user turn."""
+    def test_forced_turn_with_messages_converts(self):
+        """Forced turn level converts messages into query/response around the latest user turn."""
         evaluator = _create_mocked_evaluator_with_level(
-            evaluation_level=EvaluationLevel.TRACE
+            evaluation_level=EvaluationLevel.TURN
         )
         result = evaluator(messages=VALID_MESSAGES)
         evaluator._flow.assert_called_once()
@@ -604,10 +604,10 @@ class TestTaskCompletionEvaluationLevel:
         with pytest.raises(EvaluationException):
             evaluator(query="", response="Here's your itinerary.")
 
-    def test_forced_trace_with_messages_without_response_raises_invalid_value(self):
-        """Forced trace level requires response messages after the latest user turn."""
+    def test_forced_turn_with_messages_without_response_raises_invalid_value(self):
+        """Forced turn level requires response messages after the latest user turn."""
         evaluator = _create_mocked_evaluator_with_level(
-            evaluation_level=EvaluationLevel.TRACE
+            evaluation_level=EvaluationLevel.TURN
         )
         with pytest.raises(EvaluationException, match="last message must have role 'assistant'"):
             evaluator(
@@ -626,9 +626,9 @@ class TestTaskCompletionEvaluationLevel:
         evaluator._flow.assert_not_called()
         assert "task_completion" in result
 
-    def test_string_level_trace(self):
-        """String 'trace' is accepted as evaluation_level."""
-        evaluator = _create_mocked_evaluator_with_level(evaluation_level="trace")
+    def test_string_level_turn(self):
+        """String 'turn' is accepted as evaluation_level."""
+        evaluator = _create_mocked_evaluator_with_level(evaluation_level="turn")
         result = evaluator(query="Plan a trip.", response="Here's your itinerary.")
         evaluator._flow.assert_called_once()
         evaluator._multi_turn_flow.assert_not_called()


### PR DESCRIPTION
updating the multi turn contract to accept "conversation" and "turn" as supported Evaluation levels