### PR TITLE
Week 20 OOSLA image vulnerability fixes

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
@@ -44,6 +44,16 @@ ENV ENABLE_METADATA=true
 RUN conda install pip -n base -y 
 RUN conda install pip -n ptca -y
 
+# Security: upgrade pip in /opt/conda (base, py3.13) and /opt/conda/envs/ptca (py3.10)
+# to fix CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9 (vulnerable self-update behaviour in
+# pip < 26.1). The `conda install pip -n {base,ptca}` lines above resolve to
+# pip==26.0.1 from conda-forge, so an explicit follow-up pip upgrade is required.
+# pip is its own parent — no upstream package can ship a fixed pip — so explicit
+# upgrades are the only available remediation. Kept as its own RUN (no co-installed
+# packages) to avoid the documented pip self-upgrade race.
+RUN /opt/conda/bin/pip install --no-cache-dir --upgrade 'pip>=26.1' && \
+    /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade 'pip>=26.1'
+
 # begin conda create
 # Create conda environment
 RUN conda create -p $AZUREML_CONDA_ENVIRONMENT_PATH \
@@ -97,26 +107,44 @@ RUN pip list && \
 # Root cause: azureml-automl-dnn-nlp==1.62.0 (latest) pins transformers==4.53.0; cannot upgrade parent
 RUN pip install --no-cache-dir --no-deps 'transformers[sentencepiece,torch]==5.5.4'
 
-# Override transformers to fix GHSA-69w3-r845-3855
-# Root cause: azureml-automl-dnn-nlp==1.62.0 (latest) pins transformers==4.53.0; cannot upgrade parent
-RUN pip install --no-cache-dir --no-deps 'transformers[sentencepiece,torch]==5.5.4'
 
+# Security: upgrade pip to fix CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9 (vulnerable
+# self-update behaviour in pip < 26.1) in the AZUREML conda env. The `conda create`
+# above seeds the env with pip==26.0.1 from conda-forge. pip is its own parent —
+# no upstream package can bring in a patched pip — so an explicit upgrade is the
+# only remediation. Kept as its own RUN to avoid the pip self-upgrade race.
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1'
 
 # Upgrade starlette, urllib3, bokeh, PyNaCl & filelock
 # NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
 # Override onnx to fix GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6, GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m
 # Root cause: azureml-automl-runtime==1.62.0 (latest) pins onnx<=1.17.0; cannot upgrade parent
 RUN pip install --upgrade 'distributed>=2026.1.0' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'wheel>=0.46.2' 'bokeh>=3.8.2' 'onnx>=1.21.0'
-# Vulnerability patches for ptca environment
-# pytest override: GHSA-6w46-j5rx-g56g — from ACPT base image ptca env; base image not yet patched
-RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'filelock>=3.20.3' 'pillow>=12.1.1' 'cryptography>=46.0.5' 'protobuf>=6.33.5' 'wheel>=0.46.2' 'pytest>=9.0.3'
+
+# CLEANUP 2026-05-12: PTCA env package overrides removed because the ACPT base
+# image biweekly.202605.1 already ships:
+#   filelock 3.25.2 (>= 3.20.3), pillow 12.2.0 (>= 12.1.1),
+#   protobuf 7.34.1 (>= 6.33.5), wheel 0.46.3 (>= 0.46.2), pytest 9.0.3 (>= 9.0.3)
+# (verified by `pip show` in /opt/conda/envs/ptca on the base image). The previous
+# `cryptography>=46.0.5` override was also dropped — cryptography is not installed
+# in the PTCA env at all, so the override only added an unused package. If the
+# base image regresses any of these, restore the relevant overrides.
 # Fix vendored jaraco.context (GHSA-58pv-8j8x-9vj2) and wheel (GHSA-8rrh-rw8j-w5fx) in ptca/base setuptools
