### PR TITLE
[feat]: vulnerabilities for proj 24 and few training image batch 2

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl-dnn-forecasting-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-forecasting-gpu/context/Dockerfile
@@ -85,9 +85,12 @@ RUN pip install --no-cache-dir \
 # protobuf>=5.29.6: CVE-2026-0994 (via mlflow-skinny, azureml-automl-runtime -> onnx/onnxruntime)
 # pillow>=12.1.1: CVE-2026-25990 (via matplotlib, bokeh, tensorboard)
 # bokeh>=3.8.2: GHSA-793v-589g-574v CSWSH (overrides azureml-train-automl-runtime's bokeh<3.0.0 cap)
+# onnx>=1.21.0: GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6, GHSA-538c-55jv-c5g9,
+#   GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m (via azureml-automl-runtime -> onnxconverter-common/skl2onnx)
 RUN pip install --upgrade 'distributed>=2026.1.0' 'cryptography>=46.0.5' 'mlflow-skinny>=2.16.0' \
                           'protobuf>=5.29.6' 'pillow>=12.1.1' \
-                          'bokeh>=3.8.2'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
+                          'bokeh>=3.8.2' \
+                          'onnx>=1.21.0'  # onnx: parent azureml packages cap at <1.18; override for 6 GHSAs
 RUN pip install --no-cache-dir torch==2.8.0
 
 RUN /bin/bash -c "source activate $AZUREML_CONDA_ENVIRONMENT_PATH && \

--- a/assets/training/automl/environments/ai-ml-automl-dnn-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-gpu/context/Dockerfile
@@ -98,10 +98,13 @@ RUN pip install \
 # protobuf>=5.29.6: CVE-2026-0994 DoS recursion (via mlflow-skinny -> protobuf, azureml-automl-runtime -> onnx/onnxruntime)
 # pillow>=12.1.1: CVE-2026-25990 heap buffer overflow (via torchvision -> pillow, prophet -> matplotlib -> pillow)
 # bokeh>=3.8.2: GHSA-793v-589g-574v CSWSH (overrides azureml-train-automl-runtime's bokeh<3.0.0 cap)
+# onnx>=1.21.0: GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6, GHSA-538c-55jv-c5g9,
+#   GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m (overrides azureml-automl-runtime's onnx<=1.17.0 cap)
 RUN pip install --upgrade torchvision==0.23.0 torch==2.8.0 --no-cache-dir
 RUN pip install --upgrade 'distributed>=2026.1.0' 'mlflow-skinny>=2.16.0' \
                           'protobuf>=5.29.6' 'pillow>=12.1.1' \
-                          'bokeh>=3.8.2'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
+                          'bokeh>=3.8.2' \
+                          'onnx>=1.21.0'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
 
 # --- End Vulnerability Fixes ---
 

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
@@ -18,7 +18,6 @@ RUN pip install --no-cache-dir \
 
 # onnx and onnxruntime-training installation
 RUN pip uninstall -y onnxruntime
-RUN pip install onnx==1.21.0
 RUN pip uninstall -y onnxruntime-training
 RUN pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ onnxruntime-training==1.18.0
 
@@ -45,11 +44,8 @@ RUN pip install --upgrade 'pillow>=12.1.1'
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
 # Override onnx to fix GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6, GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m
 # Root cause: azureml-automl-runtime==1.62.0 (latest) pins onnx<=1.17.0; cannot upgrade parent
-<<<<<<< yeshwanth/solve_vulnerabilities
 RUN pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'distributed>=2026.1.0' 'filelock>=3.20.3' 'bokeh>=3.8.2' 'protobuf>=6.33.5' 'onnx>=1.21.0'
-=======
-RUN pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'distributed>=2026.1.0' 'filelock>=3.20.3' 'bokeh>=3.8.2' 'protobuf>=6.33.5' 
->>>>>>> main
+
 
 # Vulnerability patches for ptca environment
 # pytest override: GHSA-6w46-j5rx-g56g — from ACPT base image ptca env; base image not yet patched

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install --no-cache-dir \
 
 # onnx and onnxruntime-training installation
 RUN pip uninstall -y onnxruntime
-RUN pip install onnx==1.17.0
+RUN pip install onnx==1.21.0
 RUN pip uninstall -y onnxruntime-training
 RUN pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ onnxruntime-training==1.18.0
 
@@ -33,6 +33,10 @@ RUN pip install \
     accelerate==1.12.0 \
     deepspeed~=0.15.1
 
+# Override transformers to fix GHSA-69w3-r845-3855
+# Root cause: azureml-automl-dnn-nlp==1.62.0 (latest) pins transformers==4.53.0; cannot upgrade parent
+RUN pip install --no-cache-dir --no-deps 'transformers[sentencepiece,torch]==5.5.4'
+
 # Address vulnerabilities
 # Patch for Pillow vulnerability : Direct dep (used by bokeh, torchvision) from base image
 RUN pip install --upgrade 'pillow>=12.1.1'
