### PR TITLE
[feat]: week 18 vulnerabilities fixes

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
@@ -13,9 +13,6 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 ENV ENABLE_METADATA=true
 
 # System package security upgrades
-# Note: libpam0g, libpam-modules, libpam-modules-bin, libpam-runtime overrides
-# removed -- base image (openmpi5.0-ubuntu24.04) already ships patched versions
-# (1.5.3-5ubuntu5.5). Verified 2026-05-04.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
     apt-get clean && \

--- a/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
@@ -66,15 +66,12 @@ RUN pip install \
 # begin pip ad-hoc
 # Install pip ad-hoc dependencies for security updates
 #
-# pip>=26.0 (CVE-2025-8869): symlink path traversal during tar extraction
-#   Chain: direct conda dep (pip=26.0), upgraded for security
-#
-# wheel>=0.46.2 (CVE-2026-24049): path traversal & privilege escalation via malicious wheel unpack
-#   Chain: setuptools[core] -> wheel (build dependency)
 #
 # cryptography>=46.0.5 (CVE-2026-26007): EC subgroup validation flaw in ECDH/ECDSA on SECT curves
 #   Chain: mltable -> cryptography (direct dep)
 #   Also:  mltable -> azureml-dataprep -> azure-identity -> cryptography
+#   azureml-mlflow 1.61.0 caps cryptography<46.0.0; base image has 46.0.5 but automl env
+#   would resolve to <46.0.0 without this override.
 #
 # protobuf>=5.29.6 (CVE-2025-4565): DoS via uncontrolled recursion in pure-Python decoder
 #   Chain: mlflow-skinny -> protobuf (direct dep)
@@ -85,9 +82,12 @@ RUN pip install \
 #
 # bokeh>=3.8.2 (GHSA-793v-589g-574v): conda env installs 2.4.3, pip can't auto-upgrade
 #   Chain: azureml-train-automl-runtime -> bokeh
+#
+# python-dotenv>=1.2.2 (GHSA-mf9w-mj56-hr94): symlink-following file overwrite
+#   Chain: azureml-defaults -> azureml-inference-server-http -> pydantic-settings -> python-dotenv
+#   pydantic-settings (all versions through 2.14.0) only requires python-dotenv>=0.21.0;
+#   no parent package pins >=1.2.2, so direct override is required (checked 2026-05-04).
 RUN pip install --upgrade \
-    'pip>=26.0' \
-    'wheel>=0.46.2' \
     'cryptography>=46.0.5,<47' \
     'protobuf>=5.29.6,<6' \
     'distributed>=2026.1.0' \
@@ -99,9 +99,4 @@ RUN pip install --upgrade \
 #   GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6,
 #   GHSA-538c-55jv-c5g9, GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m
 # pillow: upgraded from 12.1.1 for GHSA-whj4-6x5x-4v2j
-#
-# python-dotenv>=1.2.2 (GHSA-mf9w-mj56-hr94): symlink-following file overwrite
-#   Chain: azureml-defaults -> azureml-inference-server-http -> pydantic-settings -> python-dotenv
-#   pydantic-settings (all versions through 2.14.0) only requires python-dotenv>=0.21.0;
-#   no parent package pins >=1.2.2, so direct override is required (checked 2026-05-04).
 # end pip ad-hoc

--- a/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
@@ -13,18 +13,15 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 ENV ENABLE_METADATA=true
 
 # System package security upgrades
+# Note: libpam0g, libpam-modules, libpam-modules-bin, libpam-runtime overrides
+# removed -- base image (openmpi5.0-ubuntu24.04) already ships patched versions
+# (1.5.3-5ubuntu5.5). Verified 2026-05-04.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
-    apt-get install -y --only-upgrade \
-        libpam0g \
-        libpam-modules \
-        libpam-modules-bin \
-        libpam-runtime && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
 # begin conda create
-# Create conda environment (minimal — packages installed via pip to avoid solver OOM)
+# Create conda environment (minimal -- packages installed via pip to avoid solver OOM)
 RUN conda create -p $AZUREML_CONDA_ENVIRONMENT_PATH \
     python=3.10 \
     -c conda-forge && \
@@ -94,14 +91,20 @@ RUN pip install \
 RUN pip install --upgrade \
     'pip>=26.0' \
     'wheel>=0.46.2' \
-    'cryptography>=46.0.5' \
-    'protobuf>=5.29.6' \
+    'cryptography>=46.0.5,<47' \
+    'protobuf>=5.29.6,<6' \
     'distributed>=2026.1.0' \
     'bokeh>=3.8.2' \
     'onnx>=1.21.0' \
-    'pillow>=12.2.0'
+    'pillow>=12.2.0' \
+    'python-dotenv>=1.2.2'
 # onnx: azureml-automl-runtime pins onnx<=1.17.0; override needed for
 #   GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6,
 #   GHSA-538c-55jv-c5g9, GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m
 # pillow: upgraded from 12.1.1 for GHSA-whj4-6x5x-4v2j
+#
+# python-dotenv>=1.2.2 (GHSA-mf9w-mj56-hr94): symlink-following file overwrite
+#   Chain: azureml-defaults -> azureml-inference-server-http -> pydantic-settings -> python-dotenv
+#   pydantic-settings (all versions through 2.14.0) only requires python-dotenv>=0.21.0;
+#   no parent package pins >=1.2.2, so direct override is required (checked 2026-05-04).
 # end pip ad-hoc

--- a/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
 # begin conda create
 # Create conda environment (minimal -- packages installed via pip to avoid solver OOM)
 RUN conda create -p $AZUREML_CONDA_ENVIRONMENT_PATH \
@@ -31,8 +32,7 @@ RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --no-cache-dir \
     'setuptools-git' \
     'setuptools==82.0.1' \
     'psutil>5.0.0,<6.0.0' \
-    'torch==2.8.0' \
-    'pip>=26.0'
+    'torch==2.8.0'
 # end conda create
 
 # begin pip install
@@ -66,35 +66,16 @@ RUN pip install \
 # begin pip ad-hoc
 # Install pip ad-hoc dependencies for security updates
 #
-#
-# cryptography>=46.0.5 (CVE-2026-26007): EC subgroup validation flaw in ECDH/ECDSA on SECT curves
-#   Chain: mltable -> cryptography (direct dep)
-#   Also:  mltable -> azureml-dataprep -> azure-identity -> cryptography
-#   azureml-mlflow 1.61.0 caps cryptography<46.0.0; base image has 46.0.5 but automl env
-#   would resolve to <46.0.0 without this override.
-#
-# protobuf>=5.29.6 (CVE-2025-4565): DoS via uncontrolled recursion in pure-Python decoder
-#   Chain: mlflow-skinny -> protobuf (direct dep)
-#   Also:  mlflow-skinny -> databricks-sdk -> protobuf
-#
 # distributed>=2026.1.0 (CVE-2026-23528): XSS leading to RCE via Dask dashboard
 #   Chain: azureml-train-automl-runtime -> dask[complete] -> distributed
 #
 # bokeh>=3.8.2 (GHSA-793v-589g-574v): conda env installs 2.4.3, pip can't auto-upgrade
 #   Chain: azureml-train-automl-runtime -> bokeh
-#
-# python-dotenv>=1.2.2 (GHSA-mf9w-mj56-hr94): symlink-following file overwrite
-#   Chain: azureml-defaults -> azureml-inference-server-http -> pydantic-settings -> python-dotenv
-#   pydantic-settings (all versions through 2.14.0) only requires python-dotenv>=0.21.0;
-#   no parent package pins >=1.2.2, so direct override is required (checked 2026-05-04).
 RUN pip install --upgrade \
-    'cryptography>=46.0.5,<47' \
-    'protobuf>=5.29.6,<6' \
     'distributed>=2026.1.0' \
     'bokeh>=3.8.2' \
     'onnx>=1.21.0' \
-    'pillow>=12.2.0' \
-    'python-dotenv>=1.2.2'
+    'pillow>=12.2.0'
 # onnx: azureml-automl-runtime pins onnx<=1.17.0; override needed for
 #   GHSA-3r9x-f23j-gc73, GHSA-p433-9wv8-28xj, GHSA-q56x-g2fj-4rj6,
 #   GHSA-538c-55jv-c5g9, GHSA-cmw6-hcpp-c6jp, GHSA-hqmj-h5c6-369m

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
@@ -1,16 +1,6 @@
 #PTCA image
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 USER root
-# Security: upgrade all OS packages, pin linux headers to patched versions, and upgrade binutils/git/wget
-RUN apt-get update && apt-get -y upgrade && \
-    apt-get install -y --only-upgrade linux-headers-5.15.0-163-generic=5.15.0-163.173 linux-headers-5.15.0-163=5.15.0-163.173 linux-libc-dev=5.15.0-163.173 || \
-    apt-get install -y --only-upgrade linux-headers-generic linux-libc-dev && \
-    apt-get install -y --only-upgrade git tar binutils binutils-common binutils-x86-64-linux-gnu libbinutils wget && \
-    apt-get autoremove -y linux-headers-5.15.0-153 linux-headers-5.15.0-153-generic linux-headers-5.15.0-161 linux-headers-5.15.0-161-generic 2>/dev/null && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-# Security: upgrade base conda env (python3.13) from ACPT base image (biweekly.202603.1)
-# Still vulnerable: cryptography(44.0.1), pip(25.3), setuptools(80.9.0), wheel(0.45.1)
-RUN conda run -n base python -m pip install --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 'aiohttp>=3.13.4' 'requests>=2.33.0'
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 # GHSA-jx93-g359-86wm, GHSA-hvwj-8w5g-28rg: sglang vulnerabilities; patched in >=0.5.10
@@ -21,7 +11,7 @@ RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install numpy==2.2.5
 RUN pip install azureml-evaluate-mlflow=={{latest-pypi-version}}
 
-# following are for vulnerability overrides at later\
+# following are for vulnerability overrides at later
 # release of following packages consider moving then to requirements.txt
 RUN pip install --no-cache-dir --force-reinstall "mlflow>=3.2.0,<4.0.0"
 # wandb>=0.26.0: fixes Go stdlib vulnerabilities (GO-2026-4864/4865/4866/4869/4870/4946/4947)
@@ -32,28 +22,6 @@ RUN pip install xgrammar==0.1.32
 # GHSA-69w3-r845-3855 (CVE-2026-1839): arbitrary code execution in Trainer class;
 # patched only in transformers>=5.0.0rc3. Upgrading to latest stable 5.x.
 RUN pip install transformers==5.5.4