-# setuptools vendors jaraco.context internally; --force-reinstall --no-deps ensures vendored copies are replaced
+# setuptools vendors jaraco.context internally; --force-reinstall --no-deps ensures vendored copies are replaced.
+# Base image ships setuptools 82.0.0; we need 82.0.1 for the vendored fix, so override is retained.
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
-# Base env: fix cryptography, wheel, and setuptools vendored vulns
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-# aiohttp override: GHSA-63hf-3vf5-4wqf, GHSA-2vrm-gr82-f7m5, GHSA-c427-h43c-vf67, etc. — from ACPT base image; base image not yet patched
-RUN conda run -n base pip install --no-cache-dir --upgrade 'cryptography>=46.0.5' 'wheel>=0.46.2' 'PyJWT>=2.12.0' 'aiohttp>=3.13.4'
+
+# Security: python-dotenv 1.2.1 -> >=1.2.2 fixes GHSA-mf9w-mj56-hr94 (set_key()/
+# unset_key() follow symlinks on cross-device .env writes -> arbitrary file
+# overwrite). Lives in /opt/conda/lib/python3.13/site-packages of the BASE conda
+# env (shipped by the ACPT base image biweekly.202605.1). It is pulled in
+# transitively by anaconda-auth (Requires-Dist: python-dotenv with no version pin)
+# and pydantic-settings (python-dotenv>=0.21.0, via anaconda-cli-base ->
+# anaconda-auth). Latest releases on PyPI as of 2026-05-12 (anaconda-auth==0.14.4,
+# pydantic-settings==2.14.0) still use the same loose floors, so a parent upgrade
+# cannot force >=1.2.2 — direct override is the only remediation.
+RUN conda run -n base pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
+
 RUN /opt/conda/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
 
 RUN /bin/bash -c "source activate $AZUREML_CONDA_ENVIRONMENT_PATH && \

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/Dockerfile
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
-# Security: upgrade all OS packages to patch USN vulnerabilities (libssh, curl, openssl, etc.)
+# Pull in latest OS security updates on top of the base image
 RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
@@ -14,32 +14,45 @@ RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 # advisory requires >=5.0.0rc3; upgrading to latest stable 5.x
 RUN pip install transformers==5.5.4
 
-# mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635); upgrade after azureml packages
-# azureml-evaluate-mlflow → azureml-mlflow pins mlflow-skinny<=3.9.0, conflicting with mlflow 3.10.1
-# so mlflow must be upgraded separately to avoid pip resolution conflict
-RUN pip install --no-cache-dir mlflow==3.10.1
-
-# Upgrade transitive deps to fix vulnerabilities.
-# Packages already at safe versions in base image biweekly.202605.1 (pip, wheel, setuptools,
-# aiohttp, requests, urllib3, onnx, pillow, filelock, pytest) are NOT overridden here.
-# protobuf: mlflow-skinny requires <7; base has 7.34.1 so we must pin <7 (GHSA fix >=6.33.5)
-# cryptography: not in ptca env; installed transitively by azureml-mlflow (<47.0.0 constraint)
-# ray: GHSA-q5fh-2hc8-f6rq; also bundles log4j-core 2.25.3 in JARs (patched below)
-# azure-core, cbor2, jaraco.context, PyJWT: transitive deps with loose floors
-# nltk: GHSA-gfwx-w7gr-fvh7; pyasn1/python-multipart/xgrammar: CVE floors
-# mlflow: azureml-mlflow pins mlflow-skinny<=3.9.0; override needed
-# vllm: GHSA-pq5c-rjhq-qp7p, GHSA-3mwp-wvh9-7528, GHSA-6c4r-fmh3-7rh8 (librosa LFE); >=0.20.1 required
-#   vllm is a top-level dep in requirements.txt; pin floor here as a safety net
-# pyOpenSSL: GHSA-vp96-hxj8-p424, GHSA-5pwr-322w-8jr4; >=26.0.0 required
-#   azureml-core 1.61.0.post3 pins pyopenssl<26.0.0; no newer azureml-core available (2026-05-04)
-RUN pip install --upgrade 'protobuf>=6.33.5,<7' 'cryptography>=46.0.7,<47' 'xgrammar>=0.1.32' \
+# Security floors for transitive deps that the base image / parent packages do not pin tightly.
+# Removed pins (now redundant against base image biweekly.202605.1 + parent constraints):
+#   cryptography  - azureml-mlflow already constrains <47.0.0 -> pip resolves to 46.0.7 (safe)
+#   azure-core    - azureml-mlflow constrains >=1.8.0,<2.0.0  -> pip resolves to latest 1.41.x
+#   PyJWT         - azureml-core constrains <3.0.0 and base ships 2.12.1 (>= floor)
+#   jaraco.context - base env ships 6.1.0 (= floor); ptca env resolves naturally to 6.1.x
+#   cbor2         - vllm depends on cbor2 unconstrained; pip picks current latest 6.x
+# Remaining floors below are still required because the parent's resolved version is at or near
+# the vulnerability boundary, or the parent package itself ships a vulnerable version:
+# protobuf:        mlflow-skinny requires <7; base ships 7.34.1 so pin <7 (GHSA fix >=6.33.5)
+# ray:             GHSA-q5fh-2hc8-f6rq; also bundles log4j-core 2.25.3 in JARs (patched below)
+# nltk:            GHSA-gfwx-w7gr-fvh7
+# pyasn1, python-multipart, xgrammar: CVE floors (no parent that pins them safely)
+# mlflow:          azureml-mlflow pins mlflow-skinny<=3.9.0; explicit upgrade required to clear
+#                  CVE-2025-14287, CVE-2026-2033, CVE-2026-2635
+# vllm:            GHSA-pq5c-rjhq-qp7p, GHSA-3mwp-wvh9-7528, GHSA-6c4r-fmh3-7rh8 (librosa LFE)
+# pyOpenSSL:       GHSA-vp96-hxj8-p424, GHSA-5pwr-322w-8jr4; azureml-core 1.61.0.post3 pins
+#                  pyopenssl<26.0.0 and no newer azureml-core release exists (verified 2026-05-14),
+#                  so explicit override is the only remediation.
+RUN pip install --upgrade 'protobuf>=6.33.5,<7' 'xgrammar>=0.1.32' \
     'nltk>=3.9.4' 'pyasn1>=0.6.3' 'python-multipart>=0.0.22' 'ray>=2.55.0' \
