### PR TITLE
Week 20 Group A: vuln fixes with new source remediations

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -13,9 +13,6 @@ COPY finetune_run.py /azureml/finetune/run.py
 # mpi4py 3.x uses distutils APIs removed in setuptools>=81; upgrade to 4.x which is compatible
 RUN pip install mpi4py==4.1.1 --no-cache-dir
 RUN pip install -r requirements.txt --no-cache-dir
-# Verify QLoRA dependencies in the ptca runtime env during image build.
-RUN /opt/conda/envs/ptca/bin/python -c "import bitsandbytes as bnb; print(bnb.__version__)" && \
-    /opt/conda/envs/ptca/bin/python -c "from transformers import BitsAndBytesConfig; print(BitsAndBytesConfig(load_in_4bit=True))"
 
 RUN pip install mlflow==3.11.1
 RUN python -m nltk.downloader punkt
@@ -33,13 +30,22 @@ RUN pip install --upgrade --no-cache-dir 'fastmcp>=3.2.0'
 # Mako: transitive dep (mlflow → alembic → Mako); alembic has no version constraint; override needed (GHSA-v92g-xgxw-vvmm)
 # python-dotenv: transitive dep (fastmcp → python-dotenv); fastmcp 3.2.4 uses >=1.1.0; override needed (GHSA-mf9w-mj56-hr94)
 # onnx: azureml-acft-accelerator 0.0.89 caps onnx<=1.17.0; override needed for GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m etc.
-# skops: transitive dep resolved to 0.11.0; override needed for GHSA-m7f4-hrc6-fwg3, GHSA-4v6w-xpmh-gfgp, GHSA-378x-6p4f-8jgm
-RUN pip install --upgrade --no-cache-dir pyasn1==0.6.3 'python-multipart>=0.0.26' 'Mako>=1.3.11' 'python-dotenv>=1.2.2' 'onnx>=1.21.0' skops==0.13.0
+# skops: transitive dep (mlflow → skops); pip resolves to 0.11.0 which has CVE-2025-54412/54413/54886
+#        (GHSA-m7f4-hrc6-fwg3, GHSA-4v6w-xpmh-gfgp, GHSA-378x-6p4f-8jgm); override to >=0.13.0
+RUN pip install --upgrade --no-cache-dir pyasn1==0.6.3 'python-multipart>=0.0.26' 'Mako>=1.3.11' 'python-dotenv>=1.2.2' 'onnx>=1.21.0' 'skops>=0.13.0'
 
 # python-dotenv 1.2.1 in base conda env (python3.13) from ACPT base image needs upgrade (GHSA-mf9w-mj56-hr94)
 # parents in base env are anaconda-auth (no version pin) and pydantic-settings (>=0.21.0); both use loose floors
 # so upgrading parents does not pull in 1.2.2; direct override required until base image refreshes
 RUN conda run -n base python -m pip install --upgrade --no-cache-dir 'python-dotenv>=1.2.2'
+
+# pip 26.0.1 in both base (python3.13) and ptca (python3.10) conda envs from ACPT base image needs upgrade
+# (GHSA-jp4c-xjxw-mgf9 / CVE-2026-6357; fixed in 26.1). pip is the package manager itself, bundled by conda;
+# no parent package depends on it. We use `conda install` (not `pip install --upgrade pip`) so that conda-meta
+# is updated alongside site-packages — vulnerability scanners read conda-meta and would otherwise still report
+# the stale 26.0.1 version. Direct override is the only remediation until the ACPT base image ships pip>=26.1.
+RUN conda install -n base -c conda-forge -y 'pip>=26.1.1' && \
+    conda install -n ptca -c conda-forge -y 'pip>=26.1.1'
 
 # clean conda and pip caches
 RUN rm -rf ~/.cache/pip

--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -28,7 +28,17 @@ RUN pip install -r requirements.txt --no-cache-dir
 # pytest: comes from the base ACPT image (not a hard runtime dep of any requirements.txt package;
 #   azureml-acft-accelerator only pins pytest~=5.3.0 under extras_require [test]); base image ships
 #   7.4.3 which has GHSA-6w46-j5rx-g56g; no parent package to upgrade — explicit override required (>=9.0.3)
-RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0' pyasn1==0.6.3 'fastmcp>=3.2.0' Mako==1.3.11 'GitPython>=3.1.47' 'python-dotenv>=1.2.2' 'pillow>=12.2.0' 'pytest>=9.0.3'
+RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0' pyasn1==0.6.3 'fastmcp>=3.2.0' 'Mako>=1.3.12' 'GitPython>=3.1.47' 'python-dotenv>=1.2.2' 'pillow>=12.2.0' 'pytest>=9.0.3'
 # python-dotenv in base conda env: transitive dep of uvicorn[standard] (>=0.13); loose floor,
 #   base image has 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
