### PR TITLE
Migrate acpt-pytorch-2.8-cuda12.6 off AIFX base to openmpi5.0-cuda12.6-ubuntu24.04

### DIFF
--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -38,7 +38,8 @@ RUN apt-get install -y openssh-server openssh-client
 RUN pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1'
 # vulnerability in base conda env
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'PyJWT>=2.12.0'
+# aiohttp 3.13.3 in the base conda env is vulnerable to 10 GHSAs (1 CRITICAL + 4 HIGH + 5 MEDIUM); 3.13.4 resolves all
+RUN conda run -n base python -m pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -y -n ptca pip>=26.0.1
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -1,45 +1,43 @@
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
+FROM mcr.microsoft.com/azureml/openmpi5.0-cuda12.6-ubuntu24.04:{{latest-image-tag}}
 
-# Install pip dependencies
-COPY requirements.txt .
-RUN pip install -r requirements.txt --no-cache-dir
-
-# Inference requirements
-COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20230419.v1 /artifacts /var/
+# OS updates + openssh (DeepSpeed multi-node launcher requires passwordless ssh)
 RUN apt-get update && \
-    apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
-        libcurl4 \
-        liblttng-ust1 \
-        libunwind8 \
-        libxml++2.6-2v5 \
-        nginx-light \
-        psmisc \
-        rsyslog \
-        runit \
-        unzip && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    cp /var/configuration/rsyslog.conf /etc/rsyslog.conf && \
-    cp /var/configuration/nginx.conf /etc/nginx/sites-available/app && \
-    ln -sf /etc/nginx/sites-available/app /etc/nginx/sites-enabled/app && \
-    rm -f /etc/nginx/sites-enabled/default
-ENV SVDIR=/var/runit
-ENV WORKER_TIMEOUT=400
-EXPOSE 5001 8883 8888
+        openssh-server \
+        openssh-client && \
+    apt-get autoremove -y && apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/*.deb
 
-# support Deepspeed launcher requirement of passwordless ssh login
-RUN apt-get update
-RUN apt-get install -y openssh-server openssh-client
+# Upgrade pip toolchain before any package install so resolver sees patched versions
+RUN pip install --no-cache-dir --upgrade \
+        'pip>=26.0' \
+        'setuptools>=82.0.1' \
+        'wheel>=0.46.2'
 
+# PyTorch 2.8 stack pinned to CUDA 12.6 wheels (base image ships CUDA 12.6.3)
+RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cu126 \
+        'torch==2.8.0' \
+        'torchvision==0.23.0' \
+        'torchaudio==2.8.0'
 
-# Fix security vulnerabilities
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-RUN pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1'
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-# aiohttp 3.13.3 in the base conda env is vulnerable to 10 GHSAs (1 CRITICAL + 4 HIGH + 5 MEDIUM); 3.13.4 resolves all
-RUN conda run -n base python -m pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1
-RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/
+# DeepSpeed is required by pytorch2_8_sample_test.py (--deepspeed ds_config.json)
+RUN pip install --no-cache-dir 'deepspeed>=0.15'
+
+# AzureML integration + training toolchain. Security floors that upstream deps
+# accept naturally (urllib3, pillow, aiohttp, filelock, requests) live in
+# requirements.txt so pip resolves them in one pass.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Force-upgrade only packages whose parent pins cap below the patched version:
+#   - cryptography: azureml-mlflow~=1.62 caps <46
+#   - protobuf:     azureml-mlflow / azureml-automl transitively cap <5
+#   - PyJWT:        transitively capped below 2.12 by some azureml deps
+RUN pip install --no-cache-dir --upgrade \
+        'cryptography>=46.0.5' \
+        'protobuf>=6.33.5' \
+        'PyJWT>=2.12.0'
+
+# Remove conda + pip caches to avoid opt/conda/pkgs/ scanner false-positives
+RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/ /root/.cache/pip

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -1,13 +1,34 @@
 FROM mcr.microsoft.com/azureml/openmpi5.0-cuda12.6-ubuntu24.04:{{latest-image-tag}}
 
 # OS updates + openssh (DeepSpeed multi-node launcher requires passwordless ssh)
+# + inference-server scaffolding. This curated env is dual-use: its
+# requirements.txt installs azureml-inference-server-http and inference-schema,
+# so the nginx / runit / rsyslog / port layer below is part of the image's
+# contract for online-endpoint deployments.
+COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20230419.v1 /artifacts /var/
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
+        libcurl4 \
+        liblttng-ust1 \
+        libunwind8 \
+        libxml++2.6-2v5 \
+        nginx-light \
+        psmisc \
+        rsyslog \
+        runit \
+        unzip \
         openssh-server \
         openssh-client && \
     apt-get autoremove -y && apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/*.deb
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/*.deb && \
+    cp /var/configuration/rsyslog.conf /etc/rsyslog.conf && \
+    cp /var/configuration/nginx.conf /etc/nginx/sites-available/app && \
+    ln -sf /etc/nginx/sites-available/app /etc/nginx/sites-enabled/app && \
+    rm -f /etc/nginx/sites-enabled/default
+ENV SVDIR=/var/runit
+ENV WORKER_TIMEOUT=400
+EXPOSE 5001 8883 8888
 
 # Upgrade pip toolchain before any package install so resolver sees patched versions
 RUN pip install --no-cache-dir --upgrade \

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
@@ -10,10 +10,10 @@ MarkupSafe
 regex
 pybind11
 urllib3>=2.6.3
-requests
+requests>=2.33.0
 pillow>=12.1.1
 transformers
-aiohttp>=3.13.3
+aiohttp>=3.13.4
 py-spy
 debugpy
 ipykernel

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
@@ -11,7 +11,7 @@ regex
 pybind11
 urllib3>=2.6.3
 requests>=2.33.0
-pillow>=12.1.1
+pillow>=12.2.0
 transformers
 aiohttp>=3.13.4
 py-spy

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/spec.yaml
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/spec.yaml
@@ -1,8 +1,11 @@
 $schema: https://azuremlschemas.azureedge.net/latest/environment.schema.json
 
 description: >-
-  Recommended environment for Deep Learning in public preview with PyTorch on Azure containing the Azure ML SDK with the latest compatible versions of Ubuntu, Python, PyTorch, CUDA\RocM, combined with optimizers like ORT Training,+DeepSpeed+MSCCL+ORT MoE and more. The image introduces newly released PyTorch 2.1 for early testing, and preview of new fastcheckpointing capability called Nebula. 
-  Azure Container Registry:acptdev.azurecr.io/test/public/aifx/acpt/stable-ubuntu2004-cu121-py310-torch212
+  Training environment for Deep Learning with PyTorch 2.8 on Azure ML.
+  Built on the AzureML openmpi5.0-cuda12.6-ubuntu24.04 base (OpenMPI 5.0.6,
+  CUDA 12.6.3, cuDNN, Miniconda py310) with the Azure ML SDK, PyTorch 2.8 +
+  torchvision 0.23 + torchaudio 2.8 (cu126 wheels), DeepSpeed, transformers,
+  and common training tooling (tensorboard, matplotlib, ipykernel, debugpy).
 
 name: "{{asset.name}}"
 version: "{{asset.version}}"
@@ -16,10 +19,8 @@ os_type: linux
 tags:
   PyTorch: "2.8"
   GPU: Cuda12
-  OS: Ubuntu22.04
+  OS: Ubuntu24.04
   Training: ""
   Preview: ""
   Python: "3.10"
-  DeepSpeed: "0.13.1"
-  ONNXRuntime: "1.17.1"
-  torch_ORT: "1.17.0"
+  DeepSpeed: ""


### PR DESCRIPTION
## Summary

Migrate `acpt-pytorch-2.8-cuda12.6` off `mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280` to `mcr.microsoft.com/azureml/openmpi5.0-cuda12.6-ubuntu24.04`, and install PyTorch + DeepSpeed + the existing AzureML / training toolchain explicitly on top.

## Why

EMS vuln-dashboard analysis on the published `acpt-pytorch-2.8-cuda12.6:7` tag showed **10 open CVEs, all 10 in the AIFX-provided base conda env** (`opt/conda/lib/python3.13/` — AIFX's base py3.13 env). The aiohttp CVEs (CVE-2026-34520 and siblings) are the original trigger; `acpt-pytorch-2.2-cuda12.1`, `acft-rft-training`, and `ai-ml-automl-dnn-text-gpu-ptca` show the same pattern at higher counts. Reviewer @vizhur flagged the initial patch with "don't patch base" — correct principle, but AIFX has been systemically OOSLA (every `ptebic.azurecr.io/aifx/acpt/*` image has 77–83% OoSLA vulns; PyTorch RCE CVE-2025-32434 PastDue on AIFX for 11 months, ROCm-line PMIx PastDue 2.4 years). Waiting for AIFX to patch is not a viable SLA strategy.

The AzureML openmpi line commits to a 30-day security-patch SLA (per the repo README) we can actually rely on.

## Changes

- **FROM**: AIFX torch280 biweekly tag → `mcr.microsoft.com/azureml/openmpi5.0-cuda12.6-ubuntu24.04:{{latest-image-tag}}`
- **Install on top**:
  - `torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0` from `https://download.pytorch.org/whl/cu126`
  - `deepspeed>=0.15` (required by `pytorch2_8_sample_test.py`)
  - Existing `requirements.txt` (AzureML integration + training toolchain)
- **Inference-server scaffolding kept verbatim** (nginx / runit / rsyslog / libcurl4 / etc. + COPY-from `o16n-base/python-assets` + ports 5001/8883/8888 + `SVDIR` + `WORKER_TIMEOUT`) — `requirements.txt` still installs `azureml-inference-server-http` and `inference-schema`, so this env's dual training+inference contract is preserved.
- **Security floors**: `urllib3 / pillow / aiohttp / filelock / requests` in `requirements.txt`; `cryptography / protobuf / PyJWT` as Dockerfile force-upgrade (parents cap them); `pip / setuptools / wheel` upgraded early. `pillow` floor bumped to **`>=12.2.0`** after VCM scan surfaced CVE-2026-40192 still open at 12.1.1.
- `spec.yaml`: OS tag `Ubuntu22.04 → Ubuntu24.04`; description refreshed (prior one still said "PyTorch 2.1 early testing / Nebula"); dropped stale `DeepSpeed: 0.13.1 / ONNXRuntime: 1.17.1 / torch_ORT: 1.17.0` tags.

## Known non-equivalences vs prior AIFX-based image

- Ubuntu **22.04 → 24.04**. Unavoidable: `openmpi5.0-cuda12.6-*` has no 22.04 variant. glibc 2.35 → 2.39, most pip wheels compatible.
- **MSCCL / SCCL** not installed. Advertised in prior spec.yaml but never installed by any Dockerfile in this repo we can see — almost certainly AIFX-internal binary. Multi-node training falls back to stock NCCL.
- **ORT Training / torch-ort / Nebula** not installed. Advertised but not verified to be in AIFX base (we can't pull AIFX image from this env to confirm); prior Dockerfile never `pip install`-ed them either. If downstream jobs rely on these, flag a follow-up.
- `base` py3.13 conda env removed. Was an AIFX internal artifact; no downstream consumer we know of.

## Validation

- **Built on ACR** (`imagevalidation.azurecr.io`, eastus2) — run `ch9` 9m52s.
- **Trivy + VCM (CoMET)** scan on built image: **0 `evaluate` non-compliant + 0 `show` findings** (vs baseline 10 non-compliant / 11 total on published `:7`).
- **ACI smoke test** (Ubuntu 24.04, CPU): all targeted imports OK — `torch 2.8.0+cu126`, `deepspeed 0.18.9`, `transformers 5.6.0`, `azureml.core 1.61.0.post3`, `azureml-inference-server-http 1.5.1`, `azmlinfsrv` CLI works. Scaffolding (`/var/runit`, nginx, sshd) active. All security pins exceeded (aiohttp 3.13.5 ≥ 3.13.4, pillow 12.2.0, crypto 46.0.7, protobuf 7.34.1, PyJWT 2.12.1, etc.).
- This PR's CI `environments-ci.yaml` (Trivy) and `assets-test.yaml` (`pytorch2_8_sample_test.py` — BERT-GLUE DeepSpeed on V100×2) are the real runtime gates.

## Test plan

- [ ] `environments-ci.yaml` build + Trivy scan passes
- [ ] `assets-test.yaml` — BERT-GLUE DeepSpeed 2-node training completes successfully
- [ ] EMS dashboard rescans the new tag within 24h and shows 0 open CVEs for this image

Related artifacts (internal, not committed): VCM scan output, ACI smoke logs, migration evaluation doc at `output/aifx/base-image-migration-evaluation.md` on the analysis worktree.
