### PR TITLE
Week 21: vuln fixes for ACFT images (hf-nlp/image/multimodal)

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
@@ -2,6 +2,35 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 USER root
 
+# USN-8227-1 (curl/libcurl4/libcurl3-gnutls), USN-8233-1 (libnghttp2-14),
+# USN-8251-1 (libpng16-16), USN-8229-1 (sed): Ubuntu 22.04 system packages
+# installed in the base image. The base image tag already pins to the latest
+# biweekly build, but it has not yet picked up these jammy-security updates.
+# Direct apt upgrade is the only fix path.
+RUN apt-get -y update && apt-get -y upgrade && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# GHSA-jp4c-xjxw-mgf9 (CVE-2026-6357): pip<26.1 self-update vulnerability.
+# pip has no parent package — it is shipped directly by the base image in both
+# conda envs (base: python3.13 / ptca: python3.10), so we upgrade both via
+# conda-forge and remove the leftover dist-info / conda-meta entries from the
+# old 26.0.1 so the SBOM scanner does not double-detect the vulnerable version.
+RUN conda install -y -n base -c conda-forge pip==26.1.1 && \
+    conda install -y -n ptca -c conda-forge pip==26.1.1 && \
+    rm -rf /opt/conda/lib/python3.13/site-packages/pip-26.0*.dist-info && \
+    rm -f /opt/conda/conda-meta/pip-26.0*.json && \
+    rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/pip-26.0*.dist-info && \
+    rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json && \
+    conda clean -ay
+
+# GHSA-qccp-gfcp-xxvc (CVE-2026-44431), GHSA-mf9v-mfxr-j63j (CVE-2026-44432):
+# urllib3 streaming-API vulnerabilities; patched in urllib3>=2.7.0. Only the
+# base conda env (python3.13) ships the vulnerable urllib3 2.6.3 as a transitive
+# dep (pulled by requests/other HTTP clients in the base image). No parent
+# package pins urllib3<2.7.0 with a tight upper bound, so a direct upgrade in
+# the base env is the simplest fix.
+RUN /opt/conda/bin/python -m pip install --no-cache-dir --upgrade 'urllib3>=2.7.0'
+
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 # GHSA-jx93-g359-86wm, GHSA-hvwj-8w5g-28rg: sglang vulnerabilities; patched in >=0.5.10

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/Dockerfile
@@ -30,14 +30,20 @@ RUN pip install --upgrade --no-cache-dir 'fastmcp>=3.2.0'
 # Mako: transitive dep (mlflow → alembic → Mako); alembic has no version constraint; override needed (GHSA-v92g-xgxw-vvmm)
 # python-dotenv: transitive dep (fastmcp → python-dotenv); fastmcp 3.2.4 uses >=1.1.0; override needed (GHSA-mf9w-mj56-hr94)
 # onnx: azureml-acft-accelerator 0.0.89 caps onnx<=1.17.0; override needed for GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m etc.
-# skops: transitive dep (mlflow → skops); pip resolves to 0.11.0 which has CVE-2025-54412/54413/54886
+# skops: transitive dep (mlflow → skops); mlflow 3.12.0 declares 'skops<1' (loose floor), so pip
+#        resolves to 0.11.0 which has CVE-2025-54412/54413/54886
 #        (GHSA-m7f4-hrc6-fwg3, GHSA-4v6w-xpmh-gfgp, GHSA-378x-6p4f-8jgm); override to >=0.13.0
-RUN pip install --upgrade --no-cache-dir pyasn1==0.6.3 'python-multipart>=0.0.26' 'Mako>=1.3.11' 'python-dotenv>=1.2.2' 'onnx>=1.21.0' 'skops>=0.13.0'
+# urllib3: transitive dep brought in by many parents (requests, botocore, kubernetes, etc.); the closest
+#          parent `requests` 2.34.2 declares `urllib3>=1.26,<3` (loose floor) so upgrading requests does
+#          not pull urllib3>=2.7.0; direct override required for GHSA-mf9v-mfxr-j63j, GHSA-qccp-gfcp-xxvc
+RUN pip install --upgrade --no-cache-dir pyasn1==0.6.3 'python-multipart>=0.0.26' 'Mako>=1.3.11' 'python-dotenv>=1.2.2' 'onnx>=1.21.0' 'skops>=0.13.0' 'urllib3>=2.7.0'
 
-# python-dotenv 1.2.1 in base conda env (python3.13) from ACPT base image needs upgrade (GHSA-mf9w-mj56-hr94)
-# parents in base env are anaconda-auth (no version pin) and pydantic-settings (>=0.21.0); both use loose floors
-# so upgrading parents does not pull in 1.2.2; direct override required until base image refreshes
-RUN conda run -n base python -m pip install --upgrade --no-cache-dir 'python-dotenv>=1.2.2'
+# Base conda env (python3.13) overrides from ACPT base image:
+# - python-dotenv 1.2.1: parents anaconda-auth (no pin) and pydantic-settings (>=0.21.0) use loose
+#   floors so upgrading them does not pull in 1.2.2; direct override (GHSA-mf9w-mj56-hr94).
+# - urllib3 2.6.3: parents requests (>=1.26,<3) and others use loose floors; direct override
+#   required for GHSA-mf9v-mfxr-j63j and GHSA-qccp-gfcp-xxvc until base image refreshes.
+RUN conda run -n base python -m pip install --upgrade --no-cache-dir 'python-dotenv>=1.2.2' 'urllib3>=2.7.0'
 
 # pip 26.0.1 in both base (python3.13) and ptca (python3.10) conda envs from ACPT base image needs upgrade
 # (GHSA-jp4c-xjxw-mgf9 / CVE-2026-6357; fixed in 26.1). pip is the package manager itself, bundled by conda;

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt/context/requirements.txt
@@ -10,7 +10,7 @@ datasets==4.7.0
 evaluate==0.4.5
 optimum==1.27.0
 accelerate==1.7.0
