### PR TITLE
Add slime-train PATH shim for cwd-agnostic invocation

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
@@ -115,6 +115,18 @@ RUN cd /opt/slime/slime/backends/megatron_utils/kernels/int4_qat && \
 # Megatron-LM import all succeed without requiring `--user root`.
 RUN chmod -R a+rX /opt/slime /opt/Megatron-LM
 
+# Install a PATH-resolvable `slime-train` shim. Slime's entrypoint is the
+# repo-root `train.py` script (not a Python module), so `python train.py`
+# must resolve against the cwd. AML/Singularity sets cwd to a per-job
+# working directory (e.g. /scratch/azureml/cr/j/{uuid}/exe/wd/) that does
+# not contain train.py, so consumers cannot invoke slime via the bare
+# script name. The shim lets callers run `slime-train <args>` from any
+# cwd and additionally cds to /opt/slime so any relative artefact paths
+# the slime entrypoint resolves at runtime stay anchored to the slime
+# source tree.
+RUN printf '#!/usr/bin/env bash\nset -euo pipefail\ncd /opt/slime\nexec python /opt/slime/train.py "$@"\n' > /usr/local/bin/slime-train && \
+    chmod 0755 /usr/local/bin/slime-train
+
 COPY smoke_test.py /tmp/smoke_test.py
 RUN python /tmp/smoke_test.py && \
     echo 'import importlib.util' > /tmp/slime_nonroot_check.py && \

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/smoke_test.py
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/smoke_test.py
@@ -17,6 +17,7 @@ import torch
 LOG4J_ARTIFACTS = ("log4j-api", "log4j-core", "log4j-slf4j-impl")
 RAY_DIST_NAMES = ("ray_dist.jar", "ray__dist.jar")
 EXPECTED_SLIME_ROOT = pathlib.Path("/opt/slime")
+SLIME_TRAIN_SHIM = pathlib.Path("/usr/local/bin/slime-train")
 
 
 def find_ray_dist() -> pathlib.Path:
@@ -64,6 +65,24 @@ def assert_world_accessible(path: pathlib.Path) -> None:
         assert mode & 0o001, f"{path} not world-traversable (mode={oct(mode)})"
 
 
+def assert_slime_train_shim() -> None:
+    """Verify the PATH-resolvable `slime-train` shim is installed correctly.
+
+    AML/Singularity sets the job working directory to a per-job path that
+    does not contain slime's `train.py`, so consumers cannot invoke slime
+    via the bare `python train.py`. The shim provides a stable, cwd-agnostic
+    entrypoint.
+    """
+    assert SLIME_TRAIN_SHIM.is_file(), f"missing {SLIME_TRAIN_SHIM}"
+    mode = SLIME_TRAIN_SHIM.stat().st_mode & 0o777
+    assert mode & 0o004, f"{SLIME_TRAIN_SHIM} not world-readable (mode={oct(mode)})"
+    assert mode & 0o001, f"{SLIME_TRAIN_SHIM} not world-executable (mode={oct(mode)})"
+    content = SLIME_TRAIN_SHIM.read_text()
+    assert "/opt/slime/train.py" in content, (
+        f"{SLIME_TRAIN_SHIM} does not invoke /opt/slime/train.py:\n{content}"
+    )
+
+
 assert torch.cuda.is_available() or torch.version.cuda
 assert torch.__version__.startswith("2.9.1")
 assert Version(PIL.__version__) >= Version("12.2.0")
@@ -85,6 +104,8 @@ for path in (
 slime_init = EXPECTED_SLIME_ROOT / "slime" / "__init__.py"
 if slime_init.exists():
     assert_world_accessible(slime_init)
+
+assert_slime_train_shim()
 
 ray_dist = find_ray_dist()
 for artifact in LOG4J_ARTIFACTS:


### PR DESCRIPTION
## Summary

Adds a small ``slime-train`` shim at ``/usr/local/bin/slime-train`` so consumers can launch the slime training entrypoint from any working directory.

## Motivation

Slime's entrypoint is the repo-root ``train.py`` script (not a Python module), so ``python train.py`` resolves against the caller's cwd. AML/Singularity sets cwd to a per-job working directory (e.g. ``/scratch/azureml/cr/j/{uuid}/exe/wd/``) that does not contain ``train.py``. As a result, jobs that compose their command as ``python train.py ...`` against this curated environment fail immediately with:

```
python: can't open file '/scratch/azureml/cr/j/{uuid}/exe/wd/train.py': [Errno 2] No such file or directory
```

(observed end-to-end on canary, jobs ``tb-slime-{sft,grpo}-gsm8k-qwen05b-05191606``, after the ``/root/slime`` -> ``/opt/slime`` move in #5046 unblocked image readability.)

## Change

- **Dockerfile**: install ``/usr/local/bin/slime-train`` (mode 0755) that ``cd``s to ``/opt/slime`` and ``exec``s ``python /opt/slime/train.py "$@"``. The ``cd`` keeps any relative artefact paths the slime entrypoint resolves at runtime anchored to the slime source tree.
- **smoke_test.py**: assert the shim is present, world readable+executable, and references ``/opt/slime/train.py``.

## Why not change consumers instead

Every other curated training environment (TRL, VERL, OpenRLHF, NeMo-RL, TorchForge) uses ``python -m <module>`` and is therefore cwd-independent. Slime is the only one whose entrypoint is a bare script file, so the cwd contract has to be solved either by hard-coding the absolute path in every consumer or by giving the asset a PATH-resolvable name. The latter keeps the layout knowledge inside the asset that owns it.

## Validation

Local Python parse check on ``smoke_test.py``. Image build + smoke test will validate the shim during the asset CI build.