### PR TITLE
[feat]: week 19 vulnerabilities fixes - acft-image

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -21,7 +21,14 @@ RUN pip install -r requirements.txt --no-cache-dir
 #   pip resolves to 3.1.46 which has GHSA-rpm5-65cw-6hj4, GHSA-x2qx-6953-8485; override to >=3.1.47
 # python-dotenv: transitive dep (mlflow → mlflow-skinny requires python-dotenv<2,>=0.19.0); loose floor,
 #   pip resolves to 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
-RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0' pyasn1==0.6.3 'fastmcp>=3.2.0' Mako==1.3.11 'GitPython>=3.1.47' 'python-dotenv>=1.2.2'
+# pillow: comes from the base ACPT image (not a hard runtime dep of any requirements.txt package;
+#   transformers/datasets/diffusers/optimum/huggingface-hub only require Pillow under extras_require
+#   like [vision]/[dev]/[testing]); base image ships 12.1.1 which has GHSA-whj4-6x5x-4v2j;
+#   no parent package to upgrade — explicit override required (>=12.2.0)
+# pytest: comes from the base ACPT image (not a hard runtime dep of any requirements.txt package;
+#   azureml-acft-accelerator only pins pytest~=5.3.0 under extras_require [test]); base image ships
+#   7.4.3 which has GHSA-6w46-j5rx-g56g; no parent package to upgrade — explicit override required (>=9.0.3)
+RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0' pyasn1==0.6.3 'fastmcp>=3.2.0' Mako==1.3.11 'GitPython>=3.1.47' 'python-dotenv>=1.2.2' 'pillow>=12.2.0' 'pytest>=9.0.3'
 # python-dotenv in base conda env: transitive dep of uvicorn[standard] (>=0.13); loose floor,
 #   base image has 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
 RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
@@ -10,14 +10,24 @@ RUN apt-get -y install unzip
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# Transitive dep overrides where pip may not resolve to the patched version:
-# pyasn1: mlflow → databricks-sdk → google-auth → pyasn1-modules → pyasn1;
-#   parents use loose floors so pip may resolve to <0.6.3 (CVE-2026-30922)
-# Mako: mlflow → alembic → Mako; alembic uses unpinned Mako dep
-# python-dotenv: mlflow → mlflow-skinny → python-dotenv<2,>=0.19.0;
-#   mlflow 3.11.1 (latest as of 2026-05-04) allows >=1.2.2 but pip may resolve older (GHSA-mf9w-mj56-hr94)
-RUN pip install --no-cache-dir --upgrade 'pyasn1>=0.6.3' 'Mako>=1.3.11' 'python-dotenv>=1.2.2'
-# python-dotenv in /opt/conda Python 3.13 also ships as vulnerable 1.2.1 in the base image.
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
+# Transitive dep overrides where pip may not resolve to the patched version.
+# The image has two conda envs: base (py3.13) and ptca (py3.10); the default
+# `pip` resolves to the ptca env, so base-env overrides need /opt/conda/bin/pip.
+#
+# ptca env (py3.10):
+#   pyasn1: mlflow -> databricks-sdk -> google-auth -> pyasn1-modules -> pyasn1;
+#     pyasn1-modules pins pyasn1 with no version floor so pip may resolve <0.6.3 (CVE-2026-30922)
+#   Mako: mlflow -> alembic -> Mako; alembic 1.18.4 uses unpinned `Requires-Dist: Mako`
+#   python-dotenv: mlflow -> mlflow-skinny -> python-dotenv<2,>=0.19.0;
+#     mlflow 3.11.1 (latest as of 2026-05-08) keeps that wide range so pip may resolve <1.2.2 (GHSA-mf9w-mj56-hr94)
+#
+# base conda env (py3.13):
+#   python-dotenv 1.2.1 is brought in by anaconda-auth 0.13.1 (`Requires-Dist: python-dotenv`,
+#   no version pin) and pydantic-settings 2.12.0 (`python-dotenv>=0.21.0`); both are shipped
+#   pre-installed in the base env from the upstream base image and neither parent ships a
+#   tighter pin in its latest release as of 2026-05-08, so we patch python-dotenv directly
+#   in the base env via /opt/conda/bin/pip.
+RUN pip install --no-cache-dir --upgrade 'pyasn1>=0.6.3' 'Mako>=1.3.11' 'python-dotenv>=1.2.2' \
+ && /opt/conda/bin/pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
@@ -3,19 +3,39 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest
 
 USER root
 