@@ -40,10 +44,17 @@ RUN pip install --upgrade 'pillow>=12.1.1'
 # Fix security vulnerabilities (ptca env)
 # NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-RUN pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'distributed>=2026.1.0' 'filelock>=3.20.3' 'bokeh>=3.8.2' 'protobuf>=6.33.5'
+# Override onnx to fix GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6, GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m
+# Root cause: azureml-automl-runtime==1.62.0 (latest) pins onnx<=1.17.0; cannot upgrade parent
+RUN pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'distributed>=2026.1.0' 'filelock>=3.20.3' 'bokeh>=3.8.2' 'protobuf>=6.33.5' 'onnx>=1.21.0'
+
+# Vulnerability patches for ptca environment
+# pytest override: GHSA-6w46-j5rx-g56g — from ACPT base image ptca env; base image not yet patched
+RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'pytest>=9.0.3'
 
 # Fix security vulnerabilities (conda base env)
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN /opt/conda/bin/pip install --upgrade 'cryptography>=46.0.5' 'wheel>=0.46.2' 'setuptools>=82.0.1' 'PyJWT>=2.12.0'
+# aiohttp override: GHSA-63hf-3vf5-4wqf, GHSA-2vrm-gr82-f7m5, GHSA-c427-h43c-vf67, GHSA-w2fm-2cpv-w7v5, etc. — from ACPT base image; base image not yet patched
+RUN /opt/conda/bin/pip install --upgrade 'cryptography>=46.0.5' 'wheel>=0.46.2' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4'
 

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
@@ -94,18 +94,26 @@ RUN pip list && \
                 accelerate==1.12.0 \
                 'transformers[sentencepiece,torch]==4.53.0'
 
+# Override transformers to fix GHSA-69w3-r845-3855
+# Root cause: azureml-automl-dnn-nlp==1.62.0 (latest) pins transformers==4.53.0; cannot upgrade parent
+RUN pip install --no-cache-dir --no-deps 'transformers[sentencepiece,torch]==5.5.4'
+
 
 # Upgrade starlette, urllib3, bokeh, PyNaCl & filelock
 # NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-RUN pip install --upgrade 'distributed>=2026.1.0' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'wheel>=0.46.2' 'bokeh>=3.8.2'
+# Override onnx to fix GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6, GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m
+# Root cause: azureml-automl-runtime==1.62.0 (latest) pins onnx<=1.17.0; cannot upgrade parent
+RUN pip install --upgrade 'distributed>=2026.1.0' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'wheel>=0.46.2' 'bokeh>=3.8.2' 'onnx>=1.21.0'
 # Vulnerability patches for ptca environment
-RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'filelock>=3.20.3' 'pillow>=12.1.1' 'cryptography>=46.0.5' 'protobuf>=6.33.5' 'wheel>=0.46.2'
+# pytest override: GHSA-6w46-j5rx-g56g — from ACPT base image ptca env; base image not yet patched
+RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'filelock>=3.20.3' 'pillow>=12.1.1' 'cryptography>=46.0.5' 'protobuf>=6.33.5' 'wheel>=0.46.2' 'pytest>=9.0.3'
 # Fix vendored jaraco.context (GHSA-58pv-8j8x-9vj2) and wheel (GHSA-8rrh-rw8j-w5fx) in ptca/base setuptools
 # setuptools vendors jaraco.context internally; --force-reinstall --no-deps ensures vendored copies are replaced
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
 # Base env: fix cryptography, wheel, and setuptools vendored vulns
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base pip install --no-cache-dir --upgrade 'cryptography>=46.0.5' 'wheel>=0.46.2' 'PyJWT>=2.12.0'
+# aiohttp override: GHSA-63hf-3vf5-4wqf, GHSA-2vrm-gr82-f7m5, GHSA-c427-h43c-vf67, etc. — from ACPT base image; base image not yet patched
+RUN conda run -n base pip install --no-cache-dir --upgrade 'cryptography>=46.0.5' 'wheel>=0.46.2' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4'
 RUN /opt/conda/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
 
 RUN /bin/bash -c "source activate $AZUREML_CONDA_ENVIRONMENT_PATH && \

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
@@ -20,7 +20,9 @@ RUN pip install -r requirements.txt --no-cache-dir
 # onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
 # fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
 # requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.1.1 'fastmcp>=3.2.0' 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0'
+# Mako: transitive dep (mlflow → alembic → Mako); alembic uses unpinned Mako, cannot force via parent
+# pytest: standalone test dep from base image; no parent to upgrade
+RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 'fastmcp>=3.2.0' 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'Mako>=1.3.11' 'pytest>=9.0.3'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2 
 # vulnerability in base conda env

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/requirements.txt
@@ -11,6 +11,6 @@ gdown~=5.2.0
 opencv-python~=4.10.0.84
 pydicom~=2.4.0
 pandas==2.2.3
