### PR TITLE
Fix Designer image cryptography vulnerabilities

### DIFF
--- a/assets/designer/environments/component/context/conda_dependencies.yaml
+++ b/assets/designer/environments/component/context/conda_dependencies.yaml
@@ -7,6 +7,7 @@ dependencies:
 - setuptools<82
 - pip:
   - urllib3>=2.6.0
+  - cryptography>=46.0.7
   - azure-ml-component=={{latest-pypi-version}}
   - azureml-defaults=={{latest-pypi-version}}
   - pyarrow>=14.0.1

--- a/assets/designer/environments/designer-cv-transform/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer-cv-transform/context/conda_dependencies.yaml
@@ -7,4 +7,5 @@ dependencies:
   - pip:
       - pip>=25.3
       - urllib3>=2.6.0
+      - cryptography>=46.0.7
       - azureml-designer-cv-modules==0.0.72

--- a/assets/designer/environments/designer-cv/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer-cv/context/conda_dependencies.yaml
@@ -6,4 +6,5 @@ dependencies:
   - pip:
       - pip>=25.3
       - urllib3>=2.6.0
+      - cryptography>=46.0.7
       - azureml-designer-cv-modules==0.0.72

--- a/assets/designer/environments/designer-io/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer-io/context/conda_dependencies.yaml
@@ -6,4 +6,5 @@ dependencies:
   - pip:
       - pip>=25.3
       - urllib3>=2.6.0
+      - cryptography>=46.0.7
       - azureml-designer-dataio-modules==0.0.88

--- a/assets/designer/environments/designer-pytorch-2.3-train/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer-pytorch-2.3-train/context/conda_dependencies.yaml
@@ -7,4 +7,5 @@ dependencies:
   - pip:
       - pip>=25.3
       - urllib3>=2.6.0
+      - cryptography>=46.0.7
       - azureml-designer-pytorch-modules==0.0.80

--- a/assets/designer/environments/designer-pytorch-2.3/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer-pytorch-2.3/context/conda_dependencies.yaml
@@ -7,4 +7,5 @@ dependencies:
   - pip:
       - pip>=25.3
       - urllib3>=2.6.0
+      - cryptography>=46.0.7
       - azureml-designer-pytorch-modules==0.0.80

--- a/assets/designer/environments/designer-r/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer-r/context/conda_dependencies.yaml
@@ -6,4 +6,5 @@ dependencies:
   - pip:
       - pip>=25.3
       - urllib3>=2.6.0
+      - cryptography>=46.0.7
       - azureml-designer-classic-modules==0.0.196

--- a/assets/designer/environments/designer-recommender/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer-recommender/context/conda_dependencies.yaml
@@ -6,4 +6,5 @@ dependencies:
   - pip:
       - pip>=25.3
       - urllib3>=2.6.0
+      - cryptography>=46.0.7
       - azureml-designer-recommender-modules==0.0.76

--- a/assets/designer/environments/designer-transform/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer-transform/context/conda_dependencies.yaml
@@ -6,4 +6,5 @@ dependencies:
   - pip:
       - pip>=25.3
       - urllib3>=2.6.0
+      - cryptography>=46.0.7
       - azureml-designer-datatransform-modules==0.0.103

--- a/assets/designer/environments/designer-vowpalwabbit/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer-vowpalwabbit/context/conda_dependencies.yaml
@@ -6,4 +6,5 @@ dependencies:
   - pip:
       - pip>=25.3
       - urllib3>=2.6.0
+      - cryptography>=46.0.7
       - azureml-designer-vowpal-wabbit-modules==0.0.63

--- a/assets/designer/environments/designer/context/conda_dependencies.yaml
+++ b/assets/designer/environments/designer/context/conda_dependencies.yaml
@@ -6,5 +6,6 @@ dependencies:
   - pip:
     - pip>=25.3
     - urllib3>=2.6.0
+    - cryptography>=46.0.7
     - azureml-designer-classic-modules==0.0.196
 


### PR DESCRIPTION
Pin cryptography>=46.0.7 in Designer curated environments to address GHSA-m959-cc7f-wv43 and GHSA-p423-j2cm-9vmq.