### PR TITLE
[feat]: week 18 vulnerabilities fixes - part 1 (general, multimodal, …

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
@@ -15,16 +15,11 @@ ENV ENABLE_METADATA=true
 # System package security upgrades
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
-    apt-get install -y --only-upgrade \
-        libpam0g \
-        libpam-modules \
-        libpam-modules-bin \
-        libpam-runtime && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # begin conda create
-# Create conda environment (minimal — packages installed via pip to avoid solver OOM)
+# Create conda environment (minimal -- packages installed via pip to avoid solver OOM)
 RUN conda create -p $AZUREML_CONDA_ENVIRONMENT_PATH \
     python=3.10 \
     -c conda-forge && \
@@ -37,8 +32,7 @@ RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --no-cache-dir \
     'setuptools-git' \
     'setuptools==82.0.1' \
     'psutil>5.0.0,<6.0.0' \
-    'torch==2.8.0' \
-    'pip>=26.0'
+    'torch==2.8.0'
 # end conda create
 
 # begin pip install
@@ -72,30 +66,12 @@ RUN pip install \
 # begin pip ad-hoc
 # Install pip ad-hoc dependencies for security updates
 #
-# pip>=26.0 (CVE-2025-8869): symlink path traversal during tar extraction
-#   Chain: direct conda dep (pip=26.0), upgraded for security
-#
-# wheel>=0.46.2 (CVE-2026-24049): path traversal & privilege escalation via malicious wheel unpack
-#   Chain: setuptools[core] -> wheel (build dependency)
-#
-# cryptography>=46.0.5 (CVE-2026-26007): EC subgroup validation flaw in ECDH/ECDSA on SECT curves
-#   Chain: mltable -> cryptography (direct dep)
-#   Also:  mltable -> azureml-dataprep -> azure-identity -> cryptography
-#
-# protobuf>=5.29.6 (CVE-2025-4565): DoS via uncontrolled recursion in pure-Python decoder
-#   Chain: mlflow-skinny -> protobuf (direct dep)
-#   Also:  mlflow-skinny -> databricks-sdk -> protobuf
-#
 # distributed>=2026.1.0 (CVE-2026-23528): XSS leading to RCE via Dask dashboard
 #   Chain: azureml-train-automl-runtime -> dask[complete] -> distributed
 #
 # bokeh>=3.8.2 (GHSA-793v-589g-574v): conda env installs 2.4.3, pip can't auto-upgrade
 #   Chain: azureml-train-automl-runtime -> bokeh
 RUN pip install --upgrade \
-    'pip>=26.0' \
-    'wheel>=0.46.2' \
-    'cryptography>=46.0.5' \
-    'protobuf>=5.29.6' \
     'distributed>=2026.1.0' \
     'bokeh>=3.8.2' \
     'onnx>=1.21.0' \

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
@@ -1,16 +1,6 @@
 #PTCA image
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 USER root
-# Security: upgrade all OS packages, pin linux headers to patched versions, and upgrade binutils/git/wget
-RUN apt-get update && apt-get -y upgrade && \
-    apt-get install -y --only-upgrade linux-headers-5.15.0-163-generic=5.15.0-163.173 linux-headers-5.15.0-163=5.15.0-163.173 linux-libc-dev=5.15.0-163.173 || \
-    apt-get install -y --only-upgrade linux-headers-generic linux-libc-dev && \
-    apt-get install -y --only-upgrade git tar binutils binutils-common binutils-x86-64-linux-gnu libbinutils wget && \
-    apt-get autoremove -y linux-headers-5.15.0-153 linux-headers-5.15.0-153-generic linux-headers-5.15.0-161 linux-headers-5.15.0-161-generic 2>/dev/null && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-# Security: upgrade base conda env (python3.13) from ACPT base image (biweekly.202603.1)
-# Still vulnerable: cryptography(44.0.1), pip(25.3), setuptools(80.9.0), wheel(0.45.1)
-RUN conda run -n base python -m pip install --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 'aiohttp>=3.13.4' 'requests>=2.33.0'
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 # GHSA-jx93-g359-86wm, GHSA-hvwj-8w5g-28rg: sglang vulnerabilities; patched in >=0.5.10
@@ -21,7 +11,7 @@ RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install numpy==2.2.5
 RUN pip install azureml-evaluate-mlflow=={{latest-pypi-version}}
 
-# following are for vulnerability overrides at later\
+# following are for vulnerability overrides at later
 # release of following packages consider moving then to requirements.txt
 RUN pip install --no-cache-dir --force-reinstall "mlflow>=3.2.0,<4.0.0"
 # wandb>=0.26.0: fixes Go stdlib vulnerabilities (GO-2026-4864/4865/4866/4869/4870/4946/4947)
@@ -32,25 +22,6 @@ RUN pip install xgrammar==0.1.32
 # GHSA-69w3-r845-3855 (CVE-2026-1839): arbitrary code execution in Trainer class;
 # patched only in transformers>=5.0.0rc3. Upgrading to latest stable 5.x.
 RUN pip install transformers==5.5.4
-# upgrade pip, wheel, setuptools and transitive deps to fix vulnerabilities
-# protobuf: wandb/google-cloud-storage cap <7, override needed
-# cryptography: azureml-mlflow pins <46.0.0; override needed for CVE fix
-# aiohttp: transitive dep of ray/vllm/azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: onnxruntime accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
-# anthropic: GHSA-q5f5-3gjm-7mfm, GHSA-w828-4qhx-vxx3; >=0.87.0 required
-# requests: transitive dep of azure-core/mlflow/transformers; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-RUN pip install --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 protobuf==6.33.5 \
-    'aiohttp>=3.13.4' 'requests>=2.33.0' 'onnx>=1.21.0' 'fastmcp>=3.2.0' 'anthropic>=0.87.0'
-# GHSA-6w46-j5rx-g56g (CVE-2025-71176): pytest tmpdir vulnerability; patched in >=9.0.3
-# pytest is a transitive dep from base image; no parent upgrade available, override needed.
-# GHSA-v92g-xgxw-vvmm: Mako XSS vulnerability; patched in >=1.3.11
-# Mako is a transitive dep of alembic; alembic does not yet pin Mako>=1.3.11, override needed.
-RUN pip install --no-cache-dir --upgrade "pytest>=9.0.3" "Mako>=1.3.11"
-# Fix vulnerabilities in the ptca conda environment (pre-built in base image, not targeted by above installs)
-# CVE-2026-1703 (pip), CVE-2026-24049 (wheel)
-RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade "pip>=26.0" "wheel>=0.46.2" && \
-    rm -f /opt/conda/envs/ptca/conda-meta/wheel-0.45.1*.json /opt/conda/envs/ptca/conda-meta/pip-25.3*.json
 # clean conda and pip caches
 RUN rm -rf ~/.cache/pip
 COPY loss /opt/conda/envs/ptca/lib/python3.10/site-packages/specforge/core/loss.py

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
@@ -15,39 +15,37 @@ RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install transformers==5.5.4
 
 # mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635); upgrade after azureml packages
-# azureml-evaluate-mlflow → azureml-mlflow pins mlflow-skinny<=3.5.0, conflicting with mlflow 3.10.1
+# azureml-evaluate-mlflow → azureml-mlflow pins mlflow-skinny<=3.9.0, conflicting with mlflow 3.10.1
 # so mlflow must be upgraded separately to avoid pip resolution conflict
 RUN pip install --no-cache-dir mlflow==3.10.1
 
-# upgrade pip, wheel, setuptools and transitive deps to fix vulnerabilities
-# protobuf: vllm uses loose floors, pip can't force 6.33.5 transitively
-# cryptography: azureml-mlflow~=1.62.0 pins <46.0.0; override needed for CVE fix
-# onnx: onnxruntime-training accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# nltk: GHSA-gfwx-w7gr-fvh7; >=3.9.4 required
-# filelock: transitive dep of torch/huggingface-hub; parents use loose floor (GHSA-qmgc-5h2g-mvrw)
-# urllib3: transitive dep of requests; parent uses urllib3>=1.21.1,<3 (GHSA-38jv-5279-wg99)
-# ray: GHSA-q5fh-2hc8-f6rq; >=2.54.0 required; also bundles log4j-core in JARs
-#   log4j-core 2.25.3→2.25.4: GHSA-3pxv-7cmr-fjr4, GHSA-445c-vh5m-36rj, GHSA-6hg6-v5c8-fphq
-# azure-core: transitive dep of Azure SDKs; parents use loose floor (GHSA-jm66-cg57-jjv5)
-# pytest: GHSA-6w46-j5rx-g56g (vulnerable tmpdir handling); from base image, override needed
-# cbor2: transitive dep via azure-identity → msal-extensions; parent uses loose floor (GHSA-3c37-wwvx-h642)
-# jaraco.context: transitive dep of keyring; parent uses loose floor (GHSA-58pv-8j8x-9vj2)
-# mlflow: GHSA-r23q-823p-vmf7 etc.; azureml-mlflow pins mlflow-skinny<=3.5.0, override needed
+# Upgrade transitive deps to fix vulnerabilities.
+# Packages already at safe versions in base image biweekly.202605.1 (pip, wheel, setuptools,
+# aiohttp, requests, urllib3, onnx, pillow, filelock, pytest) are NOT overridden here.
+# protobuf: mlflow-skinny requires <7; base has 7.34.1 so we must pin <7 (GHSA fix >=6.33.5)
+# cryptography: not in ptca env; installed transitively by azureml-mlflow (<47.0.0 constraint)
+# ray: GHSA-q5fh-2hc8-f6rq; also bundles log4j-core 2.25.3 in JARs (patched below)
+# azure-core, cbor2, jaraco.context, PyJWT: transitive deps with loose floors
+# nltk: GHSA-gfwx-w7gr-fvh7; pyasn1/python-multipart/xgrammar: CVE floors
+# mlflow: azureml-mlflow pins mlflow-skinny<=3.9.0; override needed
 # vllm: GHSA-pq5c-rjhq-qp7p, GHSA-3mwp-wvh9-7528 etc.; >=0.19.0 required
-RUN pip install --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 protobuf==6.33.5 cryptography==46.0.7 'xgrammar>=0.1.32' \
-    'aiohttp>=3.13.4' 'requests>=2.33.0' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pyasn1>=0.6.3' \
-    'python-multipart>=0.0.22' 'pillow>=12.1.1' 'filelock>=3.20.3' 'urllib3>=2.6.3' 'ray>=2.55.0' \
-    'azure-core>=1.38.0' 'cbor2>=5.9.0' 'jaraco.context>=6.1.0' 'PyJWT>=2.12.0' 'mlflow>=3.8.1,<4.0.0' 'vllm>=0.19.0' \
-    'pytest>=9.0.3'
-# clean conda and pip caches
+# pyOpenSSL: GHSA-vp96-hxj8-p424, GHSA-5pwr-322w-8jr4; >=26.0.0 required
+#   azureml-core 1.61.0.post3 pins pyopenssl<26.0.0; no newer azureml-core available (2026-05-04)
+RUN pip install --upgrade 'protobuf>=6.33.5,<7' 'cryptography>=46.0.7,<47' 'xgrammar>=0.1.32' \
+    'nltk>=3.9.4' 'pyasn1>=0.6.3' 'python-multipart>=0.0.22' 'ray>=2.55.0' \
+    'azure-core>=1.38.0' 'cbor2>=5.9.0' 'jaraco.context>=6.1.0' 'PyJWT>=2.12.0' \
+    'mlflow>=3.8.1,<4.0.0' 'vllm>=0.19.0' 'pyOpenSSL>=26.0.0'
 RUN rm -rf ~/.cache/pip
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y 'pip>=26.0.1' 'wheel>=0.46.2'
-# Fix vulnerabilities in base conda env (python3.13) from ACPT base image (biweekly.202603.1)
-# Still vulnerable in base: cryptography(44.0.1), pip(25.3), setuptools(80.9.0), wheel(0.45.1), requests(2.32.4), aiohttp(3.12.14), PyJWT(2.10.1)
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 \
-    'requests>=2.33.0' 'aiohttp>=3.13.4' 'PyJWT>=2.12.0'
+# python-dotenv in base conda env: GHSA-mf9w-mj56-hr94; base ships 1.2.1, need >=1.2.2
+#   parent packages: uvicorn (>=0.13), pydantic-settings (>=0.21.0) — both use loose floors
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 # ray vendors aiohttp for runtime_env agent under thirdparty_files; patch that copy too.
 RUN rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files/aiohttp* && \
-    pip install --no-cache-dir --target /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files 'aiohttp==3.13.4'
+    pip install --no-cache-dir --target /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files 'aiohttp==3.13.5'
+# Patch log4j-core 2.25.3→2.25.4 inside ray's fat JAR (ray_dist.jar).
+# ray (all versions through 2.55.1) bundles log4j-core 2.25.3 in java/dependencies.bzl.
+# No ray release includes 2.25.4; manual JAR surgery is required.
+# Fixes: GHSA-3pxv-7cmr-fjr4, GHSA-445c-vh5m-36rj, GHSA-6hg6-v5c8-fphq
+COPY patch_log4j /tmp/patch_log4j.py
+RUN python3 /tmp/patch_log4j.py 2.25.4 && rm -f /tmp/patch_log4j.py
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/patch_log4j
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/patch_log4j
@@ -1,0 +1,88 @@
+"""Patch log4j JARs inside ray's fat JAR (ray_dist.jar) with a newer version.
+
+Downloads log4j artifacts from Maven Central and replaces the bundled versions
+inside ray's distribution JAR, including classes, META-INF resources, and plugin metadata.
+"""
+import zipfile
+import os
+import sys
+import glob
+import urllib.request
+import tempfile
+
+LOG4J_VER = sys.argv[1] if len(sys.argv) > 1 else "2.25.4"
+RAY_JARS = "/opt/conda/envs/ptca/lib/python3.10/site-packages/ray/jars"
+MAVEN_BASE = "https://repo1.maven.org/maven2/org/apache/logging/log4j"
+ARTIFACTS = ["log4j-core", "log4j-api", "log4j-slf4j-impl"]
+
+patch_dir = tempfile.mkdtemp()
+
+# Download new log4j JARs
+for art in ARTIFACTS:
+    url = f"{MAVEN_BASE}/{art}/{LOG4J_VER}/{art}-{LOG4J_VER}.jar"
+    dest = os.path.join(patch_dir, f"{art}.jar")
+    print(f"Downloading {url}")
+    urllib.request.urlretrieve(url, dest)
+
+# Find ray fat JARs
+candidates = glob.glob(os.path.join(RAY_JARS, "ray?dist.jar"))
+candidates += glob.glob(os.path.join(RAY_JARS, "ray_dist.jar"))
+if not candidates:
+    all_jars = glob.glob(os.path.join(RAY_JARS, "*.jar"))
+    candidates = [c for c in all_jars if "ray" in os.path.basename(c).lower()]
+assert candidates, f"No ray fat JAR found in {RAY_JARS}: {os.listdir(RAY_JARS)}"
+
+def is_log4j_entry(name):
+    """Check if a zip entry belongs to log4j and should be replaced."""
+    return (name.startswith("org/apache/logging/log4j/") or
+            name.startswith("META-INF/org/apache/logging/log4j/") or
+            name.startswith("META-INF/maven/org.apache.logging.log4j/") or
+            name.startswith("META-INF/services/") or
+            name == "META-INF/log4j-provider.properties" or
+            "Log4j2Plugins.dat" in name)
+
+# Collect new log4j entries from downloaded JARs
+new_entries = {}
+for jf in glob.glob(os.path.join(patch_dir, "*.jar")):
+    with zipfile.ZipFile(jf, "r") as zf:
+        for info in zf.infolist():
+            name = info.filename
+            if is_log4j_entry(name):
+                new_entries[name] = (info, zf.read(name))
+
+print(f"Collected {len(new_entries)} entries from log4j {LOG4J_VER}")
+
+def is_old_log4j(name):
+    return (name.startswith("org/apache/logging/log4j/") or
+            name.startswith("META-INF/org/apache/logging/log4j/") or
+            name.startswith("META-INF/maven/org.apache.logging.log4j/") or
+            "Log4j2Plugins.dat" in name)
+
+for fat_jar in candidates:
+    print(f"Patching {fat_jar}")
+    tmp_jar = fat_jar + ".tmp"
+    kept = replaced = removed = 0
+
+    with zipfile.ZipFile(fat_jar, "r") as src, \
+         zipfile.ZipFile(tmp_jar, "w", zipfile.ZIP_DEFLATED) as dst:
+        for info in src.infolist():
+            name = info.filename
+            if name in new_entries:
+                replaced += 1
+                continue
+            if is_old_log4j(name):
+                removed += 1
+                continue
+            dst.writestr(info, src.read(name))
+            kept += 1
+        for name, (info, data) in new_entries.items():
+            dst.writestr(info, data)
+
+    os.replace(tmp_jar, fat_jar)
+    print(f"  kept={kept}, replaced={replaced}, removed={removed}, added={len(new_entries)}")
+    print(f"  Patched with log4j {LOG4J_VER}")
+
+# Cleanup
+import shutil
+shutil.rmtree(patch_dir)
+print("Done")

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
@@ -1,12 +1,9 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 USER root
-# Security: upgrade all OS packages and patch USN-8176-1 (.NET 8.0 vulnerabilities)
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --only-upgrade \
-        dotnet-host-8.0 dotnet-hostfxr-8.0 dotnet-runtime-8.0 2>/dev/null || true && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y upgrade --fix-missing || \
+    (apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y upgrade) && \
     apt-get autoremove -y && \
-    apt-get autoclean && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/*.deb
 COPY requirements.txt .
@@ -26,7 +23,7 @@ RUN pip uninstall -y mlflow
 RUN pip install --no-cache-dir --force-reinstall "mlflow>=3.2.0,<4.0.0"
 RUN pip install --no-cache-dir starlette==0.49.1
 # Upgrade wandb to latest; remove wandb-core Go binary to fix GO-2026-4864..4947
-# wandb 0.26.0 ships wandb-core compiled with Go 1.26.1 (needs 1.26.2); no fixed wandb release yet.
+# wandb 0.26.1 ships wandb-core compiled with Go 1.26.1 (needs 1.26.2); no fixed wandb release yet.
 # Removing the binary forces wandb to use its Python backend (safe fallback).
 RUN pip install --no-cache-dir --upgrade "wandb>=0.26.0" && \
     find /opt/conda/envs/ptca -name 'wandb-core' -path '*/wandb/bin/*' -delete 2>/dev/null || true
@@ -37,49 +34,35 @@ COPY __init__ /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/rewar
 COPY azure_grader /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/reward_score/azure_grader.py
 COPY azure_python_grader /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/reward_score/azure_python_grader.py
 COPY utils /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/vllm/utils.py
-RUN python3 -m pip install --upgrade pip==26.0 setuptools==82.0.0 wheel==0.46.2
 RUN pip install vllm==0.19.0
 # Keep xgrammar at the patched floor even when pulled transitively by vllm.
 RUN pip install --no-cache-dir 'xgrammar>=0.1.32'
 RUN pip install openai==2.14.0
 RUN pip install --force-reinstall --no-cache-dir --no-build-isolation git+https://github.com/deepseek-ai/DeepGEMM.git@c9f8b34dcdacc20aa746b786f983492c51072870
 RUN pip install https://github.com/yeshsurya/flash-attention/releases/download/v2.8.3-linux-1/flash_attn-2.8.3-cp310-cp310-linux_x86_64.whl
-# Fix security vulnerabilities in ptca conda env (active environment)
-# aiohttp==3.13.4: GHSA-63hf-3vf5-4wqf et al. (8 CVEs); transitive dep of vllm/sglang/azure SDK,
-#   parents use loose floors — pip can't force >=3.13.4 transitively
-# protobuf==6.33.5: CVE-2026-40186; transitive dep of vllm (requires >=6.30.0), parent uses loose floor
-# setuptools==82.0.0: GHSA-58pv-8j8x-9vj2 (vendored jaraco.context), GHSA-8rrh-rw8j-w5fx (vendored wheel)
-# pip==26.0: GHSA-4xh5-x5gv-qwph, GHSA-6vgw-5pg2-w6jp
-# wheel==0.46.2: CVE-2026-24049
-# cryptography==46.0.7: CVE-2026-41727; azureml-mlflow pins <46.0.0 but upgrading anyway for CVE fix
-# requests>=2.33.0: GHSA-gc5v-m9x4-r6x2; transitive dep of azure-core/mlflow/transformers,
-#   msal requires >=2.0.0,<3, azureml-core requires >=2.19.1,<3 — no parent pins safe floor
-# onnx>=1.21.0: GHSA-p433-9wv8-28xj, GHSA-538c-55jv-c5g9 et al.; transitive dep of onnxruntime/
-#   azureml-acft-accelerator (require >=1.16.0), no parent upgrade resolves this
+# Fix security vulnerabilities in ptca conda env not resolved by base image
+# (pip, setuptools, wheel, aiohttp, protobuf, requests, onnx, pytest are already at
+#  safe versions in base image biweekly.202605.1 and do not need overrides)
+# cryptography==46.0.7: CVE-2026-41727; not pre-installed in ptca env, pulled by azureml-mlflow
 # fastmcp>=3.2.0: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767
 # Mako>=1.3.11: CVE-2025-46803; transitive dep of alembic, parent uses loose floor
-# pytest>=9.0.3: GHSA-6w46-j5rx-g56g; pre-installed in ptca env from base image, no parent to upgrade
 # lxml>=6.1.0: GHSA-vfmq-68hx-4jfw; transitive dep of multiple packages, parent uses loose floor
-# transformers>=5.0.0rc3: GHSA-69w3-r845-3855 (CVE-2026-1839); arbitrary code execution via torch.load()
-#   in Trainer._load_rng_state(). Direct dep — upgraded from 4.57.6 to patched 5.x
-RUN pip install --upgrade aiohttp==3.13.4 protobuf==6.33.5 setuptools==82.0.0 pip==26.0 wheel==0.46.2 cryptography==46.0.7 'requests>=2.33.0' 'onnx>=1.21.0' 'fastmcp>=3.2.0' 'Mako>=1.3.11' 'pytest>=9.0.3' 'lxml>=6.1.0' 'transformers>=5.0.0rc3'
-# Fix vulnerabilities in base conda env (python 3.13) from ACPT base image (biweekly.202603.1)
-# Base env ships: cryptography(44.0.1), pip(25.3), setuptools(80.9.0), wheel(0.45.1), aiohttp(3.12.x)
-# Same CVEs as ptca env above; base env is separate and must be patched independently
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 aiohttp==3.13.4
+# transformers>=5.0.0rc3: GHSA-69w3-r845-3855 (CVE-2026-1839); direct dep, upgraded to patched 5.x
+# GitPython>=3.1.47: GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4; transitive dep of wandb (requires
+#   gitpython!=3.1.29,>=1.0.0 as of 0.26.1), parent uses loose floor — no wandb release forces >=3.1.47
+RUN pip install --upgrade cryptography==46.0.7 'fastmcp>=3.2.0' 'Mako>=1.3.11' 'lxml>=6.1.0' 'transformers>=5.0.0rc3' 'GitPython>=3.1.47'
+# python-dotenv>=1.2.2: GHSA-mf9w-mj56-hr94; transitive dep of pydantic-settings (requires >=0.21.0)
+#   and uvicorn (optional, requires >=0.13). Base image ships 1.2.1 in base conda env.
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 # ray vendors its own copy of aiohttp inside thirdparty_files/ for runtime_env agent;
 # the vendored copy is not upgraded by pip install above. Patching all copies in-place.
 RUN find /opt/conda/envs/ptca/lib/python3.10/site-packages/ray -type d -name 'thirdparty_files' | while read dir; do \
       rm -rf "$dir"/aiohttp*; \
-      pip install --no-cache-dir --target "$dir" 'aiohttp==3.13.4'; \
+      pip install --no-cache-dir --target "$dir" 'aiohttp>=3.13.4'; \
     done
 COPY vllm_rollout /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/workers/rollout/vllm_rollout/vllm_rollout.py
-# Clean up pip caches and old package files to prevent vulnerability detection
 RUN rm -rf ~/.cache/pip /tmp/* /var/tmp/*
-# Set secure defaults
 ENV PYTHONHASHSEED=random \
     PYTHONDONTWRITEBYTECODE=1
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca 'pip>=26.0.1' 'wheel>=0.46.2'
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/ /opt/conda/pkgs/
 

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
@@ -13,18 +13,11 @@ RUN pip install azureml-metrics==0.0.33 pyarrow==14.0.1
 RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install azureml-acft-accelerator=={{latest-pypi-version}}
 
-# protobuf is a transitive dep of onnxruntime-training; base image has older version pre-installed
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-# aiohttp: transitive dep of azure-core/datasets; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: onnxruntime-training accepts onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# nltk: GHSA-gfwx-w7gr-fvh7; >=3.9.4 required
-# pillow: GHSA-whj4-6x5x-4v2j; >=12.2.0 required
-# pytest: pre-installed in ACPT base image; no parent package to upgrade (GHSA-6w46-j5rx-g56g)
-# transformers: final override to ensure >=5.0.0 after azureml-* installs (GHSA-69w3-r845-3855)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 setuptools>=82.0.1 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pytest>=9.0.3' 'transformers>=5.0.0'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# setuptools: >=82.0.1 patches jaraco.context (GHSA-58pv-8j8x-9vj2); base ships 82.0.0
+# nltk: >=3.9.4 required (GHSA-gfwx-w7gr-fvh7)
+# transformers: ensure >=5.0.0 after azureml-* installs (GHSA-69w3-r845-3855)
+# onnx: onnxruntime-training has loose onnx dep; pip resolves to 1.17.0 which has multiple CVEs
+RUN pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'nltk>=3.9.4' 'transformers>=5.0.0' 'onnx>=1.21.0'
+# base conda env: setuptools and python-dotenv need upgrades above what base image ships
+# python-dotenv: transitive dep of mlflow-skinny (accepts >=0.19.0,<2); base ships 1.2.1 (GHSA-mf9w-mj56-hr94)
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'python-dotenv>=1.2.2'


### PR DESCRIPTION
This pull request focuses on security and maintenance improvements for several Dockerfiles used in training environments. The main changes include removing outdated or redundant security upgrades, refining vulnerability overrides to target only necessary packages, updating dependency pinning and comments for clarity, and introducing a script to patch bundled Java dependencies in Ray for CVE remediation.

**Security and Dependency Management Improvements:**

* Removed redundant or unnecessary OS-level and Python package upgrades from multiple Dockerfiles, streamlining the security update process and relying more on secure base images. [[1]](diffhunk://#diff-76aca007bf9a665a575213e96773ba721148b58a65a7c3beee9da129f91218a0L4-L13) [[2]](diffhunk://#diff-ddb0d1150a638dc4ae20c17d28d466321f55540135db8cb20fc314dca39df6f8L18-R22) [[3]](diffhunk://#diff-c174ddb52cc48d1e49d1ebeff3a75405d3792fe34b588c2d54f5f22806f6d08aL3-L9)
* Refined and reduced pip/conda override installs for vulnerability fixes, only upgrading transitive dependencies that are not already patched in the latest base images. This includes removing explicit upgrades for `pip`, `setuptools`, `wheel`, and other packages where the base image is already secure. [[1]](diffhunk://#diff-c174ddb52cc48d1e49d1ebeff3a75405d3792fe34b588c2d54f5f22806f6d08aL40-L83) [[2]](diffhunk://#diff-76aca007bf9a665a575213e96773ba721148b58a65a7c3beee9da129f91218a0L35-L53) [[3]](diffhunk://#diff-ddb0d1150a638dc4ae20c17d28d466321f55540135db8cb20fc314dca39df6f8L40-R35) [[4]](diffhunk://#diff-ddb0d1150a638dc4ae20c17d28d466321f55540135db8cb20fc314dca39df6f8L75-L98)
* Updated and clarified comments throughout the Dockerfiles to accurately reflect current dependency constraints, vulnerability status, and rationale for overrides or removals. [[1]](diffhunk://#diff-c174ddb52cc48d1e49d1ebeff3a75405d3792fe34b588c2d54f5f22806f6d08aL29-R26) [[2]](diffhunk://#diff-b867f2279f038dafd6a475ed0ba05905038e8aa108f956dd5c8d7b9a4c688a14L18-R50) [[3]](diffhunk://#diff-76aca007bf9a665a575213e96773ba721148b58a65a7c3beee9da129f91218a0L24-R14)

**New Security Patch Mechanism for Ray JARs:**

* Added a new script `patch_log4j` and corresponding Dockerfile step to patch Ray’s bundled Java JARs (log4j-core, log4j-api, log4j-slf4j-impl) to version 2.25.4, addressing several CVEs that are not fixed in any released Ray version. [[1]](diffhunk://#diff-7b8a4f5a186686aa2e2ab361c544e2709116247e76fb58a7080edd9482ecc83fR1-R88) [[2]](diffhunk://#diff-b867f2279f038dafd6a475ed0ba05905038e8aa108f956dd5c8d7b9a4c688a14L18-R50)

**General Maintenance:**

* Improved Dockerfile hygiene by cleaning up comments, removing obsolete package removals, and ensuring that only necessary security patches are applied. [[1]](diffhunk://#diff-c174ddb52cc48d1e49d1ebeff3a75405d3792fe34b588c2d54f5f22806f6d08aL3-L9) [[2]](diffhunk://#diff-76aca007bf9a665a575213e96773ba721148b58a65a7c3beee9da129f91218a0L24-R14)

These changes collectively reduce build complexity, improve security posture, and make maintenance of the training environments more robust and transparent.…automl, hf_nlp)

Covers: acpt-pytorch-2.2-cuda12.1, acpt-pytorch-2.8-cuda12.6, acpt_multimodal, ai-ml-automl, acpt-draft, acpt-grpo, acpt-rft, acpt