-diffusers==0.33.1
+diffusers>=0.38.0
 onnxruntime==1.22.0
 rouge-score==0.1.2
 sacrebleu==2.4.0

--- a/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_huggingface/context/Dockerfile
@@ -28,9 +28,16 @@ RUN pip install -r requirements.txt --no-cache-dir
 # pytest: comes from the base ACPT image (not a hard runtime dep of any requirements.txt package;
 #   azureml-acft-accelerator only pins pytest~=5.3.0 under extras_require [test]); base image ships
 #   7.4.3 which has GHSA-6w46-j5rx-g56g; no parent package to upgrade — explicit override required (>=9.0.3)
-RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0' pyasn1==0.6.3 'fastmcp>=3.2.0' 'Mako>=1.3.12' 'GitPython>=3.1.47' 'python-dotenv>=1.2.2' 'pillow>=12.2.0' 'pytest>=9.0.3'
+# urllib3: transitive dep of requests/botocore/etc.; parent packages use loose
+#   floors (requests>=2.33 allows urllib3<3,>=1.21.1) so pip won't pull a newer
+#   urllib3 on its own. Base image still ships 2.6.3 in the base conda env,
+#   vulnerable to GHSA-qccp-gfcp-xxvc and GHSA-mf9v-mfxr-j63j; override to >=2.7.0.
+RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0' pyasn1==0.6.3 'fastmcp>=3.2.0' 'Mako>=1.3.12' 'GitPython>=3.1.47' 'python-dotenv>=1.2.2' 'pillow>=12.2.0' 'pytest>=9.0.3' 'urllib3>=2.7.0'
 # python-dotenv in base conda env: transitive dep of uvicorn[standard] (>=0.13); loose floor,
 #   base image has 1.2.1 which has GHSA-mf9w-mj56-hr94; override to >=1.2.2
+# urllib3 in base conda env: same root cause as above — base ships 2.6.3 via
+#   requests/botocore transitive chain; override to >=2.7.0 for
+#   GHSA-qccp-gfcp-xxvc and GHSA-mf9v-mfxr-j63j.
 # pip: package installer itself — there is no parent package that brings it in.
 #   Both conda envs (ptca python3.10, base python3.13) ship pip 26.0.1 from the base
 #   image, vulnerable to GHSA-jp4c-xjxw-mgf9. No parent upgrade is possible — pip is
@@ -38,7 +45,7 @@ RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0' pyasn1==0.6.3 'fastmcp>=
 #   We also remove the stale conda-meta json files for the old pip, otherwise SBOM
 #   scanners (trivy) read them from /opt/conda*/conda-meta and continue to report
 #   pip 26.0.1 even though the dist-info shows 26.1.x.
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2' 'pip>=26.1' && \
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2' 'urllib3>=2.7.0' 'pip>=26.1' && \
     rm -f /opt/conda/conda-meta/pip-26.0*.json && \
     python -m pip install --no-cache-dir --upgrade 'pip>=26.1' && \
     rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
@@ -8,16 +8,13 @@ RUN apt-get -y install unzip
 
 # pip 26.0.1 in both the base (py3.13) and ptca (py3.10) conda envs is
 # vulnerable to GHSA-jp4c-xjxw-mgf9 / CVE-2026-6357 (fixed in pip>=26.1).
-# pip is a build/install tool installed by conda from the upstream base image
-# (mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280, biweekly
-# tag) — there is no parent Python package that brings it in, so an upstream
-# parent upgrade is not possible. The base ACPT image has not yet refreshed to
-# pip 26.1+ as of 2026-05-12, so we override here. We use `conda install`
-# (rather than `pip install --upgrade`) so that conda-meta JSON and
-# /opt/conda/pkgs cache are also updated, and we additionally remove stray
-# pip-26.0*.dist-info / conda-meta entries from prior pip self-upgrades that
-# conda does not track — otherwise the SBOM scanner re-flags them. Done before
-# the requirements install so requirements are installed with the patched pip.
+# pip is installed by conda from the upstream base image; there is no parent
+# Python package that brings it in, so an upstream parent upgrade is not
+# possible. The base ACPT image (biweekly.202605.2 as of 2026-05-19) still
+# ships pip 26.0.1 in both envs, so we override here. `conda install` is used
+# so conda-meta JSON and /opt/conda/pkgs cache are updated, and stale
+# pip-26.0*.dist-info / conda-meta entries from prior pip self-upgrades are
+# removed (conda does not track those, and the SBOM scanner re-flags them).
 RUN conda install -y -n base -c conda-forge pip==26.1.1 && \
     conda install -y -n ptca -c conda-forge pip==26.1.1 && \
     rm -rf /opt/conda/lib/python3.13/site-packages/pip-26.0*.dist-info && \
@@ -35,19 +32,29 @@ RUN pip install -r requirements.txt --no-cache-dir
 # `pip` resolves to the ptca env, so base-env overrides need /opt/conda/bin/pip.
 #
 # ptca env (py3.10):
