### PR TITLE
Fix python-dotenv vulnerability in ACFT environments

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
@@ -22,6 +22,8 @@ RUN pip install xgrammar==0.1.32
 # GHSA-69w3-r845-3855 (CVE-2026-1839): arbitrary code execution in Trainer class;
 # patched only in transformers>=5.0.0rc3. Upgrading to latest stable 5.x.
 RUN pip install transformers==5.5.4
+# python-dotenv in /opt/conda Python 3.13 ships as vulnerable 1.2.1 in the base image.
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 # clean conda and pip caches
 RUN rm -rf ~/.cache/pip
 COPY loss /opt/conda/envs/ptca/lib/python3.10/site-packages/specforge/core/loss.py

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
@@ -17,5 +17,7 @@ RUN pip install -r requirements.txt --no-cache-dir
 # python-dotenv: mlflow → mlflow-skinny → python-dotenv<2,>=0.19.0;
 #   mlflow 3.11.1 (latest as of 2026-05-04) allows >=1.2.2 but pip may resolve older (GHSA-mf9w-mj56-hr94)
 RUN pip install --no-cache-dir --upgrade 'pyasn1>=0.6.3' 'Mako>=1.3.11' 'python-dotenv>=1.2.2'
+# python-dotenv in /opt/conda Python 3.13 also ships as vulnerable 1.2.1 in the base image.
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/


### PR DESCRIPTION
## Summary
- Upgrade `python-dotenv` to `>=1.2.2` in the `/opt/conda` Python 3.13 environment for `acft-medimageinsight-adapter-finetune`.
- Upgrade `python-dotenv` to `>=1.2.2` in the `/opt/conda` Python 3.13 environment for `acft-draft-model-training`.
- Keeps the remediation targeted to the vulnerable interpreter path reported by Qualys QID 5011346.

## Validation
- Asset validation: `Found 0 error(s) in 2 asset(s)`.
- Built validation images in `imagevalidation.azurecr.io`:
  - `public/azureml/curated/acft-medimageinsight-adapter-finetune:vcm-20260509-0a1940c92-r2`, ACR run `ch1t`, digest `sha256:1772c1b940028feec96ae6e4249487cbb76b3fde7c8cfe3c65d70eaa85926ada`.
  - `public/azureml/curated/acft-draft-model-training:vcm-20260509-0a1940c92-r3`, ACR run `ch1u`, digest `sha256:d242935bb3f9b571fbd425d10f3f5ab6de7c5fb6ca6826333dc77f1a6ce969ee`.
- Generated and attached SBOMs with VCM:
  - Medimage SBOM attach run `ch1v`.
  - Draft SBOM attach run `ch1w`.
- VCM vulnerability evaluation completed as compliant for both images:
  - Medimage scan `62d09c06-91c4-4b51-b0eb-6c9a6d6e2165`: `Total non-compliant findings: 0`.
  - Draft scan `de677231-276d-43dc-ab90-00738d515548`: `Total non-compliant findings: 0`.
- Confirmed final SBOMs contain `pkg:pypi/python-dotenv@1.2.2` under `/opt/conda/lib/python3.13/site-packages`, and no matches for QID `5011346` or `python-dotenv`/`python__dotenv` 1.2.1 remain in the validation outputs.

Evidence bundle: `output/fix-dotenv-qid5011346-20260508/fix-dotenv-qid5011346-vcm-evidence.zip` in the validation worktree.
