### PR TITLE
Improve CSAT evaluator prompt to better detect explicit user dissatisfaction

### DIFF
--- a/assets/evaluators/builtin/customer_satisfaction/evaluator/customer_satisfaction.prompty
+++ b/assets/evaluators/builtin/customer_satisfaction/evaluator/customer_satisfaction.prompty
@@ -83,6 +83,8 @@ IMPORTANT CONSIDERATIONS
 - An agent that correctly declines an impossible request is not failing
 - Partial help is better than no help
 - Tone matters - even a correct answer delivered rudely affects satisfaction
+- **Explicit user dissatisfaction signals**: If the query contains follow-up messages where the user explicitly expresses dissatisfaction (e.g., "that didn't help", "this is useless", "I'm frustrated", "that's not what I asked"), treat this as strong evidence of low satisfaction. A polite but ultimately unhelpful response that the user explicitly rejects MUST score 1 or 2. The agent's professional tone does not compensate for failing to meet the user's stated needs when the user has confirmed the failure.
+- **Unresolved core requests**: If the agent cannot fulfill the user's primary request and only offers workarounds or redirects to external resources, the score should not exceed 3 even if tone and clarity are good — the user's goal was not met.
 
 OUTPUT FORMAT
 =============

--- a/assets/evaluators/builtin/customer_satisfaction/evaluator/customer_satisfaction_multi_turn.prompty
+++ b/assets/evaluators/builtin/customer_satisfaction/evaluator/customer_satisfaction_multi_turn.prompty
@@ -96,6 +96,9 @@ IMPORTANT CONSIDERATIONS
 - Consider what a typical customer would feel about the overall interaction
 - An agent that correctly declines an impossible request is not failing
 - No Satisfaction Inference: Do not assume satisfaction because the user says "thanks" — evaluate actual fulfillment
+- **Explicit user dissatisfaction signals**: If the user explicitly expresses dissatisfaction at any point (e.g., "that didn't help", "this is useless", "I'm frustrated", "that's not what I asked"), treat this as strong evidence of low satisfaction. A polite but ultimately unhelpful session that the user explicitly rejects MUST score 1 or 2. The agent must demonstrate meaningful recovery after such signals to earn a higher score. Professional tone does not compensate for failing to meet the user's stated needs when the user has confirmed the failure.
+- **Unresolved core requests**: If the agent cannot fulfill the user's primary request and only offers workarounds or redirects to external resources without resolution, the score should not exceed 3 even if tone and clarity are good — the user's goal was not met.
+- **Trailing user messages without agent response**: If the conversation ends with a user message (especially one expressing frustration) and no agent follow-up, this indicates the session ended on a negative note and should be scored accordingly.
 
 OUTPUT FORMAT
 =============


### PR DESCRIPTION
## Summary

Fixes Bug #5243079 - CSAT evaluator scores 3 (Neutral) when user explicitly expresses dissatisfaction, instead of scoring 2 (Dissatisfied).

## Problem

When the CSAT evaluator receives a conversation where the user explicitly states the agent response was unhelpful, the model gives too much credit for the agent polite tone and alternative suggestions, inflating the score to 3 instead of reflecting the user actual dissatisfaction.

This happens specifically when the conversation is passed as flattened text in the query field (which is how the production pipeline calls the single-turn evaluator).

## Changes

Added two rules to the IMPORTANT CONSIDERATIONS section of both customer_satisfaction.prompty and customer_satisfaction_multi_turn.prompty:

1. Explicit user dissatisfaction signals: If the user explicitly expresses dissatisfaction (e.g. that didnt help), the score MUST be 1 or 2 regardless of agent tone.
2. Unresolved core requests: If the agent cannot fulfill the users primary request and only offers workarounds, the score should not exceed 3.

## Test Results (gpt-5.2, temperature=0, 5 runs each)

### With DSAT present in query (text format) - the bug scenario

| Format | Original Prompt | Modified Prompt |
|--------|----------------|-----------------|
| query + User follow-up: that didnt help! | 3,3,3,3,3 | 2,2,2,2,2 |
| Turn 1 - User: hi, Turn 2 - ... | 3,3,3,3,3 | 2,2,2,2,2 |
| query + that didnt help! | 3,3,3,3,3 | 2,2,2,2,2 |

### Without DSAT (query = just user question, no follow-up)

| Scenario | Original Prompt | Modified Prompt |
|----------|----------------|-----------------|
| whats the weather in New York? only | 3,4,4,4,4 | 3,3,3,3,3 |

The unresolved core requests rule prevents inflated scores (4) when the agent could not fulfill the request.

### With full JSON conversation (structured format)

| Scenario | Original Prompt | Modified Prompt |
|----------|----------------|-----------------|
| Full JSON array as query (with DSAT) | 2,2,2,2,2 | 2,2,2,2,2 |

When conversation is passed as structured JSON, the model already handles DSAT correctly - no regression.

## Test Conversation (from production trace)

User: hi
Assistant: Hi - what can I help you with?
User: whats the weather in New York?
Assistant: I cant see live weather data from here... [offers alternatives]
User: that didnt help!

Production scored this as 3 (Neutral). With our change, it correctly scores 2 (Dissatisfied).
