### PR TITLE
Add business category to TaskCompletion evaluator

### DIFF
--- a/assets/evaluators/builtin/task_completion/spec.yaml
+++ b/assets/evaluators/builtin/task_completion/spec.yaml
@@ -1,11 +1,11 @@
 type: "evaluator"
 name: "builtin.task_completion"
-version: 10
+version: 11
 displayName: "Task-Completion-Evaluator-(Preview)"
 description: "Evaluates whether an AI agent successfully completed the requested task end to end by analyzing the conversation history and agent response to determine if all task requirements were met, ignoring rule adherence or intent understanding. This evaluator is useful for assessing agent effectiveness in task-oriented scenarios, workflow automation, and goal-oriented AI interactions."
 evaluatorType: "builtin"
 evaluatorSubType: "code"
-categories: ["agents"]
+categories: ["agents", "business"]
 tags:
   is_continuous_scenario: "true"
   provider: "Microsoft"


### PR DESCRIPTION
## Summary

Add the **business** category to the TaskCompletion evaluator spec, making it visible in the Business evaluators section of the Azure AI Foundry UI alongside Customer Satisfaction and Deflection Rate.

## Changes

- **ssets/evaluators/builtin/task_completion/spec.yaml**:
  - Added `business` to categories (now `["agents", "business"]`)
  - Bumped version from 10 to 11

## Context

TaskCompletion is one of the three ROI evaluators (alongside Customer Satisfaction and Deflection Rate). The business category tag was discussed in ROI sync as a required step to make TaskCompletion discoverable in the Business evaluators section of the Create Evaluation UI.

Customer Satisfaction and Deflection Rate already have `categories: ["business"]`. TaskCompletion retains its existing `agents` category since it is also relevant for agent evaluation workflows.

## Testing

- No logic changes - only metadata/category update
- Existing behavior tests pass unchanged

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>