### PR TITLE
Bump nemotron-speech-streaming-en-0.6b-generic-cpu to v3

### DIFF
--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/nemotron-speech-streaming-en-0.6b/onnx/cpu_and_mobile/v2
+  container_path: foundrylocal/models/nemotron-speech-streaming-en-0.6b/onnx/cpu_and_mobile/v3
   storage_name: foundrylocalmodels
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: nemotron-speech-streaming-en-0.6b-generic-cpu
-version: 2
+version: 3
 path: ./
 tags:
   foundryLocal: "test"
@@ -12,7 +12,7 @@ tags:
   task: automatic-speech-recognition
   maxOutputTokens: 2048
   alias: nemotron-speech-streaming-en-0.6b
-  directoryPath: v2
+  directoryPath: v3
   promptTemplate: ""
   capabilities: ""
   supportsReasoning: ""
@@ -30,5 +30,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 730746286
-    vRamFootprintBytes: 730746286
+    fileSizeBytes: 730746534
+    vRamFootprintBytes: 730746534


### PR DESCRIPTION
## Summary
Update nemotron-speech-streaming-en-0.6b-generic-cpu model to version 3.

## Change
Added `session_options` with `"session.intra_op.allow_spinning": "0"` to the encoder, decoder, and joiner sections of genai_config.json. This improves inference performance.

## Files changed
- **spec.yaml**: version 2→3, directoryPath v2→v3, updated fileSizeBytes/vRamFootprintBytes
- **model.yaml**: container_path updated to v3

The v3 blob is already uploaded to `foundrylocalmodels/models/foundrylocal/models/nemotron-speech-streaming-en-0.6b/onnx/cpu_and_mobile/v3/`.