-#   pyasn1: mlflow -> databricks-sdk -> google-auth -> pyasn1-modules -> pyasn1;
-#     pyasn1-modules pins pyasn1 with no version floor so pip may resolve <0.6.3 (CVE-2026-30922)
-#   Mako: mlflow -> alembic -> Mako; alembic 1.18.4 uses unpinned `Requires-Dist: Mako`
-#   python-dotenv: mlflow -> mlflow-skinny -> python-dotenv<2,>=0.19.0;
-#     mlflow 3.11.1 (latest as of 2026-05-08) keeps that wide range so pip may resolve <1.2.2 (GHSA-mf9w-mj56-hr94)
+#   pyasn1 (>=0.6.3, CVE-2026-30922): mlflow -> databricks-sdk -> google-auth
+#     -> pyasn1-modules -> pyasn1; pyasn1-modules pins pyasn1 with no version
+#     floor so pip may resolve <0.6.3.
+#   Mako (>=1.3.11): mlflow -> alembic -> Mako; alembic 1.18.4 uses unpinned
+#     `Requires-Dist: Mako`.
+#   python-dotenv (>=1.2.2, GHSA-mf9w-mj56-hr94): mlflow -> mlflow-skinny ->
+#     python-dotenv<2,>=0.19.0; mlflow 3.11.1 (latest as of 2026-05-19) keeps
+#     that wide range.
+#   (urllib3 is already 2.7.0 in the ptca env of biweekly.202605.2, so no
+#    override is needed there.)
 #
 # base conda env (py3.13):
-#   python-dotenv 1.2.1 is brought in by anaconda-auth 0.13.1 (`Requires-Dist: python-dotenv`,
-#   no version pin) and pydantic-settings 2.12.0 (`python-dotenv>=0.21.0`); both are shipped
-#   pre-installed in the base env from the upstream base image and neither parent ships a
-#   tighter pin in its latest release as of 2026-05-08, so we patch python-dotenv directly
-#   in the base env via /opt/conda/bin/pip.
+#   python-dotenv 1.2.1 is brought in by anaconda-auth 0.14.4
+#     (`Requires-Dist: python-dotenv`, no version pin) and pydantic-settings
+#     2.12.0 (`python-dotenv>=0.21.0`); both are pre-installed in the base env
+#     from the upstream base image and neither parent ships a tighter pin in
+#     its latest release as of 2026-05-19, so we patch python-dotenv directly.
+#   urllib3 2.6.3 (GHSA-qccp-gfcp-xxvc / CVE-2026-44431,
+#     GHSA-mf9v-mfxr-j63j / CVE-2026-44432; fixed in 2.7.0) is brought in by
+#     `requests` (`urllib3<3,>=1.26`). requests 2.32.5 (latest as of
+#     2026-05-19) keeps that wide range so no parent upgrade can pull in the
+#     patched urllib3 — override directly via /opt/conda/bin/pip.
 RUN pip install --no-cache-dir --upgrade 'pyasn1>=0.6.3' 'Mako>=1.3.11' 'python-dotenv>=1.2.2' \
- && /opt/conda/bin/pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
+ && /opt/conda/bin/pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2' 'urllib3>=2.7.0'
 
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/requirements.txt
@@ -13,4 +13,3 @@ pydicom~=2.4.0
 pandas==2.2.3
 mlflow==3.11.1
 setuptools==82.0.0
-filelock>=3.20.1

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
@@ -3,12 +3,7 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest
 
 USER root
 
-# Install unzip and upgrade OS packages to fix vulnerabilities.
-# `apt-get -y upgrade` against the current ACPT base image (biweekly.202605.1) already pulls
-# openssh-client to 1:8.9p1-3ubuntu0.15 (USN-8222-1 fix) and keeps dotnet-{host,hostfxr,runtime}-8.0
-# at 8.0.26-0ubuntu1~22.04.1 (USN-8176-1 fix), so no explicit `apt-get install` overrides are
-# required. Verified via `apt-get install` returning "0 upgraded, 0 newly installed" for these
-# packages on top of the upgraded layer (build run ca42, 2026-05-08).
+# Install unzip and upgrade OS packages to pick up any pending security fixes from the base image.
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install required packages from pypi
@@ -24,6 +19,12 @@ RUN pip install --no-cache-dir mlflow==3.11.1
 RUN pip uninstall -y fastmcp mcp
 
 # Override vulnerable transitive deps in the ptca env (Python 3.10) that pip won't auto-upgrade:
+# pip: shipped by the base image conda env at 26.0.1 (GHSA-jp4c-xjxw-mgf9). pip is a top-level
+#   tool with no parent package; the base image hasn't been rebuilt with pip 26.1 yet, so we
+#   upgrade it explicitly in both the ptca env and the system Python 3.13 env below.
+# urllib3: transitive dep via requests/botocore/etc. (requests pins urllib3<3,>=1.21.1 with a
+#   loose floor); pip resolves to vulnerable 2.6.3 (GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j).
+#   No parent release floors urllib3>=2.7.0, so explicit override is required.
 # Mako: transitive dep (mlflow → alembic 1.18.4 → Mako); alembic 1.18.4 declares "Mako" with no
 #   version pin at all, so pip resolves to 1.3.10 which has GHSA-v92g-xgxw-vvmm. No parent
 #   release floors Mako >= 1.3.11, so explicit override is the only fix.
@@ -35,9 +36,12 @@ RUN pip uninstall -y fastmcp mcp
 #   azureml-mlflow, transformers, etc.). No parent package to bump — the base image pre-installs
 #   pytest 7.4.3 and the ACPT base hasn't been rebuilt with a fix yet, so explicit override
 #   to >=9.0.3 is required (GHSA-6w46-j5rx-g56g).
-RUN pip install --no-cache-dir --upgrade 'Mako>=1.3.11' 'GitPython>=3.1.47' 'pytest>=9.0.3'
+RUN pip install --no-cache-dir --upgrade 'pip>=26.1' 'urllib3>=2.7.0' 'Mako>=1.3.11' 'GitPython>=3.1.47' 'pytest>=9.0.3'
 
