### PR TITLE
[feat]: week 18 vulnerabilities fixes - part 2 (acft_image)

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -8,22 +8,20 @@ RUN apt-get -y update && apt-get -y upgrade
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# upgrade pip, wheel, protobuf vulnerabilities in ptca env
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# protobuf parent is mlflow==3.5.0 (already latest) which accepts protobuf>=3.12.0, cannot force 6.33.5 via parent
-# pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
-# parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
-# aiohttp: transitive dep of azure-core/datasets; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: onnxruntime/azureml-acft-accelerator require onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# Mako: transitive dep (mlflow -> alembic -> Mako); alembic requires Mako>=1.1.0 (loose floor),
-#   upgrading mlflow alone does not force Mako upgrade; override needed (GHSA-v92g-xgxw-vvmm)
-# pytest: transitive dep from azureml packages; parent packages use loose floors so pip resolves
-#   to 7.4.3 which has CVE-2025-71176 (GHSA-6w46-j5rx-g56g); override to 9.0.3
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 'fastmcp>=3.2.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' Mako==1.3.11 pytest==9.0.3
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0 wheel>=0.46.2 setuptools>=82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# Override vulnerable transitive deps in ptca env that are not fixed in the base image
+# onnx: azureml-acft-accelerator==0.0.89 requires onnx<=1.17.0 which downgrades base 1.21.0;
+#   override needed to keep safe version (GHSA-p433-9wv8-28xj etc.)
+# pyasn1: transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
+#   parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
+# fastmcp: transitive dep (mlflow-skinny[mcp] requires fastmcp<4,>=2.0.0); loose floor,
+#   GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; override to >=3.2.0
+# Mako: transitive dep (mlflow → alembic → Mako); alembic 1.18.4 requires Mako (no version pin),
+#   pip won't upgrade pre-installed Mako; override needed (GHSA-v92g-xgxw-vvmm)
+# GitPython: transitive dep (mlflow → mlflow-skinny requires gitpython<4,>=3.1.9); loose floor,
+#   pip resolves to 3.1.46 which has GHSA-rpm5-65cw-6hj4, GHSA-x2qx-6953-8485; override to >=3.1.47
+# python-dotenv: transitive dep (mlflow → mlflow-skinny requires python-dotenv<2,>=0.19.0); loose floor,
+#   pip resolves to 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
+RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0' pyasn1==0.6.3 'fastmcp>=3.2.0' Mako==1.3.11 'GitPython>=3.1.47' 'python-dotenv>=1.2.2'
+# python-dotenv in base conda env: transitive dep of uvicorn[standard] (>=0.13); loose floor,
+#   base image has 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
@@ -4,29 +4,18 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest
 USER root
 RUN apt-get -y update && apt-get -y upgrade
 
-# Install unzip
-RUN apt-get -y install unzip libc-bin libc-bin libc-dev locales libc6 dpkg-dev dpkg libdpkg-perl libssl-dev libssl3 openssl
+RUN apt-get -y install unzip
 
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# upgrade pip, wheel, protobuf vulnerabilities in ptca env
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# protobuf parent is mlflow==3.5.0 (already latest) which accepts protobuf>=3.12.0, cannot force 6.33.5 via parent
-# pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
-# parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
-# aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# Mako: transitive dep (mlflow → alembic → Mako); alembic uses unpinned Mako, cannot force via parent
-# pytest: standalone test dep from base image; no parent to upgrade
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 'fastmcp>=3.2.0' 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'Mako>=1.3.11' 'pytest>=9.0.3'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2 
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# Transitive dep overrides where pip may not resolve to the patched version:
+# pyasn1: mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1;
+#   parents use loose floors so pip may resolve to <0.6.3 (CVE-2026-30922)
+# Mako: mlflow → alembic → Mako; alembic uses unpinned Mako dep
+# python-dotenv: mlflow → mlflow-skinny → python-dotenv<2,>=0.19.0;
+#   mlflow 3.11.1 (latest as of 2026-05-04) allows >=1.2.2 but pip may resolve older (GHSA-mf9w-mj56-hr94)
+RUN pip install --no-cache-dir --upgrade 'pyasn1>=0.6.3' 'Mako>=1.3.11' 'python-dotenv>=1.2.2'
 
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
@@ -10,26 +10,14 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get -y install unzip && apt-g
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# upgrade pip, wheel and transitive deps to fix vulnerabilities
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# protobuf is a transitive dep of mlflow-skinny/onnx; parents use loose floors (>=3.12.0), cannot force 6.33.5
 # mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635); upgrade after requirements install