-# Install unzip and upgrade OS packages to fix vulnerabilities
+# Install unzip and upgrade OS packages to fix vulnerabilities.
+# `apt-get -y upgrade` against the current ACPT base image (biweekly.202605.1) already pulls
+# openssh-client to 1:8.9p1-3ubuntu0.15 (USN-8222-1 fix) and keeps dotnet-{host,hostfxr,runtime}-8.0
+# at 8.0.26-0ubuntu1~22.04.1 (USN-8176-1 fix), so no explicit `apt-get install` overrides are
+# required. Verified via `apt-get install` returning "0 upgraded, 0 newly installed" for these
+# packages on top of the upgraded layer (build run ca42, 2026-05-08).
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635); upgrade after requirements install
-# azureml-mlflow pins mlflow-skinny<=3.9.0, so mlflow must be upgraded separately to avoid resolution conflict
+# mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635, GHSA-fh64-r2vc-xvhr);
+# upgrade after requirements install. azureml-mlflow 1.62.0.post2 pins mlflow-skinny<=3.9.0,
+# so mlflow must be upgraded separately (post-pip-install) to avoid resolver conflict.
 RUN pip install --no-cache-dir mlflow==3.11.1
 # fastmcp + mcp were installed as regular deps of mlflow 3.5.0 (fastmcp→mcp) but orphaned after
 # mlflow 3.11.1 (fastmcp moved to optional "mcp" extra); uninstall both to remove vulnerable packages
 RUN pip uninstall -y fastmcp mcp
+
+# Override vulnerable transitive deps in the ptca env (Python 3.10) that pip won't auto-upgrade:
+# Mako: transitive dep (mlflow → alembic 1.18.4 → Mako); alembic 1.18.4 declares "Mako" with no
+#   version pin at all, so pip resolves to 1.3.10 which has GHSA-v92g-xgxw-vvmm. No parent
+#   release floors Mako >= 1.3.11, so explicit override is the only fix.
+# GitPython: transitive dep (mlflow → mlflow-skinny 3.11.1 requires gitpython<4,>=3.1.9); the
+#   loose floor lets pip resolve 3.1.46 which has GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4.
+#   mlflow-skinny has no release that pins gitpython>=3.1.47, so explicit override is required.
+# pytest: shipped by the ACPT base image (NOT pulled in by any package in requirements.txt nor
+#   any of their transitive deps; verified by inspecting requires_dist of mlflow, mlflow-skinny,
+#   azureml-mlflow, transformers, etc.). No parent package to bump — the base image pre-installs
+#   pytest 7.4.3 and the ACPT base hasn't been rebuilt with a fix yet, so explicit override
+#   to >=9.0.3 is required (GHSA-6w46-j5rx-g56g).
+RUN pip install --no-cache-dir --upgrade 'Mako>=1.3.11' 'GitPython>=3.1.47' 'pytest>=9.0.3'
 
 # Upgrade python-dotenv in the system Python(3.13)
 # python-dotenv: transitive dep via pydantic-settings (>=0.21.0 floor); parent uses loose floor so base resolves to

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
@@ -16,6 +16,11 @@ sentencepiece==0.2.1
 peft==0.17.1
 ninja==1.11.1.1
 kornia==0.7.3
+# python-dotenv: CVE-2026-28684 / GHSA-mf9w-mj56-hr94 (fixed in 1.2.2).
+# Parent transitive dep chain: mlflow-skinny -> python-dotenv<2,>=0.19.0.
+# mlflow-skinny 3.11.1 (latest) still uses the loose floor >=0.19.0, so a
+# parent upgrade alone resolves to 1.2.1. Direct pin retained until mlflow
+# tightens the floor to >=1.2.2.
 python-dotenv==1.2.2
 einops==0.8.0 
 mup==1.0.0 

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -17,8 +17,15 @@ RUN pip install -r requirements.txt --no-cache-dir
 # RUN mim install mmdet==2.28.2
 
 # Override transformers to fix GHSA-69w3-r845-3855 (CVE-2026-1839, arbitrary code execution in Trainer)
