### PR TITLE
Fix multi-turn evaluators crashing on content-block list system messages

### DIFF
--- a/assets/evaluators/builtin/coherence/evaluator/_coherence.py
+++ b/assets/evaluators/builtin/coherence/evaluator/_coherence.py
@@ -765,7 +765,11 @@ def serialize_messages(messages: List[dict]) -> str:
             normalized = {**msg, "content": [{"type": "text", "text": msg["content"]}]}
 
         if role in (MessageRole.SYSTEM, MessageRole.DEVELOPER):
-            system_message = msg.get("content", "")
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                system_message = "\n".join(_extract_text_from_content(content))
+            else:
+                system_message = content
         elif role == MessageRole.USER and "content" in msg:
             if cur_agent_response:
                 formatted = _get_agent_response(cur_agent_response, include_tool_messages=True)

--- a/assets/evaluators/builtin/coherence/spec.yaml
+++ b/assets/evaluators/builtin/coherence/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.coherence"
-version: 5
+version: 6
 displayName: "Coherence-Evaluator"
 description: "Evaluates how logically connected and consistent the response is. Ensures ideas flow naturally and make sense together. It’s best used for generative business writing such as summarizing meeting notes, creating marketing materials, and drafting emails."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/customer_satisfaction/evaluator/_customer_satisfaction.py
+++ b/assets/evaluators/builtin/customer_satisfaction/evaluator/_customer_satisfaction.py
@@ -799,7 +799,11 @@ def serialize_messages(messages: List[dict]) -> str:
             normalized = {**msg, "content": [{"type": "text", "text": msg["content"]}]}
 
         if role in (MessageRole.SYSTEM, MessageRole.DEVELOPER):
-            system_message = msg.get("content", "")
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                system_message = "\n".join(_extract_text_from_content(content))
+            else:
+                system_message = content
 
         elif role == MessageRole.USER and "content" in msg:
             if cur_agent_response:

--- a/assets/evaluators/builtin/customer_satisfaction/spec.yaml
+++ b/assets/evaluators/builtin/customer_satisfaction/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.customer_satisfaction"
-version: 8
+version: 9
 displayName: "Customer-Satisfaction-Evaluator"
 description: "Evaluates the predicted customer satisfaction level of an AI agent interaction on a 1-5 Likert scale. This evaluator assesses whether the agent's response would likely result in a satisfied customer based on helpfulness, completeness, tone, and resolution of the user's needs. Useful for measuring customer support quality, chatbot effectiveness, and overall user experience."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -52,6 +52,7 @@ class MessageRole(str, Enum):
     ASSISTANT = "assistant"
     SYSTEM = "system"
     TOOL = "tool"
+    DEVELOPER = "developer"
 
 
 class ContentType(str, Enum):
@@ -885,8 +886,12 @@ def serialize_messages(messages: List[dict]) -> str:
         if role == MessageRole.ASSISTANT and isinstance(msg.get("content"), str):
             normalized = {**msg, "content": [{"type": "text", "text": msg["content"]}]}
 
-        if role == MessageRole.SYSTEM:
-            system_message = msg.get("content", "")
+        if role in (MessageRole.SYSTEM, MessageRole.DEVELOPER):
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                system_message = "\n".join(_extract_text_from_content(content))
+            else:
+                system_message = content
 
         elif role == MessageRole.USER and "content" in msg:
             if cur_agent_response:

--- a/assets/evaluators/builtin/groundedness/spec.yaml
+++ b/assets/evaluators/builtin/groundedness/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.groundedness"
-version: 10
+version: 11
 displayName: "Groundedness-Evaluator"
 description: "Assesses whether the response stays true to the given context in a retrieval-augmented generation scenario. It’s best used for retrieval-augmented generation (RAG) scenarios, including question and answering and summarization. Use the groundedness metric when you need to verify that ai-generated responses align with and are validated by the provided context."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/task_adherence/evaluator/_task_adherence.py
+++ b/assets/evaluators/builtin/task_adherence/evaluator/_task_adherence.py
@@ -48,6 +48,7 @@ class MessageRole(str, Enum):
     ASSISTANT = "assistant"
     SYSTEM = "system"
     TOOL = "tool"
+    DEVELOPER = "developer"
 
 
 class ContentType(str, Enum):
@@ -771,8 +772,12 @@ def serialize_messages(messages: List[dict]) -> str:
         if role == MessageRole.ASSISTANT and isinstance(message.get("content"), str):
             normalized_message = {**message, "content": [{"type": "text", "text": message["content"]}]}
 
-        if role == MessageRole.SYSTEM:
-            system_message = message.get("content", "")
+        if role in (MessageRole.SYSTEM, MessageRole.DEVELOPER):
+            content = message.get("content", "")
+            if isinstance(content, list):
+                system_message = "\n".join(_extract_text_from_content(content))
+            else:
+                system_message = content
         elif role == MessageRole.USER and "content" in message:
             if current_agent_response:
                 formatted = _get_agent_response(current_agent_response, include_tool_messages=True)

