### PR TITLE
Add Foundry tags to post-training curated environments

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/spec.yaml
@@ -14,3 +14,4 @@ os_type: linux
 
 tags:
   Preview: ""
+  Foundry: ""

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/spec.yaml
@@ -14,3 +14,4 @@ os_type: linux
 
 tags:
   Preview: ""
+  Foundry: ""

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/spec.yaml
@@ -20,6 +20,7 @@ tags:
   OS: Ubuntu24.04
   Training: ""
   Preview: ""
+  Foundry: ""
   Python: "3.10"
   slime: "THUDM"
   SGLang: "0.5.10.post1"


### PR DESCRIPTION
## Summary
- Add the AzureML environment metadata tag `Foundry` to the TRL curated environment `acft-hf-nlp-gpu`.
- Add the `Foundry` tag to the Verl/RFT curated environment `acft-rft-training`.
- Add the `Foundry` tag to the Slime curated environment `slime-pytorch-2.9-cuda12.8`.

## Notes
- Metadata-only change in environment `spec.yaml` files.
- No Dockerfile, package, or image layer changes.

## Validation
- `python -u scripts\azureml-assets\azureml\assets\validate_assets.py -i assets\training\finetune_acft_hf_nlp\environments -a asset.yaml -c <changed-specs> -n -I -C -b -t -e`
- `python -u scripts\azureml-assets\azureml\assets\validate_tree.py -i assets\training\finetune_acft_hf_nlp\environments`