### PR TITLE
Week 20 Group A2: retry vuln fixes with new source remediations

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
@@ -10,12 +10,17 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 
 # Inference requirements
 COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20250310.v1 /artifacts /var/
-# USN-8222-1 (CVE-2026-35385/35386/35387/35388/35414): openssh-client must be
-# >= 1:8.9p1-3ubuntu0.15. openssh-client is shipped by the Ubuntu 22.04 ACPT base
-# image (no pip parent in this asset's context); the only fix path is the OS package
-# manager. `apt-get upgrade` alone has been observed to leave the held openssh
-# version in place when an older base layer is cached, so reinstall openssh-client
-# explicitly to force pickup of the patched version. Only openssh-client is
+# OS security upgrades against the Ubuntu 22.04 ACPT base image
+# (mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:latest); these are
+# all OS packages with no pip parent, so the apt package manager is the only fix path.
+#   USN-8222-1 (CVE-2026-35385/35386/35387/35388/35414): openssh-client >= 1:8.9p1-3ubuntu0.15
+#   USN-8226-1: kmod, libkmod2 >= 29-1ubuntu1.1
+#   USN-8227-1: curl, libcurl4, libcurl3-gnutls >= 7.81.0-1ubuntu1.24
+#   USN-8229-1: sed >= 4.8-1ubuntu2.1
+#   USN-8233-1: libnghttp2-14 >= 1.43.0-1ubuntu0.3
+# `apt-get upgrade -y` covers all of the above except openssh-client — that one has
+# been observed to stay at the held version when an older base layer is cached, so
+# reinstall it explicitly to force pickup of the patched build. Only openssh-client is
 # pre-installed in this base image — openssh-server / openssh-sftp-server are not
 # present (and would pull in systemd and fail postinst inside docker build).
 RUN apt-get update && \
@@ -50,21 +55,34 @@ RUN conda install pip -n ptca -y
 
 # Create conda environment
 # begin conda create
