### PR TITLE
Fix acft-hf-nlp-gpu bitsandbytes 4-bit floor

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -13,6 +13,9 @@ COPY finetune_run.py /azureml/finetune/run.py
 # mpi4py 3.x uses distutils APIs removed in setuptools>=81; upgrade to 4.x which is compatible
 RUN pip install mpi4py==4.1.1 --no-cache-dir
 RUN pip install -r requirements.txt --no-cache-dir
+# Verify QLoRA dependencies in the ptca runtime env during image build.
+RUN /opt/conda/envs/ptca/bin/python -c "import bitsandbytes as bnb; print(bnb.__version__)" && \
+    /opt/conda/envs/ptca/bin/python -c "from transformers import BitsAndBytesConfig; print(BitsAndBytesConfig(load_in_4bit=True))"
 
 RUN pip install mlflow==3.11.1
 RUN python -m nltk.downloader punkt

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -14,7 +14,7 @@ diffusers==0.33.1
 onnxruntime==1.22.0
 rouge-score==0.1.2
 sacrebleu==2.4.0
-bitsandbytes==0.46.0
+bitsandbytes==0.46.1
 einops==0.7.0
 aiohttp>=3.13.5
 peft==0.18.0


### PR DESCRIPTION
## Summary

Bump the `acft-hf-nlp-gpu` curated environment's `bitsandbytes` pin from `0.46.0` to `0.46.1` and add a build-time smoke check that verifies the package is importable from the `ptca` runtime environment used by the image.

## Failure being fixed

FoundryCommandJob training block now generates a clean TRL SFT command and reaches the TRL runtime successfully, but QLoRA fails during model loading because Transformers 5 requires `bitsandbytes>=0.46.1` for 4-bit quantization.

- AzureML environment: `azureml://registries/azureml/environments/acft-hf-nlp-gpu`
- Latest tested version: `116`
- Runtime conda env: `/opt/conda/envs/ptca`
- Test job: `tb-trl-sft-gsm8k-qwen05b-0511222314-3d5fec`
- Run artifacts: `D:\git\WorkingBot\output\eastus2euap-training-submit-0511222314-3d5fec`
- Generated command:

```bash
trl sft --model_name_or_path '${{inputs.base_model}}' --dataset_name '${{inputs.train_data}}' --use_peft true --lora_r 16 --lora_alpha 32 --lora_dropout 0.05 --lora_target_modules auto --load_in_4bit true --eval_steps 50 --output_dir ./outputs/model
```

- Runtime failure:

```text
ImportError: Using `bitsandbytes` 4-bit quantization requires bitsandbytes: `pip install -U bitsandbytes>=0.46.1`
```

This is not a missing package from scratch: the image already pins `bitsandbytes==0.46.0`; the pin is just below the current Transformers 5 4-bit quantizer floor.

## Change

- Update `assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt` to pin `bitsandbytes==0.46.1`.
- Add Dockerfile smoke checks that execute with `/opt/conda/envs/ptca/bin/python`:
  - `import bitsandbytes as bnb; print(bnb.__version__)`
  - `from transformers import BitsAndBytesConfig; print(BitsAndBytesConfig(load_in_4bit=True))`

## Validation

- Ran local asset validation for the changed environment files:

```bash
python -u scripts/azureml-assets/azureml/assets/validate_assets.py -i assets -a asset.yaml -c "assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt,assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile" -d "" -n -I -C -b -t -e
```

- Expected PR validation: `environments-ci` builds/tests the changed image and runs the repository Trivy vulnerability scan step.

## Scope note

I checked the related GRPO image source (`assets/training/finetune_acft_hf_nlp/environments/acpt-grpo`). I did not include it in this PR because this failure is specifically from the `acft-hf-nlp-gpu` TRL SFT path, and I did not find a direct same-runtime `load_in_4bit` failure for GRPO in this scope.