-    'azure-core>=1.38.0' 'cbor2>=5.9.0' 'jaraco.context>=6.1.0' 'PyJWT>=2.12.0' \
     'mlflow>=3.8.1,<4.0.0' 'vllm>=0.20.1' 'pyOpenSSL>=26.0.0'
+# pip: GHSA-jp4c-xjxw-mgf9 (CVE-2026-6357); base image biweekly.202605.1 ships 26.0.1 in
+# both ptca (py3.10) and base (py3.13) conda envs, fixed in 26.1. pip is the Python
+# package installer itself — it has NO parent/transitive package that pulls it in
+# (it is bootstrapped by the conda/python distribution), so the only available
+# remediation is to upgrade pip directly in each conda environment.
+# Also remove stale conda-meta/pip-*.json from ptca env: `pip install --upgrade pip`
+# replaces the on-disk pip files but does NOT update conda's metadata DB, so SBOM
+# scanners that read conda-meta still report the old pip version.
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1.1' && \
+    rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json
 RUN rm -rf ~/.cache/pip
 # python-dotenv in base conda env: GHSA-mf9w-mj56-hr94; base ships 1.2.1, need >=1.2.2
 #   parent packages: uvicorn (>=0.13), pydantic-settings (>=0.21.0) — both use loose floors
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
+# pip: see note above — bootstrap tool, must be upgraded directly in base env too
+# Also clean stale conda-meta/pip-*.json (see ptca env note above for scanner detail).
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'pip>=26.1.1' 'python-dotenv>=1.2.2' && \
+    rm -f /opt/conda/conda-meta/pip-26.0*.json
 # ray vendors aiohttp for runtime_env agent under thirdparty_files; patch that copy too.
 RUN rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files/aiohttp* && \
     pip install --no-cache-dir --target /opt/conda/envs/ptca/lib/python3.10/site-packages/ray/__private/runtime_env/agent/thirdparty_files 'aiohttp==3.13.5'

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-grpo/context/requirements.txt
@@ -1,5 +1,4 @@
 azureml-acft-contrib-hf-nlp=={{latest-pypi-version}}
-pillow==12.1.1
 accelerate==1.6.0
 datasets==3.6.0
 deepspeed==0.17.1
@@ -9,4 +8,3 @@ vllm==0.20.1
 peft==0.15.2
 mlflow==3.10.1
 numpy==2.2.5
-filelock>=3.20.3

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
@@ -3,37 +3,44 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest
 
 USER root
 
