### PR TITLE
Add qwen3.5-2b text only model into Foundry Local

### DIFF
--- a/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized text-only version of Qwen3.5-2B to enable local inference on GPUs with CUDA. This model uses RTN quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of the Qwen3.5-2B text model for local inference on GPUs with CUDA.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Qwen3.5-2B](https://huggingface.co/Qwen/Qwen3.5-2B) for details.

--- a/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/qwen3.5-2b-text/onnx/cuda/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/model.yaml
@@ -1,7 +1,7 @@
 path:
   container_name: models
   container_path: foundrylocal/models/qwen3.5-2b-text/onnx/cuda/v1
-  storage_name: foundrylocalmodels
+  storage_name: foundrylocalassetdata
   type: azureblob
 publish:
   description: description.md

--- a/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/spec.yaml
@@ -1,0 +1,41 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3.5-2b-text-cuda-gpu
+version: 1
+path: ./
+tags:
+  foundryLocal: "test"
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE>."
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: chat-completion
+  maxOutputTokens: 2048
+  alias: qwen3.5-2b-text
+  directoryPath: v1
+  promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: "true"
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
+  toolResponseStart: "<tool_response>"
+  toolResponseEnd: "</tool_response>"
+  capabilities: "reasoning,tool-calling"
+  supportsReasoning: "true"
+  reasoningStart: "<think>"
+  reasoningEnd: "</think>"
+  contextLength: 262144
+  minFLVersion: "1.1.0"
+  disable-maap: "true"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3.5-2b-text/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'gpu'
+    executionProvider: 'CUDAExecutionProvider'
+    fileSizeBytes: 1417129106
+    vRamFootprintBytes: 1417129106

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/description.md
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized text-only version of Qwen3.5-2B to enable local inference on CPUs. This model uses RTN quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of the Qwen3.5-2B text model for local inference on CPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Qwen3.5-2B](https://huggingface.co/Qwen/Qwen3.5-2B) for details.

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/qwen3.5-2b-text/onnx/cpu_and_mobile/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/model.yaml
@@ -1,7 +1,7 @@
 path:
   container_name: models
   container_path: foundrylocal/models/qwen3.5-2b-text/onnx/cpu_and_mobile/v1
-  storage_name: foundrylocalmodels
+  storage_name: foundrylocalassetdata
   type: azureblob
 publish:
   description: description.md

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/spec.yaml
@@ -1,0 +1,41 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3.5-2b-text-generic-cpu
+version: 1
+path: ./
+tags:
+  foundryLocal: "test"
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE>."
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: chat-completion
+  maxOutputTokens: 2048
+  alias: qwen3.5-2b-text
+  directoryPath: v1
+  promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: "true"
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
+  toolResponseStart: "<tool_response>"
+  toolResponseEnd: "</tool_response>"
+  capabilities: "reasoning,tool-calling"
+  supportsReasoning: "true"
+  reasoningStart: "<think>"
+  reasoningEnd: "</think>"
+  contextLength: 262144
+  minFLVersion: "1.1.0"
+  disable-maap: "true"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3.5-2b-text/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'cpu'
+    executionProvider: 'CPUExecutionProvider'
+    fileSizeBytes: 1535843405
+    vRamFootprintBytes: 1535843405

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/description.md
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized text-only version of Qwen3.5-2B to enable local inference on GPUs with WebGPU. This model uses RTN quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of the Qwen3.5-2B text model for local inference on GPUs with WebGPU.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Qwen3.5-2B](https://huggingface.co/Qwen/Qwen3.5-2B) for details.

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/model.yaml
@@ -1,7 +1,7 @@
 path:
   container_name: models
   container_path: foundrylocal/models/qwen3.5-2b-text/onnx/webgpu/v1
-  storage_name: foundrylocalmodels
+  storage_name: foundrylocalassetdata
   type: azureblob
 publish:
   description: description.md

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/qwen3.5-2b-text/onnx/webgpu/v1
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
@@ -1,0 +1,41 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3.5-2b-text-generic-gpu
+version: 1
+path: ./
+tags:
+  foundryLocal: "test"
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE>."
+  author: Microsoft
+  inputModalities: "text"
+  outputModalities: "text"
+  task: chat-completion
+  maxOutputTokens: 2048
+  alias: qwen3.5-2b-text
+  directoryPath: v1
+  promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
+  supportsToolCalling: "true"
+  toolCallStart: "<tool_call>"
+  toolCallEnd: "</tool_call>"
+  toolRegisterStart: "<tools>"
+  toolRegisterEnd: "</tools>"
+  toolResponseStart: "<tool_response>"
+  toolResponseEnd: "</tool_response>"
+  capabilities: "reasoning,tool-calling"
+  supportsReasoning: "true"
+  reasoningStart: "<think>"
+  reasoningEnd: "</think>"
+  contextLength: 262144
+  minFLVersion: "1.1.0"
+  disable-maap: "true"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/qwen3.5-2b-text/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'gpu'
+    executionProvider: 'WebGPUExecutionProvider'
+    fileSizeBytes: 1417160957
+    vRamFootprintBytes: 1417160957

--- a/assets/models/foundrylocal/qwen3.5-2b-text/asset.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3.5-2b-text/description.md
+++ b/assets/models/foundrylocal/qwen3.5-2b-text/description.md
@@ -1,0 +1,16 @@
+This model is an optimized text-only version of Qwen3.5-2B for local inference. Optimized models are published here in ONNX format to run on CPU and GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs, with the precision best suited to each of these targets.
+
+# ONNX Models
+Here are some of the optimized configurations we have added:
+1. ONNX model for CPU and mobile using RTN quantization.
+2. ONNX model for GPU using RTN quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of the Qwen3.5-2B text model for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Qwen3.5-2B](https://huggingface.co/Qwen/Qwen3.5-2B) for details.

--- a/assets/models/foundrylocal/qwen3.5-2b-text/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/qwen3.5-2b-text
+  storage_name: foundrylocalmodels
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/qwen3.5-2b-text/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text/model.yaml
@@ -1,7 +1,7 @@
 path:
   container_name: models
   container_path: foundrylocal/models/qwen3.5-2b-text
-  storage_name: foundrylocalmodels
+  storage_name: foundrylocalassetdata
   type: azureblob
 publish:
   description: description.md

--- a/assets/models/foundrylocal/qwen3.5-2b-text/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text/spec.yaml
@@ -1,0 +1,7 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: qwen3.5-2b-text
+version: 1
+path: ./
+tags:
+  foundryLocal: ""
+type: custom_model


### PR DESCRIPTION
The customer requires the text only model of qwen3.5-2b at Foundry Local. This PR is to publish ONNX models to Foundry Loal Catalog with

- qwen3.5-2b-text-generic-cpu
- qwen3.5-2b-text-generic-gpu
- qwen3.5-2b-text-cuda-gpu

Models are tested locally and will be archived.