### PR TITLE
Update qwen3.5 task to vision-language-chat

### DIFF
--- a/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-0.8b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-0.8b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-0.8b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-2b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-2b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-2b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-4b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-4b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-4b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-9b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-9b
   directoryPath: v2

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
   author: Microsoft
   inputModalities: "text,image"
   outputModalities: "text"
-  task: chat-completion
+  task: vision-language-chat
   maxOutputTokens: 2048
   alias: qwen3.5-9b
   directoryPath: v2


### PR DESCRIPTION
Qwen3.5 family is VL models. Update task metadata from chat-completion to vision-language-chat.