-# azureml-mlflow pins mlflow-skinny<=3.5.0, so mlflow must be upgraded separately to avoid resolution conflict
-# mlflow 3.11.1: GHSA-fh64-r2vc-xvhr requires >=3.11.1
+# azureml-mlflow pins mlflow-skinny<=3.9.0, so mlflow must be upgraded separately to avoid resolution conflict
 RUN pip install --no-cache-dir mlflow==3.11.1
-# pyasn1 is a transitive dep (mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1);
-# parent packages use loose floors so pip resolves to 0.6.2 which has CVE-2026-30922; override to >=0.6.3
-# onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# fastmcp: GHSA-rww4-4w9c-7733, GHSA-m8x7-r2rg-vh5g, GHSA-vv7q-7jx5-f767; >=3.2.0 required
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pillow: GHSA-whj4-6x5x-4v2j requires >=12.2.0; direct dep override
-# Mako: GHSA-v92g-xgxw-vvmm requires >=1.3.11; transitive via alembic→mlflow, alembic has no version floor on Mako so override needed
-# pytest: GHSA-6w46-j5rx-g56g requires >=9.0.3; installed by base image, no parent to upgrade so override needed
-RUN pip install --no-cache-dir --upgrade protobuf==6.33.5 cryptography==46.0.7 pyasn1==0.6.3 pillow==12.2.0 wheel>=0.46.2 'fastmcp>=3.2.0' 'onnx>=1.21.0' 'requests>=2.33.0' 'Mako>=1.3.11' 'pytest>=9.0.3'
+# fastmcp + mcp were installed as regular deps of mlflow 3.5.0 (fastmcp→mcp) but orphaned after
+# mlflow 3.11.1 (fastmcp moved to optional "mcp" extra); uninstall both to remove vulnerable packages
+RUN pip uninstall -y fastmcp mcp
 
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
-
-# Upgrade packages in the system Python(3.13) for fixing vulnerability
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade urllib3==2.6.3 aiohttp==3.13.4 PyNaCl==1.6.2 pip==26.0 wheel==0.46.2 setuptools==82.0.0 cryptography==46.0.7 'PyJWT>=2.12.0' 'requests>=2.33.0'
+# Upgrade python-dotenv in the system Python(3.13)
+# python-dotenv: transitive dep via pydantic-settings (>=0.21.0 floor); parent uses loose floor so base resolves to
+# vulnerable 1.2.1 (GHSA-mf9w-mj56-hr94); override to >=1.2.2
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
@@ -10,22 +10,3 @@ RUN apt-get update && \
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 RUN pip install --no-build-isolation git+https://github.com/facebookresearch/detectron2.git@a1ce2f9
-
-# protobuf is a transitive dep of mlflow-skinny/onnx; parents require >=3.12.0, cannot force 6.33.5
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-# mlflow-skinny 2.13.2 has CVEs; upgrade after requirements install
-# azureml-mlflow pins mlflow-skinny<=3.5.0, so must be upgraded separately to avoid resolution conflict
-RUN pip install --no-cache-dir mlflow-skinny==3.10.1
-# aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# nltk: GHSA-gfwx-w7gr-fvh7; >=3.9.4 required
-# pydicom: GHSA-v856-2rf8-9f28; requirements.txt pins ~=2.4.0 allowing vulnerable 2.4.4; override to >=2.4.5
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pytest: transitive dep from base image; not a direct requirement of any parent package (GHSA-6w46-j5rx-g56g)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 setuptools>=82.0.1 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 'requests>=2.33.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'nltk>=3.9.4' 'pydicom>=2.4.5' 'pytest>=9.0.3'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -n ptca -y pip>=26.0.1 wheel>=0.46.2
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
@@ -4,7 +4,7 @@ hydra-core==1.3.2
 marshmallow==3.26.2
 azure-ai-ml==1.16.1
 azure-identity==1.16.1
-mlflow-skinny==2.13.2
+mlflow-skinny==3.11.1
 azureml-mlflow==1.56.0
 azureml-dataprep==5.4.1
 timm==0.9.16
@@ -23,12 +23,11 @@ pydicom>=2.4.5
 SimpleITK==2.4.0
 scikit-image==0.24.0 
 arrow==1.3.0 
-nltk==3.9.3 
+nltk==3.9.4 
 dotmap==1.3.30
 h5py==3.14.0
 appdirs==1.4.4
 ffmpeg==1.4
-wheel==0.46.3
 lightning==2.5.5
 azureml-acft-image-components[mip]=={{latest-pypi-version}}
 filelock>=3.20.1

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
-RUN apt-get -y update && apt-get -y upgrade && apt-get install -y expat
+RUN apt-get -y update && apt-get -y upgrade
 
 # Install required packages from pypi
 COPY requirements.txt .