-# upgrade pip, wheel, setuptools and transitive deps to fix vulnerabilities
-# protobuf: google-cloud-storage caps <7 (extras); wandb now allows <8; override to ensure patched version
-# cryptography: azureml-mlflow pins <47.0.0; override needed to ensure patched 46.x installed
-# aiohttp: transitive dep of ray/vllm/azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: onnxruntime accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
-# anthropic: GHSA-q5f5-3gjm-7mfm, GHSA-w828-4qhx-vxx3; >=0.87.0 required
-# requests: transitive dep of azure-core/mlflow/transformers; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# python-dotenv: GHSA-mf9w-mj56-hr94; transitive dep of fastmcp(>=1.1.0) and uvicorn(>=0.13);
-#   parents accept >=1.2.2 via loose floors, pin to ensure patched version on rebuild
-RUN pip install --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 protobuf==6.33.5 \
-    'aiohttp>=3.13.4' 'requests>=2.33.0' 'onnx>=1.21.0' 'fastmcp>=3.2.0' 'anthropic>=0.87.0' \
-    'python-dotenv>=1.2.2'
-# GHSA-6w46-j5rx-g56g (CVE-2025-71176): pytest tmpdir vulnerability; patched in >=9.0.3
-# pytest is a transitive dep from base image; no parent upgrade available, override needed.
-# GHSA-v92g-xgxw-vvmm: Mako XSS vulnerability; patched in >=1.3.11
-# Mako is a transitive dep of alembic; alembic requires Mako (no version pin), override ensures patched version.
-RUN pip install --no-cache-dir --upgrade "pytest>=9.0.3" "Mako>=1.3.11"
-# Fix vulnerabilities in the ptca conda environment (pre-built in base image, not targeted by above installs)
-# CVE-2026-1703 (pip), CVE-2026-24049 (wheel)
-RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade "pip>=26.0" "wheel>=0.46.2" && \
-    rm -f /opt/conda/envs/ptca/conda-meta/wheel-0.45.1*.json /opt/conda/envs/ptca/conda-meta/pip-25.3*.json
 # clean conda and pip caches
 RUN rm -rf ~/.cache/pip
 COPY loss /opt/conda/envs/ptca/lib/python3.10/site-packages/specforge/core/loss.py

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
@@ -33,19 +33,22 @@ RUN pip install xgrammar==0.1.32
 # patched only in transformers>=5.0.0rc3. Upgrading to latest stable 5.x.
 RUN pip install transformers==5.5.4
 # upgrade pip, wheel, setuptools and transitive deps to fix vulnerabilities
-# protobuf: wandb/google-cloud-storage cap <7, override needed
-# cryptography: azureml-mlflow pins <46.0.0; override needed for CVE fix
+# protobuf: google-cloud-storage caps <7 (extras); wandb now allows <8; override to ensure patched version
+# cryptography: azureml-mlflow pins <47.0.0; override needed to ensure patched 46.x installed
 # aiohttp: transitive dep of ray/vllm/azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
 # onnx: onnxruntime accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
 # fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
 # anthropic: GHSA-q5f5-3gjm-7mfm, GHSA-w828-4qhx-vxx3; >=0.87.0 required
 # requests: transitive dep of azure-core/mlflow/transformers; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
+# python-dotenv: GHSA-mf9w-mj56-hr94; transitive dep of fastmcp(>=1.1.0) and uvicorn(>=0.13);
+#   parents accept >=1.2.2 via loose floors, pin to ensure patched version on rebuild
 RUN pip install --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 protobuf==6.33.5 \
-    'aiohttp>=3.13.4' 'requests>=2.33.0' 'onnx>=1.21.0' 'fastmcp>=3.2.0' 'anthropic>=0.87.0'
+    'aiohttp>=3.13.4' 'requests>=2.33.0' 'onnx>=1.21.0' 'fastmcp>=3.2.0' 'anthropic>=0.87.0' \
+    'python-dotenv>=1.2.2'
 # GHSA-6w46-j5rx-g56g (CVE-2025-71176): pytest tmpdir vulnerability; patched in >=9.0.3
 # pytest is a transitive dep from base image; no parent upgrade available, override needed.
 # GHSA-v92g-xgxw-vvmm: Mako XSS vulnerability; patched in >=1.3.11
-# Mako is a transitive dep of alembic; alembic does not yet pin Mako>=1.3.11, override needed.
+# Mako is a transitive dep of alembic; alembic requires Mako (no version pin), override ensures patched version.
 RUN pip install --no-cache-dir --upgrade "pytest>=9.0.3" "Mako>=1.3.11"
 # Fix vulnerabilities in the ptca conda environment (pre-built in base image, not targeted by above installs)
 # CVE-2026-1703 (pip), CVE-2026-24049 (wheel)

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
@@ -15,47 +15,33 @@ RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install transformers==5.5.4
 
 # mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635); upgrade after azureml packages
-# azureml-evaluate-mlflow → azureml-mlflow pins mlflow-skinny<=3.9.0 (updated from <=3.5.0), conflicting with mlflow 3.10.1
+# azureml-evaluate-mlflow → azureml-mlflow pins mlflow-skinny<=3.9.0, conflicting with mlflow 3.10.1
 # so mlflow must be upgraded separately to avoid pip resolution conflict
 RUN pip install --no-cache-dir mlflow==3.10.1
 
-# upgrade pip, wheel, setuptools and transitive deps to fix vulnerabilities
-# protobuf: vllm uses loose floors, pip can't force 6.33.5 transitively
-# cryptography: azureml-mlflow 1.62.0.post2 raised ceiling to <47.0.0 (was <46.0.0); override still needed to force CVE-fixed version
-# onnx: onnxruntime-training accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# nltk: GHSA-gfwx-w7gr-fvh7; >=3.9.4 required
-# filelock: transitive dep of torch/huggingface-hub; parents use loose floor (GHSA-qmgc-5h2g-mvrw)
-# urllib3: transitive dep of requests; parent uses urllib3>=1.21.1,<3 (GHSA-38jv-5279-wg99)
-# ray: GHSA-q5fh-2hc8-f6rq; >=2.54.0 required; also bundles log4j-core in JARs
-#   log4j-core 2.25.3→2.25.4: GHSA-3pxv-7cmr-fjr4, GHSA-445c-vh5m-36rj, GHSA-6hg6-v5c8-fphq
-# azure-core: transitive dep of Azure SDKs; parents use loose floor (GHSA-jm66-cg57-jjv5)
-# pytest: GHSA-6w46-j5rx-g56g (vulnerable tmpdir handling); from base image, override needed
-# cbor2: transitive dep via azure-identity → msal-extensions; parent uses loose floor (GHSA-3c37-wwvx-h642)
-# jaraco.context: transitive dep of keyring; parent uses loose floor (GHSA-58pv-8j8x-9vj2)
-# mlflow: GHSA-r23q-823p-vmf7 etc.; azureml-mlflow pins mlflow-skinny<=3.9.0 (was <=3.5.0), override still needed
+# Upgrade transitive deps to fix vulnerabilities.
+# Packages already at safe versions in base image biweekly.202605.1 (pip, wheel, setuptools,
+# aiohttp, requests, urllib3, onnx, pillow, filelock, pytest) are NOT overridden here.
+# protobuf: mlflow-skinny requires <7; base has 7.34.1 so we must pin <7 (GHSA fix >=6.33.5)
+# cryptography: not in ptca env; installed transitively by azureml-mlflow (<47.0.0 constraint)
+# ray: GHSA-q5fh-2hc8-f6rq; also bundles log4j-core 2.25.3 in JARs (patched below)
+# azure-core, cbor2, jaraco.context, PyJWT: transitive deps with loose floors
+# nltk: GHSA-gfwx-w7gr-fvh7; pyasn1/python-multipart/xgrammar: CVE floors
+# mlflow: azureml-mlflow pins mlflow-skinny<=3.9.0; override needed
 # vllm: GHSA-pq5c-rjhq-qp7p, GHSA-3mwp-wvh9-7528 etc.; >=0.19.0 required
-# vllm GHSA-6c4r-fmh3-7rh8: advisory 404s on GitHub/OSV.dev (not publicly available as of 2026-05-04).
-#   Scanner shows installed=0.19.1, required=0.18.0 (required < installed, ambiguous).
-#   vllm 0.20.x requires CUDA 13 / PyTorch 2.11 (incompatible with base image cu126/torch280).
-#   vllm 0.19.2 not released (only rc0 tag exists). No compatible fix available; revisit when 0.19.2 ships.
-RUN pip install --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 protobuf==6.33.5 cryptography==46.0.7 'xgrammar>=0.1.32' \
-    'aiohttp>=3.13.4' 'requests>=2.33.0' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pyasn1>=0.6.3' \
-    'python-multipart>=0.0.22' 'pillow>=12.1.1' 'filelock>=3.20.3' 'urllib3>=2.6.3' 'ray>=2.55.0' \
-    'azure-core>=1.38.0' 'cbor2>=5.9.0' 'jaraco.context>=6.1.0' 'PyJWT>=2.12.0' 'mlflow>=3.8.1,<4.0.0' 'vllm>=0.19.0' \
-    'pytest>=9.0.3'
-# clean conda and pip caches
+# pyOpenSSL: GHSA-vp96-hxj8-p424, GHSA-5pwr-322w-8jr4; >=26.0.0 required
+#   azureml-core 1.61.0.post3 pins pyopenssl<26.0.0; no newer azureml-core available (2026-05-04)
+RUN pip install --upgrade 'protobuf>=6.33.5,<7' 'cryptography>=46.0.7,<47' 'xgrammar>=0.1.32' \
+    'nltk>=3.9.4' 'pyasn1>=0.6.3' 'python-multipart>=0.0.22' 'ray>=2.55.0' \
+    'azure-core>=1.38.0' 'cbor2>=5.9.0' 'jaraco.context>=6.1.0' 'PyJWT>=2.12.0' \
+    'mlflow>=3.8.1,<4.0.0' 'vllm>=0.19.0' 'pyOpenSSL>=26.0.0'
 RUN rm -rf ~/.cache/pip
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y 'pip>=26.0.1' 'wheel>=0.46.2'
-# Fix vulnerabilities in base conda env (python3.13) from ACPT base image (biweekly.202603.1)
-# Still vulnerable in base: cryptography(44.0.1), pip(25.3), setuptools(80.9.0), wheel(0.45.1), requests(2.32.4), aiohttp(3.12.14), PyJWT(2.10.1)
-# python-dotenv: GHSA-mf9w-mj56-hr94 (symlink following in set_key/unset_key); >=1.2.2 required
-#   parent packages: uvicorn (>=0.13), pydantic-settings (>=0.21.0) — both use loose floors, upgrade safe
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 \
-    'requests>=2.33.0' 'aiohttp>=3.13.4' 'PyJWT>=2.12.0' 'python-dotenv>=1.2.2'
+# python-dotenv in base conda env: GHSA-mf9w-mj56-hr94; base ships 1.2.1, need >=1.2.2
+#   parent packages: uvicorn (>=0.13), pydantic-settings (>=0.21.0) — both use loose floors
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 # ray vendors aiohttp for runtime_env agent under thirdparty_files; patch that copy too.
 RUN rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files/aiohttp* && \
-    pip install --no-cache-dir --target /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files 'aiohttp==3.13.4'
+    pip install --no-cache-dir --target /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files 'aiohttp==3.13.5'
 # Patch log4j-core 2.25.3→2.25.4 inside ray's fat JAR (ray_dist.jar).
 # ray (all versions through 2.55.1) bundles log4j-core 2.25.3 in java/dependencies.bzl.
 # No ray release includes 2.25.4; manual JAR surgery is required.

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
@@ -15,13 +15,13 @@ RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install transformers==5.5.4
 
 # mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635); upgrade after azureml packages
-# azureml-evaluate-mlflow → azureml-mlflow pins mlflow-skinny<=3.5.0, conflicting with mlflow 3.10.1
+# azureml-evaluate-mlflow → azureml-mlflow pins mlflow-skinny<=3.9.0 (updated from <=3.5.0), conflicting with mlflow 3.10.1
 # so mlflow must be upgraded separately to avoid pip resolution conflict
 RUN pip install --no-cache-dir mlflow==3.10.1
 
 # upgrade pip, wheel, setuptools and transitive deps to fix vulnerabilities
 # protobuf: vllm uses loose floors, pip can't force 6.33.5 transitively
-# cryptography: azureml-mlflow~=1.62.0 pins <46.0.0; override needed for CVE fix
+# cryptography: azureml-mlflow 1.62.0.post2 raised ceiling to <47.0.0 (was <46.0.0); override still needed to force CVE-fixed version
 # onnx: onnxruntime-training accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
 # nltk: GHSA-gfwx-w7gr-fvh7; >=3.9.4 required
 # filelock: transitive dep of torch/huggingface-hub; parents use loose floor (GHSA-qmgc-5h2g-mvrw)
