### PR TITLE
[feat]: Fixed vulnerable images automl-dnn-* gpu, text-gpu,text-gpu-ptca,forecasting-gpu

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl-dnn-forecasting-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-forecasting-gpu/context/Dockerfile
@@ -85,9 +85,12 @@ RUN pip install --no-cache-dir \
 # protobuf>=5.29.6: CVE-2026-0994 (via mlflow-skinny, azureml-automl-runtime -> onnx/onnxruntime)
 # pillow>=12.1.1: CVE-2026-25990 (via matplotlib, bokeh, tensorboard)
 # bokeh>=3.8.2: GHSA-793v-589g-574v CSWSH (overrides azureml-train-automl-runtime's bokeh<3.0.0 cap)
+# onnx>=1.21.0: GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6, GHSA-538c-55jv-c5g9,
+#   GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m (via azureml-automl-runtime -> onnxconverter-common/skl2onnx)
 RUN pip install --upgrade 'distributed>=2026.1.0' 'cryptography>=46.0.5' 'mlflow-skinny>=2.16.0' \
                           'protobuf>=5.29.6' 'pillow>=12.1.1' \
-                          'bokeh>=3.8.2'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
+                          'bokeh>=3.8.2' \
+                          'onnx>=1.21.0'  # onnx: parent azureml packages cap at <1.18; override for 6 GHSAs
 RUN pip install --no-cache-dir torch==2.8.0
 
 RUN /bin/bash -c "source activate $AZUREML_CONDA_ENVIRONMENT_PATH && \

--- a/assets/training/automl/environments/ai-ml-automl-dnn-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-gpu/context/Dockerfile
@@ -98,10 +98,13 @@ RUN pip install \
 # protobuf>=5.29.6: CVE-2026-0994 DoS recursion (via mlflow-skinny -> protobuf, azureml-automl-runtime -> onnx/onnxruntime)
 # pillow>=12.1.1: CVE-2026-25990 heap buffer overflow (via torchvision -> pillow, prophet -> matplotlib -> pillow)
 # bokeh>=3.8.2: GHSA-793v-589g-574v CSWSH (overrides azureml-train-automl-runtime's bokeh<3.0.0 cap)
+# onnx>=1.21.0: GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6, GHSA-538c-55jv-c5g9,
+#   GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m (overrides azureml-automl-runtime's onnx<=1.17.0 cap)
 RUN pip install --upgrade torchvision==0.23.0 torch==2.8.0 --no-cache-dir
 RUN pip install --upgrade 'distributed>=2026.1.0' 'mlflow-skinny>=2.16.0' \
                           'protobuf>=5.29.6' 'pillow>=12.1.1' \
-                          'bokeh>=3.8.2'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
+                          'bokeh>=3.8.2' \
+                          'onnx>=1.21.0'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
 
 # --- End Vulnerability Fixes ---
 

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
@@ -28,7 +28,6 @@ RUN pip install torch-ort==1.18.0 && TORCH_CUDA_ARCH_LIST="5.2;6.0;7.0;8.0;8.6;9
 RUN pip uninstall -y onnxruntime
 
 RUN pip install \ 
-    transformers==4.53.0 \
     optimum==1.23.3 \
     accelerate==1.12.0 \
     deepspeed~=0.15.1
@@ -46,7 +45,7 @@ RUN pip install --upgrade 'pillow>=12.1.1'
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
 # Override onnx to fix GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6, GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m
 # Root cause: azureml-automl-runtime==1.62.0 (latest) pins onnx<=1.17.0; cannot upgrade parent
-RUN pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'distributed>=2026.1.0' 'filelock>=3.20.3' 'bokeh>=3.8.2' 'protobuf>=6.33.5' 'onnx>=1.21.0'
+RUN pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'distributed>=2026.1.0' 'filelock>=3.20.3' 'bokeh>=3.8.2' 'protobuf>=6.33.5' 
 
 # Vulnerability patches for ptca environment
 # pytest override: GHSA-6w46-j5rx-g56g — from ACPT base image ptca env; base image not yet patched

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --no-cache-dir \
 
 # onnx and onnxruntime-training installation
 RUN pip uninstall -y onnxruntime
