### PR TITLE
Fix supportedEvaluationLevels placement in customer_satisfaction spec

### DIFF
--- a/assets/evaluators/builtin/customer_satisfaction/spec.yaml
+++ b/assets/evaluators/builtin/customer_satisfaction/spec.yaml
@@ -10,7 +10,7 @@ tags:
   provider: "Microsoft"
   preview: "true"
   is_continuous_scenario: "true"
-  supportedEvaluationLevels: ["conversation", "turn"]
+supportedEvaluationLevels: ["conversation", "turn"]
 initParameterSchema:
   type: "object"
   properties:


### PR DESCRIPTION
## Summary
Move `supportedEvaluationLevels` from nested under `tags` to a top-level field in `customer_satisfaction/spec.yaml`, matching the structure in `task_completion/spec.yaml`.

## Problem
The release pipeline for `builtin.customer_satisfaction` was failing because `supportedEvaluationLevels` was incorrectly nested under `tags` instead of being a top-level field.

## Changes
- `assets/evaluators/builtin/customer_satisfaction/spec.yaml`: Move `supportedEvaluationLevels` to top-level (un-indent by one level)