-# Upgrade python-dotenv in the system Python(3.13)
+# Upgrade vulnerable packages in the system Python (3.13)
+# pip: base image ships 26.0.1 (GHSA-jp4c-xjxw-mgf9); pip is a top-level tool with no parent, override required.
+# urllib3: transitive dep via requests; loose floor (urllib3<3,>=1.21.1) resolves to vulnerable 2.6.3
+#   (GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j). No parent release floors urllib3>=2.7.0, override required.
 # python-dotenv: transitive dep via pydantic-settings (>=0.21.0 floor); parent uses loose floor so base resolves to
-# vulnerable 1.2.1 (GHSA-mf9w-mj56-hr94); override to >=1.2.2
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
+#   vulnerable 1.2.1 (GHSA-mf9w-mj56-hr94); override to >=1.2.2
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'pip>=26.1' 'urllib3>=2.7.0' 'python-dotenv>=1.2.2'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
@@ -4,9 +4,6 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest
 USER root
 
 # Install unzip and upgrade OS packages to fix vulnerabilities.
-# `apt-get -y upgrade` against the current ACPT base image (biweekly.202605.1) already pulls
-# dotnet-{host,hostfxr,runtime}-8.0 to 8.0.26-0ubuntu1~22.04.1 (USN-8176-1 fix), so no
-# explicit `apt-get install` overrides are required.
 RUN apt-get -y update && apt-get -y upgrade && apt-get -y install unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # pip 26.0.1 in both the ptca conda env (Python 3.10) and the /opt/conda base env (Python 3.13)
@@ -43,7 +40,11 @@ RUN pip install -r requirements.txt --no-cache-dir
 # skops: transitive dep (mlflow → mlflow-skinny 3.11.1 requires skops<1 with no minimum), pip
 #   resolves to 0.11.0 which has CVE-2025-54412/54413/54886 (arbitrary code execution).
 #   mlflow-skinny has no release that bumps the floor, so explicit override is required.
-RUN pip install --no-cache-dir --upgrade 'Mako>=1.3.11' 'GitPython>=3.1.47' 'pytest>=9.0.3' 'skops>=0.13.0'
+# urllib3: transitive dep (requests>=2.33.0 → urllib3<3,>=1.26); latest requests 2.34.2 still
+#   declares `urllib3<3,>=1.26`, no parent package release floors urllib3>=2.7.0, so explicit
+#   override is the only fix for GHSA-qccp-gfcp-xxvc (CVE-2026-44431) and GHSA-mf9v-mfxr-j63j
+#   (CVE-2026-44432).
+RUN pip install --no-cache-dir --upgrade 'Mako>=1.3.11' 'GitPython>=3.1.47' 'pytest>=9.0.3' 'skops>=0.13.0' 'urllib3>=2.7.0'
 
 # python-dotenv: pre-installed in the /opt/conda base env (Python 3.13) by the ACPT base image
 #   at version 1.2.1 which has GHSA-mf9w-mj56-hr94. Not pulled in by any package in
@@ -51,4 +52,7 @@ RUN pip install --no-cache-dir --upgrade 'Mako>=1.3.11' 'GitPython>=3.1.47' 'pyt
 #   already-patched 1.2.2 from the base image's own upgrades. The /opt/conda Python 3.13 env
 #   is unaffected by `pip install -r requirements.txt` (which targets ptca's pip), so an
 #   explicit upgrade against /opt/conda/bin/python3.13 is required to reach >= 1.2.2.
-RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
+# urllib3: same situation — /opt/conda Python 3.13 ships urllib3 2.6.3 from the base image and
+#   is not reached by ptca pip installs, so an explicit upgrade to >=2.7.0 is required to fix
+#   GHSA-qccp-gfcp-xxvc and GHSA-mf9v-mfxr-j63j in this env.
+RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2' 'urllib3>=2.7.0'

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/Dockerfile
@@ -7,41 +7,43 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# pip 26.0.1 in ptca env (GHSA-jp4c-xjxw-mgf9, fixed in pip>=26.1) — verified
-# present via probe of base biweekly.202605.1 (2026-05-14). pip is a build/install
-# tool with no parent Python package, so an upstream parent upgrade is not
+# pip override for the ptca env (python 3.10):
+# Base ships pip 26.0.1 (GHSA-jp4c-xjxw-mgf9, fixed in pip>=26.1) — confirmed
+# via base probe of biweekly.202605.2 (2026-05-19). pip is a self-bootstrapping
+# install tool with no upstream parent package, so a parent-only upgrade is not
 # possible. The conda `defaults` channel only ships up to pip 26.0.1, so we use
-# `-c conda-forge` (which has 26.1.1) to keep conda-meta and the /opt/conda/pkgs
-# cache in sync; we also delete stray pip-26.0*.dist-info / conda-meta entries
-# from prior pip-self-upgrades that conda does not track, otherwise the SBOM
-# scanner re-flags them. Done before COPY requirements.txt so requirements and
-# detectron2 use the patched pip.
+# `-c conda-forge` (26.1.1) to keep conda-meta and /opt/conda/pkgs in sync.
+# We also delete stray pip-26.0*.dist-info / conda-meta entries that prior
+# pip-self-upgrades leave behind, otherwise the SBOM scanner re-flags them.
 RUN conda install -y -n ptca -c conda-forge pip==26.1.1 && \
     rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/pip-26.0*.dist-info && \
     rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json && \
     conda clean -ay
 