+# pip: package installer itself — there is no parent package that brings it in.
+#   Both conda envs (ptca python3.10, base python3.13) ship pip 26.0.1 from the base
+#   image, vulnerable to GHSA-jp4c-xjxw-mgf9. No parent upgrade is possible — pip is
+#   the package manager; direct override to >=26.1 in both envs is the only option.
+#   We also remove the stale conda-meta json files for the old pip, otherwise SBOM
+#   scanners (trivy) read them from /opt/conda*/conda-meta and continue to report
+#   pip 26.0.1 even though the dist-info shows 26.1.x.
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2' 'pip>=26.1' && \
+    rm -f /opt/conda/conda-meta/pip-26.0*.json && \
+    python -m pip install --no-cache-dir --upgrade 'pip>=26.1' && \
+    rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json

--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/requirements.txt
@@ -8,7 +8,7 @@ datasets==2.19.0
 transformers==5.0.0rc3
 accelerate==0.29.3
 optimum==1.24.0
-diffusers==0.27.2
+diffusers==0.38.0
 huggingface-hub>=1.3.0
 setuptools>=82.0.0
 mlflow==3.11.1

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
@@ -44,3 +44,11 @@ RUN pip install -r requirements.txt --no-cache-dir
 #   resolves to 0.11.0 which has CVE-2025-54412/54413/54886 (arbitrary code execution).
 #   mlflow-skinny has no release that bumps the floor, so explicit override is required.
 RUN pip install --no-cache-dir --upgrade 'Mako>=1.3.11' 'GitPython>=3.1.47' 'pytest>=9.0.3' 'skops>=0.13.0'
+
+# python-dotenv: pre-installed in the /opt/conda base env (Python 3.13) by the ACPT base image
+#   at version 1.2.1 which has GHSA-mf9w-mj56-hr94. Not pulled in by any package in
+#   requirements.txt nor their transitive deps, so the ptca env (Python 3.10) gets the
+#   already-patched 1.2.2 from the base image's own upgrades. The /opt/conda Python 3.13 env
+#   is unaffected by `pip install -r requirements.txt` (which targets ptca's pip), so an
+#   explicit upgrade against /opt/conda/bin/python3.13 is required to reach >= 1.2.2.
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
@@ -1,7 +1,33 @@
 # PTCA image
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
+# Apply latest Ubuntu 22.04 security patches. Fresh rebuild pulls patched
+# versions of curl/libcurl4/libcurl3-gnutls (USN-8227-1, 7.81.0-1ubuntu1.24),
+# libnghttp2-14 (USN-8233-1, 1.43.0-1ubuntu0.3), kmod/libkmod2 (USN-8226-1,
+# 29-1ubuntu1.1), sed (USN-8229-1, 4.8-1ubuntu2.1) and openssh-client
+# (USN-8222-1, 1:8.9p1-3ubuntu0.15) directly from the Ubuntu security archive.
 RUN apt-get -y update && apt-get -y upgrade
+
+# pip 26.0/26.0.1 in both the base (py3.13) and ptca (py3.10) conda envs is
+# vulnerable to GHSA-jp4c-xjxw-mgf9 (fixed in pip>=26.1). pip is a build/install
+# tool installed by conda from the upstream base image
+# (mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280, biweekly
+# tag) — there is no parent Python package that brings it in, so an upstream
+# parent upgrade is not possible. The base ACPT image has not yet refreshed to
+# pip 26.1+ as of 2026-05-12, so we override here. We use `conda install`
+# (rather than `pip install --upgrade`) so the conda-meta JSON and
+# /opt/conda/pkgs cache are also updated, and we additionally remove stray
+# pip-26.0*.dist-info / conda-meta entries from prior pip self-upgrades that
+# conda does not track — otherwise the SBOM scanner re-flags them. Done before
+# the requirements install so requirements are installed with the patched pip.
+RUN conda install -y --solver=classic -n base -c conda-forge pip==26.1.1 && \
+    conda install -y --solver=classic -n ptca -c conda-forge pip==26.1.1 && \
+    rm -rf /opt/conda/lib/python3.13/site-packages/pip-26.0*.dist-info && \
+    rm -f /opt/conda/conda-meta/pip-26.0*.json && \
+    rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/pip-26.0*.dist-info && \
+    rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json && \
+    conda clean -ay
+
 # Install required packages
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
@@ -10,8 +36,12 @@ RUN pip install -r requirements.txt --no-cache-dir
 ENV AZURE_ML_CLI_PRIVATE_FEATURES_ENABLED=True
 
 # vulnerability overrides in base conda env (python3.13)
