### PR TITLE
Fix acft-rft-training VERL compatibility

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
@@ -11,7 +11,7 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install azureml-evaluate-mlflow=={{latest-pypi-version}}
-RUN pip install verl==0.7.0
+RUN pip install verl==0.7.1
 RUN pip install sacrebleu==2.5.1
 COPY tracking /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/tracking.py
 
@@ -35,6 +35,7 @@ COPY azure_grader /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/r
 COPY azure_python_grader /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/reward_score/azure_python_grader.py
 COPY utils /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/vllm/utils.py
 RUN pip install vllm==0.19.0
+RUN python -c "from transformers import HybridCache; import verl.utils.model; from verl.utils.transformers_compat import get_auto_model_for_vision2seq; assert get_auto_model_for_vision2seq() is not None"
 # Keep xgrammar at the patched floor even when pulled transitively by vllm.
 RUN pip install --no-cache-dir 'xgrammar>=0.1.32'
 RUN pip install openai==2.14.0
@@ -65,4 +66,3 @@ RUN rm -rf ~/.cache/pip /tmp/* /var/tmp/*
 ENV PYTHONHASHSEED=random \
     PYTHONDONTWRITEBYTECODE=1
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/ /opt/conda/pkgs/
-


### PR DESCRIPTION
## Summary

- Upgrade `acft-rft-training` VERL from `0.7.0` to `0.7.1` so VERL uses its Transformers compatibility path for `AutoModelForVision2Seq`.
- Add a build-time import guard for the startup path that previously failed in the Vienna Foundry VERL SFT smoke: `HybridCache`, `verl.utils.model`, and `get_auto_model_for_vision2seq()`.

## Validation

- Ran asset validation on this branch:
  `python -u scripts\azureml-assets\azureml\assets\validate_assets.py -i assets\training\finetune_acft_hf_nlp\environments -a asset.yaml -c assets\training\finetune_acft_hf_nlp\environments\acpt-rft\context\Dockerfile -n -I -C -b -t -e`
  - Result: `Found 0 error(s) in 6 asset(s)`
  - Existing warning: `Name 'acft-rft-training' is missing framework`

- Validation image built successfully before PR creation for the VERL fix:
  - Image: `imagevalidation.azurecr.io/public/azureml/curated/acft-rft-training:vcm-20260508-bcd934e75-r2`
  - Digest: `sha256:991e26c3cb2c0d61dcf69e688de03345d1a91f85ffe1da1a13c02dccddd431dc`
  - ACR build: `ch1c`

- VCM on-demand vulnerability validation completed with scan ID `5dc51781-9c67-4187-81ea-558db0ce34ea`.
  - Result: non-compliant due remaining vulnerability findings.
  - This PR fixes the VERL/Transformers compatibility failure and does not claim to resolve all VCM findings.