-mlflow==3.10.1
+mlflow==3.11.1
 setuptools==82.0.0
 filelock>=3.20.1

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
@@ -15,13 +15,17 @@ RUN pip install -r requirements.txt --no-cache-dir
 # protobuf is a transitive dep of mlflow-skinny/onnx; parents use loose floors (>=3.12.0), cannot force 6.33.5
 # mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635); upgrade after requirements install
 # azureml-mlflow pins mlflow-skinny<=3.5.0, so mlflow must be upgraded separately to avoid resolution conflict
-RUN pip install --no-cache-dir mlflow==3.10.1
+# mlflow 3.11.1: GHSA-fh64-r2vc-xvhr requires >=3.11.1
+RUN pip install --no-cache-dir mlflow==3.11.1
 # pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
 # parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
 # onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
 # fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
 # requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-RUN pip install --no-cache-dir --upgrade protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.1.1 wheel>=0.46.2 'fastmcp>=3.2.0' 'onnx>=1.21.0' 'requests>=2.33.0'
+# pillow: GHSA-whj4-6x5x-4v2j requires >=12.2.0; direct dep override
+# Mako: GHSA-v92g-xgxw-vvmm requires >=1.3.11; transitive via alembic→mlflow, alembic has no version floor on Mako so override needed
+# pytest: GHSA-6w46-j5rx-g56g requires >=9.0.3; installed by base image, no parent to upgrade so override needed
+RUN pip install --no-cache-dir --upgrade protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 wheel>=0.46.2 'fastmcp>=3.2.0' 'onnx>=1.21.0' 'requests>=2.33.0' 'Mako>=1.3.11' 'pytest>=9.0.3'
 
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/requirements.txt
@@ -12,10 +12,10 @@ timm==0.9.12
 numpy==1.22.2
 einops==0.8.1
 fvcore==0.1.5.post20221221
-transformers==4.53.0
+transformers==5.5.4
 sentencepiece==0.2.1
 ftfy==6.3.1
-regex==2024.11.6
+regex==2026.4.4
 vision-datasets==0.2.7
 tenacity==9.0.0
 requests>=2.33.0

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
@@ -26,8 +26,13 @@ RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2
 # aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
 # onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
 # requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
+# pytest comes from the base ACPT image (not a transitive dep of any requirements.txt package);
+# no parent package to upgrade — explicit override required (GHSA-6w46-j5rx-g56g)
+# Mako: transitive dep of mlflow → alembic → Mako; alembic uses loose floor (no version pin),
+# so upgrading mlflow/alembic won't force >=1.3.11 — explicit override required (GHSA-v92g-xgxw-vvmm)
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade 'skops>=0.13.0' 'wheel>=0.46.2' \
-    cryptography==46.0.7 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0'
+    cryptography==46.0.7 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' 'pytest>=9.0.3' \
+    'Mako>=1.3.11'
 
 # Upgrade requests, urllib3, aiohttpin the system Python (3.13) for fixing vulnerability
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/requirements.txt
@@ -1,6 +1,6 @@
 azureml-acft-common-components=={{latest-pypi-version}}
 azureml-acft-contrib-hf-nlp=={{latest-pypi-version}}
-mlflow==3.10.1
+mlflow==3.11.1
 cloudpickle==2.2.1
 colorama==0.4.6
 einops==0.8.0
@@ -20,7 +20,7 @@ sentencepiece==0.2.1
 tenacity==9.0.0
 timm==1.0.13
 tornado>=6.5.5
-transformers==4.53.0
+transformers==5.0.0
 setuptools>=82.0.0
 filelock>=3.20.1
 pillow>=12.1.1

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
@@ -22,7 +22,8 @@ RUN pip install --no-cache-dir mlflow-skinny==3.10.1
 # nltk: GHSA-gfwx-w7gr-fvh7; >=3.9.4 required
 # pydicom: GHSA-v856-2rf8-9f28; requirements.txt pins ~=2.4.0 allowing vulnerable 2.4.4; override to >=2.4.5
 # requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools>=82.0.1 protobuf==6.33.5 cryptography==46.0.7 pillow==12.1.1 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pydicom>=2.4.5'
+# pytest: transitive dep from base image; not a direct requirement of any parent package (GHSA-6w46-j5rx-g56g)
+RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools>=82.0.1 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pydicom>=2.4.5' 'pytest>=9.0.3'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2
 # vulnerability in base conda env

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
@@ -10,7 +10,7 @@ azureml-dataprep==5.4.1
 timm==0.9.16
 opencv-python-headless==4.11.0.86
 deepspeed==0.15.1