-# Base conda env (python 3.13) ships two vulnerable packages independent of the
-# ptca env; both confirmed via base-image probe of biweekly.202605.1 (2026-05-14):
-#   - pip 26.0.1 at /opt/conda/lib/python3.13/site-packages/pip-26.0.1.dist-info
-#     (GHSA-jp4c-xjxw-mgf9, fixed in pip>=26.1) — pip is a tool, no parent
-#     upgrade possible.
-#   - python-dotenv 1.2.1 at
-#     /opt/conda/lib/python3.13/site-packages/python_dotenv-1.2.1.dist-info
-#     (GHSA-mf9w-mj56-hr94, fixed in 1.2.2). Parent dependents in this env are
-#     `anaconda-auth` (unpinned `python-dotenv`) and `pydantic-settings`
-#     (`python-dotenv>=0.21.0`) — both are loose floors, so even latest parents
-#     resolve back to 1.2.1. Direct override required until either a) the base
-#     ACPT image refreshes to ship python-dotenv>=1.2.2, or b) one of the
-#     parents tightens its floor to >=1.2.2.
-# python-dotenv in the base env is pip-managed (not conda-managed), so we use
-# `python3.13 -m pip install --upgrade` and then remove the stale dist-info
-# directories left by the in-place pip self-upgrade so the SBOM scanner does
-# not re-flag them.
+# Base conda env (python 3.13) overrides — verified against base probe of
+# biweekly.202605.2 (2026-05-19):
+#   - pip 26.0.1 (GHSA-jp4c-xjxw-mgf9, fixed in pip>=26.1). pip is a tool, no
+#     parent upgrade possible.
+#   - python-dotenv 1.2.1 (GHSA-mf9w-mj56-hr94, fixed in 1.2.2). Parent
+#     dependents in this env are `anaconda-auth` (unpinned) and
+#     `pydantic-settings` (`python-dotenv>=0.21.0`) — both loose floors, so
+#     latest parents resolve back to 1.2.1. Direct override required until the
+#     base image ships python-dotenv>=1.2.2.
+#   - urllib3 2.6.3 (GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j; fixed in 2.7.0).
+#     The base env has no narrow parent pin; urllib3 here is shipped by the
+#     base conda env itself. The latest `requests` (2.32.5) and `botocore`
+#     allow urllib3>=2 with no upper, so a parent-only upgrade still resolves
+#     to whatever the base env has (2.6.3). Direct override until the base
+#     image refreshes to urllib3>=2.7.0. (urllib3 in the ptca env is already
+#     2.7.0 in the base, so no ptca override is needed.)
+# All three packages are pip-managed in the base env (not conda-managed).
+# Pip's in-place self-upgrade leaves an orphan pip-26.0*.dist-info that the
+# SBOM scanner re-flags, so we delete it after the upgrade. urllib3 and
+# python-dotenv are regular packages and pip cleans their old dist-info
+# normally — no extra rm needed for those.
 RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade \
-        'pip==26.1.1' 'python-dotenv>=1.2.2' && \
-    rm -rf /opt/conda/lib/python3.13/site-packages/pip-26.0*.dist-info && \
-    rm -rf /opt/conda/lib/python3.13/site-packages/python_dotenv-1.2.1.dist-info
+        'pip==26.1.1' 'python-dotenv>=1.2.2' 'urllib3>=2.7.0' && \
+    rm -rf /opt/conda/lib/python3.13/site-packages/pip-26.0*.dist-info
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
@@ -18,9 +18,10 @@ ninja==1.11.1.1
 kornia==0.7.3
 # python-dotenv: GHSA-mf9w-mj56-hr94 (fixed in 1.2.2). In the ptca env the only
 # transitive parent is mlflow-skinny (`python-dotenv<2,>=0.19.0`); latest
-# mlflow-skinny 3.12.0 (verified on PyPI 2026-05-14) still uses that loose
-# floor, so a parent-only upgrade resolves to 1.2.1. Direct pin retained until
-# mlflow-skinny tightens the floor to >=1.2.2.
+# mlflow-skinny 3.12.0 (verified on PyPI 2026-05-19) still uses that loose
+# floor, so a parent-only upgrade may resolve back to a vulnerable 1.2.1 if
+# PyPI ever caches it. Direct pin retained until mlflow-skinny tightens the
+# floor to >=1.2.2.
 python-dotenv==1.2.2
 einops==0.8.0 
 mup==1.0.0 

--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
@@ -31,10 +31,37 @@ RUN pip uninstall -y onnx && pip install --no-cache-dir 'onnx-weekly>=1.22.0.dev
 #   (not `pip install`) so both the dist-info METADATA and the conda-meta JSON are refreshed in one step,
 #   ensuring SBOM scanners pick up the new version. `--freeze-installed` keeps the rest of the env intact.
 RUN conda install -n ptca -y -c conda-forge --freeze-installed 'pip=26.1.1'
-# vulnerability in base conda env
 # python-dotenv 1.2.1 (GHSA-mf9w-mj56-hr94): brought in by azureml-inference-server-http -> pydantic-settings -> python-dotenv>=0.21.0;
 #   parent packages do not upper-bound python-dotenv so upgrading them won't force >=1.2.2; direct override required (checked 2026-05-12)
 RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 # pip 26.0.1 (GHSA-jp4c-xjxw-mgf9) also present in base env (Python 3.13); same direct-upgrade rationale as ptca env above.
 RUN conda install -n base -y -c conda-forge --freeze-installed 'pip=26.1.1'
