### PR TITLE
Add a license to Nemotron ASR Foundry Local model

### DIFF
--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/description.md
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/description.md
@@ -1,11 +1,13 @@
 This model is an optimized version of nemotron-speech-streaming-en-0.6b to enable local inference on CPUs. This model uses RTN quantization.
 
 # Model Description
+
 - **Developed by:** Microsoft
 - **Model type:** ONNX
-- **License:** apache-2.0
-- **Model Description:** This is a conversion of the nemotron-speech-streaming-en-0.6b for local inference on CPUs.
+- **License:** MIT
+- **Model Description:** This is an optimized version of the nemotron-speech-streaming-en-0.6b model for local inference on CPUs.
 - **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
 
 # Base Model Information
+
 See Hugging Face model [nemotron-speech-streaming-en-0.6b](https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b) for details.

--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/nemotron-speech-streaming-en-0.6b/onnx/cpu_and_mobile/v1
+  container_path: foundrylocal/models/nemotron-speech-streaming-en-0.6b/onnx/cpu_and_mobile/v2
   storage_name: foundrylocalmodels
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
@@ -1,18 +1,18 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: nemotron-speech-streaming-en-0.6b-generic-cpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: "test"
-  license: "apache-2.0"
-  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b/blob/main/LICENSE>."
+  license: "mit"
+  licenseDescription: "This model is provided under the License Terms available at <https://github.com/microsoft/Foundry-Local/blob/main/licenses/nemotron-speech-streaming.md>."
   author: Microsoft
   inputModalities: "audio"
   outputModalities: "text"
   task: automatic-speech-recognition
   maxOutputTokens: 2048
   alias: nemotron-speech-streaming-en-0.6b
-  directoryPath: v1
+  directoryPath: v2
   promptTemplate: ""
   capabilities: ""
   supportsReasoning: ""
@@ -30,5 +30,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 730744832
-    vRamFootprintBytes: 730744832
+    fileSizeBytes: 730746286
+    vRamFootprintBytes: 730746286

--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
@@ -4,7 +4,7 @@ version: 2
 path: ./
 tags:
   foundryLocal: "test"
-  license: "mit"
+  license: "MIT"
   licenseDescription: "This model is provided under the License Terms available at <https://github.com/microsoft/Foundry-Local/blob/main/licenses/nemotron-speech-streaming.md>."
   author: Microsoft
   inputModalities: "audio"


### PR DESCRIPTION
Nemotron-speech-streaming-en-0.6b model has nvidia-open-model-license. To publish ONNX variants of this model, MIT license and NOTICES must be included to the model artifacts.