### PR TITLE
Optimize groundedness multi-turn prompt (v5)  +14pp gpt-5.4 accuracy

### DIFF
--- a/assets/evaluators/builtin/groundedness/evaluator/groundedness_multi_turn.prompty
+++ b/assets/evaluators/builtin/groundedness/evaluator/groundedness_multi_turn.prompty
@@ -36,9 +36,27 @@ user:
 > If the agent contradicts or forgets information that was explicitly provided by the user or returned by a tool in an earlier turn, and that information is directly relevant to the current response, this counts as a grounding failure.
 
 ## Important Evaluation Checks
-Before scoring, verify these two things:
-1. **Inferences and extrapolations:** Does the agent make causal claims, generalizations, or extrapolations across turns that go beyond what the grounding sources explicitly state? Plausible-sounding inferences are still ungrounded if the grounding sources do not state them. Score 2 if the conversation's core claims rely on inference rather than explicit grounding.
-2. **Unsupported additions:** Does the agent add significant claims not found in any grounding source? A conversation that is mostly grounded but includes one or more major unsupported claims should be scored lower (2 if significant, 4 if only minor additions).
+Before scoring, follow this procedure:
+1. **Locate the agent's natural-language response:** In multi-turn conversations, agent turns may contain [TOOL_CALL] and [TOOL_RESULT] blocks followed by natural-language text. The text that appears AFTER the tool results IS the agent's response and MUST be evaluated. Do not skip responses that follow tool call blocks or treat the entire turn as "just a tool call."
+2. **Extract factual propositions:** From the agent's natural-language response, identify every factual proposition about the world, entities, events, or data. Strip away conversational wrappers first — greetings, self-referential framing ("I know...", "I'm not sure but...", "I can't confirm..."), expressions of uncertainty, polite filler, and question framing are NOT factual propositions and should be set aside before evaluation.
+3. **Check each factual proposition against grounding sources:** For each proposition, determine whether its meaning is supported by the grounding sources (user statements, tool results, system context). Focus on whether the core meaning is preserved, not exact wording. Groundedness evaluates whether facts are supported by grounding sources, NOT whether the agent's response is topically relevant to the user's question. An off-topic but factually supported response is still grounded.
+4. **Classify unsupported content:**
+   - **Substantive hallucinations** (MUST lower score): Fabricated facts about the topic not in any grounding source, personal opinions or stated preferences about the topic ("my favorite", "I love it"), made-up anecdotes or experiences about the topic ("I had heard of...", "I read that..."), specific factual claims that contradict or materially distort information from the grounding sources.
+   - **NOT hallucinations** (do NOT penalize these — they are normal conversational behavior):
+     - Self-referential framing: "I'm a bot", "I can't eat", "I know a bit about it", "I can't confirm that", "I don't have examples right now", "I don't know that detail", "Swimming is not possible for a bot like me". These are meta-statements about the agent, not factual claims about the world. Always ignore them.
+     - Expressions of uncertainty: "I'm not sure", "I don't really know, but...", "Not really", "No, I don't know"
+     - Polite filler and engagement: "That's interesting!", "It is great!", "Wow!", "I'm happy to help", "Cool!"
+     - Follow-up questions and topic-steering: "Have you been there?", "Did you know...?", "What about you?", "Have you heard of [entity]?", "Do you like X?", "Have you ever tried...?"
+     - Pronoun references ("it", "they", "them") where the referent is identifiable from the conversation context
+     - Minor paraphrasing that preserves the core meaning: synonym substitutions ("last" → "final"), word form changes ("skateboarders" → "skateboards"), softening/strengthening hedges ("may be the most familiar" → "the most familiar"), restating facts as questions, summarizing with slightly different wording. If the original meaning is preserved, it is grounded.
+     - Minor typos or grammar errors that don't change the meaning
+5. **Apply this decision tree to score:**
+   - **No factual propositions to evaluate** (response consists entirely of greetings, questions, or acknowledgments with zero factual assertions) → Score 3. Do NOT use score 3 if the response contains at least one factual proposition — instead, evaluate whether each proposition is supported.
+   - **Any substantive hallucination identified** (even one) → Score 2 (or 1 if pervasive fabrication)
+   - **All factual propositions grounded but response is incomplete** → Score 4
+   - **All factual propositions grounded and response is complete** → Score 5
+
+> CRITICAL: If you identify a substantive hallucination (fabricated facts, unsupported opinions about the topic, or claims that contradict or materially distort grounding sources), the score MUST be 2 or lower. Scores 4-5 require zero substantive hallucinations. Self-referential framing, expressions of uncertainty, engagement phrases, follow-up questions, polite filler, pronoun references, and meaning-preserving paraphrasing are NOT hallucinations and must NOT lower the score.
 
 # Ratings
 ## [Groundedness: 1] (Not Grounded)
@@ -54,7 +72,7 @@ Before scoring, verify these two things:
   Agent turn 2: Common side effects include dizziness and muscle pain. You should also avoid grapefruit juice while on these medications.
 
 ## [Groundedness: 2] (Contains Incorrect or Unsupported Information)
-**Definition:** Agent responses attempt to engage with the conversation but include incorrect, fabricated, or unsupported claims. This includes contradicting information from prior turns, distorting facts from tool results, introducing details not present in any grounding source, or making inferences and extrapolations beyond what the grounding sources explicitly state. Even if some parts are correct, the presence of significant unsupported claims makes the conversation unreliable.
+**Definition:** Agent responses attempt to engage with the conversation but include incorrect, fabricated, or unsupported claims. This includes contradicting information from prior turns, distorting facts from tool results, introducing details not present in any grounding source, making inferences and extrapolations beyond what the grounding sources explicitly state, or expressing personal opinions/experiences/anecdotes as if they were facts. Even if most content is correct, the presence of ANY unsupported claim makes the conversation unreliable.
 
 **Examples:**
   **CONVERSATION:**
