### PR TITLE
Fix mlflow vulnerability in RAI tabular image

### DIFF
--- a/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
@@ -50,8 +50,8 @@ RUN pip install 'cryptography>=46.0.5'
 # TODO: remove rai-core-flask pin with next raiwidgets release
 RUN pip install 'rai-core-flask==0.7.6'
 
-# To resolve vulnerability issue (GHSA-xch3-2f9x-wh9f, GHSA-q2r8-vmq7-fpx2, GHSA-gq3w-7jj3-x7gr)
-RUN pip install 'mlflow>=3.8.0,<=3.10.0'
+# To resolve vulnerability issue (GHSA-xch3-2f9x-wh9f, GHSA-q2r8-vmq7-fpx2, GHSA-gq3w-7jj3-x7gr, GHSA-fh64-r2vc-xvhr)
+RUN pip install 'mlflow>=3.11.1'
 RUN pip install 'gunicorn>=22.0.0'
 RUN pip install 'Werkzeug>=3.0.3'
 RUN pip install 'tqdm>=4.66.3'


### PR DESCRIPTION
Fix mlflow vulnerability in RAI tabular Docker image:

- **mlflow**: bump from `>=3.8.0,<=3.10.0` to `>=3.11.1` (GHSA-fh64-r2vc-xvhr / CVE-2026-33865)

This is the only remaining vulnerability blocking release (QID 5010630, due 2026-05-09).

Corresponding test PR: https://github.com/Azure/RAI-vNext-Preview/pull/233