-# Root cause: azureml-acft-image-components pins transformers==4.53.0; cannot upgrade parent
-# Using --no-deps to avoid pulling incompatible transitive deps for the older HF stack
+# Root cause (verified 2026-05 via importlib.metadata against the built image):
+#   - requirements.txt line 8 directly pins `transformers==4.53.0` for compatibility with the
+#     pinned HF stack (accelerate==0.25.0, optimum==1.23.3, diffusers==0.24.0, peft==0.15.2).
+#   - azureml-acft-image-components==0.0.89 (current latest) only constrains transformers via
+#     optional extras (hf/all -> ==4.33.0; mip/mip3d -> >=4.40); none of those extras are
+#     activated in this image, so the parent does NOT block an upgrade.
+#   - Bumping the explicit requirements.txt pin to 5.x is a major-version jump that risks
+#     breaking the rest of the pinned HF stack and is out of scope for a CVE-only patch.
+# Using --no-deps to avoid pulling incompatible transitive deps for the older HF stack.
 RUN pip install --no-cache-dir --no-deps 'transformers==5.5.4'
 
 # vulnerability fixes - this will be removed once we update to MMTracking's latest version
@@ -33,6 +40,14 @@ RUN pip install numpy==1.23.5
 # https://github.com/open-mmlab/mmdetection/issues/10962
 RUN pip install yapf==0.40.1
 
-# python-dotenv 1.2.1 in system Python (3.13) needs upgrade to 1.2.2 (GHSA-mf9w-mj56-hr94, symlink overwrite);
-# transitive dep of mlflow-skinny (>=0.19.0,<2) and pydantic-settings (>=0.21.0) — parents use loose floors
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
+# python-dotenv 1.2.1 in system Python (3.13) needs upgrade to 1.2.2 (GHSA-mf9w-mj56-hr94, symlink overwrite).
+# Root cause (verified 2026-05 via importlib.metadata against /opt/conda py3.13):
+#   - python-dotenv is installed in the base /opt/conda env (py3.13) by the upstream
+#     base image, brought in transitively by anaconda-auth (no version constraint) and
+#     pydantic-settings (>=0.21.0); both parents accept any 1.x including 1.2.2.
+#   - No parent in /opt/conda blocks the upgrade, but neither parent has been re-released
+#     to require >=1.2.2 yet, so we must override here until the base image catches up.
+#   - The ptca conda env (py3.10) already gets 1.2.2 transitively via mlflow-skinny when
+#     requirements.txt is installed above, so this RUN only needs to fix the py3.13 env.
+# Bound the upgrade to the 1.x line to keep rebuilds reproducible without locking out future patches.
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2,<2'


### PR DESCRIPTION
This pull request focuses on improving container security and dependency management for several ACFT image training environments. The main changes address vulnerabilities in transitive dependencies by explicitly upgrading or pinning affected Python packages, clarifying the reasoning for each override, and ensuring both system and environment-specific Python installations are patched.

**Dependency vulnerability fixes and management:**

* Explicitly override and upgrade vulnerable packages (`python-dotenv`, `Mako`, `GitPython`, `pillow`, `pytest`, `onnx`, `fastmcp`, `pyasn1`) in various `Dockerfile`s to address known CVEs and GitHub security advisories, with detailed comments justifying each change and clarifying transitive dependency chains. [[1]](diffhunk://#diff-614d4f818759eed6c42c2234e3e4f8800ccb63137999925c15cac7519703f789L24-R31) [[2]](diffhunk://#diff-24bdf0db3018f96f42f479157adc29bb5acae2cc2103df7aa4e01ceaa0d6a80fL6-R39) [[3]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L13-R31)
* In `acft_image_medimageparse_finetune/context/requirements.txt`, directly pin `python-dotenv==1.2.2` to mitigate CVE-2026-28684 and GHSA-mf9w-mj56-hr94, with comments explaining the unresolved loose floor in `mlflow-skinny`.

**System Python environment patching:**

* Ensure the system `/opt/conda` Python 3.13 environment is directly patched for `python-dotenv` using a version-bound upgrade, with expanded comments explaining the root cause and compatibility considerations. [[1]](diffhunk://#diff-db501b51e7d3a3e3694d90f50b2593cf7fd66088c640bfbb2254fe15028f6cdfL36-R53) [[2]](diffhunk://#diff-07cfce7d5603c4d5efd0ae2c0686d67f07a0146692adada42ee41228f3da3021L13-R31)

**Transformers package update:**

* In the video MMTracking environment, update `transformers` to a secure version (`5.5.4`) using `--no-deps` to avoid incompatibilities with the existing HuggingFace stack, and clarify that the parent package does not block the upgrade.

**Base image and OS-level clarifications:**

* Add detailed comments in Dockerfiles documenting the current status of OS package upgrades (e.g., `openssh-client`, `dotnet-*`) and why no further explicit overrides are necessary, improving maintainability and auditability.