### PR TITLE
Fix RAG image build: accept msodbcsql17 EULA during apt upgrade (ICM …

### DIFF
--- a/assets/large_language_models/rag/environments/rag_embeddings/context/Dockerfile
+++ b/assets/large_language_models/rag/environments/rag_embeddings/context/Dockerfile
@@ -28,8 +28,8 @@ RUN pip install torch==2.9.1 torchvision torchaudio --index-url https://download
 
 RUN set -eux; \
     apt-get update; \
-    # Update system packages to fix PAM vulnerability (USN-7580-1)
-    apt-get upgrade -y; \
+    # Accept EULA for msodbcsql17 and upgrade all system packages
+    ACCEPT_EULA=Y apt-get upgrade -y; \
     apt-get install -y --no-install-recommends \
     # utilities for keeping Debian and OpenJDK CA certificates in sync
     ca-certificates p11-kit wget \


### PR DESCRIPTION
…787278734)

Baseline rebuild resolves all known Python and OS vulnerabilities:
- All pip_constraints.txt packages resolve above minimum safe versions
- apt-get upgrade picks up latest OS security patches
- Tika 3.3.0 (latest) with jetty 11.0.26 and log4j 2.25.3

The only code change needed is accepting the msodbcsql17 EULA to prevent apt-get upgrade from failing when that package is updated.