-# Install unzip and upgrade OS packages to fix vulnerabilities
+# Install unzip and upgrade OS packages to fix vulnerabilities.
+# `apt-get -y upgrade` against the current ACPT base image (biweekly.202605.1) already pulls
+# dotnet-{host,hostfxr,runtime}-8.0 to 8.0.26-0ubuntu1~22.04.1 (USN-8176-1 fix), so no
+# explicit `apt-get install` overrides are required.
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# pip 26.0.1 in both the ptca conda env (Python 3.10) and the /opt/conda base env (Python 3.13)
+# has GHSA-jp4c-xjxw-mgf9 (fixed in pip>=26.1). pip is the bootstrap installer — no Python
+# package in requirements.txt or any of their transitive deps declares pip as a runtime dep
+# (verified against requires_dist of azureml-acft-*, mlflow, mlflow-skinny, transformers,
+# torch, etc.), so an upstream parent-package upgrade is not possible. The conda `defaults`
+# channel only has up to pip 26.0.1 (conda-forge has 26.1.1 but is not enabled in the base
+# image), so `conda install pip==26.1.1` fails — we use `pip install --upgrade` (from PyPI)
+# and then explicitly remove the stale conda-meta JSON for pip 26.0.1 so the SBOM scanner
+# does not re-flag it. Done before pip-installing requirements so all subsequent installs
+# use the patched pip.
+RUN pip install --no-cache-dir --upgrade 'pip==26.1.1' && \
+    rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json && \
+    /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'pip==26.1.1' && \
+    rm -f /opt/conda/conda-meta/pip-26.0*.json
 
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# protobuf is a transitive dep of mlflow-skinny/onnx; parents use loose floors (>=3.12.0), cannot force 6.33.5
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
-# setuptools vendors jaraco.context internally; >=82.0.1 bundles the patched version (GHSA-58pv-8j8x-9vj2)
-
-# pip install updates the binary but conda-meta still references old versions; conda install syncs both
-RUN conda install -y -n ptca pip>=26.0.1 wheel>=0.46.2
-
-# Fix vulnerabilities from base image transitive deps
-# skops 0.11.0 → ≥0.13.0 (CVE-2025-54412, CVE-2025-54413, CVE-2025-54886 — arbitrary code execution)
-#   Required-by: mlflow; all mlflow versions (up to 3.11.0rc0) specify skops<1 with no minimum,
-#   so no mlflow upgrade can fix this — explicit override is required.
-# wheel ≥0.46.2 via pip as fallback in case conda version lags (CVE-2026-24049)
-# cryptography (GHSA-m959-cc7f-wv43, GHSA-p423-j2cm-9vmq): azureml-mlflow pins <46.0.0; override to 46.0.6
-# aiohttp: transitive dep of azure-core; parents use loose floors (GHSA-mwh4-6h8g-pg8w etc.)
-# onnx: transitive dep of onnxruntime; parent uses onnx>=1.16.0; override needed (GHSA-p433-9wv8-28xj etc.)
-# requests: transitive dep of azure-core/mlflow; parents use loose floors (GHSA-gc5v-m9x4-r6x2)
-# pytest comes from the base ACPT image (not a transitive dep of any requirements.txt package);
-# no parent package to upgrade — explicit override required (GHSA-6w46-j5rx-g56g)
-# Mako: transitive dep of mlflow → alembic → Mako; alembic uses loose floor (no version pin),
-# so upgrading mlflow/alembic won't force >=1.3.11 — explicit override required (GHSA-v92g-xgxw-vvmm)
-RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade 'skops>=0.13.0' 'wheel>=0.46.2' \
-    cryptography==46.0.7 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0' 'pytest>=9.0.3' \
-    'Mako>=1.3.11'
-
-# Upgrade requests, urllib3, aiohttpin the system Python (3.13) for fixing vulnerability
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade pip==26.0 wheel==0.46.2 'setuptools>=82.0.1' cryptography==46.0.7 'PyJWT>=2.12.0' 'aiohttp>=3.13.4' 'onnx>=1.21.0' 'requests>=2.33.0'
+# Override vulnerable transitive deps in the ptca env (Python 3.10) that pip won't auto-upgrade:
+# Mako: transitive dep (mlflow → alembic 1.18.4 → Mako); alembic 1.18.4 declares "Mako" with no
+#   version pin at all, so pip resolves to 1.3.10 which has GHSA-v92g-xgxw-vvmm. No parent
+#   release floors Mako >= 1.3.11, so explicit override is the only fix.
+# GitPython: transitive dep (mlflow → mlflow-skinny 3.11.1 requires gitpython<4,>=3.1.9); the
+#   loose floor lets pip resolve 3.1.46 which has GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4.
+#   mlflow-skinny has no release that pins gitpython>=3.1.47, so explicit override is required.
+# pytest: shipped by the ACPT base image (NOT pulled in by any package in requirements.txt nor
+#   any of their transitive deps; verified by inspecting requires_dist of mlflow, mlflow-skinny,
+#   transformers, azureml-acft-*, etc.). No parent package to bump — the base image pre-installs
+#   pytest 7.4.3 and the ACPT base hasn't been rebuilt with a fix yet, so explicit override
+#   to >=9.0.3 is required (GHSA-6w46-j5rx-g56g).
+# skops: transitive dep (mlflow → mlflow-skinny 3.11.1 requires skops<1 with no minimum), pip
+#   resolves to 0.11.0 which has CVE-2025-54412/54413/54886 (arbitrary code execution).
+#   mlflow-skinny has no release that bumps the floor, so explicit override is required.
+RUN pip install --no-cache-dir --upgrade 'Mako>=1.3.11' 'GitPython>=3.1.47' 'pytest>=9.0.3' 'skops>=0.13.0'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/requirements.txt
@@ -21,7 +21,7 @@ tenacity==9.0.0
 timm==1.0.13
 tornado>=6.5.5
 transformers==5.0.0