@@ -33,15 +33,6 @@ RUN pip install numpy==1.23.5
 # https://github.com/open-mmlab/mmdetection/issues/10962
 RUN pip install yapf==0.40.1
 
-# protobuf is a transitive dep of onnx/mlflow-skinny; parents use loose floors (>=3.12.0), cannot force 6.33.5
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# aiohttp: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pillow: upgrade 12.1.1→12.2.0 for GHSA-whj4-6x5x-4v2j
-# pytest: from ACPT base image ptca env; no parent to upgrade (GHSA-6w46-j5rx-g56g, CVE-2025-71176 tmpdir handling)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 protobuf==6.33.5 cryptography==46.0.7 pillow==12.2.0 'aiohttp>=3.13.4' 'requests>=2.33.0' 'pytest>=9.0.3'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2 
-# Upgrade requests, urllib3, aiohttpin the system Python (3.13) for fixing vulnerability
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade pip>=26.0.1 wheel>=0.46.2 setuptools>=82.0.1 cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
+# python-dotenv 1.2.1 in system Python (3.13) needs upgrade to 1.2.2 (GHSA-mf9w-mj56-hr94, symlink overwrite);
+# transitive dep of mlflow-skinny (>=0.19.0,<2) and pydantic-settings (>=0.21.0) — parents use loose floors
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
@@ -6,23 +6,11 @@ RUN apt-get -y update && apt-get -y upgrade
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# upgrade pip, wheel, protobuf vulnerabilities in ptca env
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-# protobuf parent is mlflow (already latest) which accepts protobuf>=3.12.0, cannot force 6.33.5 via parent
-# aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pytest: installed in base ACPT image; no parent package to upgrade (GHSA-6w46-j5rx-g56g, CVE-2025-71176 tmpdir handling)
-# Mako: transitive dep of mlflow -> alembic; alembic requires Mako with no version floor, cannot force >=1.3.11 via parent (GHSA-v92g-xgxw-vvmm)
-RUN pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 cryptography==46.0.7 'setuptools>=82.0.1' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' 'pytest>=9.0.3' 'Mako>=1.3.11'
-
 # Flag needed to enable control flow which is in PrP.
 ENV AZURE_ML_CLI_PRIVATE_FEATURES_ENABLED=True
 
-# vulnerability in base conda env
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 'setuptools>=82.0.1' cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'requests>=2.33.0'
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2
+# vulnerability overrides in base conda env (python3.13)
+# setuptools: base image has 82.0.0, need >=82.0.1 for GHSA-58pv-8j8x-9vj2
+# python-dotenv: transitive dep of uvicorn[standard] (>=0.13) and pydantic-settings (>=0.21.0); parents use loose floors, cannot force >=1.2.2 via parent (GHSA-mf9w-mj56-hr94)
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'python-dotenv>=1.2.2'
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/requirements.txt
@@ -3,10 +3,4 @@ mldesigner
 mlflow
 azureml-mlflow
 azureml-core
-requests>=2.33.0
-setuptools>=82.0.0
-Werkzeug>=3.1.5
-filelock>=3.20.1
-pillow>=12.1.1
-# protobuf 6.33.4 has CVE-2026-0994 (HIGH 8.6); transitive dep from mlflow -> mlflow-skinny (requires >=3.12.0,<7)
-protobuf>=6.33.5
+setuptools>=82.0.1


### PR DESCRIPTION
This pull request focuses on improving the security and maintainability of several Docker build environments for ACFT image and video training by tightening dependency management and removing unnecessary or vulnerable package installations. The changes primarily address vulnerabilities in transitive dependencies by explicitly overriding versions, removing redundant installations, and cleaning up Dockerfiles and requirements files for clarity.

**Dependency Security and Vulnerability Fixes:**

