### PR TITLE
Use a new storage account for Foundry Local models

### DIFF
--- a/assets/models/foundrylocal/nemotron-speech-streaming-es-0.6b-ft-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-es-0.6b-ft-generic-cpu/model.yaml
@@ -1,7 +1,7 @@
 path:
   container_name: models
   container_path: foundrylocal/models/nemotron-speech-streaming-es-0.6b-ft/onnx/cpu_and_mobile/v1
-  storage_name: foundrylocalmodels
+  storage_name: foundrylocalassetdata
   type: azureblob
 publish:
   description: description.md


### PR DESCRIPTION
Replication policy was set up from foundrylocalmodels to foundrylocalassetdata to enable IPP pipeline.