### PR TITLE
Add business category to TaskCompletion evaluator

### DIFF
--- a/assets/evaluators/builtin/task_completion/spec.yaml
+++ b/assets/evaluators/builtin/task_completion/spec.yaml
@@ -1,11 +1,11 @@
 type: "evaluator"
 name: "builtin.task_completion"
-version: 10
+version: 11
 displayName: "Task-Completion-Evaluator-(Preview)"
 description: "Evaluates whether an AI agent successfully completed the requested task end to end by analyzing the conversation history and agent response to determine if all task requirements were met, ignoring rule adherence or intent understanding. This evaluator is useful for assessing agent effectiveness in task-oriented scenarios, workflow automation, and goal-oriented AI interactions."
 evaluatorType: "builtin"
 evaluatorSubType: "code"
-categories: ["agents"]
+categories: ["agents", "business"]
 tags:
   is_continuous_scenario: "true"
   provider: "Microsoft"


### PR DESCRIPTION
## Summary
Adds the business category to the TaskCompletion evaluator so it appears alongside Customer Satisfaction and Deflection Rate in the Business evaluators section of Azure AI Foundry.

## Changes
- spec.yaml: Added business to categories: ["agents"] to ["agents", "business"]
- Version bump: 10 to 11

## Context
TaskCompletion is the third business evaluator for the ROI project, alongside Customer Satisfaction and Deflection Rate. The ROI sync team agreed that only a category tag change is needed, no logic or benchmarking changes required.

Note: business is added as the second category to keep the primary UI grouping under Agents (the UI groups by categories[0]), while also making it discoverable as a business evaluator for ROI evaluation flows.