-transformers==4.53.0
+transformers==5.0.0
 open-clip-torch==2.26.1
 sentencepiece==0.2.1
 peft==0.17.1

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
@@ -13,7 +13,9 @@ RUN pip install -r requirements.txt --no-cache-dir
 # aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
 # onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
 # requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 cryptography==46.0.7 'setuptools>=82.0.1' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0'
+# pytest: installed in base ACPT image; no parent package to upgrade (GHSA-6w46-j5rx-g56g, CVE-2025-71176 tmpdir handling)
+# Mako: transitive dep of mlflow -> alembic; alembic requires Mako with no version floor, cannot force >=1.3.11 via parent (GHSA-v92g-xgxw-vvmm)
+RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 cryptography==46.0.7 'setuptools>=82.0.1' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' 'pytest>=9.0.3' 'Mako>=1.3.11'
 
 # Flag needed to enable control flow which is in PrP.
 ENV AZURE_ML_CLI_PRIVATE_FEATURES_ENABLED=True

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
@@ -19,7 +19,10 @@ RUN pip install azureml-acft-accelerator=={{latest-pypi-version}}
 # aiohttp: transitive dep of azure-core/datasets; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
 # onnx: onnxruntime-training accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
 # nltk: GHSA-gfwx-w7gr-fvh7; >=3.9.4 required
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pillow==12.1.1 setuptools>=82.0.1 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'nltk>=3.9.4'
+# pillow: GHSA-whj4-6x5x-4v2j; >=12.2.0 required
+# pytest: pre-installed in ACPT base image; no parent package to upgrade (GHSA-6w46-j5rx-g56g)
+# transformers: final override to ensure >=5.0.0 after azureml-* installs (GHSA-69w3-r845-3855)
+RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 setuptools>=82.0.1 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pytest>=9.0.3' 'transformers>=5.0.0'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
 # vulnerability in base conda env

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/requirements.txt
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/requirements.txt
@@ -6,7 +6,7 @@ azureml-acft-contrib-hf-nlp=={{latest-pypi-version}}
 # azureml_acft_multimodal_components=={{latest-pypi-version}}
 # needed by multimodal
 mltable==1.5.0
-transformers==4.53.0
+transformers==5.0.0
 peft==0.4.0
 deepspeed==0.16.9
 optimum==1.23.3

--- a/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
+++ b/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
@@ -47,9 +47,18 @@ RUN pip install cryptography>=46.0.5
 # fix until the base packages are updated with the new cryptography version. 
 # distributed is transitively pinned at 2023.2.0 by azureml-train-automl-runtime, which depends on dask==2023.2.0 
 # that in turn pulls in the matching distributed version, so it cannot be upgraded independently without updating azureml-train-automl-runtime itself.
+#
+# onnx>=1.21.0 — GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6,
+#                GHSA-538c-55jv-c5g9, GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m
+#   Parent packages cap onnx<=1.17.0; upgrading the parent is not possible because
+#   both azureml-automl-runtime==1.62.0 and azureml-train-automl-runtime==1.62.0
+#   (the latest releases) still enforce onnx<=1.17.0,>=1.16.1.
+#   Override is required to remediate the vulnerability.
+#   Chain: azureml-automl-runtime / azureml-train-automl-runtime -> onnx<=1.17.0
 RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --upgrade --no-cache-dir \
     'cryptography>=46.0.5' 'setuptools>=79.0.0' 'distributed>=2026.1.0' \
-    'bokeh>=3.8.2'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
+    'bokeh>=3.8.2' \
+    'onnx>=1.21.0'
 
 # Clean conda pkgs cache to remove stale vendored copies
 RUN rm -rf /opt/miniconda/pkgs/

--- a/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
@@ -5,7 +5,7 @@ RUN conda install -n base -c conda-forge pip=26.0 -y
 # These are from base image adding till we get new base image tag
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
 # aiohttp 3.12.14 (8 CVEs) and urllib3 2.5.0 (3 CVEs) are also in base env from base image
-RUN conda run -n base python -m pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.3' 'urllib3>=2.6.3'
+RUN conda run -n base python -m pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.7' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'urllib3>=2.6.3' 'requests>=2.33.0'
 
 
 # Upgrade ptca environment conda packages
@@ -47,7 +47,7 @@ RUN apt-get install -y openssh-server openssh-client
 
 # Fix Vulnerability 
 # TODO: latest version of azureml-mlflow ~ 1.62.0 depends on cryptography<46.0.0
-RUN pip install --upgrade --no-cache-dir 'cryptography>=46.0.5'
+RUN pip install --upgrade --no-cache-dir 'cryptography>=46.0.7'
 # CVE-2026-23949 (jaraco.context) & CVE-2026-24049 (wheel) - upgrade setuptools in ptca and base envs
 # setuptools vendors jaraco.context internally; --force-reinstall --no-deps ensures vendored copies are replaced
 RUN pip install --force-reinstall --no-deps 'setuptools>=82.0.1'

