### PR TITLE
[feat]: week 19 vulnerabilities fixes - general

### DIFF
--- a/assets/training/general/environments/sklearn-1.5/context/Dockerfile
+++ b/assets/training/general/environments/sklearn-1.5/context/Dockerfile
@@ -9,10 +9,17 @@ ENV PATH=$CONDA_PREFIX/bin:$PATH
 # This is needed for mpi to locate libpython
 ENV LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
 
-# Update package lists, upgrade all OS packages, and reinstall system OpenSSL & OpenSSH
+# Update package lists and upgrade all OS packages to pull latest security patches
+# (e.g. openssh USN-8222-1, curl USN-8227-1, kmod USN-8226-1, sed USN-8229-1,
+# nghttp2 USN-8233-1 currently outstanding in base image openmpi5.0-ubuntu24.04:latest).
+# Previously this step also did `apt-get install --reinstall openssl libssl-dev
+# openssh-server libpam-runtime libc-bin dpkg-dev` but those reinstalls became
+# redundant after `apt-get upgrade` was added: a fresh scan of the base image
+# (mcr.microsoft.com/azureml/openmpi5.0-ubuntu24.04:latest, digest 53c17a5a) shows
+# none of those packages other than openssh have an outstanding USN, and openssh
+# is already fixed by the upgrade above. Removed to keep the layer minimal.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
-    apt-get install --reinstall -y openssl libssl-dev openssh-server libpam-runtime libc-bin dpkg-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -23,8 +30,10 @@ RUN apt-get update && \
 # conda and pip dependencies together. Splitting them avoids the memory spike.
 
 # Step 1: Create conda env with only conda-channel packages (small, fast solve)
+# pip=26.1.1: fixes CVE-2026-6357 (GHSA-jp4c-xjxw-mgf9). Pip <26.1 ran self-update
+# check after wheel install which could import newly installed packages.
 COPY conda_dependencies.yaml .
-RUN conda create -p $CONDA_PREFIX -q -y python=3.10 pip=26.0 'pandas~=1.5.3' 'scipy~=1.10.0' 'numpy~=1.22.0' -c conda-forge -c anaconda && \
+RUN conda create -p $CONDA_PREFIX -q -y python=3.10 pip=26.1.1 'pandas~=1.5.3' 'scipy~=1.10.0' 'numpy~=1.22.0' -c conda-forge -c anaconda && \
     conda clean -a -y
 
 # Step 2: Install pip packages separately (pip resolver uses less memory than conda's SAT solver)
@@ -50,8 +59,17 @@ RUN conda run -p $CONDA_PREFIX pip install --no-cache-dir \
     rm conda_dependencies.yaml
 
 # Security vulnerability fixes
-# cryptography, pip, setuptools, urllib3, wheel already fixed in openmpi base (20260315.v1)
-# cryptography: azureml-mlflow==1.62.0 (latest) caps cryptography<46.0.0, so conda env installs 44.x;
-#   override after conda env create to restore 46.0.7
-RUN conda run -p $CONDA_PREFIX pip install --no-cache-dir --upgrade \
+# setuptools, urllib3, wheel already fixed in openmpi base (latest tag).
+# pip: openmpi base (20260409.v4) still ships pip=26.0.1 in /opt/miniconda which is
+#   vulnerable to CVE-2026-6357 (GHSA-jp4c-xjxw-mgf9). Upgrade /opt/miniconda's pip to
+#   26.1.1 explicitly here. (The azureml-envs/sklearn-1.5 conda env is created with
+#   pip=26.1.1 via the conda create command above.)
+# cryptography: azureml-mlflow==1.62.0.post2 (latest) caps cryptography<47.0.0 (was
+#   <46.0.0 in 1.62.0); cap no longer prevents 46.x but pip's resolver may still pick
+#   an older 46.x patch via transitive constraints (azureml-core -> pyopenssl<26.0.0,
+#   pyopenssl -> cryptography>=...). Pin 46.0.7 explicitly to ensure latest patch.
+# aiohttp / distributed: kept overrides to ensure latest patched versions; transitive
+#   parent constraints (mlflow-skinny, dask) don't require these specific patches.
+RUN /opt/miniconda/bin/pip install --no-cache-dir --upgrade pip==26.1.1 && \
+    conda run -p $CONDA_PREFIX pip install --no-cache-dir --upgrade \
     aiohttp==3.13.4 cryptography==46.0.7 'distributed>=2026.1.0'

