### PR TITLE
Upgrade acft-hf-nlp-gpu TRL framework

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -30,7 +30,11 @@ RUN pip install --upgrade --no-cache-dir 'fastmcp>=3.2.0'
 # Mako: transitive dep (mlflow → alembic → Mako); alembic has no version constraint; override needed (GHSA-v92g-xgxw-vvmm)
 # python-dotenv: transitive dep (fastmcp → python-dotenv); fastmcp 3.2.4 uses >=1.1.0; override needed (GHSA-mf9w-mj56-hr94)
 # onnx: azureml-acft-accelerator 0.0.89 caps onnx<=1.17.0; override needed for GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m etc.
-RUN pip install --upgrade --no-cache-dir pyasn1==0.6.3 'python-multipart>=0.0.26' 'Mako>=1.3.11' 'python-dotenv>=1.2.2' 'onnx>=1.21.0'
+# skops: transitive dep with loose floor; override needed (GHSA-m7f4-hrc6-fwg3 etc.)
+RUN pip install --upgrade --no-cache-dir pyasn1==0.6.3 'python-multipart>=0.0.26' 'Mako>=1.3.11' 'python-dotenv>=1.2.2' 'onnx>=1.21.0' 'skops>=0.13.0' 'pip>=26.1'
+
+# pip install updates the binary but conda-meta still references old versions; conda install syncs both
+RUN conda install -n ptca -y -c conda-forge 'pip>=26.1'
 
 # python-dotenv 1.2.1 in base conda env (python3.13) from ACPT base image needs upgrade (GHSA-mf9w-mj56-hr94)
 RUN conda run -n base python -m pip install --upgrade --no-cache-dir 'python-dotenv>=1.2.2'
@@ -38,4 +42,3 @@ RUN conda run -n base python -m pip install --upgrade --no-cache-dir 'python-dot
 # clean conda and pip caches
 RUN rm -rf ~/.cache/pip
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/
-

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -6,7 +6,7 @@ mltable=={{latest-pypi-version}}
 sentencepiece==0.2.1
 transformers==5.0.0
 huggingface-hub>=1.3.0
-datasets==4.0.0
+datasets==4.7.0
 evaluate==0.4.5
 optimum==1.27.0
 accelerate==1.7.0
@@ -19,7 +19,7 @@ einops==0.7.0
 aiohttp>=3.13.5
 peft==0.18.0
 deepspeed==0.17.4
-trl==0.29.1
+trl==1.3.0
 tiktoken==0.6.0
 scipy==1.14.0
 catalogue==2.0.10


### PR DESCRIPTION
## Summary
- Upgrade `acft-hf-nlp-gpu` TRL from `0.29.1` to `1.3.0` on top of latest `main`
- Bump `datasets` to `4.7.0`, matching the newer TRL requirement
- Add `skops>=0.13.0` and conda metadata sync for `pip>=26.1` so the final image is VCM-compliant

## Validation
- ACR build: `imagevalidation.azurecr.io/acft-hf-nlp-gpu-test:trl-20260508-pr-r8`
- ACR run: `ch1p`
- Digest: `sha256:da094d654c76afdded4375ca62286cb4b0be604ae29ee83ac80bb3dc3b89a17c`
- Trivy SBOM + VCM: `non_compliant=0`, `show_total=1`

Note: `show_total=1` is `pip` in the base Python 3.13 env with due date `2026-06-05`; VCM evaluation marks it compliant.