--- a/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/requirements.txt
+++ b/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/requirements.txt
@@ -12,10 +12,17 @@ MarkupSafe==2.1.2
 regex
 pybind11
 urllib3==2.6.3
-requests==2.32.5
-pillow==12.1.1
-transformers==4.54.1
-aiohttp>=3.12.14
+requests>=2.33.0
+pillow>=12.2.0
+# GHSA-69w3-r845-3855 requires transformers>=5.0.0rc3; upgrading to stable 5.x
+transformers>=5.0.0
+aiohttp>=3.13.4
+# onnx: transitive dep of onnxruntime in base image; parent uses loose floor (>=1.16.0);
+# override needed for GHSA-p433-9wv8-28xj, GHSA-538c-55jv-c5g9, GHSA-cmw6-hcpp-c6jp, GHSA-q56x-g2fj-4rj6, GHSA-hqmj-h5c6-369m
+onnx>=1.21.0
+# pytest: pre-installed in base image ptca conda env (7.4.3); no parent pip package pulls it;
+# override needed for GHSA-6w46-j5rx-g56g
+pytest>=9.0.3
 py-spy==0.3.12
 debugpy~=1.6.3
 ipykernel~=6.0

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -35,10 +35,12 @@ RUN apt-get install -y openssh-server openssh-client
 # Fix security vulnerabilities
 # NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-RUN pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1'
+# pytest 7.4.3 (GHSA-6w46-j5rx-g56g) is installed in ptca env from ACPT base image; overriding since base image hasn't been patched yet
+RUN pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'pytest>=9.0.3'
 # vulnerability in base conda env
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'PyJWT>=2.12.0'
+# aiohttp 3.13.3 (GHSA-63hf-3vf5-4wqf et al.) is in base conda env; upgrading to >=3.13.4 for multiple CVE fixes
+RUN conda run -n base python -m pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.5' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -y -n ptca pip>=26.0.1
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
@@ -13,7 +13,7 @@ urllib3>=2.6.3
 requests
 pillow>=12.1.1
 transformers
-aiohttp>=3.13.3
+aiohttp>=3.13.4
 py-spy
 debugpy
 ipykernel

--- a/assets/training/general/environments/lightgbm-3.3/context/Dockerfile
+++ b/assets/training/general/environments/lightgbm-3.3/context/Dockerfile
@@ -54,4 +54,4 @@ RUN conda run -p $CONDA_PREFIX pip install --no-cache-dir \
 # cryptography, pip, setuptools, urllib3, wheel already fixed in openmpi base (20260315.v1)
 # Only override packages still vulnerable after conda env create
 RUN conda run -p $CONDA_PREFIX pip install --no-cache-dir --upgrade \
-    aiohttp==3.13.3 'protobuf>=6.33.5' 'distributed>=2026.1.0'
+    'aiohttp>=3.13.5' 'protobuf>=6.33.5' 'distributed>=2026.1.0'

--- a/assets/training/general/environments/sklearn-1.5/context/Dockerfile
+++ b/assets/training/general/environments/sklearn-1.5/context/Dockerfile
@@ -52,6 +52,6 @@ RUN conda run -p $CONDA_PREFIX pip install --no-cache-dir \
 # Security vulnerability fixes
 # cryptography, pip, setuptools, urllib3, wheel already fixed in openmpi base (20260315.v1)
 # cryptography: azureml-mlflow==1.62.0 (latest) caps cryptography<46.0.0, so conda env installs 44.x;
-#   override after conda env create to restore 46.0.5
+#   override after conda env create to restore 46.0.7
 RUN conda run -p $CONDA_PREFIX pip install --no-cache-dir --upgrade \
-    aiohttp==3.13.3 cryptography==46.0.5 'distributed>=2026.1.0'
+    aiohttp==3.13.4 cryptography==46.0.7 'distributed>=2026.1.0'

--- a/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
+++ b/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
@@ -240,7 +240,6 @@ RUN conda env create -p $CONDA_PREFIX -f conda_dependencies.yaml -q && \
     conda run -p $CONDA_PREFIX pip cache purge && \
     conda clean -a -y
 
-RUN conda run -p $CONDA_PREFIX
 
 RUN HOROVOD_WITH_TENSORFLOW=1  HOROVOD_CUDA_HOME=/usr/local/cuda pip  install --no-cache-dir --no-build-isolation horovod["tensorflow"]==0.28.1
 

--- a/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
+++ b/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
@@ -81,6 +81,8 @@ RUN apt-get update && \
         linux-headers-generic \
         locales \
         openssl \