--- a/assets/training/general/environments/sklearn-1.5/context/conda_dependencies.yaml
+++ b/assets/training/general/environments/sklearn-1.5/context/conda_dependencies.yaml
@@ -4,7 +4,7 @@ channels:
 - anaconda
 dependencies:
 - python=3.10
-- pip=26.0
+- pip=26.1.1
 - pandas~=1.5.3
 - scipy~=1.10.0
 - numpy~=1.22.0

--- a/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
+++ b/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
@@ -227,9 +227,15 @@ ENV CONDA_PREFIX=/azureml-envs/tensorflow-2.16-cuda12
 ENV CONDA_DEFAULT_ENV=$CONDA_PREFIX
 ENV PATH=$CONDA_PREFIX/bin:$PATH
 
-# Enable debug
+# Enable debug + USN-8222-1 OpenSSH upgrade
+# USN-8222-1 (CVE-2026-35385/35386/35387/35388/35414) requires openssh >= 1:8.9p1-3ubuntu0.15.
+# openssh-client/openssh-server/openssh-sftp-server are root-level OS packages from the
+# 'openssh' Debian source package (no transitive parent); the fixed parent is published in
+# the jammy-security archive (2026-04-29), so we install them directly to pick up the patched
+# version (plain `apt-get install` after `apt-get update` resolves to the latest candidate).
 RUN apt-get update && \
-    apt-get install --reinstall -y openssl libssl-dev openssh-server openssh-client && \
+    apt-get install --reinstall -y openssl libssl-dev && \
+    apt-get install -y openssh-server openssh-client openssh-sftp-server && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This pull request updates the `sklearn-1.5` and `tensorflow-2.16-cuda12` training environments to address recent security vulnerabilities and streamline package management. The most important changes include upgrading pip to fix a critical CVE, refining how security patches are applied in Dockerfiles, and ensuring the latest patched versions of key OS packages are installed.

**Security and vulnerability fixes:**

* Upgraded `pip` to version `26.1.1` in both `conda_dependencies.yaml` and the `Dockerfile` to fix CVE-2026-6357 (GHSA-jp4c-xjxw-mgf9), ensuring both the conda environment and the base `/opt/miniconda` are patched. [[1]](diffhunk://#diff-b146446a09dde4625e5187a545fc530c83ca0f17ed294cd64f7037799b06f2aeL7-R7) [[2]](diffhunk://#diff-96ecc5c7d147cf3543f72b0b9ac62a4704a3d3b1c4a45dd925be9eefda49c574R33-R36) [[3]](diffhunk://#diff-96ecc5c7d147cf3543f72b0b9ac62a4704a3d3b1c4a45dd925be9eefda49c574L53-R74)
* Explicitly installed the latest patched versions of `openssh-server`, `openssh-client`, and `openssh-sftp-server` in the `tensorflow-2.16-cuda12` Dockerfile to address USN-8222-1 and related CVEs.

**Dockerfile and package management improvements:**

* Simplified the OS upgrade step in the `sklearn-1.5` Dockerfile by removing redundant package reinstalls, relying on `apt-get upgrade` to pull in all relevant security patches and keeping the Docker layer minimal.
* Improved documentation and comments throughout the Dockerfiles to clarify the rationale for each security fix and package pinning, making maintenance easier. [[1]](diffhunk://#diff-96ecc5c7d147cf3543f72b0b9ac62a4704a3d3b1c4a45dd925be9eefda49c574L12-L15) [[2]](diffhunk://#diff-96ecc5c7d147cf3543f72b0b9ac62a4704a3d3b1c4a45dd925be9eefda49c574R33-R36) [[3]](diffhunk://#diff-96ecc5c7d147cf3543f72b0b9ac62a4704a3d3b1c4a45dd925be9eefda49c574L53-R74) [[4]](diffhunk://#diff-1eaefbb2fa8ee8ae74cbed0326db4480d82a2e11f5fd7cac9103b5e01c38abdcL230-R238)
* Ensured explicit pinning of `cryptography==46.0.7` and latest patched versions of `aiohttp` and `distributed` to avoid vulnerable transitive dependencies in the `sklearn-1.5` environment.