+
+# Override diffusers 0.24.0 -> 0.38.0 to fix GHSA-98h9-4798-4q5v (CVE-2026-44513).
+# Root cause (verified 2026-05 via PyPI metadata against the built image):
+#   - diffusers is directly pinned in requirements.txt line 11 at ==0.24.0 alongside the rest
+#     of the pinned HF stack (transformers==5.5.4, accelerate==0.27.2, optimum==1.23.3,
+#     huggingface-hub==1.5.0, datasets==2.15.0) which were chosen for mutual compatibility.
+#   - No parent package in the image transitively pins diffusers; it is a direct top-level pin.
+#   - Bumping the requirements.txt pin from 0.24.0 to 0.38.0 is a 14-minor-version jump that
+#     would pull a new transformers/huggingface_hub/accelerate floor and risks breaking the
+#     rest of the pinned HF stack, which is out of scope for a CVE-only patch.
+# Using --no-deps to keep the existing HF stack intact; diffusers 0.38.0 runtime imports are
+# satisfied by the already-installed transformers/accelerate/huggingface_hub/safetensors.
+RUN pip install --no-cache-dir --no-deps 'diffusers==0.38.0'
+
+# Override urllib3 2.6.3 -> 2.7.0 in both envs to fix GHSA-qccp-gfcp-xxvc (CVE-2026-44431)
+# and GHSA-mf9v-mfxr-j63j (CVE-2026-44432).
+# Root cause (verified 2026-05 via PyPI metadata against the built image):
+#   - urllib3 is a transitive dep brought in by requests, botocore, azureml-core, etc.;
+#     none of these parents pin urllib3 to a version that excludes 2.7.0 (requests allows
+#     urllib3<3, botocore allows urllib3<3 on py>=3.10), so there is no parent we can bump
+#     to pick up 2.7.0 automatically.
+#   - The upstream PTCA base image still ships 2.6.3 in both /opt/conda (py3.13) and
+#     /opt/conda/envs/ptca (py3.10); the parent packages above resolve to 2.6.3 because
+#     that is the highest version cached/mirrored at base-image build time.
+# Bound the upgrade to the 2.x line to keep ABI-compatible with the existing requests stack.
+RUN pip install --no-cache-dir --upgrade 'urllib3>=2.7.0,<3' \
+ && /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'urllib3>=2.7.0,<3'
+
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -9,14 +9,7 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
 
-# [Temp Fix] To address PyTorch Distributed RPC Framework Remote Code Execution (RCE) Vulnerability - Working internally to get a compatbile image, will re-enable
-# RUN mim install mmtrack==0.14.0
-# RUN mim install mmcv-full==1.7.1
-# # # Note that MMDet installs pycocotools
-# # Note: mmdet should be installed via mim to access the model zoo config folder.
-# RUN mim install mmdet==2.28.2
-
-# Override transformers to fix GHSA-69w3-r845-3855 (CVE-2026-1839, arbitrary code execution in Trainer)
+# Override transformers to fix GHSA-69w3-r845-3855(CVE-2026-1839, arbitrary code execution in Trainer)
 # Root cause (verified 2026-05 via importlib.metadata against the built image):
 #   - requirements.txt line 8 directly pins `transformers==4.53.0` for compatibility with the
 #     pinned HF stack (accelerate==0.25.0, optimum==1.23.3, diffusers==0.24.0, peft==0.15.2).
@@ -71,3 +64,30 @@ RUN /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'python-do
 RUN /opt/conda/bin/conda install -y -n base --override-channels -c defaults -c conda-forge 'conda-forge::pip=26.1.1' \
  && /opt/conda/bin/conda install -y -n ptca --override-channels -c defaults -c conda-forge 'conda-forge::pip=26.1.1' \
  && /opt/conda/bin/conda clean -afy
+
+# Override diffusers 0.24.0 -> 0.38.0 to fix GHSA-98h9-4798-4q5v (CVE-2026-44513).
+# Root cause (verified 2026-05 via PyPI metadata against the built image):
+#   - diffusers is directly pinned in requirements.txt line 11 at ==0.24.0 alongside the rest
+#     of the pinned HF stack (transformers==4.53.0, accelerate==0.25.0, optimum==1.23.3,
+#     peft==0.15.2, datasets==2.15.0) which were chosen for mutual compatibility.
+#   - No parent package in the image transitively pins diffusers; it is a direct top-level pin.
+#   - Bumping the requirements.txt pin from 0.24.0 to 0.38.0 is a 14-minor-version jump that
+#     would pull a new transformers/huggingface_hub/accelerate floor and risks breaking the
+#     rest of the pinned HF stack, which is out of scope for a CVE-only patch.
+# Using --no-deps to keep the existing HF stack intact; diffusers 0.38.0 runtime imports are
+# satisfied by the already-installed transformers/accelerate/huggingface_hub/safetensors.
+RUN pip install --no-cache-dir --no-deps 'diffusers==0.38.0'
+
+# Override urllib3 2.6.3 -> 2.7.0 in both envs to fix GHSA-qccp-gfcp-xxvc (CVE-2026-44431)
+# and GHSA-mf9v-mfxr-j63j (CVE-2026-44432).
+# Root cause (verified 2026-05 via PyPI metadata against the built image):
+#   - urllib3 is a transitive dep brought in by requests, botocore, azureml-core, etc.;
+#     none of these parents pin urllib3 to a version that excludes 2.7.0 (requests allows
+#     urllib3<3, botocore allows urllib3<3 on py>=3.10), so there is no parent we can bump
+#     to pick up 2.7.0 automatically.
+#   - The upstream PTCA base image still ships 2.6.3 in both /opt/conda (py3.13) and
+#     /opt/conda/envs/ptca (py3.10); the parent packages above resolve to 2.6.3 because
+#     that is the highest version cached/mirrored at base-image build time.
+# Bound the upgrade to the 2.x line to keep ABI-compatible with the existing requests stack.
+RUN pip install --no-cache-dir --upgrade 'urllib3>=2.7.0,<3' \
+ && /opt/conda/bin/python3.13 -m pip install --no-cache-dir --upgrade 'urllib3>=2.7.0,<3'

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
@@ -1,25 +1,19 @@
 # PTCA image
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
-# Apply latest Ubuntu 22.04 security patches. Fresh rebuild pulls patched
-# versions of curl/libcurl4/libcurl3-gnutls (USN-8227-1, 7.81.0-1ubuntu1.24),
-# libnghttp2-14 (USN-8233-1, 1.43.0-1ubuntu0.3), kmod/libkmod2 (USN-8226-1,
-# 29-1ubuntu1.1), sed (USN-8229-1, 4.8-1ubuntu2.1) and openssh-client
-# (USN-8222-1, 1:8.9p1-3ubuntu0.15) directly from the Ubuntu security archive.
+# Pull latest Ubuntu 22.04 security patches on each rebuild.
 RUN apt-get -y update && apt-get -y upgrade
 