+        libssl-dev \
+        libssl3 \
         gnupg2 \
         systemd \
         systemd-sysv \
@@ -248,7 +250,14 @@ RUN conda run -p $CONDA_PREFIX conda install -c conda-forge openssl
 # Security vulnerability fixes
 # NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-RUN conda run -p $CONDA_PREFIX pip install --upgrade 'pip>=26.0' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'protobuf>=5.29.6'
+# Upgrade vulnerable packages in the conda env
+# cryptography>=46.0.7 fixes GHSA-m959-cc7f-wv43 and GHSA-p423-j2cm-9vmq
+# requests>=2.33.0 fixes GHSA-gc5v-m9x4-r6x2
+# pillow>=12.2.0 fixes GHSA-whj4-6x5x-4v2j
+RUN conda run -p $CONDA_PREFIX pip install --upgrade 'pip>=26.0' 'cryptography>=46.0.7' 'setuptools>=82.0.1' 'protobuf>=5.29.6' 'requests>=2.33.0' 'pillow>=12.2.0'
+
+# Upgrade vulnerable packages in the base miniconda env (python3.10)
+RUN pip install --upgrade 'cryptography>=46.0.7' 'requests>=2.33.0'
 
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH

--- a/assets/training/general/environments/tensorflow-2.16-cuda12/context/conda_dependencies.yaml
+++ b/assets/training/general/environments/tensorflow-2.16-cuda12/context/conda_dependencies.yaml
@@ -27,5 +27,5 @@ dependencies:
   - debugpy~=1.6.3
   - idna>=3.7
   - flask-cors==6.0.0
-  - pillow==12.1.1
+  - pillow>=12.2.0  # GHSA-whj4-6x5x-4v2j - bumped from 12.1.1
   

--- a/assets/training/vision/environments/automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/vision/environments/automl-dnn-vision-gpu/context/Dockerfile
@@ -84,32 +84,40 @@ RUN pip install --no-cache-dir \
 # Security: fix torch remote code execution (CVE-2025-32434)
 RUN pip install --upgrade torch==2.8.0 torchvision==0.23.0
 # Security: fix urllib3 (CVE-2026-37152) — transitive dep of azureml SDK
-RUN pip install --upgrade urllib3>=2.6.3
+RUN pip install --upgrade 'urllib3>=2.6.3'
+# Security: fix onnx (multiple CVEs) — transitive dep of azureml-automl-runtime via onnxruntime; parent pinned, cannot upgrade
+RUN pip install --upgrade 'onnx>=1.21.0'
 
 # Security: fix base conda env (python 3.13) — aiohttp (CVE-2026-37899), wheel (CVE-2026-24049),
 # cryptography (CVE-2026-41727), PyJWT (CVE-2026-32597), urllib3, filelock, pillow, bokeh
-RUN /opt/conda/bin/pip install --no-cache-dir --upgrade requests 'urllib3>=2.6.3' 'aiohttp>=3.13.3' 'wheel>=0.46.2' \
-    'setuptools>=82.0.1' 'cryptography>=46.0.5' 'PyJWT>=2.12.0' 'pip>=26.0' \
-    'filelock>=3.20.3' 'pillow>=12.1.1' \
+RUN /opt/conda/bin/pip install --no-cache-dir --upgrade 'requests>=2.33.0' 'urllib3>=2.6.3' 'aiohttp>=3.13.4' 'wheel>=0.46.2' \
+    'setuptools>=82.0.1' 'cryptography>=46.0.7' 'PyJWT>=2.12.0' 'pip>=26.0' \
+    'filelock>=3.20.3' 'pillow>=12.2.0' 'onnx>=1.21.0' \
     'bokeh>=3.8.2'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
 # Security: fix ptca conda env — torch (CVE-2025-32434), protobuf (CVE-2026-40186),
 # wheel/setuptools, urllib3, filelock, pillow, PyJWT, bokeh overrides for conda env
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade torch==2.8.0 torchvision==0.23.0 
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade 'urllib3>=2.6.3' 'filelock>=3.20.3' \
     'wheel>=0.46.2' 'setuptools>=82.0.1' 'protobuf>=6.33.5' \
-    'PyJWT>=2.12.0' 'pillow>=12.1.1' \
+    'PyJWT>=2.12.0' 'pillow>=12.2.0' 'onnx>=1.21.0' 'requests>=2.33.0' \
+    'aiohttp>=3.13.4' 'cryptography>=46.0.7' 'pytest>=9.0.3' \
     'bokeh>=3.8.2'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
 
