### PR TITLE
Update qwen3.5-2b-text webgpu version

### DIFF
--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-2b-text/onnx/webgpu/v1
+  container_path: foundrylocal/models/qwen3.5-2b-text/onnx/webgpu/v2
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen3.5-2b-text-generic-gpu
-version: 1
+version: 2
 path: ./
 tags:
   foundryLocal: "test"
@@ -12,7 +12,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: qwen3.5-2b-text
-  directoryPath: v1
+  directoryPath: v2
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
@@ -37,5 +37,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'WebGPUExecutionProvider'
-    fileSizeBytes: 1417160957
-    vRamFootprintBytes: 1417160957
+    fileSizeBytes: 2164370322
+    vRamFootprintBytes: 2164370322


### PR DESCRIPTION
This pull request updates the Qwen 3.5-2B Text model for GPU usage to a new version (v2), reflecting changes in both the model's storage path and its metadata. The update includes adjustments to the model's directory references, versioning, and resource requirements.

**Model version and directory update:**
- Bumped the model version from `1` to `2` in `spec.yaml` and updated the `directoryPath` tag to `v2` to match the new model version. [[1]](diffhunk://#diff-5d1c705d97d75567cd9a59b340a1870fef7446b59c784dd63e1cac936edd6112L3-R3) [[2]](diffhunk://#diff-5d1c705d97d75567cd9a59b340a1870fef7446b59c784dd63e1cac936edd6112L15-R15)
- Changed the `container_path` in `model.yaml` from `v1` to `v2` to point to the updated model assets.

**Resource requirement update:**
- Increased the `fileSizeBytes` and `vRamFootprintBytes` in the `variantInfo` section to reflect the larger size of the new model version.