* Explicitly override vulnerable transitive dependencies in multiple Dockerfiles (e.g., `pyasn1`, `Mako`, `python-dotenv`, `onnx`, `fastmcp`, `GitPython`) to ensure patched versions are installed, mitigating known CVEs and supply chain risks. [[1]](diffhunk://#diff-614d4f818759eed6c42c2234e3e4f8800ccb63137999925c15cac7519703f789L11-R27) [[2]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L7-R19) [[3]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL13-R23) [[4]](diffhunk://#diff-689fb8a8f5377d4487f707ed378c0aeeb00aa46a5b84592ce3a51a7b1270ba97L26-R33) [[5]](diffhunk://#diff-db501b51e7d3a3e3694d90f50b2593cf7fd66088c640bfbb2254fe15028f6cdfL36-R38) [[6]](diffhunk://#diff-12ea0abdd51681a59d213c8042d554d6438c291efdc18a8b29ac31f5e81dee9fL9-R15)
* Upgrade or remove specific vulnerable packages in the system and conda environments, such as `python-dotenv` (GHSA-mf9w-mj56-hr94), `onnx` (GHSA-p433-9wv8-28xj), and `requests`, and ensure patched versions are used where parent packages have loose version floors. [[1]](diffhunk://#diff-614d4f818759eed6c42c2234e3e4f8800ccb63137999925c15cac7519703f789L11-R27) [[2]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L7-R19) [[3]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL13-R23) [[4]](diffhunk://#diff-689fb8a8f5377d4487f707ed378c0aeeb00aa46a5b84592ce3a51a7b1270ba97L26-R33) [[5]](diffhunk://#diff-db501b51e7d3a3e3694d90f50b2593cf7fd66088c640bfbb2254fe15028f6cdfL36-R38) [[6]](diffhunk://#diff-12ea0abdd51681a59d213c8042d554d6438c291efdc18a8b29ac31f5e81dee9fL9-R15)

**Dockerfile and Build Process Simplification:**

* Remove redundant or unnecessary package installation commands from Dockerfiles, such as dropping unneeded system package installs (e.g., `libc-bin`, `libssl-dev`, `expat`) and consolidating pip upgrade commands. [[1]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L7-R19) [[2]](diffhunk://#diff-689fb8a8f5377d4487f707ed378c0aeeb00aa46a5b84592ce3a51a7b1270ba97L6-L12) [[3]](diffhunk://#diff-db501b51e7d3a3e3694d90f50b2593cf7fd66088c640bfbb2254fe15028f6cdfL5-R5)
* Refactor Dockerfile comments and structure for clarity, grouping vulnerability overrides and documenting rationale for each override or removal. [[1]](diffhunk://#diff-614d4f818759eed6c42c2234e3e4f8800ccb63137999925c15cac7519703f789L11-R27) [[2]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L7-R19) [[3]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL13-R23) [[4]](diffhunk://#diff-689fb8a8f5377d4487f707ed378c0aeeb00aa46a5b84592ce3a51a7b1270ba97L26-R33) [[5]](diffhunk://#diff-12ea0abdd51681a59d213c8042d554d6438c291efdc18a8b29ac31f5e81dee9fL9-R15)

**Requirements File Updates:**

* Update pinned versions in `requirements.txt` files to address vulnerabilities, such as bumping `mlflow-skinny` to `3.11.1` and `nltk` to `3.9.4`, and ensuring minimum safe versions for packages like `setuptools`. [[1]](diffhunk://#diff-b54246f3534427a5b820c96fe63808af73410b2322af7a7643ee911c8a5763fdL7-R7) [[2]](diffhunk://#diff-b54246f3534427a5b820c96fe63808af73410b2322af7a7643ee911c8a5763fdL26-L31) [[3]](diffhunk://#diff-8f3e01336fcedba6e71054aca405fe4864626e505fc52d29db09b081fb4047cbL6-R6)

**Environment-specific Adjustments:**

* Remove or adjust package upgrades and uninstallations based on environment-specific dependency graphs, such as uninstalling `fastmcp` and `mcp` after upgrading `mlflow` in the embedding environment, and using `onnx-weekly` in the mmdetection environment for the latest security fixes. [[1]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL13-R23) [[2]](diffhunk://#diff-689fb8a8f5377d4487f707ed378c0aeeb00aa46a5b84592ce3a51a7b1270ba97L26-R33)

**General Clean-up:**

* Remove outdated or redundant comments, streamline upgrade logic, and ensure that only necessary security overrides are present, reducing Docker image complexity and build time. [[1]](diffhunk://#diff-614d4f818759eed6c42c2234e3e4f8800ccb63137999925c15cac7519703f789L11-R27) [[2]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L7-R19) [[3]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL13-R23) [[4]](diffhunk://#diff-26925c62753afe63696e348bf368d2700ac8e2b5b0999a84a8431d062c86029dL13-L31) [[5]](diffhunk://#diff-12ea0abdd51681a59d213c8042d554d6438c291efdc18a8b29ac31f5e81dee9fL9-R15)

These changes collectively improve the security posture of the environments, reduce technical debt, and make the Dockerfiles and requirements easier to maintain.Covers: acft_image_huggingface, acft_image_medimageinsight_adapter_finetune, acft_image_medimageinsight_embedding, acft_image_medimageparse_finetune, acft_image_mmdetection, acft_video_mmtracking, acpt_image_framework_selector