### PR TITLE
Remove a test tag from Foundry Local models

### DIFF
--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: nemotron-speech-streaming-en-0.6b-generic-cpu
 version: 3
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "MIT"
   licenseDescription: "This model is provided under the License Terms available at <https://github.com/microsoft/Foundry-Local/blob/main/licenses/nemotron-speech-streaming.md>."
   author: Microsoft

--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-generic-cpu/spec.yaml
@@ -19,7 +19,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 0
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-0.6b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-0.6b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-0.6b-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-0.6B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-0.6b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-0.6b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-0.6b-generic-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-0.6B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-1.7b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-1.7b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-1.7b-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-1.7B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-1.7b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-1.7b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-1.7b-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-1.7B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-1.7b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-1.7b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-1.7b-generic-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-1.7B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-14b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-14b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-14b-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-14B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-14b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-14b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-14b-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-14B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-14b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-14b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-14b-generic-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-14B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-4b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-4b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-4b-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-4B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-4b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-4b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-4b-generic-cpu
 version: 3
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-4B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-4b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-4b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-4b-generic-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-4B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-8b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-8b-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-8B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-8b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-8b-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-8B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-8b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-8b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-8b-generic-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-8B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-0.6b-cuda-gpu
 version: 1
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-cuda-gpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-0.6b-generic-cpu
 version: 1
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-cpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-0.6b-generic-gpu
 version: 1
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-0.6B/blob/main/LICENSE"
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b-generic-gpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-0.6b/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-0.6b/spec.yaml
@@ -3,5 +3,5 @@ name: qwen3-embedding-0.6b
 version: 1
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
 type: custom_model

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-8b-cuda-gpu
 version: 1
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-8b-generic-cpu
 version: 1
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-gpu/spec.yaml
@@ -20,7 +20,7 @@ tags:
   reasoningStart: ""
   reasoningEnd: ""
   contextLength: 32768
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3-embedding-8b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-embedding-8b-generic-gpu
 version: 1
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at https://huggingface.co/Qwen/Qwen3-Embedding-8B/blob/main/LICENSE"
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-embedding-8b/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-embedding-8b/spec.yaml
@@ -3,5 +3,5 @@ name: qwen3-embedding-8b
 version: 1
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
 type: custom_model

--- a/assets/models/foundrylocal/qwen3-vl-2b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-vl-2b-instruct-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-vl-2b-instruct-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-vl-2b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-vl-2b-instruct-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-vl-2b-instruct-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-VL-2B-Instruct/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-vl-4b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-vl-4b-instruct-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-vl-4b-instruct-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-vl-4b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-vl-4b-instruct-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-vl-4b-instruct-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-VL-4B-Instruct/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-vl-8b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-vl-8b-instruct-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-vl-8b-instruct-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3-vl-8b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3-vl-8b-instruct-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3-vl-8b-instruct-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-0.8b-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-0.8B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-0.8b-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-0.8B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-0.8b-generic-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-0.8B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-2b-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-2b-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-2b-generic-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-4b-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-4b-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-4b-generic-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-4B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-9b-cuda-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-9B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-9b-generic-cpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-9B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/spec.yaml
@@ -3,7 +3,7 @@ name: qwen3.5-9b-generic-gpu
 version: 2
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-9B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/spec.yaml
@@ -26,7 +26,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "0.0.0"
+  minFLVersion: "1.1.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:


### PR DESCRIPTION
This PR is to remove "test" tag from Foundry Local models that are well tested with a new release. These model family will be publicly available at Foundry Local CLI and SDK without a specific environment variables.

- nemotron-speech-streaming-en-0.6b
- qwen3
- qwen3-embedding
- qwen3-vl
- qwen3.5

This PR also sets the minimum version of Foundry Local for nemotron-speech-streaming-en-0.6b, qwen3-embedding, and qwen3.5 model family.