-# Patch pillow vulnerability (CVE-2026-45483) across all three conda environments
-RUN pip install --upgrade pillow==12.1.1
-RUN /opt/conda/bin/pip install --upgrade pillow==12.1.1 
-RUN /opt/conda/envs/ptca/bin/pip install --upgrade pillow==12.1.1 
+# Patch pillow vulnerability (GHSA-whj4-6x5x-4v2j) across all three conda environments
+RUN pip install --upgrade 'pillow>=12.2.0'
+RUN /opt/conda/bin/pip install --upgrade 'pillow>=12.2.0'
+RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'pillow>=12.2.0'
 
 # Fix security vulnerabilities in active conda env (azureml-automl-dnn-vision-gpu)
 # aiohttp (CVE-2026-37899), bokeh (GHSA-793v-589g-574v), distributed (CVE-2026-23528),
 # protobuf (CVE-2026-40186), cryptography, filelock, wheel, setuptools, PyJWT, urllib3, pillow
-RUN pip install --upgrade 'aiohttp>=3.13.3' 'distributed>=2026.1.0' 'protobuf>=6.33.5' 'pip>=26.0' 'cryptography>=46.0.5' \
-    'filelock>=3.20.3' 'wheel>=0.46.2' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'urllib3>=2.6.3' 'pillow>=12.1.1' \
+# onnx: transitive dep of azureml-automl-runtime (via onnxruntime); parent uses template version, cannot upgrade parent
+# requests: transitive dep of azure SDK packages; parent uses template version, cannot upgrade parent
+# aiohttp: transitive dep of azure SDK; parent uses template version, cannot upgrade parent
+# pytest: dev dep in ptca base image; no parent to upgrade
+RUN pip install --upgrade 'aiohttp>=3.13.4' 'distributed>=2026.1.0' 'protobuf>=6.33.5' 'pip>=26.0' 'cryptography>=46.0.7' \
+    'filelock>=3.20.3' 'wheel>=0.46.2' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'urllib3>=2.6.3' 'pillow>=12.2.0' \
+    'onnx>=1.21.0' 'requests>=2.33.0' \
     'bokeh>=3.8.2'  # bokeh: conda env installs 2.4.3, override needed for GHSA-793v-589g-574v
 # Remove stale vendored metadata that scanners pick up
 RUN rm -rf /opt/conda/lib/python3.13/site-packages/setuptools/__vendor/jaraco.context-5.3.0.dist-info \


### PR DESCRIPTION
This pull request focuses on upgrading and patching dependencies across several Dockerfiles and requirements files to address multiple security vulnerabilities, particularly in the `onnx`, `transformers`, `pytest`, `pillow`, and related packages. The changes ensure that the latest secure versions are installed, even when parent packages enforce restrictive version caps, by explicitly overriding those constraints. The updates also include new or upgraded requirements for `mlflow`, `Mako`, `aiohttp`, and other dependencies to remediate known CVEs and GitHub security advisories (GHSAs).

Key dependency and security updates:

**ONNX and Related Security Fixes**
* Explicitly override parent package version caps to install `onnx>=1.21.0` in all affected Dockerfiles, addressing six critical GHSAs (GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6, GHSA-538c-55jv-c5g9, GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m). [[1]](diffhunk://#diff-157fbe9064f13f8611e7e3717fa8e82389c1557831c8222089d0a3497d4d8d69R88-R93) [[2]](diffhunk://#diff-7041d3a90487fe26014bfb3137be9a501fed4b7f100254636d9e77785c7ee6a0R101-R107) [[3]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631L21-R21) [[4]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631R36-R59) [[5]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fR97-R116) [[6]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L23-R25) [[7]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL18-R28) [[8]](diffhunk://#diff-ea5928c9941f9e5584bc7c8563e5125785ff2821cb29792a0a55803cfd5563b5R29-R35) [[9]](diffhunk://#diff-26925c62753afe63696e348bf368d2700ac8e2b5b0999a84a8431d062c86029dL25-R26) [[10]](diffhunk://#diff-12ea0abdd51681a59d213c8042d554d6438c291efdc18a8b29ac31f5e81dee9fL16-R18) [[11]](diffhunk://#diff-1f6b04351bdaed7ac2af71c0b93b3a424620eb1415a381f9a915abe55bbe4cd9R50-R61)

**Transformers, Pillow, and Other Vulnerable Packages**
* Upgrade `transformers` to `>=5.0.0` to fix GHSA-69w3-r845-3855, overriding parent pins where necessary. [[1]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631R36-R59) [[2]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fR97-R116) [[3]](diffhunk://#diff-49cb89f0184676a28a0df3bf701b240589f1cfffdbb0e4a723c6498aaa046006L15-R18) [[4]](diffhunk://#diff-f4bf47bcf0c9d6267a1f937216296f8a7979f16cb53844821d291bf41aaf50bdL23-R23) [[5]](diffhunk://#diff-b54246f3534427a5b820c96fe63808af73410b2322af7a7643ee911c8a5763fdL13-R13) [[6]](diffhunk://#diff-e76a44f429827332aac6567e27f4d82c3529e93db6592574e8411c0becda2f40L9-R9) [[7]](diffhunk://#diff-3c474e734766cbbc0192a217f67a59068aa7a97a4d15db5db509e1e9f8cec1e2L22-R25)
* Upgrade `pillow` to `>=12.2.0` to remediate GHSA-whj4-6x5x-4v2j and other vulnerabilities. [[1]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L23-R25) [[2]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL18-R28) [[3]](diffhunk://#diff-26925c62753afe63696e348bf368d2700ac8e2b5b0999a84a8431d062c86029dL25-R26) [[4]](diffhunk://#diff-3c474e734766cbbc0192a217f67a59068aa7a97a4d15db5db509e1e9f8cec1e2L22-R25)
* Add or upgrade `aiohttp`, `requests`, and related libraries to address CVEs and ensure secure versions are used. [[1]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L23-R25) [[2]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL18-R28) [[3]](diffhunk://#diff-fc4860afcc39bf70b7192ba197495457fdddc97bc335af430f9d02061593b088L8-R8) [[4]](diffhunk://#diff-12ea0abdd51681a59d213c8042d554d6438c291efdc18a8b29ac31f5e81dee9fL16-R18)

**Test and Build Tooling**
* Add or upgrade `pytest>=9.0.3` in all environments to patch GHSA-6w46-j5rx-g56g and CVE-2025-71176, even when not directly required by any parent package. [[1]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631R36-R59) [[2]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fR97-R116) [[3]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L23-R25) [[4]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL18-R28) [[5]](diffhunk://#diff-ea5928c9941f9e5584bc7c8563e5125785ff2821cb29792a0a55803cfd5563b5R29-R35) [[6]](diffhunk://#diff-26925c62753afe63696e348bf368d2700ac8e2b5b0999a84a8431d062c86029dL25-R26) [[7]](diffhunk://#diff-12ea0abdd51681a59d213c8042d554d6438c291efdc18a8b29ac31f5e81dee9fL16-R18) [[8]](diffhunk://#diff-3c474e734766cbbc0192a217f67a59068aa7a97a4d15db5db509e1e9f8cec1e2L22-R25)
* Add or upgrade `Mako>=1.3.11` to address GHSA-v92g-xgxw-vvmm, especially where it is a transitive dependency via `alembic`. [[1]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L23-R25) [[2]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL18-R28) [[3]](diffhunk://#diff-ea5928c9941f9e5584bc7c8563e5125785ff2821cb29792a0a55803cfd5563b5R29-R35) [[4]](diffhunk://#diff-12ea0abdd51681a59d213c8042d554d6438c291efdc18a8b29ac31f5e81dee9fL16-R18)

**MLflow and Other ML Libraries**
* Upgrade `mlflow` to `3.11.1` (and `mlflow-skinny` where needed) to patch GHSA-fh64-r2vc-xvhr and other vulnerabilities. [[1]](diffhunk://#diff-92bc2e5d7f60896d770b745047d342990144fbf91f2630589e84dd3b0e34773fL14-R14) [[2]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL18-R28) [[3]](diffhunk://#diff-f4bf47bcf0c9d6267a1f937216296f8a7979f16cb53844821d291bf41aaf50bdL3-R3)
* Update other ML and utility libraries (e.g., `protobuf`, `cryptography`, `setuptools`, `wheel`, `PyJWT`) to secure versions as part of the overall hardening. [[1]](diffhunk://#diff-157fbe9064f13f8611e7e3717fa8e82389c1557831c8222089d0a3497d4d8d69R88-R93) [[2]](diffhunk://#diff-7041d3a90487fe26014bfb3137be9a501fed4b7f100254636d9e77785c7ee6a0R101-R107) [[3]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631R36-R59) [[4]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fR97-R116) [[5]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L23-R25) [[6]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL18-R28) [[7]](diffhunk://#diff-ea5928c9941f9e5584bc7c8563e5125785ff2821cb29792a0a55803cfd5563b5R29-R35) [[8]](diffhunk://#diff-26925c62753afe63696e348bf368d2700ac8e2b5b0999a84a8431d062c86029dL25-R26) [[9]](diffhunk://#diff-12ea0abdd51681a59d213c8042d554d6438c291efdc18a8b29ac31f5e81dee9fL16-R18) [[10]](diffhunk://#diff-fc4860afcc39bf70b7192ba197495457fdddc97bc335af430f9d02061593b088L8-R8) [[11]](diffhunk://#diff-1f6b04351bdaed7ac2af71c0b93b3a424620eb1415a381f9a915abe55bbe4cd9R50-R61)

These changes collectively ensure that all environments are protected against a wide range of known security issues by overriding restrictive parent package pins and directly patching vulnerable dependencies.