@@ -32,8 +32,12 @@ RUN pip install --no-cache-dir mlflow==3.10.1
 # pytest: GHSA-6w46-j5rx-g56g (vulnerable tmpdir handling); from base image, override needed
 # cbor2: transitive dep via azure-identity → msal-extensions; parent uses loose floor (GHSA-3c37-wwvx-h642)
 # jaraco.context: transitive dep of keyring; parent uses loose floor (GHSA-58pv-8j8x-9vj2)
-# mlflow: GHSA-r23q-823p-vmf7 etc.; azureml-mlflow pins mlflow-skinny<=3.5.0, override needed
+# mlflow: GHSA-r23q-823p-vmf7 etc.; azureml-mlflow pins mlflow-skinny<=3.9.0 (was <=3.5.0), override still needed
 # vllm: GHSA-pq5c-rjhq-qp7p, GHSA-3mwp-wvh9-7528 etc.; >=0.19.0 required
+# vllm GHSA-6c4r-fmh3-7rh8: advisory 404s on GitHub/OSV.dev (not publicly available as of 2026-05-04).
+#   Scanner shows installed=0.19.1, required=0.18.0 (required < installed, ambiguous).
+#   vllm 0.20.x requires CUDA 13 / PyTorch 2.11 (incompatible with base image cu126/torch280).
+#   vllm 0.19.2 not released (only rc0 tag exists). No compatible fix available; revisit when 0.19.2 ships.
 RUN pip install --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 protobuf==6.33.5 cryptography==46.0.7 'xgrammar>=0.1.32' \
     'aiohttp>=3.13.4' 'requests>=2.33.0' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pyasn1>=0.6.3' \
     'python-multipart>=0.0.22' 'pillow>=12.1.1' 'filelock>=3.20.3' 'urllib3>=2.6.3' 'ray>=2.55.0' \
@@ -45,9 +49,17 @@ RUN rm -rf ~/.cache/pip
 RUN conda install -n ptca -y 'pip>=26.0.1' 'wheel>=0.46.2'
 # Fix vulnerabilities in base conda env (python3.13) from ACPT base image (biweekly.202603.1)
 # Still vulnerable in base: cryptography(44.0.1), pip(25.3), setuptools(80.9.0), wheel(0.45.1), requests(2.32.4), aiohttp(3.12.14), PyJWT(2.10.1)
+# python-dotenv: GHSA-mf9w-mj56-hr94 (symlink following in set_key/unset_key); >=1.2.2 required
+#   parent packages: uvicorn (>=0.13), pydantic-settings (>=0.21.0) — both use loose floors, upgrade safe
 RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 \
-    'requests>=2.33.0' 'aiohttp>=3.13.4' 'PyJWT>=2.12.0'
+    'requests>=2.33.0' 'aiohttp>=3.13.4' 'PyJWT>=2.12.0' 'python-dotenv>=1.2.2'
 # ray vendors aiohttp for runtime_env agent under thirdparty_files; patch that copy too.
 RUN rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files/aiohttp* && \
     pip install --no-cache-dir --target /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files 'aiohttp==3.13.4'
+# Patch log4j-core 2.25.3→2.25.4 inside ray's fat JAR (ray_dist.jar).
+# ray (all versions through 2.55.1) bundles log4j-core 2.25.3 in java/dependencies.bzl.
+# No ray release includes 2.25.4; manual JAR surgery is required.
+# Fixes: GHSA-3pxv-7cmr-fjr4, GHSA-445c-vh5m-36rj, GHSA-6hg6-v5c8-fphq
+COPY patch_log4j /tmp/patch_log4j.py
+RUN python3 /tmp/patch_log4j.py 2.25.4 && rm -f /tmp/patch_log4j.py
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/patch_log4j
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/patch_log4j
@@ -1,0 +1,88 @@
+"""Patch log4j JARs inside ray's fat JAR (ray_dist.jar) with a newer version.
+
+Downloads log4j artifacts from Maven Central and replaces the bundled versions
+inside ray's distribution JAR, including classes, META-INF resources, and plugin metadata.
+"""
+import zipfile
+import os
+import sys
+import glob
+import urllib.request
+import tempfile
+
+LOG4J_VER = sys.argv[1] if len(sys.argv) > 1 else "2.25.4"
+RAY_JARS = "/opt/conda/envs/ptca/lib/python3.10/site-packages/ray/jars"
+MAVEN_BASE = "https://repo1.maven.org/maven2/org/apache/logging/log4j"
+ARTIFACTS = ["log4j-core", "log4j-api", "log4j-slf4j-impl"]
+
+patch_dir = tempfile.mkdtemp()
+
+# Download new log4j JARs
+for art in ARTIFACTS:
+    url = f"{MAVEN_BASE}/{art}/{LOG4J_VER}/{art}-{LOG4J_VER}.jar"
+    dest = os.path.join(patch_dir, f"{art}.jar")
+    print(f"Downloading {url}")
+    urllib.request.urlretrieve(url, dest)
+
+# Find ray fat JARs
+candidates = glob.glob(os.path.join(RAY_JARS, "ray?dist.jar"))
+candidates += glob.glob(os.path.join(RAY_JARS, "ray_dist.jar"))
+if not candidates:
+    all_jars = glob.glob(os.path.join(RAY_JARS, "*.jar"))
+    candidates = [c for c in all_jars if "ray" in os.path.basename(c).lower()]
+assert candidates, f"No ray fat JAR found in {RAY_JARS}: {os.listdir(RAY_JARS)}"
+
+def is_log4j_entry(name):
+    """Check if a zip entry belongs to log4j and should be replaced."""
+    return (name.startswith("org/apache/logging/log4j/") or
+            name.startswith("META-INF/org/apache/logging/log4j/") or
+            name.startswith("META-INF/maven/org.apache.logging.log4j/") or
+            name.startswith("META-INF/services/") or
+            name == "META-INF/log4j-provider.properties" or
+            "Log4j2Plugins.dat" in name)
+
+# Collect new log4j entries from downloaded JARs
+new_entries = {}
+for jf in glob.glob(os.path.join(patch_dir, "*.jar")):
+    with zipfile.ZipFile(jf, "r") as zf:
+        for info in zf.infolist():
+            name = info.filename
+            if is_log4j_entry(name):
+                new_entries[name] = (info, zf.read(name))
+
+print(f"Collected {len(new_entries)} entries from log4j {LOG4J_VER}")
+
+def is_old_log4j(name):
+    return (name.startswith("org/apache/logging/log4j/") or
+            name.startswith("META-INF/org/apache/logging/log4j/") or
+            name.startswith("META-INF/maven/org.apache.logging.log4j/") or
+            "Log4j2Plugins.dat" in name)
+
+for fat_jar in candidates:
+    print(f"Patching {fat_jar}")
+    tmp_jar = fat_jar + ".tmp"
+    kept = replaced = removed = 0
+
+    with zipfile.ZipFile(fat_jar, "r") as src, \
+         zipfile.ZipFile(tmp_jar, "w", zipfile.ZIP_DEFLATED) as dst:
+        for info in src.infolist():
+            name = info.filename
+            if name in new_entries:
+                replaced += 1
+                continue
+            if is_old_log4j(name):
+                removed += 1
+                continue
+            dst.writestr(info, src.read(name))
+            kept += 1
+        for name, (info, data) in new_entries.items():
+            dst.writestr(info, data)
+
+    os.replace(tmp_jar, fat_jar)
+    print(f"  kept={kept}, replaced={replaced}, removed={removed}, added={len(new_entries)}")
+    print(f"  Patched with log4j {LOG4J_VER}")
+
+# Cleanup
+import shutil
+shutil.rmtree(patch_dir)
+print("Done")

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
@@ -62,11 +62,15 @@ RUN pip install https://github.com/yeshsurya/flash-attention/releases/download/v
 # lxml>=6.1.0: GHSA-vfmq-68hx-4jfw; transitive dep of multiple packages, parent uses loose floor
 # transformers>=5.0.0rc3: GHSA-69w3-r845-3855 (CVE-2026-1839); arbitrary code execution via torch.load()
 #   in Trainer._load_rng_state(). Direct dep — upgraded from 4.57.6 to patched 5.x
-RUN pip install --upgrade aiohttp==3.13.4 protobuf==6.33.5 setuptools==82.0.0 pip==26.0 wheel==0.46.2 cryptography==46.0.7 'requests>=2.33.0' 'onnx>=1.21.0' 'fastmcp>=3.2.0' 'Mako>=1.3.11' 'pytest>=9.0.3' 'lxml>=6.1.0' 'transformers>=5.0.0rc3'
+# GitPython>=3.1.47: GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4; transitive dep of wandb (requires
+#   gitpython!=3.1.29,>=1.0.0 as of 0.26.1), parent uses loose floor — no wandb release forces >=3.1.47
+RUN pip install --upgrade aiohttp==3.13.4 protobuf==6.33.5 setuptools==82.0.0 pip==26.0 wheel==0.46.2 cryptography==46.0.7 'requests>=2.33.0' 'onnx>=1.21.0' 'fastmcp>=3.2.0' 'Mako>=1.3.11' 'pytest>=9.0.3' 'lxml>=6.1.0' 'transformers>=5.0.0rc3' 'GitPython>=3.1.47'
 # Fix vulnerabilities in base conda env (python 3.13) from ACPT base image (biweekly.202603.1)
 # Base env ships: cryptography(44.0.1), pip(25.3), setuptools(80.9.0), wheel(0.45.1), aiohttp(3.12.x)
 # Same CVEs as ptca env above; base env is separate and must be patched independently
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 aiohttp==3.13.4
+# python-dotenv>=1.2.2: GHSA-mf9w-mj56-hr94; transitive dep of pydantic-settings (requires >=0.21.0)
+#   and uvicorn (optional, requires >=0.13). No parent release forces >=1.2.2 as of 2026-05-04.
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 aiohttp==3.13.4 'python-dotenv>=1.2.2'
 # ray vendors its own copy of aiohttp inside thirdparty_files/ for runtime_env agent;
 # the vendored copy is not upgraded by pip install above. Patching all copies in-place.
 RUN find /opt/conda/envs/ptca/lib/python3.10/site-packages/ray -type d -name 'thirdparty_files' | while read dir; do \

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
@@ -1,12 +1,9 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 USER root
-# Security: upgrade all OS packages and patch USN-8176-1 (.NET 8.0 vulnerabilities)
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --only-upgrade \
-        dotnet-host-8.0 dotnet-hostfxr-8.0 dotnet-runtime-8.0 2>/dev/null || true && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y upgrade --fix-missing || \
+    (apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade) && \
     apt-get autoremove -y && \