--- a/assets/evaluators/builtin/task_adherence/spec.yaml
+++ b/assets/evaluators/builtin/task_adherence/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.task_adherence"
-version: 9
+version: 10
 displayName: "Task-Adherence-Evaluator-(Preview)"
 description: "Evaluates whether the agent completed the task within the confines of the instructions given to the agentic system. Higher scores indicate better compliance with the instructions. This evaluator is useful when useful for end-to-end system-level task evaluation for agents. Example outputs include actions such as updating a database and textual responses such as writing a report."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
+++ b/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
@@ -809,7 +809,11 @@ def serialize_messages(messages: List[dict]) -> str:
             normalized = {**msg, "content": [{"type": "text", "text": msg["content"]}]}
 
         if role in (MessageRole.SYSTEM, MessageRole.DEVELOPER):
-            system_message = msg.get("content", "")
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                system_message = "\n".join(_extract_text_from_content(content))
+            else:
+                system_message = content
 
         elif role == MessageRole.USER and "content" in msg:
             # A new user message after agent messages ends the current agent turn

--- a/assets/evaluators/builtin/task_completion/spec.yaml
+++ b/assets/evaluators/builtin/task_completion/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.task_completion"
-version: 12
+version: 13
 displayName: "Task-Completion-Evaluator-(Preview)"
 description: "Evaluates whether an AI agent successfully completed the requested task end to end by analyzing the conversation history and agent response to determine if all task requirements were met, ignoring rule adherence or intent understanding. This evaluator is useful for assessing agent effectiveness in task-oriented scenarios, workflow automation, and goal-oriented AI interactions."
 evaluatorType: "builtin"

--- a/assets/evaluators/tests/test_evaluators_behavior/test_coherence_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_coherence_evaluator_behavior.py
@@ -337,5 +337,73 @@ class TestCoherenceSerializeMessages:
         assert "Hello" in output
         assert "Hi there!" in output
 
