### PR TITLE
Replace Whisper models in Foundry Local with mixed or int4 quantized ones

### DIFF
--- a/assets/models/foundrylocal/openai-whisper-large-v3-turbo-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/openai-whisper-large-v3-turbo-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/openai-whisper-large-v3-turbo/onnx/cpu_and_mobile/v3
+  container_path: foundrylocal/models/openai-whisper-large-v3-turbo/onnx/cpu_and_mobile/v4
   storage_name: foundrylocalmodels
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/openai-whisper-large-v3-turbo-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/openai-whisper-large-v3-turbo-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: openai-whisper-large-v3-turbo-generic-cpu
-version: 3
+version: 4
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: automatic-speech-recognition
   maxOutputTokens: 2048
   alias: whisper-large-v3-turbo
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"prompt\": \"<|startoftranscript|> <|en|> <|transcribe|> <|notimestamps|>\"}"
   contextLength: 448
   capabilities: ""
@@ -30,5 +30,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 1678544910
-    vRamFootprintBytes: 1678544910
+    fileSizeBytes: 1346943518
+    vRamFootprintBytes: 1346943518

--- a/assets/models/foundrylocal/openai-whisper-medium-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/openai-whisper-medium-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/openai-whisper-medium/onnx/cpu_and_mobile/v3
+  container_path: foundrylocal/models/openai-whisper-medium/onnx/cpu_and_mobile/v4
   storage_name: foundrylocalmodels
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/openai-whisper-medium-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/openai-whisper-medium-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: openai-whisper-medium-generic-cpu
-version: 3
+version: 4
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: automatic-speech-recognition
   maxOutputTokens: 2048
   alias: whisper-medium
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"prompt\": \"<|startoftranscript|> <|en|> <|transcribe|> <|notimestamps|>\"}"
   contextLength: 448
   capabilities: ""
@@ -30,5 +30,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 1334385110
-    vRamFootprintBytes: 1334385110
+    fileSizeBytes: 982596829
+    vRamFootprintBytes: 982596829

--- a/assets/models/foundrylocal/openai-whisper-small-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/openai-whisper-small-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/openai-whisper-small/onnx/cpu_and_mobile/v3
+  container_path: foundrylocal/models/openai-whisper-small/onnx/cpu_and_mobile/v4
   storage_name: foundrylocalmodels
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/openai-whisper-small-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/openai-whisper-small-generic-cpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: openai-whisper-small-generic-cpu
-version: 3
+version: 4
 path: ./
 tags:
   foundryLocal: ""
@@ -12,7 +12,7 @@ tags:
   task: automatic-speech-recognition
   maxOutputTokens: 2048
   alias: whisper-small
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"prompt\": \"<|startoftranscript|> <|en|> <|transcribe|> <|notimestamps|>\"}"
   contextLength: 448
   capabilities: ""
@@ -30,5 +30,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'cpu'
     executionProvider: 'CPUExecutionProvider'
-    fileSizeBytes: 516028869
-    vRamFootprintBytes: 516028869
+    fileSizeBytes: 459461019
+    vRamFootprintBytes: 459461019


### PR DESCRIPTION
This PR is to replace existing Whsper models with mixed or int4 quantized models to keep WER low and model size smaller.

openai-whisper-large-v3-turbo-generic-cpu - 19.76% reduction
openai-whisper-medium-generic-cpu - 26.36% reduction
openai-whisper-small-generic-cpu - 10.96% reduction