-    apt-get autoclean && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/*.deb
 COPY requirements.txt .
@@ -26,7 +23,7 @@ RUN pip uninstall -y mlflow
 RUN pip install --no-cache-dir --force-reinstall "mlflow>=3.2.0,<4.0.0"
 RUN pip install --no-cache-dir starlette==0.49.1
 # Upgrade wandb to latest; remove wandb-core Go binary to fix GO-2026-4864..4947
-# wandb 0.26.0 ships wandb-core compiled with Go 1.26.1 (needs 1.26.2); no fixed wandb release yet.
+# wandb 0.26.1 ships wandb-core compiled with Go 1.26.1 (needs 1.26.2); no fixed wandb release yet.
 # Removing the binary forces wandb to use its Python backend (safe fallback).
 RUN pip install --no-cache-dir --upgrade "wandb>=0.26.0" && \
     find /opt/conda/envs/ptca -name 'wandb-core' -path '*/wandb/bin/*' -delete 2>/dev/null || true
@@ -37,53 +34,35 @@ COPY __init__ /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/rewar
 COPY azure_grader /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/reward_score/azure_grader.py
 COPY azure_python_grader /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/reward_score/azure_python_grader.py
 COPY utils /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/vllm/utils.py
-RUN python3 -m pip install --upgrade pip==26.0 setuptools==82.0.0 wheel==0.46.2
 RUN pip install vllm==0.19.0
 # Keep xgrammar at the patched floor even when pulled transitively by vllm.
 RUN pip install --no-cache-dir 'xgrammar>=0.1.32'
 RUN pip install openai==2.14.0
 RUN pip install --force-reinstall --no-cache-dir --no-build-isolation git+https://github.com/deepseek-ai/DeepGEMM.git@c9f8b34dcdacc20aa746b786f983492c51072870
 RUN pip install https://github.com/yeshsurya/flash-attention/releases/download/v2.8.3-linux-1/flash_attn-2.8.3-cp310-cp310-linux_x86_64.whl
-# Fix security vulnerabilities in ptca conda env (active environment)
-# aiohttp==3.13.4: GHSA-63hf-3vf5-4wqf et al. (8 CVEs); transitive dep of vllm/sglang/azure SDK,
-#   parents use loose floors — pip can't force >=3.13.4 transitively
-# protobuf==6.33.5: CVE-2026-40186; transitive dep of vllm (requires >=6.30.0), parent uses loose floor
-# setuptools==82.0.0: GHSA-58pv-8j8x-9vj2 (vendored jaraco.context), GHSA-8rrh-rw8j-w5fx (vendored wheel)
-# pip==26.0: GHSA-4xh5-x5gv-qwph, GHSA-6vgw-5pg2-w6jp
-# wheel==0.46.2: CVE-2026-24049
-# cryptography==46.0.7: CVE-2026-41727; azureml-mlflow pins <46.0.0 but upgrading anyway for CVE fix
-# requests>=2.33.0: GHSA-gc5v-m9x4-r6x2; transitive dep of azure-core/mlflow/transformers,
-#   msal requires >=2.0.0,<3, azureml-core requires >=2.19.1,<3 — no parent pins safe floor
-# onnx>=1.21.0: GHSA-p433-9wv8-28xj, GHSA-538c-55jv-c5g9 et al.; transitive dep of onnxruntime/
-#   azureml-acft-accelerator (require >=1.16.0), no parent upgrade resolves this
+# Fix security vulnerabilities in ptca conda env not resolved by base image
+# (pip, setuptools, wheel, aiohttp, protobuf, requests, onnx, pytest are already at
+#  safe versions in base image biweekly.202605.1 and do not need overrides)
+# cryptography==46.0.7: CVE-2026-41727; not pre-installed in ptca env, pulled by azureml-mlflow
 # fastmcp>=3.2.0: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767
 # Mako>=1.3.11: CVE-2025-46803; transitive dep of alembic, parent uses loose floor
-# pytest>=9.0.3: GHSA-6w46-j5rx-g56g; pre-installed in ptca env from base image, no parent to upgrade
 # lxml>=6.1.0: GHSA-vfmq-68hx-4jfw; transitive dep of multiple packages, parent uses loose floor
-# transformers>=5.0.0rc3: GHSA-69w3-r845-3855 (CVE-2026-1839); arbitrary code execution via torch.load()
-#   in Trainer._load_rng_state(). Direct dep — upgraded from 4.57.6 to patched 5.x
+# transformers>=5.0.0rc3: GHSA-69w3-r845-3855 (CVE-2026-1839); direct dep, upgraded to patched 5.x
 # GitPython>=3.1.47: GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4; transitive dep of wandb (requires
 #   gitpython!=3.1.29,>=1.0.0 as of 0.26.1), parent uses loose floor — no wandb release forces >=3.1.47
-RUN pip install --upgrade aiohttp==3.13.4 protobuf==6.33.5 setuptools==82.0.0 pip==26.0 wheel==0.46.2 cryptography==46.0.7 'requests>=2.33.0' 'onnx>=1.21.0' 'fastmcp>=3.2.0' 'Mako>=1.3.11' 'pytest>=9.0.3' 'lxml>=6.1.0' 'transformers>=5.0.0rc3' 'GitPython>=3.1.47'
-# Fix vulnerabilities in base conda env (python 3.13) from ACPT base image (biweekly.202603.1)
-# Base env ships: cryptography(44.0.1), pip(25.3), setuptools(80.9.0), wheel(0.45.1), aiohttp(3.12.x)
-# Same CVEs as ptca env above; base env is separate and must be patched independently
+RUN pip install --upgrade cryptography==46.0.7 'fastmcp>=3.2.0' 'Mako>=1.3.11' 'lxml>=6.1.0' 'transformers>=5.0.0rc3' 'GitPython>=3.1.47'
 # python-dotenv>=1.2.2: GHSA-mf9w-mj56-hr94; transitive dep of pydantic-settings (requires >=0.21.0)
-#   and uvicorn (optional, requires >=0.13). No parent release forces >=1.2.2 as of 2026-05-04.
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 aiohttp==3.13.4 'python-dotenv>=1.2.2'
+#   and uvicorn (optional, requires >=0.13). Base image ships 1.2.1 in base conda env.
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 # ray vendors its own copy of aiohttp inside thirdparty_files/ for runtime_env agent;
 # the vendored copy is not upgraded by pip install above. Patching all copies in-place.
 RUN find /opt/conda/envs/ptca/lib/python3.10/site-packages/ray -type d -name 'thirdparty_files' | while read dir; do \
       rm -rf "$dir"/aiohttp*; \
-      pip install --no-cache-dir --target "$dir" 'aiohttp==3.13.4'; \
+      pip install --no-cache-dir --target "$dir" 'aiohttp>=3.13.4'; \
     done
 COPY vllm_rollout /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/workers/rollout/vllm_rollout/vllm_rollout.py
-# Clean up pip caches and old package files to prevent vulnerability detection
 RUN rm -rf ~/.cache/pip /tmp/* /var/tmp/*
-# Set secure defaults
 ENV PYTHONHASHSEED=random \
     PYTHONDONTWRITEBYTECODE=1
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca 'pip>=26.0.1' 'wheel>=0.46.2'
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/ /opt/conda/pkgs/
 

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -25,19 +25,18 @@ RUN pip install nltk==3.9.4 # Pinning to fix the unsafe deserialization vulnerab
 RUN pip install --upgrade --no-cache-dir 'fastmcp>=3.2.0'
 
 # protobuf is required by onnxruntime, mlflow
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# pyans1 is required by azureml-acft-accelerator, mlflow and both dont pin the libs hence upgrade
+# NOTE: mlflow 3.11.1 pins cryptography<47,>=43.0.0; pinning to 46.0.7 for CVE fix
 # pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
 # parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
 # aiohttp: transitive dep of ray/vllm/azure-core; parents use loose floors (>=3.10); override needed (GHSA-mwh4-6h8g-pg8w etc.)
 # onnx: onnxruntime/azureml-acft-accelerator require onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# requests: transitive dep of azure-core/mlflow/transformers; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pillow: GHSA-whj4-6x5x-4v2j; >=12.2.0 required
+# requests: transitive dep of azure-core/mlflow/vllm; parents use loose floors (>=2.21.0/>=2.26.0) (GHSA-gc5v-m9x4-r6x2)
+# pillow: GHSA-whj4-6x5x-4v2j; >=12.2.0 required; transformers only pins >=10.0.1
 # pytest: pre-installed in ACPT base image; no parent package to upgrade (GHSA-6w46-j5rx-g56g)
-# transformers: final override to ensure >=5.0.0 after azureml-* installs (GHSA-69w3-r845-3855)
-# python-multipart: transitive dep (fastmcp → fastapi → python-multipart); parent uses loose floor; override needed (GHSA-mj87-hwqh-73pj)
-# Mako: transitive dep (mlflow → alembic → Mako); parent uses loose floor; override needed (GHSA-v92g-xgxw-vvmm)
-RUN pip install --upgrade pip>=26.0 wheel>=0.46.2 protobuf==6.33.5 pyasn1==0.6.3 cryptography==46.0.7 pillow==12.2.0 'python-multipart>=0.0.26' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' 'pytest>=9.0.3' 'transformers>=5.0.0' 'Mako>=1.3.11'
+# python-multipart: transitive dep (fastmcp → fastapi → python-multipart); fastapi pins >=0.0.18; override needed (GHSA-mj87-hwqh-73pj)
+# Mako: transitive dep (mlflow → alembic → Mako); alembic has no version constraint; override needed (GHSA-v92g-xgxw-vvmm)
+# python-dotenv: transitive dep (fastmcp → python-dotenv); fastmcp 3.2.4 uses >=1.1.0; override needed (GHSA-mf9w-mj56-hr94)
+RUN pip install --upgrade pip>=26.0 wheel>=0.46.2 protobuf==6.33.5 pyasn1==0.6.3 cryptography==46.0.7 pillow==12.2.0 'python-multipart>=0.0.26' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' 'pytest>=9.0.3' 'Mako>=1.3.11' 'python-dotenv>=1.2.2'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -n ptca -y wheel>=0.46.2 pip>=26.0.1
 # vulnerability in base conda env

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -24,24 +24,16 @@ RUN pip install nltk==3.9.4 # Pinning to fix the unsafe deserialization vulnerab
 # fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
 RUN pip install --upgrade --no-cache-dir 'fastmcp>=3.2.0'
 
-# protobuf is required by onnxruntime, mlflow
-# NOTE: mlflow 3.11.1 pins cryptography<47,>=43.0.0; pinning to 46.0.7 for CVE fix
 # pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
 # parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
-# aiohttp: transitive dep of ray/vllm/azure-core; parents use loose floors (>=3.10); override needed (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: onnxruntime/azureml-acft-accelerator require onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# requests: transitive dep of azure-core/mlflow/vllm; parents use loose floors (>=2.21.0/>=2.26.0) (GHSA-gc5v-m9x4-r6x2)
-# pillow: GHSA-whj4-6x5x-4v2j; >=12.2.0 required; transformers only pins >=10.0.1
-# pytest: pre-installed in ACPT base image; no parent package to upgrade (GHSA-6w46-j5rx-g56g)
 # python-multipart: transitive dep (fastmcp → fastapi → python-multipart); fastapi pins >=0.0.18; override needed (GHSA-mj87-hwqh-73pj)
 # Mako: transitive dep (mlflow → alembic → Mako); alembic has no version constraint; override needed (GHSA-v92g-xgxw-vvmm)
 # python-dotenv: transitive dep (fastmcp → python-dotenv); fastmcp 3.2.4 uses >=1.1.0; override needed (GHSA-mf9w-mj56-hr94)
-RUN pip install --upgrade pip>=26.0 wheel>=0.46.2 protobuf==6.33.5 pyasn1==0.6.3 cryptography==46.0.7 pillow==12.2.0 'python-multipart>=0.0.26' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' 'pytest>=9.0.3' 'Mako>=1.3.11' 'python-dotenv>=1.2.2'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y wheel>=0.46.2 pip>=26.0.1
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --upgrade pip>=26.0 wheel>=0.46.2 setuptools>=82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# onnx: azureml-acft-accelerator 0.0.89 caps onnx<=1.17.0; override needed for GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m etc.
+RUN pip install --upgrade --no-cache-dir pyasn1==0.6.3 'python-multipart>=0.0.26' 'Mako>=1.3.11' 'python-dotenv>=1.2.2' 'onnx>=1.21.0'
+
+# python-dotenv 1.2.1 in base conda env (python3.13) from ACPT base image needs upgrade (GHSA-mf9w-mj56-hr94)
+RUN conda run -n base python -m pip install --upgrade --no-cache-dir 'python-dotenv>=1.2.2'
 
 # clean conda and pip caches
 RUN rm -rf ~/.cache/pip

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -16,14 +16,12 @@ rouge-score==0.1.2
 sacrebleu==2.4.0
 bitsandbytes==0.46.0
 einops==0.7.0
-aiohttp==3.13.3
+aiohttp>=3.13.5
 peft==0.17.0
 deepspeed==0.17.4
 trl==0.21.0
 tiktoken==0.6.0
 scipy==1.14.0
 catalogue==2.0.10
-cryptography==46.0.7
-setuptools==82.0.0
 requests>=2.33.0
 filelock>=3.20.1

--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -8,22 +8,28 @@ RUN apt-get -y update && apt-get -y upgrade
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# upgrade pip, wheel, protobuf vulnerabilities in ptca env
+# upgrade pip, wheel, and override vulnerable transitive deps in ptca env
 # NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# protobuf parent is mlflow==3.5.0 (already latest) which accepts protobuf>=3.12.0, cannot force 6.33.5 via parent
-# pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
-# parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
+# protobuf: mlflow-skinny==3.11.1 requires protobuf<8,>=3.12.0 (loose floor); override needed
+# pyasn1: transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
+#   parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
 # aiohttp: transitive dep of azure-core/datasets; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
 # onnx: onnxruntime/azureml-acft-accelerator require onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
 # fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# Mako: transitive dep (mlflow -> alembic -> Mako); alembic requires Mako>=1.1.0 (loose floor),
-#   upgrading mlflow alone does not force Mako upgrade; override needed (GHSA-v92g-xgxw-vvmm)
+# requests: transitive dep of azure-core/mlflow-skinny; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
+# Mako: transitive dep (mlflow → alembic → Mako); alembic 1.18.4 requires Mako (no version pin),
+#   pip won't upgrade pre-installed Mako; override needed (GHSA-v92g-xgxw-vvmm)
 # pytest: transitive dep from azureml packages; parent packages use loose floors so pip resolves
-#   to 7.4.3 which has CVE-2025-71176 (GHSA-6w46-j5rx-g56g); override to 9.0.3
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 'fastmcp>=3.2.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' Mako==1.3.11 pytest==9.0.3
+#   to 7.4.3 which has CVE-2025-71176 (GHSA-6w46-j5rx-g56g); override to >=9.0.3
+# GitPython: transitive dep (mlflow → mlflow-skinny requires gitpython<4,>=3.1.9); loose floor,
+#   pip resolves to 3.1.46 which has GHSA-rpm5-65cw-6hj4, GHSA-x2qx-6953-8485; override to >=3.1.47
+# python-dotenv: transitive dep (mlflow → mlflow-skinny requires python-dotenv<2,>=0.19.0); loose floor,
+#   pip resolves to 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
+RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 'fastmcp>=3.2.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' Mako==1.3.11 'pytest>=9.0.3' 'GitPython>=3.1.47' 'python-dotenv>=1.2.2'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2
 # vulnerability in base conda env
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0 wheel>=0.46.2 setuptools>=82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# python-dotenv: transitive dep of uvicorn[standard] (>=0.13) in base env; loose floor,
+#   pip resolves to 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0 wheel>=0.46.2 setuptools>=82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -8,28 +8,20 @@ RUN apt-get -y update && apt-get -y upgrade
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# upgrade pip, wheel, and override vulnerable transitive deps in ptca env
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# protobuf: mlflow-skinny==3.11.1 requires protobuf<8,>=3.12.0 (loose floor); override needed
+# Override vulnerable transitive deps in ptca env that are not fixed in the base image
+# onnx: azureml-acft-accelerator==0.0.89 requires onnx<=1.17.0 which downgrades base 1.21.0;
+#   override needed to keep safe version (GHSA-p433-9wv8-28xj etc.)
 # pyasn1: transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
 #   parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
-# aiohttp: transitive dep of azure-core/datasets; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: onnxruntime/azureml-acft-accelerator require onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
-# requests: transitive dep of azure-core/mlflow-skinny; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
+# fastmcp: transitive dep (mlflow-skinny[mcp] requires fastmcp<4,>=2.0.0); loose floor,
+#   GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; override to >=3.2.0
 # Mako: transitive dep (mlflow → alembic → Mako); alembic 1.18.4 requires Mako (no version pin),
 #   pip won't upgrade pre-installed Mako; override needed (GHSA-v92g-xgxw-vvmm)
-# pytest: transitive dep from azureml packages; parent packages use loose floors so pip resolves
-#   to 7.4.3 which has CVE-2025-71176 (GHSA-6w46-j5rx-g56g); override to >=9.0.3
 # GitPython: transitive dep (mlflow → mlflow-skinny requires gitpython<4,>=3.1.9); loose floor,
 #   pip resolves to 3.1.46 which has GHSA-rpm5-65cw-6hj4, GHSA-x2qx-6953-8485; override to >=3.1.47
 # python-dotenv: transitive dep (mlflow → mlflow-skinny requires python-dotenv<2,>=0.19.0); loose floor,
 #   pip resolves to 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 'fastmcp>=3.2.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' Mako==1.3.11 'pytest>=9.0.3' 'GitPython>=3.1.47' 'python-dotenv>=1.2.2'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-# python-dotenv: transitive dep of uvicorn[standard] (>=0.13) in base env; loose floor,
-#   pip resolves to 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0 wheel>=0.46.2 setuptools>=82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'
+RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0' pyasn1==0.6.3 'fastmcp>=3.2.0' Mako==1.3.11 'GitPython>=3.1.47' 'python-dotenv>=1.2.2'
+# python-dotenv in base conda env: transitive dep of uvicorn[standard] (>=0.13); loose floor,
+#   base image has 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
@@ -4,31 +4,18 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest
 USER root
 RUN apt-get -y update && apt-get -y upgrade
 
-# Install unzip
-RUN apt-get -y install unzip libc-bin libc-dev locales libc6 dpkg-dev dpkg libdpkg-perl libssl-dev libssl3 openssl
+RUN apt-get -y install unzip
 
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# upgrade pip, wheel, protobuf vulnerabilities in ptca env
-# NOTE: mlflow==3.11.1 pins cryptography<47,>=43.0.0; upgrading to 46.0.7 for CVE fix
-# protobuf parent is mlflow-tracing==3.11.1 (via mlflow==3.11.1) which accepts protobuf<8,>=3.12.0; pip resolves older; override needed
-# pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
-# parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
-# aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# Mako: transitive dep (mlflow → alembic → Mako); alembic uses unpinned Mako, cannot force via parent
-# pytest: standalone test dep from base image; no parent to upgrade
-# python-dotenv: transitive dep (mlflow → mlflow-skinny → python-dotenv<2,>=0.19.0);
-# mlflow 3.11.1 (latest as of 2026-05-04) allows >=1.2.2 but pip resolves to 1.2.1; override for GHSA-mf9w-mj56-hr94
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 'fastmcp>=3.2.0' 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'Mako>=1.3.11' 'pytest>=9.0.3' 'python-dotenv>=1.2.2'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2 
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# Transitive dep overrides where pip may not resolve to the patched version:
+# pyasn1: mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1;
+#   parents use loose floors so pip may resolve to <0.6.3 (CVE-2026-30922)
+# Mako: mlflow → alembic → Mako; alembic uses unpinned Mako dep
+# python-dotenv: mlflow → mlflow-skinny → python-dotenv<2,>=0.19.0;
+#   mlflow 3.11.1 (latest as of 2026-05-04) allows >=1.2.2 but pip may resolve older (GHSA-mf9w-mj56-hr94)
+RUN pip install --no-cache-dir --upgrade 'pyasn1>=0.6.3' 'Mako>=1.3.11' 'python-dotenv>=1.2.2'
 
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
@@ -5,15 +5,15 @@ USER root
 RUN apt-get -y update && apt-get -y upgrade
 
 # Install unzip
-RUN apt-get -y install unzip libc-bin libc-bin libc-dev locales libc6 dpkg-dev dpkg libdpkg-perl libssl-dev libssl3 openssl
+RUN apt-get -y install unzip libc-bin libc-dev locales libc6 dpkg-dev dpkg libdpkg-perl libssl-dev libssl3 openssl
 
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
 # upgrade pip, wheel, protobuf vulnerabilities in ptca env
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# protobuf parent is mlflow==3.5.0 (already latest) which accepts protobuf>=3.12.0, cannot force 6.33.5 via parent
+# NOTE: mlflow==3.11.1 pins cryptography<47,>=43.0.0; upgrading to 46.0.7 for CVE fix
+# protobuf parent is mlflow-tracing==3.11.1 (via mlflow==3.11.1) which accepts protobuf<8,>=3.12.0; pip resolves older; override needed
 # pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
 # parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
 # aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
@@ -22,7 +22,9 @@ RUN pip install -r requirements.txt --no-cache-dir
 # requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
 # Mako: transitive dep (mlflow → alembic → Mako); alembic uses unpinned Mako, cannot force via parent
 # pytest: standalone test dep from base image; no parent to upgrade
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 'fastmcp>=3.2.0' 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'Mako>=1.3.11' 'pytest>=9.0.3'
+# python-dotenv: transitive dep (mlflow → mlflow-skinny → python-dotenv<2,>=0.19.0);
+# mlflow 3.11.1 (latest as of 2026-05-04) allows >=1.2.2 but pip resolves to 1.2.1; override for GHSA-mf9w-mj56-hr94
+RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 'fastmcp>=3.2.0' 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'Mako>=1.3.11' 'pytest>=9.0.3' 'python-dotenv>=1.2.2'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2 
 # vulnerability in base conda env

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
@@ -10,30 +10,14 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y install unzip && apt-g
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# upgrade pip, wheel and transitive deps to fix vulnerabilities
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; upgrading anyway for CVE fix
-# protobuf is a transitive dep of mlflow-skinny/onnx; parents use loose floors (>=3.12.0), cannot force 6.33.5
 # mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635); upgrade after requirements install
 # azureml-mlflow pins mlflow-skinny<=3.9.0, so mlflow must be upgraded separately to avoid resolution conflict
-# mlflow 3.11.1: GHSA-fh64-r2vc-xvhr requires >=3.11.1
 RUN pip install --no-cache-dir mlflow==3.11.1
-# pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
-# parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
-# onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pillow: GHSA-whj4-6x5x-4v2j requires >=12.2.0; direct dep override
-# Mako: GHSA-v92g-xgxw-vvmm requires >=1.3.11; transitive via alembic→mlflow, alembic has no version floor on Mako so override needed
-# pytest: GHSA-6w46-j5rx-g56g requires >=9.0.3; installed by base image, no parent to upgrade so override needed
-# GitPython: GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4 require >=3.1.47; transitive via mlflow→mlflow-skinny
-# which pins gitpython>=3.1.9,<4 (loose floor); no newer mlflow-skinny tightens this, so override needed
-RUN pip install --no-cache-dir --upgrade protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 wheel>=0.46.2 'fastmcp>=3.2.0' 'onnx>=1.21.0' 'requests>=2.33.0' 'Mako>=1.3.11' 'pytest>=9.0.3' 'GitPython>=3.1.47'
+# fastmcp + mcp were installed as regular deps of mlflow 3.5.0 (fastmcp→mcp) but orphaned after
+# mlflow 3.11.1 (fastmcp moved to optional "mcp" extra); uninstall both to remove vulnerable packages
+RUN pip uninstall -y fastmcp mcp
 
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
-
-# Upgrade packages in the system Python(3.13) for fixing vulnerability
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-# python-dotenv: transitive dep via pydantic-settings (>=0.21.0 floor); parent uses loose floor so pip resolves to
+# Upgrade python-dotenv in the system Python(3.13)
+# python-dotenv: transitive dep via pydantic-settings (>=0.21.0 floor); parent uses loose floor so base resolves to
 # vulnerable 1.2.1 (GHSA-mf9w-mj56-hr94); override to >=1.2.2
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade urllib3==2.6.3 aiohttp==3.13.4 PyNaCl==1.6.2 pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'requests>=2.33.0' 'python-dotenv>=1.2.2'
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
@@ -11,10 +11,10 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
 # upgrade pip, wheel and transitive deps to fix vulnerabilities
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
+# NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; upgrading anyway for CVE fix
 # protobuf is a transitive dep of mlflow-skinny/onnx; parents use loose floors (>=3.12.0), cannot force 6.33.5
 # mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635); upgrade after requirements install
-# azureml-mlflow pins mlflow-skinny<=3.5.0, so mlflow must be upgraded separately to avoid resolution conflict
+# azureml-mlflow pins mlflow-skinny<=3.9.0, so mlflow must be upgraded separately to avoid resolution conflict
 # mlflow 3.11.1: GHSA-fh64-r2vc-xvhr requires >=3.11.1
 RUN pip install --no-cache-dir mlflow==3.11.1
 # pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
@@ -25,11 +25,15 @@ RUN pip install --no-cache-dir mlflow==3.11.1
 # pillow: GHSA-whj4-6x5x-4v2j requires >=12.2.0; direct dep override
 # Mako: GHSA-v92g-xgxw-vvmm requires >=1.3.11; transitive via alembic→mlflow, alembic has no version floor on Mako so override needed
 # pytest: GHSA-6w46-j5rx-g56g requires >=9.0.3; installed by base image, no parent to upgrade so override needed
-RUN pip install --no-cache-dir --upgrade protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 wheel>=0.46.2 'fastmcp>=3.2.0' 'onnx>=1.21.0' 'requests>=2.33.0' 'Mako>=1.3.11' 'pytest>=9.0.3'
+# GitPython: GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4 require >=3.1.47; transitive via mlflow→mlflow-skinny
+# which pins gitpython>=3.1.9,<4 (loose floor); no newer mlflow-skinny tightens this, so override needed
+RUN pip install --no-cache-dir --upgrade protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 wheel>=0.46.2 'fastmcp>=3.2.0' 'onnx>=1.21.0' 'requests>=2.33.0' 'Mako>=1.3.11' 'pytest>=9.0.3' 'GitPython>=3.1.47'
 
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
 
 # Upgrade packages in the system Python(3.13) for fixing vulnerability
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade urllib3==2.6.3 aiohttp==3.13.4 PyNaCl==1.6.2 pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'requests>=2.33.0'
+# python-dotenv: transitive dep via pydantic-settings (>=0.21.0 floor); parent uses loose floor so pip resolves to
+# vulnerable 1.2.1 (GHSA-mf9w-mj56-hr94); override to >=1.2.2
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade urllib3==2.6.3 aiohttp==3.13.4 PyNaCl==1.6.2 pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'requests>=2.33.0' 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
@@ -19,13 +19,12 @@ RUN pip install --no-build-isolation git+https://github.com/facebookresearch/det
 RUN pip install --no-cache-dir mlflow-skinny==3.10.1
 # aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
 # onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# nltk: GHSA-gfwx-w7gr-fvh7; >=3.9.4 required
-# pydicom: GHSA-v856-2rf8-9f28; requirements.txt pins ~=2.4.0 allowing vulnerable 2.4.4; override to >=2.4.5
 # requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
 # pytest: transitive dep from base image; not a direct requirement of any parent package (GHSA-6w46-j5rx-g56g)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools>=82.0.1 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pydicom>=2.4.5' 'pytest>=9.0.3'
+RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools>=82.0.1 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'pytest>=9.0.3'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2
 # vulnerability in base conda env
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# python-dotenv: transitive dep of mlflow-skinny (requires python-dotenv>=0.19.0,<2); base conda env has 1.2.1 from base image; GHSA-mf9w-mj56-hr94 requires >=1.2.2
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
@@ -10,21 +10,3 @@ RUN apt-get update && \
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 RUN pip install --no-build-isolation git+https://github.com/facebookresearch/detectron2.git@a1ce2f9
-
-# protobuf is a transitive dep of mlflow-skinny/onnx; parents require >=3.12.0, cannot force 6.33.5
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-# mlflow-skinny 2.13.2 has CVEs; upgrade after requirements install
-# azureml-mlflow pins mlflow-skinny<=3.5.0, so must be upgraded separately to avoid resolution conflict
-RUN pip install --no-cache-dir mlflow-skinny==3.10.1
-# aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pytest: transitive dep from base image; not a direct requirement of any parent package (GHSA-6w46-j5rx-g56g)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools>=82.0.1 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'pytest>=9.0.3'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-# python-dotenv: transitive dep of mlflow-skinny (requires python-dotenv>=0.19.0,<2); base conda env has 1.2.1 from base image; GHSA-mf9w-mj56-hr94 requires >=1.2.2
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
@@ -4,7 +4,7 @@ hydra-core==1.3.2
 marshmallow==3.26.2
 azure-ai-ml==1.16.1
 azure-identity==1.16.1
-mlflow-skinny==2.13.2
+mlflow-skinny==3.11.1
 azureml-mlflow==1.56.0
 azureml-dataprep==5.4.1
 timm==0.9.16
@@ -28,7 +28,6 @@ dotmap==1.3.30
 h5py==3.14.0
 appdirs==1.4.4
 ffmpeg==1.4
-wheel==0.46.3
 lightning==2.5.5
 azureml-acft-image-components[mip]=={{latest-pypi-version}}
 filelock>=3.20.1

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
@@ -23,7 +23,7 @@ pydicom>=2.4.5
 SimpleITK==2.4.0
 scikit-image==0.24.0 
 arrow==1.3.0 
-nltk==3.9.3 
+nltk==3.9.4 
 dotmap==1.3.30
 h5py==3.14.0
 appdirs==1.4.4

--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
@@ -8,7 +8,6 @@ RUN apt-get -y update && apt-get -y upgrade && \
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
-RUN apt-get update && apt-get install -y expat && apt-get clean && rm -rf /var/lib/apt/lists/*
 # openmim still imports pkg_resources, which is removed from setuptools>=82.
 # Keep a temporary compatibility pin for mim installation, then restore setuptools.
 RUN pip install --no-cache-dir 'setuptools<82'
@@ -22,16 +21,14 @@ RUN mim install mmcv==2.2.0 -f https://download.openmmlab.com/mmcv/dist/cu118/to
 RUN pip install --no-cache-dir --upgrade setuptools==82.0.0
 RUN sed -i 's/2.2.0/2.3.0/' /opt/conda/envs/ptca/lib/python3.10/site-packages/mmdet/__init__.py
 
-# upgrade pip, wheel, setuptools and transitive dependencies in ptca env
-# NOTE: azureml-mlflow~=1.62.0.post2 pins cryptography<47.0.0; upgrading anyway for CVE fix
-# protobuf is required by azureml-acft-accelerator but it is not pinned hence upgrade
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 setuptools==82.0.0 cryptography==46.0.7 pillow==12.2.0 \
-    'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'pytest>=9.0.3'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y 'pip>=26.0.1' 'wheel>=0.46.2'
+# requests==2.32.4 in requirements.txt downgrades the base-image version; re-upgrade for security
+# onnx: azureml-acft-accelerator pins onnx<=1.17.0 but that range has known CVEs;
+#   onnx-weekly 1.22.0.dev20260504 includes main-branch security fixes (GHSA-3r9x-f23j-gc73,
+#   GHSA-538c-55jv-c5g9, GHSA-hqmj-h5c6-369m, etc.) not yet in a stable PyPI release (checked 2026-05-04)
+RUN pip install --no-cache-dir --upgrade 'requests>=2.33.0' && \
+    pip uninstall -y onnx && pip install --no-cache-dir 'onnx-weekly>=1.22.0.dev20260504'
 # vulnerability in base conda env
 # python-dotenv 1.2.1 (GHSA-mf9w-mj56-hr94): brought in by azureml-inference-server-http -> pydantic-settings -> python-dotenv>=0.21.0;
 #   parent packages do not upper-bound python-dotenv so upgrading them won't force >=1.2.2; direct override required (checked 2026-05-04)
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'pip>=26.0.1' 'wheel>=0.46.2' 'setuptools>=82.0.1' \
-    cryptography==46.0.7 'requests>=2.33.0' 'aiohttp>=3.13.4' 'python-dotenv>=1.2.2'
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
@@ -3,7 +3,6 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest
 
 USER root
 RUN apt-get -y update && apt-get -y upgrade && \
-    apt-get install -y --only-upgrade udev libsystemd0 libudev1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install required packages from pypi
@@ -24,14 +23,15 @@ RUN pip install --no-cache-dir --upgrade setuptools==82.0.0
 RUN sed -i 's/2.2.0/2.3.0/' /opt/conda/envs/ptca/lib/python3.10/site-packages/mmdet/__init__.py
 
 # upgrade pip, wheel, setuptools and transitive dependencies in ptca env
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
+# NOTE: azureml-mlflow~=1.62.0.post2 pins cryptography<47.0.0; upgrading anyway for CVE fix
 # protobuf is required by azureml-acft-accelerator but it is not pinned hence upgrade
 RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 setuptools==82.0.0 cryptography==46.0.7 pillow==12.2.0 \
     'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'pytest>=9.0.3'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -n ptca -y 'pip>=26.0.1' 'wheel>=0.46.2'
 # vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
+# python-dotenv 1.2.1 (GHSA-mf9w-mj56-hr94): brought in by azureml-inference-server-http -> pydantic-settings -> python-dotenv>=0.21.0;
+#   parent packages do not upper-bound python-dotenv so upgrading them won't force >=1.2.2; direct override required (checked 2026-05-04)
 RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'pip>=26.0.1' 'wheel>=0.46.2' 'setuptools>=82.0.1' \
-    cryptography==46.0.7 'PyJWT>=2.12.0' 'requests>=2.33.0' 'aiohttp>=3.13.4'
+    cryptography==46.0.7 'requests>=2.33.0' 'aiohttp>=3.13.4' 'python-dotenv>=1.2.2'
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -34,7 +34,7 @@ RUN pip install numpy==1.23.5
 RUN pip install yapf==0.40.1
 
 # protobuf is a transitive dep of onnx/mlflow-skinny; parents use loose floors (>=3.12.0), cannot force 6.33.5
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
+# NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; upgrading anyway for CVE fix
 # aiohttp: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
 # requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
 # pillow: upgrade 12.1.1→12.2.0 for GHSA-whj4-6x5x-4v2j
@@ -42,6 +42,8 @@ RUN pip install yapf==0.40.1
 RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 'aiohttp>=3.13.4' 'requests>=2.33.0' 'pytest>=9.0.3'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
-# Upgrade requests, urllib3, aiohttpin the system Python (3.13) for fixing vulnerability
+# Upgrade requests, urllib3, aiohttp in the system Python (3.13) for fixing vulnerability
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# python-dotenv: transitive dep of mlflow-skinny (>=0.19.0,<2) and pydantic-settings (>=0.21.0);
+#   parents use loose version floors so upgrading them won't force >=1.2.2 (GHSA-mf9w-mj56-hr94, symlink overwrite in set_key/unset_key)
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
-RUN apt-get -y update && apt-get -y upgrade && apt-get install -y expat
+RUN apt-get -y update && apt-get -y upgrade
 
 # Install required packages from pypi
 COPY requirements.txt .
@@ -33,17 +33,6 @@ RUN pip install numpy==1.23.5
 # https://github.com/open-mmlab/mmdetection/issues/10962
 RUN pip install yapf==0.40.1
 
-# protobuf is a transitive dep of onnx/mlflow-skinny; parents use loose floors (>=3.12.0), cannot force 6.33.5
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; upgrading anyway for CVE fix
-# aiohttp: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pillow: upgrade 12.1.1→12.2.0 for GHSA-whj4-6x5x-4v2j
-# pytest: from ACPT base image ptca env; no parent to upgrade (GHSA-6w46-j5rx-g56g, CVE-2025-71176 tmpdir handling)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 'aiohttp>=3.13.4' 'requests>=2.33.0' 'pytest>=9.0.3'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
-# Upgrade requests, urllib3, aiohttp in the system Python (3.13) for fixing vulnerability
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-# python-dotenv: transitive dep of mlflow-skinny (>=0.19.0,<2) and pydantic-settings (>=0.21.0);
-#   parents use loose version floors so upgrading them won't force >=1.2.2 (GHSA-mf9w-mj56-hr94, symlink overwrite in set_key/unset_key)
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'
+# python-dotenv 1.2.1 in system Python (3.13) needs upgrade to 1.2.2 (GHSA-mf9w-mj56-hr94, symlink overwrite);
+# transitive dep of mlflow-skinny (>=0.19.0,<2) and pydantic-settings (>=0.21.0) — parents use loose floors
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
@@ -7,7 +7,7 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
 # upgrade pip, wheel, protobuf vulnerabilities in ptca env
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
+# NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; upgrading anyway for CVE fix
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
 # protobuf parent is mlflow (already latest) which accepts protobuf>=3.12.0, cannot force 6.33.5 via parent
 # aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
@@ -22,7 +22,8 @@ ENV AZURE_ML_CLI_PRIVATE_FEATURES_ENABLED=True
 
 # vulnerability in base conda env
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 'setuptools>=82.0.1' cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# python-dotenv: transitive dep of uvicorn[standard] (>=0.13) and pydantic-settings (>=0.21.0) in base conda env; parents use loose floors, cannot force >=1.2.2 via parent (GHSA-mf9w-mj56-hr94)
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 'setuptools>=82.0.1' cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'
 # pip install updates the binary but conda-meta still references old versions; conda install syncs both
 RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
@@ -6,24 +6,11 @@ RUN apt-get -y update && apt-get -y upgrade
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# upgrade pip, wheel, protobuf vulnerabilities in ptca env
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; upgrading anyway for CVE fix
-# setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-# protobuf parent is mlflow (already latest) which accepts protobuf>=3.12.0, cannot force 6.33.5 via parent
-# aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pytest: installed in base ACPT image; no parent package to upgrade (GHSA-6w46-j5rx-g56g, CVE-2025-71176 tmpdir handling)
-# Mako: transitive dep of mlflow -> alembic; alembic requires Mako with no version floor, cannot force >=1.3.11 via parent (GHSA-v92g-xgxw-vvmm)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 cryptography==46.0.7 'setuptools>=82.0.1' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' 'pytest>=9.0.3' 'Mako>=1.3.11'
-
 # Flag needed to enable control flow which is in PrP.
 ENV AZURE_ML_CLI_PRIVATE_FEATURES_ENABLED=True
 
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-# python-dotenv: transitive dep of uvicorn[standard] (>=0.13) and pydantic-settings (>=0.21.0) in base conda env; parents use loose floors, cannot force >=1.2.2 via parent (GHSA-mf9w-mj56-hr94)
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 'setuptools>=82.0.1' cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2
+# vulnerability overrides in base conda env (python3.13)
+# setuptools: base image has 82.0.0, need >=82.0.1 for GHSA-58pv-8j8x-9vj2
+# python-dotenv: transitive dep of uvicorn[standard] (>=0.13) and pydantic-settings (>=0.21.0); parents use loose floors, cannot force >=1.2.2 via parent (GHSA-mf9w-mj56-hr94)
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'python-dotenv>=1.2.2'
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/requirements.txt
@@ -3,10 +3,4 @@ mldesigner
 mlflow
 azureml-mlflow
 azureml-core
-requests>=2.33.0
-setuptools>=82.0.0
-Werkzeug>=3.1.5
-filelock>=3.20.1
-pillow>=12.1.1
-# protobuf 6.33.4 has CVE-2026-0994 (HIGH 8.6); transitive dep from mlflow -> mlflow-skinny (requires >=3.12.0,<7)
-protobuf>=6.33.5
+setuptools>=82.0.1

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
@@ -13,19 +13,11 @@ RUN pip install azureml-metrics==0.0.33 pyarrow==14.0.1
 RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install azureml-acft-accelerator=={{latest-pypi-version}}
 
-# protobuf is a transitive dep of onnxruntime-training; base image has older version pre-installed
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; upgrading anyway for CVE fix
-# setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-# aiohttp: transitive dep of azure-core/datasets; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: onnxruntime-training accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# nltk: GHSA-gfwx-w7gr-fvh7; >=3.9.4 required
-# pillow: GHSA-whj4-6x5x-4v2j; >=12.2.0 required
-# pytest: pre-installed in ACPT base image; no parent package to upgrade (GHSA-6w46-j5rx-g56g)
-# transformers: final override to ensure >=5.0.0 after azureml-* installs (GHSA-69w3-r845-3855)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 setuptools>=82.0.1 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pytest>=9.0.3' 'transformers>=5.0.0'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-# python-dotenv: transitive dep of mlflow-skinny (which accepts >=0.19.0,<2); base image ships 1.2.1 (GHSA-mf9w-mj56-hr94)
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'
+# setuptools: >=82.0.1 patches jaraco.context (GHSA-58pv-8j8x-9vj2); base ships 82.0.0
+# nltk: >=3.9.4 required (GHSA-gfwx-w7gr-fvh7)
+# transformers: ensure >=5.0.0 after azureml-* installs (GHSA-69w3-r845-3855)
+# onnx: onnxruntime-training has loose onnx dep; pip resolves to 1.17.0 which has multiple CVEs
+RUN pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'nltk>=3.9.4' 'transformers>=5.0.0' 'onnx>=1.21.0'
+# base conda env: setuptools and python-dotenv need upgrades above what base image ships
+# python-dotenv: transitive dep of mlflow-skinny (accepts >=0.19.0,<2); base ships 1.2.1 (GHSA-mf9w-mj56-hr94)
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install azureml-acft-accelerator=={{latest-pypi-version}}
 
 # protobuf is a transitive dep of onnxruntime-training; base image has older version pre-installed
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
+# NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; upgrading anyway for CVE fix
 # setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
 # aiohttp: transitive dep of azure-core/datasets; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
 # onnx: onnxruntime-training accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
@@ -27,4 +27,5 @@ RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.
 RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
 # vulnerability in base conda env
 # PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# python-dotenv: transitive dep of mlflow-skinny (which accepts >=0.19.0,<2); base image ships 1.2.1 (GHSA-mf9w-mj56-hr94)
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0' 'python-dotenv>=1.2.2'

--- a/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
@@ -1,16 +1,15 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
-# Upgrade base conda packages
-RUN conda install -n base -c conda-forge pip=26.0 -y
-# These are from base image adding till we get new base image tag
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-# aiohttp 3.12.14 (8 CVEs) and urllib3 2.5.0 (3 CVEs) are also in base env from base image
-# python-dotenv 1.1.0 (GHSA-mf9w-mj56-hr94) is in base env from base image; no direct parent pip package pulls it
+# Upgrade pip in base conda env (CVE-2026-1703 requires pip>=26.0; base image ships pip 25.3)
+RUN conda install -n base -c conda-forge 'pip>=26.0' -y
+# Base image packages requiring security upgrades (base image biweekly.202601.1 not yet patched):
+# PyJWT 2.10.1 (CVE-2026-32597), aiohttp 3.12.14, urllib3 2.5.0, python-dotenv 1.1.0 (GHSA-mf9w-mj56-hr94),
+# cryptography 44.0.1, setuptools 80.9.0, wheel 0.45.1, requests 2.32.4
+# No parent pip packages in the base env pull these at fixed versions; direct overrides required.
 RUN conda run -n base python -m pip install --upgrade 'wheel>=0.46.2' 'cryptography>=46.0.7' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'urllib3>=2.6.3' 'requests>=2.33.0' 'python-dotenv>=1.2.2'
 
-
-# Upgrade ptca environment conda packages
-RUN conda install -c conda-forge pip=26.0 -y && \
+# Upgrade pip in ptca conda env (CVE-2026-1703 requires pip>=26.0; base image ships pip 25.3)
+RUN conda install -c conda-forge 'pip>=26.0' -y && \
     conda clean -a -y
 
 # Install pip dependencies
@@ -46,8 +45,7 @@ EXPOSE 5001 8883 8888
 RUN apt-get update
 RUN apt-get install -y openssh-server openssh-client
 
-# Fix Vulnerability 
-# TODO: latest version of azureml-mlflow ~ 1.62.0 depends on cryptography<46.0.0
+# Fix Vulnerability: cryptography (azureml-mlflow 1.62.0 allows cryptography<47.0.0)
 RUN pip install --upgrade --no-cache-dir 'cryptography>=46.0.7'
 # CVE-2026-23949 (jaraco.context) & CVE-2026-24049 (wheel) - upgrade setuptools in ptca and base envs
 # setuptools vendors jaraco.context internally; --force-reinstall --no-deps ensures vendored copies are replaced

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -28,39 +28,18 @@ ENV WORKER_TIMEOUT=400
 EXPOSE 5001 8883 8888
 
 # support Deepspeed launcher requirement of passwordless ssh login
-# Remove dotnet-* packages once its fixed in base image (04-05-2026)
 RUN apt-get update && \
     apt-get install -y openssh-server openssh-client && \
     apt-get upgrade -y && \
-    apt-get install -y --only-upgrade \
-        dotnet-host-8.0 \
-        dotnet-hostfxr-8.0 \
-        dotnet-runtime-8.0 || true && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-
 # Fix security vulnerabilities in ptca conda env (active environment)
-# pip>=26.0: GHSA-4xh5-x5gv-qwph, GHSA-6vgw-5pg2-w6jp
-# wheel>=0.46.2: CVE-2026-24049
-# cryptography>=46.0.7: CVE-2026-41727 (NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; compatible)
-# pillow>=12.1.1: GHSA-cfh3-3jmp-rvhc; transitive dep of matplotlib (requires >=8), no parent upgrade resolves this
-# protobuf>=6.33.5: CVE-2026-40186; transitive dep of onnxruntime/tensorboard, parents use loose floors
-# setuptools>=82.0.1: GHSA-58pv-8j8x-9vj2 (vendored jaraco.context), GHSA-8rrh-rw8j-w5fx (vendored wheel)
-# pytest>=9.0.3: GHSA-6w46-j5rx-g56g; pre-installed in ptca env from ACPT base image (7.4.3), no parent to upgrade
-# GitPython>=3.1.47: GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4; transitive dep chain: azureml-mlflow -> mlflow-skinny
-#   -> GitPython (>=3.1.9,<4). mlflow-skinny (all versions through 3.11.1) uses loose floor, no parent upgrade resolves this
-RUN pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.7' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'pytest>=9.0.3' 'GitPython>=3.1.47'
+# setuptools>=82.0.1: GHSA-58pv-8j8x-9vj2, GHSA-8rrh-rw8j-w5fx; base image has 82.0.0
+RUN pip install --upgrade 'setuptools>=82.0.1'
 
 # Fix security vulnerabilities in base conda env (python 3.13)
-# Same CVEs as above for pip/wheel/cryptography/pillow/protobuf/setuptools, plus:
-# PyJWT>=2.12.0: CVE-2026-32597; transitive dep of msal (>=1.0.0,<3) and azureml-core (<3.0.0), no parent pins safe floor
-# aiohttp>=3.13.4: GHSA-63hf-3vf5-4wqf et al. (8 CVEs); transitive dep of azure SDK, parents use loose floors
-# python-dotenv>=1.2.2: CVE-2026-28684 (GHSA-mf9w-mj56-hr94); transitive dep chain: azureml-defaults
-#   -> azureml-inference-server-http -> pydantic-settings -> python-dotenv>=0.21.0.
-#   pydantic-settings (all versions through 2.14.0) only requires >=0.21.0, no parent upgrade resolves this
-# requests>=2.33.0: GHSA-gc5v-m9x4-r6x2; transitive dep of msal (>=2.0.0,<3) and azureml-core (>=2.19.1,<3), no parent pins safe floor
-# urllib3>=2.6.3: CVE-2026-37152; transitive dep of requests/azure SDK, parents use loose floors
-RUN conda run -n base python -m pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.7' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'python-dotenv>=1.2.2' 'requests>=2.33.0' 'urllib3>=2.6.3'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1
+# setuptools>=82.0.1: same CVEs as above; base image has 82.0.0
+# python-dotenv>=1.2.2: CVE-2026-28684 (GHSA-mf9w-mj56-hr94); base env ships 1.2.1
+RUN conda run -n base python -m pip install --upgrade 'setuptools>=82.0.1' 'python-dotenv>=1.2.2'
+
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -28,6 +28,7 @@ ENV WORKER_TIMEOUT=400
 EXPOSE 5001 8883 8888
 
 # support Deepspeed launcher requirement of passwordless ssh login
+# Remove dotnet-* packages once its fixed in base image (04-05-2026)
 RUN apt-get update && \
     apt-get install -y openssh-server openssh-client && \
     apt-get upgrade -y && \

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -31,18 +31,24 @@ EXPOSE 5001 8883 8888
 RUN apt-get update && \
     apt-get install -y openssh-server openssh-client && \
     apt-get upgrade -y && \
+    apt-get install -y --only-upgrade \
+        dotnet-host-8.0 \
+        dotnet-hostfxr-8.0 \
+        dotnet-runtime-8.0 || true && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 
 # Fix security vulnerabilities in ptca conda env (active environment)
 # pip>=26.0: GHSA-4xh5-x5gv-qwph, GHSA-6vgw-5pg2-w6jp
 # wheel>=0.46.2: CVE-2026-24049
-# cryptography>=46.0.7: CVE-2026-41727 (NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway)
+# cryptography>=46.0.7: CVE-2026-41727 (NOTE: azureml-mlflow~=1.62.0 pins cryptography<47.0.0; compatible)
 # pillow>=12.1.1: GHSA-cfh3-3jmp-rvhc; transitive dep of matplotlib (requires >=8), no parent upgrade resolves this
 # protobuf>=6.33.5: CVE-2026-40186; transitive dep of onnxruntime/tensorboard, parents use loose floors
 # setuptools>=82.0.1: GHSA-58pv-8j8x-9vj2 (vendored jaraco.context), GHSA-8rrh-rw8j-w5fx (vendored wheel)
 # pytest>=9.0.3: GHSA-6w46-j5rx-g56g; pre-installed in ptca env from ACPT base image (7.4.3), no parent to upgrade
-RUN pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.7' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'pytest>=9.0.3'
+# GitPython>=3.1.47: GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4; transitive dep chain: azureml-mlflow -> mlflow-skinny
+#   -> GitPython (>=3.1.9,<4). mlflow-skinny (all versions through 3.11.1) uses loose floor, no parent upgrade resolves this
+RUN pip install --upgrade 'pip>=26.0' 'wheel>=0.46.2' 'cryptography>=46.0.7' 'pillow>=12.1.1' 'protobuf>=6.33.5' 'setuptools>=82.0.1' 'pytest>=9.0.3' 'GitPython>=3.1.47'
 
 # Fix security vulnerabilities in base conda env (python 3.13)
 # Same CVEs as above for pip/wheel/cryptography/pillow/protobuf/setuptools, plus:

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
@@ -9,11 +9,7 @@ inference-schema
 MarkupSafe
 regex
 pybind11
-urllib3>=2.6.3
-requests>=2.33.0
-pillow>=12.1.1
 transformers
-aiohttp>=3.13.4
 py-spy
 debugpy
 ipykernel
@@ -23,22 +19,14 @@ matplotlib
 tqdm
 py-cpuinfo
 torch-tb-profiler
-filelock>=3.20.1
+# starlette: transitive dep of azureml-inference-server-http -> fastapi -> starlette.
+#   Not pre-installed in base ptca env; fastapi uses loose floor.
 starlette>=0.49.1
-wheel>=0.46.2
-protobuf>=6.33.5
-# onnx: transitive dep of onnxruntime in base image; parent uses loose floor (>=1.16.0);
-# override needed for GHSA-p433-9wv8-28xj, GHSA-538c-55jv-c5g9, GHSA-cmw6-hcpp-c6jp
-onnx>=1.21.0
 # python-dotenv: transitive dep chain: azureml-defaults -> azureml-inference-server-http
 #   -> pydantic-settings -> python-dotenv>=0.21.0. pydantic-settings (all versions through
 #   2.14.0) only requires >=0.21.0 which does not constrain to a CVE-safe version.
 #   No parent upgrade resolves this. Floor pin required to fix CVE-2026-28684 (GHSA-mf9w-mj56-hr94).
 python-dotenv>=1.2.2
-# PyJWT: transitive dep of msal (requires >=1.0.0,<3) and azureml-core (requires <3.0.0).
-#   No parent version constrains PyJWT to a CVE-safe floor.
-#   Floor pin required to fix CVE-2026-32597.
-PyJWT>=2.12.0
 # GitPython: transitive dep chain: azureml-mlflow -> mlflow-skinny -> GitPython (>=3.1.9,<4).
 #   mlflow-skinny (all versions through 3.11.1) only requires >=3.1.9,<4 which does not
 #   constrain to a CVE-safe floor. No parent upgrade resolves this.

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
@@ -39,3 +39,8 @@ python-dotenv>=1.2.2
 #   No parent version constrains PyJWT to a CVE-safe floor.
 #   Floor pin required to fix CVE-2026-32597.
 PyJWT>=2.12.0
+# GitPython: transitive dep chain: azureml-mlflow -> mlflow-skinny -> GitPython (>=3.1.9,<4).
+#   mlflow-skinny (all versions through 3.11.1) only requires >=3.1.9,<4 which does not
+#   constrain to a CVE-safe floor. No parent upgrade resolves this.
+#   Floor pin required to fix GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4.
+GitPython>=3.1.47


### PR DESCRIPTION
This pull request focuses on upgrading and patching dependencies across several Dockerfiles to address recent security vulnerabilities, especially those affecting transitive dependencies. The changes ensure that all direct and transitive packages are pinned to secure versions, and introduce a custom script to patch log4j in Ray's fat JARs. The most significant updates are grouped below by theme.

**Security vulnerability mitigation and dependency upgrades:**

- **Pinning and upgrading vulnerable transitive dependencies:**  
  Added or updated explicit pins for `python-dotenv>=1.2.2` (GHSA-mf9w-mj56-hr94), `GitPython>=3.1.47` (GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4), and clarified/raised minimum versions for `protobuf`, `cryptography`, `onnx`, `requests`, `aiohttp`, `Mako`, and others in both pip and conda install commands across all relevant Dockerfiles to address multiple CVEs and ensure patched versions are installed, even when parent packages use loose floors or ceilings. [[1]](diffhunk://#diff-ddb0d1150a638dc4ae20c17d28d466321f55540135db8cb20fc314dca39df6f8L97-R109) [[2]](diffhunk://#diff-76aca007bf9a665a575213e96773ba721148b58a65a7c3beee9da129f91218a0L36-R51) [[3]](diffhunk://#diff-c174ddb52cc48d1e49d1ebeff3a75405d3792fe34b588c2d54f5f22806f6d08aL65-R73) [[4]](diffhunk://#diff-bf3e222b93d760c49d71daf36bb59813fa7b12b23faa5be3b8f4d91a3fbc1ac1L28-R39) [[5]](diffhunk://#diff-614d4f818759eed6c42c2234e3e4f8800ccb63137999925c15cac7519703f789L11-R35)

- **Expanded and clarified vulnerability comments:**  
  Updated and expanded inline comments to document the rationale for each override, including new advisories, changes in parent package pins, and transitive dependency chains, making the security context and necessity of each pin explicit for future maintainers. [[1]](diffhunk://#diff-ddb0d1150a638dc4ae20c17d28d466321f55540135db8cb20fc314dca39df6f8L97-R109) [[2]](diffhunk://#diff-76aca007bf9a665a575213e96773ba721148b58a65a7c3beee9da129f91218a0L36-R51) [[3]](diffhunk://#diff-b867f2279f038dafd6a475ed0ba05905038e8aa108f956dd5c8d7b9a4c688a14L18-R24) [[4]](diffhunk://#diff-b867f2279f038dafd6a475ed0ba05905038e8aa108f956dd5c8d7b9a4c688a14L35-R40) [[5]](diffhunk://#diff-bf3e222b93d760c49d71daf36bb59813fa7b12b23faa5be3b8f4d91a3fbc1ac1L28-R39) [[6]](diffhunk://#diff-614d4f818759eed6c42c2234e3e4f8800ccb63137999925c15cac7519703f789L11-R35) [[7]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L8-R16)

**Log4j patching in Ray:**

- **Automated patching of log4j in Ray's fat JARs:**  
  Added a new script, `patch_log4j`, which downloads patched log4j artifacts from Maven Central and replaces the vulnerable classes and resources inside Ray's distributed JARs. This is invoked in the Dockerfile to ensure log4j-core is updated to 2.25.4, mitigating several recent CVEs not yet addressed in upstream Ray releases. [[1]](diffhunk://#diff-7b8a4f5a186686aa2e2ab361c544e2709116247e76fb58a7080edd9482ecc83fR1-R88) [[2]](diffhunk://#diff-b867f2279f038dafd6a475ed0ba05905038e8aa108f956dd5c8d7b9a4c688a14R52-R64)

**Base image and system package handling:**

- **Removed redundant system package upgrades:**  
  Dropped explicit upgrades for PAM libraries from the Dockerfiles where the base image already includes patched versions, reducing unnecessary steps and potential for conflicts.

**Dependency resolution and compatibility:**

- **Clarified parent package constraints and pip resolution issues:**  
  Updated comments and pins to reflect changes in parent package version constraints (e.g., `mlflow-skinny` ceiling raised from 3.5.0 to 3.9.0), and documented workarounds for pip resolution conflicts, especially where patched versions are not yet available upstream. [[1]](diffhunk://#diff-b867f2279f038dafd6a475ed0ba05905038e8aa108f956dd5c8d7b9a4c688a14L18-R24) [[2]](diffhunk://#diff-b867f2279f038dafd6a475ed0ba05905038e8aa108f956dd5c8d7b9a4c688a14L35-R40) [[3]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L8-R16)

These changes collectively harden the build against known vulnerabilities and make the Dockerfiles more maintainable and auditable for future updates.