+    def test_system_content_block_list_flattened_to_string(self):
+        """System message with content-block list is flattened, not passed as raw list."""
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "You are a helpful assistant." in result
+        assert "SYSTEM_PROMPT:" in result
+
+    def test_developer_content_block_list_flattened_to_string(self):
+        """Developer message with content-block list is treated like system."""
+        messages = [
+            {"role": "developer", "content": [{"type": "text", "text": "Be concise."}]},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Be concise." in result
+
+    def test_system_string_content_still_works(self):
+        """System message with plain string content still works after the fix."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "You are helpful." in result
+
+    def test_user_content_block_list_produces_flat_turns(self):
+        """User messages with content-block lists produce correctly flattened turns."""
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Question one."}]},
+            {"role": "assistant", "content": "Answer one."},
+        ]
+        result = serialize_messages(messages)
+        assert "Question one." in result
+        assert "User turn 1:" in result
+
+    def test_multi_text_block_user_message(self):
+        """User message with multiple text blocks produces flat turn content."""
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Part A."},
+                {"type": "text", "text": "Part B."},
+            ]},
+            {"role": "assistant", "content": "Got it."},
+        ]
+        result = serialize_messages(messages)
+        assert "Part A." in result
+        assert "Part B." in result
+
+    def test_system_content_block_multi_text(self):
+        """System message with multiple text blocks joins them with newline."""
+        messages = [
+            {"role": "system", "content": [
+                {"type": "text", "text": "Rule 1."},
+                {"type": "text", "text": "Rule 2."},
+            ]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Rule 1." in result
+        assert "Rule 2." in result
+
 
 # endregion

--- a/assets/evaluators/tests/test_evaluators_behavior/test_customer_satisfaction_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_customer_satisfaction_evaluator_behavior.py
@@ -14,6 +14,7 @@ from azure.ai.evaluation._exceptions import EvaluationException
 from .base_evaluator_behavior_test import BaseEvaluatorBehaviorTest
 from ...builtin.customer_satisfaction.evaluator._customer_satisfaction import (
     CustomerSatisfactionEvaluator,
+    serialize_messages,
 )
 from ..common.evaluator_mock_config import get_flow_side_effect_for_evaluator
 
@@ -401,6 +402,82 @@ class TestCustomerSatisfactionEvaluationLevel:
         """Non-string/non-enum evaluation_level raises at init time."""
         with pytest.raises(EvaluationException, match="Invalid evaluation_level"):
             _create_mocked_evaluator_with_level(evaluation_level=42)
+
+
+# region serialize_messages tests
+
+
+@pytest.mark.unittest
+class TestCustomerSatisfactionSerializeMessages:
+    """Unit tests for the serialize_messages helper used by customer satisfaction."""
+
+    def test_system_content_block_list_flattened_to_string(self):
+        """System message with content-block list is flattened, not passed as raw list."""
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "You are a helpful assistant." in result
+        assert "SYSTEM_PROMPT:" in result
+
+    def test_developer_content_block_list_flattened_to_string(self):
+        """Developer message with content-block list is treated like system."""
+        messages = [
+            {"role": "developer", "content": [{"type": "text", "text": "Be concise."}]},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Be concise." in result
+
+    def test_system_string_content_still_works(self):
+        """System message with plain string content still works after the fix."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "You are helpful." in result
+
+    def test_user_content_block_list_produces_flat_turns(self):
+        """User messages with content-block lists produce correctly flattened turns."""
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Question one."}]},
+            {"role": "assistant", "content": "Answer one."},
+        ]
+        result = serialize_messages(messages)
+        assert "Question one." in result
+        assert "User turn 1:" in result
+
+    def test_multi_text_block_user_message(self):
+        """User message with multiple text blocks produces flat turn content."""
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Part A."},
+                {"type": "text", "text": "Part B."},
+            ]},
+            {"role": "assistant", "content": "Got it."},
+        ]
+        result = serialize_messages(messages)
+        assert "Part A." in result
+        assert "Part B." in result
+
+    def test_system_content_block_multi_text(self):
+        """System message with multiple text blocks joins them with newline."""
+        messages = [
+            {"role": "system", "content": [
+                {"type": "text", "text": "Rule 1."},
+                {"type": "text", "text": "Rule 2."},
+            ]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Rule 1." in result
+        assert "Rule 2." in result
 
 
 # endregion

--- a/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
@@ -587,5 +587,63 @@ class TestGroundednessSerializeMessages:
         result = serialize_messages(messages)
         assert "You are a helpful assistant." in result
 
+    def test_system_content_block_list_flattened_to_string(self):
+        """System message with content-block list is flattened, not passed as raw list."""
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "You are a helpful assistant." in result
+        assert "SYSTEM_PROMPT:" in result
+
+    def test_developer_content_block_list_flattened_to_string(self):
+        """Developer message with content-block list is treated like system."""
+        messages = [
+            {"role": "developer", "content": [{"type": "text", "text": "Be concise."}]},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Be concise." in result
+
+    def test_user_content_block_list_produces_flat_turns(self):
+        """User messages with content-block lists produce correctly flattened turns."""
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Question one."}]},
+            {"role": "assistant", "content": "Answer one."},
+        ]
+        result = serialize_messages(messages)
+        assert "Question one." in result
+        assert "User turn 1:" in result
+
+    def test_multi_text_block_user_message(self):
+        """User message with multiple text blocks produces flat turn content."""
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Part A."},
+                {"type": "text", "text": "Part B."},
+            ]},
+            {"role": "assistant", "content": "Got it."},
+        ]
+        result = serialize_messages(messages)
+        assert "Part A." in result
+        assert "Part B." in result
+
+    def test_system_content_block_multi_text(self):
+        """System message with multiple text blocks joins them with newline."""
+        messages = [
+            {"role": "system", "content": [
+                {"type": "text", "text": "Rule 1."},
+                {"type": "text", "text": "Rule 2."},
+            ]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Rule 1." in result
+        assert "Rule 2." in result
+
 
 # endregion

--- a/assets/evaluators/tests/test_evaluators_behavior/test_task_adherence_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_task_adherence_evaluator_behavior.py
@@ -516,5 +516,73 @@ class TestTaskAdherenceSerializeMessages:
         assert "Agent turn 1:" in result
         assert "The sky is blue." in result
 
+    def test_system_content_block_list_flattened_to_string(self):
+        """System message with content-block list is flattened, not passed as raw list."""
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "You are a helpful assistant." in result
+        assert "SYSTEM_PROMPT:" in result
+
+    def test_developer_content_block_list_flattened_to_string(self):
+        """Developer message with content-block list is treated like system."""
+        messages = [
+            {"role": "developer", "content": [{"type": "text", "text": "Be concise."}]},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Be concise." in result
+
+    def test_system_string_content_still_works(self):
+        """System message with plain string content still works after the fix."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "You are helpful." in result
+
+    def test_user_content_block_list_produces_flat_turns(self):
+        """User messages with content-block lists produce correctly flattened turns."""
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Question one."}]},
+            {"role": "assistant", "content": "Answer one."},
+        ]
+        result = serialize_messages(messages)
+        assert "Question one." in result
+        assert "User turn 1:" in result
+
+    def test_multi_text_block_user_message(self):
+        """User message with multiple text blocks produces flat turn content."""
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Part A."},
+                {"type": "text", "text": "Part B."},
+            ]},
+            {"role": "assistant", "content": "Got it."},
+        ]
+        result = serialize_messages(messages)
+        assert "Part A." in result
+        assert "Part B." in result
+
+    def test_system_content_block_multi_text(self):
+        """System message with multiple text blocks joins them with newline."""
+        messages = [
+            {"role": "system", "content": [
+                {"type": "text", "text": "Rule 1."},
+                {"type": "text", "text": "Rule 2."},
+            ]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Rule 1." in result
+        assert "Rule 2." in result
+
 
 # endregion

--- a/assets/evaluators/tests/test_evaluators_behavior/test_task_completion_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_task_completion_evaluator_behavior.py
@@ -794,5 +794,73 @@ class TestSerializeMessages:
         )
         assert serialize_messages(messages) == expected
 
+    def test_system_content_block_list_flattened_to_string(self):
+        """System message with content-block list is flattened, not passed as raw list."""
+        messages = [
+            {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "You are a helpful assistant." in result
+        assert "SYSTEM_PROMPT:" in result
+
+    def test_developer_content_block_list_flattened_to_string(self):
+        """Developer message with content-block list is treated like system."""
+        messages = [
+            {"role": "developer", "content": [{"type": "text", "text": "Be concise."}]},
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Be concise." in result
+
+    def test_system_string_content_still_works(self):
+        """System message with plain string content still works after the fix."""
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "You are helpful." in result
+
+    def test_user_content_block_list_produces_flat_turns(self):
+        """User messages with content-block lists produce correctly flattened turns."""
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Question one."}]},
+            {"role": "assistant", "content": "Answer one."},
+        ]
+        result = serialize_messages(messages)
+        assert "Question one." in result
+        assert "User turn 1:" in result
+
+    def test_multi_text_block_user_message(self):
+        """User message with multiple text blocks produces flat turn content."""
+        messages = [
+            {"role": "user", "content": [
+                {"type": "text", "text": "Part A."},
+                {"type": "text", "text": "Part B."},
+            ]},
+            {"role": "assistant", "content": "Got it."},
+        ]
+        result = serialize_messages(messages)
+        assert "Part A." in result
+        assert "Part B." in result
+
+    def test_system_content_block_multi_text(self):
+        """System message with multiple text blocks joins them with newline."""
+        messages = [
+            {"role": "system", "content": [
+                {"type": "text", "text": "Rule 1."},
+                {"type": "text", "text": "Rule 2."},
+            ]},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        result = serialize_messages(messages)
+        assert "Rule 1." in result
+        assert "Rule 2." in result
+
 
 # endregion


### PR DESCRIPTION
## Summary

All 5 conversation-level multi-turn evaluators (**customer_satisfaction**, **groundedness**, **coherence**, **task_completion**, **task_adherence**) crash with `TypeError: can only concatenate str (not 'list') to str` when system/developer messages use OpenAI content-block list format:

```json
[{"type": "text", "text": "You are a helpful assistant."}]
```

This is the standard format emitted by Foundry agents and the OpenAI Responses API.

Link to BUG REPORT: https://dev.azure.com/msdata/Vienna/_workitems/edit/5254843

## Root Cause

`serialize_messages()` assigns the raw list from `msg.get('content')` directly to `system_message`. The downstream `_pretty_format_conversation_history()` function then performs string concatenation (`'  ' + system_message + '\n\n'`), which raises `TypeError`.

## Fix

- **Bug A (crash)**: Check if system/developer message content is a list; if so, extract text blocks using `_extract_text_from_content()` and join into a string.
- **Missing enum**: Add `DEVELOPER = 'developer'` to `MessageRole` in groundedness and task_adherence (already present in the other 3 evaluators).
- **Missing role handling**: Handle `MessageRole.DEVELOPER` alongside `MessageRole.SYSTEM` in groundedness and task_adherence `serialize_messages()`.

## Files Changed

**Evaluator source (5 files)**:
- `assets/evaluators/builtin/customer_satisfaction/evaluator/_customer_satisfaction.py`
- `assets/evaluators/builtin/groundedness/evaluator/_groundedness.py`
- `assets/evaluators/builtin/coherence/evaluator/_coherence.py`
- `assets/evaluators/builtin/task_completion/evaluator/_task_completion.py`
- `assets/evaluators/builtin/task_adherence/evaluator/_task_adherence.py`

**Test files (5 files)**:
- Added 6-7 unit tests per evaluator covering: system content-block list, developer content-block list, plain string system (regression), user content-block list, multi-text-block messages.

## Testing

All 475 tests pass across all 5 evaluator test suites.

## Repro

Minimal failing input (before fix):
```json
[
  {"role": "system", "content": [{"type": "text", "text": "You are helpful"}]},
  {"role": "user",   "content": "Hello"},
  {"role": "assistant", "content": "Hi!"}
]
```