-RUN pip install onnx==1.17.0
+RUN pip install onnx==1.21.0
 RUN pip uninstall -y onnxruntime-training
 RUN pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ onnxruntime-training==1.18.0
 
@@ -33,6 +33,10 @@ RUN pip install \
     accelerate==1.12.0 \
     deepspeed~=0.15.1
 
+# Override transformers to fix GHSA-69w3-r845-3855
+# Root cause: azureml-automl-dnn-nlp==1.62.0 (latest) pins transformers==4.53.0; cannot upgrade parent
+RUN pip install --no-cache-dir --no-deps 'transformers[sentencepiece,torch]==5.5.4'
+
 # Address vulnerabilities
 # Patch for Pillow vulnerability : Direct dep (used by bokeh, torchvision) from base image
 RUN pip install --upgrade 'pillow>=12.1.1'
@@ -40,10 +44,17 @@ RUN pip install --upgrade 'pillow>=12.1.1'
 # Fix security vulnerabilities (ptca env)
 # NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-RUN pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'distributed>=2026.1.0' 'filelock>=3.20.3' 'bokeh>=3.8.2' 'protobuf>=6.33.5'
+# Override onnx to fix GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6, GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m
+# Root cause: azureml-automl-runtime==1.62.0 (latest) pins onnx<=1.17.0; cannot upgrade parent
+RUN pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'distributed>=2026.1.0' 'filelock>=3.20.3' 'bokeh>=3.8.2' 'protobuf>=6.33.5' 'onnx>=1.21.0'
+
+# Vulnerability patches for ptca environment
+# pytest override: GHSA-6w46-j5rx-g56g — from ACPT base image ptca env; base image not yet patched
+RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'pytest>=9.0.3'
 
 # Fix security vulnerabilities (conda base env)
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN /opt/conda/bin/pip install --upgrade 'cryptography>=46.0.5' 'wheel>=0.46.2' 'setuptools>=82.0.1' 'PyJWT>=2.12.0'
+# aiohttp override: GHSA-63hf-3vf5-4wqf, GHSA-2vrm-gr82-f7m5, GHSA-c427-h43c-vf67, GHSA-w2fm-2cpv-w7v5, etc. — from ACPT base image; base image not yet patched
+RUN /opt/conda/bin/pip install --upgrade 'cryptography>=46.0.5' 'wheel>=0.46.2' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4'
 

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
@@ -94,18 +94,26 @@ RUN pip list && \
                 accelerate==1.12.0 \
                 'transformers[sentencepiece,torch]==4.53.0'
 
+# Override transformers to fix GHSA-69w3-r845-3855
+# Root cause: azureml-automl-dnn-nlp==1.62.0 (latest) pins transformers==4.53.0; cannot upgrade parent
+RUN pip install --no-cache-dir --no-deps 'transformers[sentencepiece,torch]==5.5.4'
+
 
 # Upgrade starlette, urllib3, bokeh, PyNaCl & filelock
 # NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-RUN pip install --upgrade 'distributed>=2026.1.0' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'wheel>=0.46.2' 'bokeh>=3.8.2'
+# Override onnx to fix GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6, GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m
+# Root cause: azureml-automl-runtime==1.62.0 (latest) pins onnx<=1.17.0; cannot upgrade parent
+RUN pip install --upgrade 'distributed>=2026.1.0' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'wheel>=0.46.2' 'bokeh>=3.8.2' 'onnx>=1.21.0'
 # Vulnerability patches for ptca environment
-RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'filelock>=3.20.3' 'pillow>=12.1.1' 'cryptography>=46.0.5' 'protobuf>=6.33.5' 'wheel>=0.46.2'
+# pytest override: GHSA-6w46-j5rx-g56g — from ACPT base image ptca env; base image not yet patched
+RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'filelock>=3.20.3' 'pillow>=12.1.1' 'cryptography>=46.0.5' 'protobuf>=6.33.5' 'wheel>=0.46.2' 'pytest>=9.0.3'
 # Fix vendored jaraco.context (GHSA-58pv-8j8x-9vj2) and wheel (GHSA-8rrh-rw8j-w5fx) in ptca/base setuptools
 # setuptools vendors jaraco.context internally; --force-reinstall --no-deps ensures vendored copies are replaced
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
 # Base env: fix cryptography, wheel, and setuptools vendored vulns
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base pip install --no-cache-dir --upgrade 'cryptography>=46.0.5' 'wheel>=0.46.2' 'PyJWT>=2.12.0'
+# aiohttp override: GHSA-63hf-3vf5-4wqf, GHSA-2vrm-gr82-f7m5, GHSA-c427-h43c-vf67, etc. — from ACPT base image; base image not yet patched
+RUN conda run -n base pip install --no-cache-dir --upgrade 'cryptography>=46.0.5' 'wheel>=0.46.2' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4'
 RUN /opt/conda/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
 
 RUN /bin/bash -c "source activate $AZUREML_CONDA_ENVIRONMENT_PATH && \

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
@@ -91,8 +91,7 @@ RUN pip install --no-cache-dir \
 # by fixing dependencies in the base packages
 RUN pip list && \
     pip install pyarrow==14.0.2 \
-                accelerate==1.12.0 \
-                'transformers[sentencepiece,torch]==4.53.0'
+                accelerate==1.12.0 
 
 # Override transformers to fix GHSA-69w3-r845-3855
 # Root cause: azureml-automl-dnn-nlp==1.62.0 (latest) pins transformers==4.53.0; cannot upgrade parent


### PR DESCRIPTION
This pull request updates several Dockerfiles for AzureML AutoML DNN GPU environments to address multiple security vulnerabilities by overriding and upgrading key dependencies. The most important changes focus on patching high/critical CVEs and GitHub security advisories (GHSAs) in `onnx`, `transformers`, `pytest`, and `aiohttp`, even when parent AzureML packages pin older (vulnerable) versions.

**Security vulnerability fixes:**

* Upgraded `onnx` to version `>=1.21.0` in all relevant environments to address six GHSAs (GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6, GHSA-538c-55jv-c5g9, GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m), overriding parent package pins. [[1]](diffhunk://#diff-157fbe9064f13f8611e7e3717fa8e82389c1557831c8222089d0a3497d4d8d69R88-R93) [[2]](diffhunk://#diff-7041d3a90487fe26014bfb3137be9a501fed4b7f100254636d9e77785c7ee6a0R101-R107) [[3]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631L21-R21) [[4]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631R36-R59) [[5]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fR97-R116)
* Upgraded `transformers` to `5.5.4` in text GPU environments to resolve GHSA-69w3-r845-3855, overriding the parent package pin. [[1]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631R36-R59) [[2]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fR97-R116)
* Patched `pytest` to `>=9.0.3` in the `ptca` environment to address GHSA-6w46-j5rx-g56g, working around base image vulnerabilities. [[1]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631R36-R59) [[2]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fR97-R116)
* Upgraded `aiohttp` to `>=3.13.4` in the base conda environment to address multiple GHSAs (GHSA-63hf-3vf5-4wqf, GHSA-2vrm-gr82-f7m5, GHSA-c427-h43c-vf67, GHSA-w2fm-2cpv-w7v5, etc.), even though the base image is not yet patched. [[1]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631R36-R59) [[2]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fR97-R116)

**General dependency maintenance:**

* Ensured all patched dependencies are installed with `--upgrade` and `--no-cache-dir` flags for reliability and reproducibility. (All references above)

These changes ensure the environments are protected against known vulnerabilities, even in cases where upstream AzureML dependencies have not yet been updated.