### PR TITLE
Fix aiohttp vulnerabilities in acpt-pytorch-2.8-cuda12.6 (GHSA-63hf-3vf5-4wqf, GHSA-p998-jp59-783m, GHSA-m5qp-6w8w-w647, GHSA-hcc4-c3v8-rx92, GHSA-w2fm-2cpv-w7v5)

### DIFF
--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -38,7 +38,8 @@ RUN apt-get install -y openssh-server openssh-client
 RUN pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1'
 # vulnerability in base conda env
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'PyJWT>=2.12.0'
+# aiohttp 3.13.3 in the base conda env is vulnerable to 10 GHSAs (1 CRITICAL + 4 HIGH + 5 MEDIUM); 3.13.4 resolves all
+RUN conda run -n base python -m pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -y -n ptca pip>=26.0.1
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/


### PR DESCRIPTION
## Summary
Bumps `aiohttp` from `3.13.3` to `>=3.13.4` in the `base` conda env of `azureml/curated/acpt-pytorch-2.8-cuda12.6`. Resolves 10 open aiohttp CVEs (1 CRITICAL, 4 HIGH, 5 MEDIUM) reported by the EMS vulnerability dashboard against tag `7`.

## Vulnerabilities addressed
| Risk | GHSA | Required version |
|------|------|------------------|
| CRITICAL | [GHSA-63hf-3vf5-4wqf](https://github.com/advisories/GHSA-63hf-3vf5-4wqf) | 3.13.4 |
| HIGH | [GHSA-p998-jp59-783m](https://github.com/advisories/GHSA-p998-jp59-783m) | 3.13.4 |
| HIGH | [GHSA-m5qp-6w8w-w647](https://github.com/advisories/GHSA-m5qp-6w8w-w647) | 3.13.4 |
| HIGH | [GHSA-hcc4-c3v8-rx92](https://github.com/advisories/GHSA-hcc4-c3v8-rx92) | 3.13.4 |
| HIGH | [GHSA-w2fm-2cpv-w7v5](https://github.com/advisories/GHSA-w2fm-2cpv-w7v5) | 3.13.4 |
| MEDIUM | [GHSA-mwh4-6h8g-pg8w](https://github.com/advisories/GHSA-mwh4-6h8g-pg8w) | 3.13.4 |
| MEDIUM | [GHSA-966j-vmvw-g2g9](https://github.com/advisories/GHSA-966j-vmvw-g2g9) | 3.13.4 |
| MEDIUM | [GHSA-3wq7-rqq7-wx6j](https://github.com/advisories/GHSA-3wq7-rqq7-wx6j) | 3.13.4 |
| MEDIUM | [GHSA-c427-h43c-vf67](https://github.com/advisories/GHSA-c427-h43c-vf67) | 3.13.4 |
| MEDIUM | [GHSA-2vrm-gr82-f7m5](https://github.com/advisories/GHSA-2vrm-gr82-f7m5) | 3.13.4 |

## Scope
- **Only the `base` conda env is patched.** The EMS scan reports `aiohttp` only at `opt/conda/lib/python3.13/site-packages/` (= base env). The `ptca` env is not affected (aiohttp not installed there).
- Follows the existing `# Fix security vulnerabilities` pattern in this Dockerfile; append-only, no reorder of prior upgrades.

## Test plan
- [ ] `environments-ci.yaml` build + Trivy passes with `aiohttp-3.13.4` reported in the image.
- [ ] `assets-test.yaml` pytest passes (runs `pytorch2_8_sample_test.py` on AML).
- [ ] After merge, next EMS scan of `acpt-pytorch-2.8-cuda12.6` shows all 10 aiohttp GHSAs resolved.

## Automation pilot disclaimer
This is the first manually-executed PR in a proposed auto-patch workflow for AzureML curated-image CVEs (Training + Project_24_25 owners). The workflow consumes the EMS Kusto dashboard and proposes Dockerfile upgrades per the existing `# Fix security vulnerabilities` pattern in each env. On-call owns rollback decisions — the bot will not auto-revert.