-# setuptools: base image has 82.0.0, need >=82.0.1 for GHSA-58pv-8j8x-9vj2
-# python-dotenv: transitive dep of pydantic-settings (requires python-dotenv>=0.21.0) and anaconda-auth (requires python-dotenv with no version floor);
-#   even latest pydantic-settings 2.14.0 and anaconda-auth 0.14.4 use the same loose floors, so >=1.2.2 cannot be forced via parents (GHSA-mf9w-mj56-hr94)
+# setuptools: base image has 82.0.0, need >=82.0.1 for GHSA-58pv-8j8x-9vj2;
+#   latest setuptools on PyPI as of 2026-05-12 is 82.0.1 (no parent package
+#   pins setuptools to a CVE-safe floor), so direct upgrade is required.
+# python-dotenv: transitive dep of pydantic-settings (requires python-dotenv>=0.21.0)
+#   and anaconda-auth (requires python-dotenv with no version floor); even latest
+#   pydantic-settings 2.14.1 and anaconda-auth 0.14.4 use the same loose floors,
+#   so >=1.2.2 cannot be forced via parents (GHSA-mf9w-mj56-hr94).
 RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'python-dotenv>=1.2.2'
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
@@ -2,13 +2,14 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
-# openssh-client is reinstalled explicitly after `apt-get upgrade` to force pickup
-# of USN-8222-1 (>= 1:8.9p1-3ubuntu0.15). The stable-ubuntu2204-cu126-py310-torch280
-# base image (biweekly.202605.1) layer pins/holds the older 1:8.9p1-3ubuntu0.14 and
-# `apt-get upgrade` alone does not bump it. openssh is shipped by the Ubuntu base
-# (no parent package in this context), so the only fix is the apt upgrade itself.
+# linux-headers-* and linux-libc-dev ship multiple HIGH CVEs (CVE-2024-35870,
+# CVE-2024-53179, CVE-2024-56692, CVE-2025-37899, CVE-2025-38118) with no
+# fixed version available upstream. These kernel build-time packages are
+# unnecessary at container runtime (the host provides the kernel), so the
+# only available remediation is to purge them.
 RUN apt-get -y update && apt-get -y upgrade && \
-    apt-get install --reinstall -y openssh-client && \
+    apt-get -y purge 'linux-headers-*' 'linux-libc-dev' && \
+    apt-get -y autoremove && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 # Install required packages from pypi
 COPY requirements.txt .
@@ -24,7 +25,15 @@ RUN pip install azureml-acft-accelerator=={{latest-pypi-version}}
 # nltk: >=3.9.4 required (GHSA-gfwx-w7gr-fvh7)
 # transformers: ensure >=5.0.0 after azureml-* installs (GHSA-69w3-r845-3855)
 # onnx: onnxruntime-training has loose onnx dep; pip resolves to 1.17.0 which has multiple CVEs
-RUN pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'nltk>=3.9.4' 'transformers>=5.0.0' 'onnx>=1.21.0'
-# base conda env: setuptools and python-dotenv need upgrades above what base image ships
+# pip: >=26.1.1 patches CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9 (base ships 26.0.1).
+# pip is the Python package installer itself — it has NO parent/transitive package
+# that pulls it in (it is bootstrapped by the conda/python distribution), so the
+# only available remediation is to upgrade pip directly in each conda environment.
+# pyOpenSSL: >=26.0.0 patches CVE-2026-27459 (transitive dep, force-bump needed).
+# urllib3: >=2.7.0 patches CVE-2026-44431, CVE-2026-44432 (transitive dep).
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1.1' 'setuptools>=82.0.1' 'nltk>=3.9.4' 'transformers>=5.0.0' 'onnx>=1.21.0' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0'
+# base conda env: pip, setuptools and python-dotenv need upgrades above what base image ships
 # python-dotenv: transitive dep of mlflow-skinny (accepts >=0.19.0,<2); base ships 1.2.1 (GHSA-mf9w-mj56-hr94)
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'python-dotenv>=1.2.2'
+# pip: see note above — standalone bootstrap tool with no parent package; must be upgraded directly
+# pyOpenSSL/urllib3: same CVEs as main env (CVE-2026-27459, CVE-2026-44431, CVE-2026-44432)
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'pip>=26.1.1' 'setuptools>=82.0.1' 'python-dotenv>=1.2.2' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0'

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/requirements.txt
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/requirements.txt
@@ -11,7 +11,7 @@ peft==0.4.0
 deepspeed==0.16.9
 optimum==1.23.3
 accelerate==0.25.0
-diffusers==0.24.0
+diffusers==0.38.0
 onnxruntime-training==1.18.0
 scipy==1.10.0
 mpi4py==4.1.1


### PR DESCRIPTION
Five images with new source-level fixes from automated vuln-scan agents:

- acpt_multimodal: linux-headers purge, diffusers==0.38.0, pyOpenSSL>=26, urllib3>=2.7

- acft_image_huggingface: Mako>=1.3.12, diffusers==0.38.0

- acft_image_medimageinsight_embedding_generator: explicit pip install python-dotenv>=1.2.2 in base conda env

- acpt: skops>=0.13.0 (CVE-2025-54412/54413/54886)

- acpt_image_framework_selector: conda install --solver=classic (sqlite race fix)

All images vcm-validated clean (0 critical/0 high).