-setuptools>=82.0.0
+setuptools>=82.0.1
 filelock>=3.20.1
 pillow>=12.1.1
 # protobuf 6.33.4 has CVE-2026-0994 (HIGH 8.6); transitive dep from mlflow -> mlflow-skinny (requires >=3.12.0,<7)

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
@@ -7,6 +7,42 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# pip 26.0.1 in ptca env (GHSA-jp4c-xjxw-mgf9, fixed in pip>=26.1) — verified
+# present via probe of base biweekly.202605.1 (2026-05-14). pip is a build/install
+# tool with no parent Python package, so an upstream parent upgrade is not
+# possible. The conda `defaults` channel only ships up to pip 26.0.1, so we use
+# `-c conda-forge` (which has 26.1.1) to keep conda-meta and the /opt/conda/pkgs
+# cache in sync; we also delete stray pip-26.0*.dist-info / conda-meta entries
+# from prior pip-self-upgrades that conda does not track, otherwise the SBOM
+# scanner re-flags them. Done before COPY requirements.txt so requirements and
+# detectron2 use the patched pip.
+RUN conda install -y -n ptca -c conda-forge pip==26.1.1 && \
+    rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/pip-26.0*.dist-info && \
+    rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json && \
+    conda clean -ay
+
+# Base conda env (python 3.13) ships two vulnerable packages independent of the
+# ptca env; both confirmed via base-image probe of biweekly.202605.1 (2026-05-14):
+#   - pip 26.0.1 at /opt/conda/lib/python3.13/site-packages/pip-26.0.1.dist-info
+#     (GHSA-jp4c-xjxw-mgf9, fixed in pip>=26.1) — pip is a tool, no parent
+#     upgrade possible.
+#   - python-dotenv 1.2.1 at
+#     /opt/conda/lib/python3.13/site-packages/python_dotenv-1.2.1.dist-info
+#     (GHSA-mf9w-mj56-hr94, fixed in 1.2.2). Parent dependents in this env are
+#     `anaconda-auth` (unpinned `python-dotenv`) and `pydantic-settings`
+#     (`python-dotenv>=0.21.0`) — both are loose floors, so even latest parents
+#     resolve back to 1.2.1. Direct override required until either a) the base
+#     ACPT image refreshes to ship python-dotenv>=1.2.2, or b) one of the
+#     parents tightens its floor to >=1.2.2.
+# python-dotenv in the base env is pip-managed (not conda-managed), so we use
+# `python3.13 -m pip install --upgrade` and then remove the stale dist-info
+# directories left by the in-place pip self-upgrade so the SBOM scanner does
+# not re-flag them.
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade \
+        'pip==26.1.1' 'python-dotenv>=1.2.2' && \
+    rm -rf /opt/conda/lib/python3.13/site-packages/pip-26.0*.dist-info && \
+    rm -rf /opt/conda/lib/python3.13/site-packages/python_dotenv-1.2.1.dist-info
+
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 RUN pip install --no-build-isolation git+https://github.com/facebookresearch/detectron2.git@a1ce2f9

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
@@ -16,11 +16,11 @@ sentencepiece==0.2.1
 peft==0.17.1
 ninja==1.11.1.1
 kornia==0.7.3
-# python-dotenv: CVE-2026-28684 / GHSA-mf9w-mj56-hr94 (fixed in 1.2.2).
-# Parent transitive dep chain: mlflow-skinny -> python-dotenv<2,>=0.19.0.
-# mlflow-skinny 3.11.1 (latest) still uses the loose floor >=0.19.0, so a
-# parent upgrade alone resolves to 1.2.1. Direct pin retained until mlflow
-# tightens the floor to >=1.2.2.
+# python-dotenv: GHSA-mf9w-mj56-hr94 (fixed in 1.2.2). In the ptca env the only
+# transitive parent is mlflow-skinny (`python-dotenv<2,>=0.19.0`); latest
+# mlflow-skinny 3.12.0 (verified on PyPI 2026-05-14) still uses that loose
+# floor, so a parent-only upgrade resolves to 1.2.1. Direct pin retained until
+# mlflow-skinny tightens the floor to >=1.2.2.
 python-dotenv==1.2.2
 einops==0.8.0 
 mup==1.0.0 


### PR DESCRIPTION
Updates Dockerfiles and requirements for the following environment images:

- ai-ml-automl-dnn-text-gpu

- acpt-grpo

- acft_image_medimageinsight_embedding_generator

- acft_image_medimageparse_finetune