-RUN conda create -p $AZUREML_CONDA_ENVIRONMENT_PATH \
-    python=3.10 \
-    # begin conda dependencies
-    pip \
-    numpy~=1.23.5\
-    libffi=3.4.4 \
-    pycocotools=2.0.4 \
-    shap=0.39.0 \
-    llvmlite=0.39.1 \
-    scipy=1.10.1 \
-    setuptools=82.0.1 \
-    wheel=0.46.2 \
-    tbb=2021.1.1 \
-    # end conda dependencies
-    -c conda-forge -c cerebis && \
+# Retry conda create up to 3 times to tolerate transient repodata sqlite cache locks
+# observed when many builds run in parallel on a shared docker daemon.
+RUN for i in 1 2 3; do \
+        conda create -p $AZUREML_CONDA_ENVIRONMENT_PATH \
+            python=3.10 \
+            # begin conda dependencies
+            # pip=26.1.1 (CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9): pin the patched pip at env-create
+            # time so that (a) all subsequent pip installs in this env run under the fixed pip
+            # rather than the vulnerable 26.0.x picked by conda's default resolver, and (b) the
+            # conda-meta record for pip in $AZUREML_CONDA_ENVIRONMENT_PATH/conda-meta/ is
+            # written for 26.1.1, avoiding the stale-conda-meta scanner false positive that the
+            # base/ptca envs work around with `rm /opt/conda*/conda-meta/pip-26.0.*.json`. pip
+            # is its own parent (no upstream pypi/conda package can pull a fixed pip via dependency
+            # resolution), so an explicit pin is the only remediation path.
+            pip=26.1.1 \
+            numpy~=1.23.5 \
+            libffi=3.4.4 \
+            pycocotools=2.0.4 \
+            shap=0.39.0 \
+            llvmlite=0.39.1 \
+            scipy=1.10.1 \
+            setuptools=82.0.1 \
+            wheel=0.46.2 \
+            tbb=2021.1.1 \
+            # end conda dependencies
+            -c conda-forge -c cerebis -y && break || \
+        { echo "conda create attempt $i failed, retrying..."; rm -rf /opt/conda/pkgs/cache/*; sleep 10; }; \
+    done && \
     conda clean -a -y
 # end conda create
 
@@ -101,7 +119,7 @@ RUN pip install --no-cache-dir \
 RUN pip install --no-cache-dir --upgrade \
                 'cryptography>=46.0.5' \
                 'distributed>=2026.1.0' \
-                'mlflow-skinny>=2.16.0' \ 
+                'mlflow-skinny>=2.16.0' \
                 'bokeh>=3.8.2' \
                 'pillow==12.2.0' \
                 'onnx>=1.21.0'

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
@@ -2,6 +2,40 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 USER root
 
+# Apply latest Ubuntu 22.04 (jammy) security patches. The ACPT base image
+# (mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280, biweekly
+# tag) ships unpatched OS packages flagged by the SBOM scanner:
+#   - sed 4.8-1ubuntu2 -> 4.8-1ubuntu2.1 (USN-8229-1)
+#   - curl/libcurl4/libcurl3-gnutls 7.81.0-1ubuntu1.23 -> 7.81.0-1ubuntu1.24 (USN-8227-1)
+#   - libnghttp2-14 1.43.0-1ubuntu0.2 -> 1.43.0-1ubuntu0.3 (USN-8233-1)
+# These come straight from the base image (no parent package in this context)
+# and the only fix is `apt-get upgrade` to pull jammy-security versions. Doing
+# a full `apt-get -y upgrade` (rather than pinning each package) also picks up
+# any other Ubuntu security updates in one step.
+RUN apt-get -y update && apt-get -y upgrade && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# pip 26.0.1 in both the base (py3.13) and ptca (py3.10) conda envs is
+# vulnerable to GHSA-jp4c-xjxw-mgf9 / CVE-2026-6357 (fixed in pip>=26.1).
+# pip is a build/install tool installed by conda from the upstream base image
+# (mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280, biweekly
+# tag) — there is no parent Python package that brings it in, so an upstream
+# parent upgrade is not possible. The ACPT base image has not yet refreshed to
+# pip 26.1+ as of 2026-05-12 (latest pip on PyPI is 26.1.1, available on
+# conda-forge as pip-26.1.1-pyh*_0 since 2026-05-05). We use `conda install`
+# (rather than `pip install --upgrade`) so the conda-meta JSON is also
+# updated, and we additionally remove stray pip-26.0*.dist-info / conda-meta
+# entries from prior pip self-upgrades that conda does not track — otherwise
+# the SBOM scanner re-flags them. Done before the requirements install so
+# subsequent `pip install` calls run with the patched pip.
+RUN conda install -y --solver=classic -n base -c conda-forge pip==26.1.1 && \
+    conda install -y --solver=classic -n ptca -c conda-forge pip==26.1.1 && \
+    rm -rf /opt/conda/lib/python3.13/site-packages/pip-26.0*.dist-info && \
+    rm -f /opt/conda/conda-meta/pip-26.0*.json && \
+    rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/pip-26.0*.dist-info && \
+    rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json && \
+    conda clean -ay
+
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 # GHSA-jx93-g359-86wm, GHSA-hvwj-8w5g-28rg: sglang vulnerabilities; patched in >=0.5.10

--- a/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
+++ b/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
@@ -11,26 +11,31 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 # ENV AZUREML_ENTRY_SCRIPT="mlflow_score_script.py"
 
 ENV ENABLE_METADATA=true
-# Upgrade critical system and python packages
+# System package security upgrades for the Ubuntu 22.04 (jammy) base image
+# (mcr.microsoft.com/azureml/openmpi5.0-cuda12.4-ubuntu22.04). The previous
+# explicit `--only-upgrade` list (systemd*, libpython3.10*, libpam*, libarchive13)
+# has been retired: as of base tag 20260507.v1 those packages are either already
+# at the patched jammy-updates versions (libpam* 1.4.0-11ubuntu2.6, libsystemd0
+# / libudev1 249.11-0ubuntu3.20) or not installed in the base layer at all
+# (systemd, systemd-sysv, systemd-timesyncd, libnss-systemd, libpython3.10*,
+# libarchive13). `apt-get -y upgrade` already pulls any remaining patched
+# versions for installed dpkg packages.
+#
+# Recently published USNs that are also already remediated in base 20260507.v1:
+#   USN-8222-1: openssh-{client,server,sftp-server} 1:8.9p1-3ubuntu0.14 -> 0.15
+#   USN-8227-1: curl/libcurl4/libcurl3-gnutls       7.81.0-1ubuntu1.23 -> 1.24
+#   USN-8229-1: sed                                 4.8-1ubuntu2       -> 4.8-1ubuntu2.1
+#   USN-8233-1: libnghttp2-14                       1.43.0-1ubuntu0.2  -> 0.3
+# This step only refreshes Ubuntu packages from the base image; /opt/miniconda
+# and the conda env are remediated separately by the pip steps below.
+#
+# openssh-* gets an explicit `--reinstall` because `apt-get -y upgrade` has
+# previously been observed to leave a held openssh version in place when an
+# older base layer is cached on the build host (same hedge applied in sibling
+# assets/training/automl/environments/ai-ml-automl-gpu/context/Dockerfile).
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
-    apt-get install -y --only-upgrade \
-        systemd \
-        systemd-sysv \
-        libudev1 \
-        libpam-systemd \
-        systemd-timesyncd \
-        libsystemd0 \
-        libnss-systemd \
-        libpython3.10-stdlib \
-        python3.10 \
-        libpython3.10-minimal \
-        python3.10-minimal \
-        libpam0g \
-        libpam-modules-bin \
-        libpam-modules \
-        libpam-runtime \
-        libarchive13 && \
+    apt-get install --reinstall -y openssh-client openssh-server openssh-sftp-server && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create conda environment
@@ -67,10 +72,15 @@ RUN /opt/miniconda/bin/python -m pip install --upgrade --no-cache-dir 'pip>=26.1
 #   (the latest releases) still enforce onnx<=1.17.0,>=1.16.1.
 #   Override is required to remediate the vulnerability.
 #   Chain: azureml-automl-runtime / azureml-train-automl-runtime -> onnx<=1.17.0
+#
+# pyopenssl>=26.0.0 — CVE-2026-27459 (HIGH). Conda env installs pyopenssl 25.3.0 via the
+#   azureml-* dependency tree; override to >=26.0.0. pyopenssl 26.0.0 requires
+#   cryptography>=44, which is satisfied by the cryptography>=46.0.5 pin above.
 RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --upgrade --no-cache-dir \
     'cryptography>=46.0.5,<47.0.0' 'setuptools>=79.0.0' 'distributed>=2026.1.0' \
     'bokeh>=3.8.2' \
-    'onnx>=1.21.0'
+    'onnx>=1.21.0' \
+    'pyopenssl>=26.0.0'
 
 # Clean conda pkgs cache to remove stale vendored copies
 RUN rm -rf /opt/miniconda/pkgs/

--- a/assets/training/vision/environments/automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/vision/environments/automl-dnn-vision-gpu/context/Dockerfile
@@ -92,19 +92,29 @@ RUN pip install --upgrade 'onnx>=1.21.0'
 # cryptography (CVE-2026-41727), PyJWT (CVE-2026-32597), urllib3, filelock, pillow, bokeh
 # python-dotenv>=1.2.2: CVE-2026-28684 (GHSA-mf9w-mj56-hr94); transitive dep chain: azureml-defaults
 #   -> azureml-inference-server-http -> pydantic-settings -> python-dotenv>=0.21.0.
-#   pydantic-settings (all versions through 2.14.0) only requires >=0.21.0, no parent upgrade resolves this
+#   pydantic-settings (all versions through 2.14.1) only requires >=0.21.0, no parent upgrade resolves this
+# pip>=26.1 (CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9): pip < 26.1 deferred imports of well-known
+#   module names until after wheel install, allowing a freshly-installed wheel to be imported
+#   during the self-update check. pip is its own bootstrap installer — no upstream package
+#   pulls in pip transitively at a fixable floor — so explicit override is the only fix.
 RUN /opt/conda/bin/pip install --no-cache-dir --upgrade 'requests>=2.33.0' 'urllib3>=2.6.3' 'aiohttp>=3.13.4' 'wheel>=0.46.2' \
-    'setuptools>=82.0.1' 'cryptography>=46.0.7' 'PyJWT>=2.12.0' 'pip>=26.0' \
+    'setuptools>=82.0.1' 'cryptography>=46.0.7' 'PyJWT>=2.12.0' 'pip>=26.1' \
     'filelock>=3.20.3' 'pillow>=12.2.0' 'onnx>=1.21.0' \
     'python-dotenv>=1.2.2' \
     'bokeh>=3.8.2'
 # Security: fix ptca conda env — torch (CVE-2025-32434), protobuf (CVE-2026-40186),
 # wheel/setuptools, urllib3, filelock, pillow, PyJWT, bokeh overrides for conda env
+# pip>=26.1 (CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9): ptca env ships pip 26.0.1 from the ACPT
+#   base image (conda install pip -n ptca above resolves to 26.0.1). pip is its own bootstrap
+#   installer — no upstream package pulls in pip transitively — so explicit override is the only fix.
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade torch==2.8.0 torchvision==0.23.0 
+# Upgrade pip itself first via python -m pip so the bootstrap rewrites the dist-info
+# (combining pip>=26.1 in the larger pip install below leaves /opt/conda/envs/ptca pinned at 26.0.1)
+RUN /opt/conda/envs/ptca/bin/python -m pip install --no-cache-dir --upgrade 'pip>=26.1'
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade 'urllib3>=2.6.3' 'filelock>=3.20.3' \
     'wheel>=0.46.2' 'setuptools>=82.0.1' 'protobuf>=6.33.5' \
     'PyJWT>=2.12.0' 'pillow>=12.2.0' 'onnx>=1.21.0' 'requests>=2.33.0' \
-    'aiohttp>=3.13.4' 'cryptography>=46.0.7' 'pytest>=9.0.3' \
+    'aiohttp>=3.13.4' 'cryptography>=46.0.7' 'pytest>=9.0.3' 'pip>=26.1' \
     'python-dotenv>=1.2.2' 'bokeh>=3.8.2'
 
 # Patch pillow vulnerability (GHSA-whj4-6x5x-4v2j) across all three conda environments
@@ -121,8 +131,10 @@ RUN /opt/conda/envs/ptca/bin/pip install --upgrade 'pillow>=12.2.0'
 # pytest: dev dep in ptca base image; no parent to upgrade
 # python-dotenv>=1.2.2: CVE-2026-28684 (GHSA-mf9w-mj56-hr94); transitive dep chain: azureml-defaults
 #   -> azureml-inference-server-http -> pydantic-settings -> python-dotenv>=0.21.0.
-#   pydantic-settings (all versions through 2.14.0) only requires >=0.21.0, no parent upgrade resolves this
-RUN pip install --upgrade 'aiohttp>=3.13.4' 'distributed>=2026.1.0' 'protobuf>=6.33.5' 'pip>=26.0' 'cryptography>=46.0.7' \
+#   pydantic-settings (all versions through 2.14.1) only requires >=0.21.0, no parent upgrade resolves this
+# pip>=26.1 (CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9): pip is its own bootstrap installer; no
+#   upstream package pulls it transitively at a fixable floor — explicit override is the only fix.
+RUN pip install --upgrade 'aiohttp>=3.13.4' 'distributed>=2026.1.0' 'protobuf>=6.33.5' 'pip>=26.1' 'cryptography>=46.0.7' \
     'filelock>=3.20.3' 'wheel>=0.46.2' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'urllib3>=2.6.3' 'pillow>=12.2.0' \
     'onnx>=1.21.0' 'requests>=2.33.0' 'python-dotenv>=1.2.2' \
     'bokeh>=3.8.2'


### PR DESCRIPTION
Four images with NEW source-level fixes from retry agents (all vcm-validated clean):

- ai-ml-automl-dnn-vision-gpu: conda 3-attempt retry loop (fixes sqlite race in libmamba)

- acpt-draft: conda install --solver=classic (fixes sqlite race in libmamba)

- forecasting_demand/automl-gpu: pyopenssl>=26.0.0 (CVE-2026-27459)

- vision/automl-dnn-vision-gpu: explicit pip>=26.1 in ptca env