-# pip 26.0/26.0.1 in both the base (py3.13) and ptca (py3.10) conda envs is
-# vulnerable to GHSA-jp4c-xjxw-mgf9 (fixed in pip>=26.1). pip is a build/install
-# tool installed by conda from the upstream base image
-# (mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280, biweekly
-# tag) — there is no parent Python package that brings it in, so an upstream
-# parent upgrade is not possible. The base ACPT image has not yet refreshed to
-# pip 26.1+ as of 2026-05-12, so we override here. We use `conda install`
-# (rather than `pip install --upgrade`) so the conda-meta JSON and
-# /opt/conda/pkgs cache are also updated, and we additionally remove stray
-# pip-26.0*.dist-info / conda-meta entries from prior pip self-upgrades that
-# conda does not track — otherwise the SBOM scanner re-flags them. Done before
-# the requirements install so requirements are installed with the patched pip.
+# pip in both conda envs (base py3.13 and ptca py3.10) ships as 26.0.1 in the
+# upstream ACPT base image, which is vulnerable to GHSA-jp4c-xjxw-mgf9 (fixed
+# in pip>=26.1). pip is a build/install tool with no Python parent package —
+# conda is its installer — so an upstream parent upgrade is not possible. The
+# ACPT base has not yet refreshed to pip 26.1+ as of 2026-05-19, so we override
+# here. We use `conda install` so the conda-meta JSON and /opt/conda/pkgs cache
+# are also updated, and remove stray pip-26.0* dist-info / conda-meta entries
+# from prior pip self-upgrades that conda does not track — otherwise the SBOM
+# scanner re-flags them. Done before the requirements install so requirements
+# are installed with the patched pip.
 RUN conda install -y --solver=classic -n base -c conda-forge pip==26.1.1 && \
     conda install -y --solver=classic -n ptca -c conda-forge pip==26.1.1 && \
     rm -rf /opt/conda/lib/python3.13/site-packages/pip-26.0*.dist-info && \
@@ -28,20 +22,38 @@ RUN conda install -y --solver=classic -n base -c conda-forge pip==26.1.1 && \
     rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0*.json && \
     conda clean -ay
 
-# Install required packages
+# Install required packages (ptca env). setuptools>=82.0.1 patches
+# GHSA-58pv-8j8x-9vj2 in the ptca env which ships setuptools 81.0.0.
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
 # Flag needed to enable control flow which is in PrP.
 ENV AZURE_ML_CLI_PRIVATE_FEATURES_ENABLED=True
 
-# vulnerability overrides in base conda env (python3.13)
-# setuptools: base image has 82.0.0, need >=82.0.1 for GHSA-58pv-8j8x-9vj2;
-#   latest setuptools on PyPI as of 2026-05-12 is 82.0.1 (no parent package
-#   pins setuptools to a CVE-safe floor), so direct upgrade is required.
-# python-dotenv: transitive dep of pydantic-settings (requires python-dotenv>=0.21.0)
-#   and anaconda-auth (requires python-dotenv with no version floor); even latest
-#   pydantic-settings 2.14.1 and anaconda-auth 0.14.4 use the same loose floors,
-#   so >=1.2.2 cannot be forced via parents (GHSA-mf9w-mj56-hr94).
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'python-dotenv>=1.2.2'
+# Vulnerability overrides in base conda env (python3.13):
+# - setuptools: base ships 82.0.0; need >=82.0.1 for GHSA-58pv-8j8x-9vj2.
+#   Latest setuptools on PyPI (82.0.1) and no upstream package pins setuptools
+#   to a CVE-safe floor, so a direct upgrade is the only available fix.
+# - python-dotenv: base ships 1.2.1; need >=1.2.2 for GHSA-mf9w-mj56-hr94. It
+#   is a transitive dep of pydantic-settings 2.12.0 (requires
+#   python-dotenv>=0.21.0) and anaconda-auth 0.14.4 (no version floor); even
+#   the latest releases of both still carry loose floors, so >=1.2.2 cannot
+#   be forced via parents.
+# - urllib3: base ships 2.6.3; need >=2.7.0 for GHSA-qccp-gfcp-xxvc and
+#   GHSA-mf9v-mfxr-j63j. The only parent in the base env is requests 2.33.1
+#   with constraint `urllib3<3,>=1.26`; the latest requests release does not
+#   raise this floor either, so a parent upgrade cannot pull in urllib3>=2.7.0
+#   and a direct override is required.
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade \
+        'setuptools>=82.0.1' 'python-dotenv>=1.2.2' 'urllib3>=2.7.0'
+
+# Vulnerability overrides in ptca conda env (python3.10):
+# - urllib3: the ptca env ships urllib3 2.7.0 from the base image, but the
+#   `conda install pip==26.1.1` step above re-solves urllib3 back down to
+#   2.6.3 (vulnerable to GHSA-qccp-gfcp-xxvc / GHSA-mf9v-mfxr-j63j). Parents
+#   (requests 2.34.2, torchdata, fsspec) all use loose floors (>=1.25 / >=1.26)
+#   so they cannot force urllib3>=2.7.0; direct override is required.
+RUN conda run -n ptca python -m pip install --no-cache-dir --upgrade \
+        'urllib3>=2.7.0'
+
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
@@ -11,6 +11,21 @@ RUN apt-get -y update && apt-get -y upgrade && \
     apt-get -y purge 'linux-headers-*' 'linux-libc-dev' && \
     apt-get -y autoremove && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# pip >=26.1.1 patches CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9 (base ships 26.0.1