@@ -73,8 +91,17 @@ Before scoring, verify these two things:
   User turn 2: How can I prepare my garden for the winter season?
   Agent turn 2: To prepare your garden for the winter season, mow your lawn, trim hedges, edge the lawn, and control weeds. These actions help maintain the health and appearance of your yard during the colder months.
 
+  **CONVERSATION:**
+  User turn 1: Tell me about Dylan's Candy Bar.
+  [TOOL_CALL] search_info(query="Dylan's Candy Bar")
+  [TOOL_RESULT] Dylan's Candy Bar is a chain of boutique candy stores founded by Dylan Lauren. Flagship store on Third Avenue in New York City, opened in 2001.
+  Agent turn 1: Dylan's Candy Bar is a boutique candy store founded by Dylan Lauren, with a flagship on Third Avenue in NYC since 2001. It's my favorite candy store — I love it!
+  *Why score 2: "my favorite" and "I love it" are personal opinions/experiences not found in any grounding source.*
+
 ## [Groundedness: 3] (Nothing to be Grounded)
 **Definition:** Agent responses do not provide any information that can be evaluated against the grounding sources. This includes responses that are polite fillers, clarification requests, follow-up questions, or acknowledgments that make no factual claims.
+
+**Important:** Score 3 applies ONLY when the agent makes zero factual propositions. If the agent restates, paraphrases, or summarizes information from tool results, that IS a factual response and should be scored 4 or 5, not 3.
 
 **Examples:**
   **CONVERSATION:**
@@ -83,8 +110,8 @@ Before scoring, verify these two things:
   User turn 2: I need to update my shipping address.
   Agent turn 2: Sure, I can help with that. Could you provide your new address?
 
-## [Groundedness: 4] (Partially Correct Response)
-**Definition:** Agent responses provide correct information from the grounding sources but are incomplete or lack specific details that were available. The agent captures some of the necessary information but omits key elements needed for a full understanding. All major stated claims are supported by the grounding sources; only minor details may be missing or slightly imprecise.
+## [Groundedness: 4] (Fully Grounded but Incomplete)
+**Definition:** Agent responses provide correct information from the grounding sources but are incomplete or lack specific details that were available. The agent captures some of the necessary information but omits key elements needed for a full understanding. All stated claims are supported by the grounding sources with zero unsupported additions — no fabricated details, personal opinions, or unverifiable claims are present.
 
 **Examples:**
   **CONVERSATION:**
@@ -100,6 +127,14 @@ Before scoring, verify these two things:
   [TOOL_CALL] search_help(query="Netflix parental controls")
   [TOOL_RESULT] Disney+: To set up parental controls, go to Profile > Settings > Content Rating.
   Agent turn 1: The available information does not cover Netflix parental controls. However, for Disney+ you can set up parental controls by going to Profile > Settings > Content Rating.
+
+  **CONVERSATION:**
+  User turn 1: I see, what else do you know about cheerleading?
+  Agent turn 1:
+    [TOOL_CALL] search_knowledge(query="what else do you know about cheerleading")
+    [TOOL_RESULT] It can be performed to motivate sports teams, entertain the audience, or for competition.
+    It is performed to motivate sports teams, entertain the audience, or for competition.
+  *Why score 4: The agent's response after the tool result paraphrases the tool information. This is grounded (the meaning is preserved) but incomplete (only covers one aspect of cheerleading).*
 
 ## [Groundedness: 5] (Fully Grounded & Complete)
 **Definition:** All agent responses across all turns are thoroughly accurate, directly supported by grounding sources, and correctly retain information from prior turns. No fabrications, contradictions, or unsupported claims. Every factual claim is supported by the grounding sources.


### PR DESCRIPTION
## Summary

Data-driven optimization of the groundedness multi-turn prompt, validated on 300 FaithDial traces (100 hallucinated + 200 faithful) with two judge models.

## Key Changes

1. **5-step evaluation procedure** replacing the 2-check format  includes tool-result parsing, factual proposition extraction, classification, and decision tree
2. **Substantive hallucination vs NOT hallucination taxonomy**  explicit list of conversational behaviors that should NOT be penalized (self-referential framing, uncertainty expressions, follow-up questions, minor paraphrasing, pronoun references)
3. **Score-3 tightening**  only for responses with zero factual propositions; agent paraphrases of tool results should score 4-5
4. **Score-4 example** showing tool-call + paraphrase pattern (fixes score-3 overuse)
5. **Score-2 example** with personal opinion pattern (Dylan's Candy Bar)
6. **CRITICAL rule**: any substantive hallucination  score  2

## Results (v1  v5)

| Model | v1 Accuracy | v5 Accuracy | v5 F1 | v5 FP | v5 FN |
|---|---|---|---|---|---|
| gpt-5.4-mini | 76.3% | **83.7%** | 88.2% | 31 | 17 |
| gpt-5.4 | 65.7% | **79.7%** | 83.1% | 11 | 50 |

- gpt-5.4 accuracy improved by **+14pp** (biggest gain from fixing score-3 overuse)
- gpt-5.4-mini accuracy improved by **+7.4pp** with no regression
- Model gap narrowed from 10.6pp to 4.0pp

## Methodology

- Iterative error analysis: FP analysis (v1v3), FN analysis (v3v4v5)
- Tested 5 prompt versions across both models on FaithDial benchmark
- Full analysis in [evaluator quality report](https://msdata.visualstudio.com/Vienna/_git/evaluators?path=/experiments/evaluator_quality_analysis/reports/azure_mt_evaluator_quality_report.md)
