### PR TITLE
Fix acpt-rft PEFT pin for Transformers 5

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/requirements.txt
@@ -14,7 +14,7 @@ mathruler==0.1.0
 numpy==1.26.4
 packaging==25.0
 pandas==2.3.1
-peft==0.17.0
+peft==0.18.0
 pre-commit==4.3.0
 pyarrow==21.0.0
 pybind11==3.0.0


### PR DESCRIPTION
## Summary
- bump PEFT in the acpt-rft environment from 0.17.0 to 0.18.0
- fix the VERL runtime failure where PEFT 0.17.0 imports HybridCache from Transformers at module import time
- mirror the PEFT compatibility part of #4996 for the RFT/VERL environment; no TRL bump is needed because this environment does not pin TRL

## Evidence
- VERL smoke job tb-verl-sft-gsm8k-qwen05b-05052107 resolved azureml://registries/azureml/environments/acft-rft-training/versions/9 and failed with ImportError: cannot import name 'HybridCache' from 'transformers'
- PEFT 0.18.0 removes the top-level HybridCache import present in PEFT 0.17.0
- targeted import-regression smoke confirms PEFT 0.17.0 fails on the HybridCache import block while PEFT 0.18.0 passes

## Validation
- python -u scripts\azureml-assets\azureml\assets\validate_assets.py -i assets\training\finetune_acft_hf_nlp\environments\acpt-rft -a asset.yaml