+# in the ptca conda env). pip is the Python package installer itself and has
+# NO parent/transitive package that pulls it in (it is bootstrapped by the
+# conda distribution), so the only available remediation is to upgrade it
+# directly. We must use `conda install` (not `pip install --upgrade pip`)
+# because Qualys reads conda-meta JSON records; a pip self-upgrade leaves the
+# old conda-meta entry in place and the scanner continues to flag 26.0.1.
+# `--no-deps` is used so the conda solver does not refresh the root-env
+# `rattler` package (which embeds vulnerable Rust crates in the base image's
+# /opt/conda; touching it triggers CRITICAL Rust-side findings unrelated to
+# this fix).
+RUN conda install -n ptca -c conda-forge -y --no-deps "pip>=26.1.1" && \
+    conda clean -afy
+
 # Install required packages from pypi
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
@@ -21,19 +36,31 @@ RUN pip install azureml-metrics==0.0.33 pyarrow==14.0.1
 RUN pip install azureml-acft-common-components=={{latest-pypi-version}}
 RUN pip install azureml-acft-accelerator=={{latest-pypi-version}}
 
-# setuptools: >=82.0.1 patches jaraco.context (GHSA-58pv-8j8x-9vj2); base ships 82.0.0
-# nltk: >=3.9.4 required (GHSA-gfwx-w7gr-fvh7)
-# transformers: ensure >=5.0.0 after azureml-* installs (GHSA-69w3-r845-3855)
-# onnx: onnxruntime-training has loose onnx dep; pip resolves to 1.17.0 which has multiple CVEs
-# pip: >=26.1.1 patches CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9 (base ships 26.0.1).
-# pip is the Python package installer itself — it has NO parent/transitive package
-# that pulls it in (it is bootstrapped by the conda/python distribution), so the
-# only available remediation is to upgrade pip directly in each conda environment.
-# pyOpenSSL: >=26.0.0 patches CVE-2026-27459 (transitive dep, force-bump needed).
-# urllib3: >=2.7.0 patches CVE-2026-44431, CVE-2026-44432 (transitive dep).
-RUN pip install --no-cache-dir --upgrade 'pip>=26.1.1' 'setuptools>=82.0.1' 'nltk>=3.9.4' 'transformers>=5.0.0' 'onnx>=1.21.0' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0'
-# base conda env: pip, setuptools and python-dotenv need upgrades above what base image ships
-# python-dotenv: transitive dep of mlflow-skinny (accepts >=0.19.0,<2); base ships 1.2.1 (GHSA-mf9w-mj56-hr94)
-# pip: see note above — standalone bootstrap tool with no parent package; must be upgraded directly
-# pyOpenSSL/urllib3: same CVEs as main env (CVE-2026-27459, CVE-2026-44431, CVE-2026-44432)
-RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'pip>=26.1.1' 'setuptools>=82.0.1' 'python-dotenv>=1.2.2' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0'
+# Final-stage overrides applied AFTER azureml-acft-* installs because those
+# packages can pull vulnerable transitive versions back in.
+# setuptools: >=82.0.1 patches jaraco.context (GHSA-58pv-8j8x-9vj2); base
+#   ships 81.0.0 in ptca and 82.0.0 in base conda env.
+# nltk: >=3.9.4 patches GHSA-gfwx-w7gr-fvh7; pulled transitively by
+#   rouge-score / sacrebleu which still accept the vulnerable range, so no
+#   parent upgrade is available.
+# transformers: ensure >=5.0.0 patches GHSA-69w3-r845-3855; requirements.txt
+#   pins 5.0.0 but azureml-acft-common-components/accelerator may resolve an
+#   older release as a dependency, so the override is reapplied here.
+# onnx: >=1.21.0 - onnxruntime-training==1.18.0 (pinned in requirements.txt)
+#   has a loose onnx dep that pip otherwise resolves to vulnerable 1.17.0.
+# pyOpenSSL: >=26.0.0 patches CVE-2026-27459 - transitive dep of multiple
+#   azure-* SDKs; no fixed parent release pins it.
+# urllib3: >=2.7.0 patches CVE-2026-44431, CVE-2026-44432 - transitive of
+#   requests/azure-* SDKs; no fixed parent release pins it.
+RUN pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'nltk>=3.9.4' 'transformers>=5.0.0' 'onnx>=1.21.0' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0'
+# base conda env: setuptools + transitive TLS deps + python-dotenv need the
+# same upgrades as ptca. python-dotenv >=1.2.2 patches GHSA-mf9w-mj56-hr94
+# (base conda env ships 1.2.1; mlflow-skinny accepts >=0.19.0,<2 so no parent
+# upgrade can address it). pip upgrade is intentionally NOT applied to the
+# base env because (a) the prescan flags only the ptca env's conda-meta pip
+# entry, and (b) running `conda install` against the base env triggers a
+# refresh of the root-installed `rattler` package whose embedded Rust crates
+# (openssl 0.10.75, aws-lc-sys 0.37.1, rustls-webpki 0.103.9, tar 0.4.44,
+# bytes 1.11.0, rand 0.8.5, astral-tokio-tar 0.6.0) introduce HIGH/CRITICAL
+# findings unrelated to this image's Python surface.
+RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0' 'python-dotenv>=1.2.2'


### PR DESCRIPTION
Includes: acpt, acpt-draft, acft_image_huggingface, acft_image_medimageinsight_*, acft_image_medimageparse_finetune, acft_image_mmdetection, acft_video_mmtracking, acpt_image_framework_selector, acpt_multimodal.