### PR TITLE
Pin cryptography>=46.0.7 for component, mldesigner, mldesigner-minimal

### DIFF
--- a/assets/designer/environments/component/context/conda_dependencies.yaml
+++ b/assets/designer/environments/component/context/conda_dependencies.yaml
@@ -6,6 +6,7 @@ dependencies:
 - pip=26.0
 - setuptools<82
 - pip:
+  - cryptography>=46.0.7
   - urllib3>=2.6.0
   - azure-ml-component=={{latest-pypi-version}}
   - azureml-defaults=={{latest-pypi-version}}

--- a/assets/pipelines/environments/mldesigner-minimal/context/conda_dependencies.yaml
+++ b/assets/pipelines/environments/mldesigner-minimal/context/conda_dependencies.yaml
@@ -6,4 +6,5 @@ dependencies:
 - pip=26.0
 - setuptools<82
 - pip:
+  - cryptography>=46.0.7
   - mldesigner=={{latest-pypi-version:pre}}

--- a/assets/pipelines/environments/mldesigner/context/conda_dependencies.yaml
+++ b/assets/pipelines/environments/mldesigner/context/conda_dependencies.yaml
@@ -6,6 +6,7 @@ dependencies:
 - pip=26.0
 - setuptools<82
 - pip:
+  - cryptography>=46.0.7
   - azure-ai-ml=={{latest-pypi-version}}
   - azureml-mlflow=={{latest-pypi-version}}
   - mldesigner=={{latest-pypi-version:pre}}


### PR DESCRIPTION
## Summary
Pin `cryptography>=46.0.7` in conda_dependencies.yaml for three curated environments to fix critical and medium vulnerabilities.

## Vulnerabilities Addressed
| Vulnerability ID | Advisory | Severity | Package | Required Version |
|---|---|---|---|---|
| 5010145 | GHSA-m959-cc7f-wv43 | Medium | cryptography | >=46.0.6 |
| 5010634 | GHSA-p423-j2cm-9vmq | Critical | cryptography | >=46.0.7 |

## Affected Environments
- `component` (public/azureml/curated/component:74) — `assets/designer/environments/component/`
- `mldesigner-minimal` (public/azureml/curated/mldesigner-minimal:54) — `assets/pipelines/environments/mldesigner-minimal/`
- `mldesigner` (public/azureml/curated/mldesigner:55) — `assets/pipelines/environments/mldesigner/`

## Changes
Added explicit `cryptography>=46.0.7` pin under `pip:` in each environment's `conda_dependencies.yaml`. The package was previously pulled in as a transitive dependency and resolved to vulnerable versions (46.0.5 / 46.0.6).

## Note
OpenSSL vulnerability (USN-8155-1, ID 6032693, Critical) is OS-level in the base images and will be resolved by rebuilding against the latest MCR base images (`openmpi5.0-ubuntu24.04` / `openmpi4.1.0-ubuntu22.04`). No source change is needed — the Dockerfiles already use `{{latest-image-tag}}`.