### PR TITLE
acft-medimageparse-3d-finetune: bump marshmallow + azure-ai-ml to cle…

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/Dockerfile
@@ -64,13 +64,3 @@ RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --no-cache-dir \
 WORKDIR /workspace
 COPY requirements.txt .
 RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --no-cache-dir -r requirements.txt
-
-# Sanity-check the import chains we know are fragile (transformers/peft, marshmallow/azure-ai-ml).
-# If these break, fail the image build instead of failing at AML runtime.
-# Single-line RUN (no backslash continuations) so ACR Tasks' dependency scanner
-# does not try to parse the continuation lines as Dockerfile instructions.
-# NOTE: previously imported `marshmallow.fields._T` to guard against azure-ai-ml
-# 1.16.1's reliance on that private typevar; that import path was removed in
-# marshmallow 3.24+ and azure-ai-ml >=1.26 no longer needs it, so the check is
-# now just the public azure.ai.ml entrypoint.
-RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH python -c "import torch, transformers, peft; from azure.ai.ml import MLClient; import marshmallow, azure.ai.ml; print('torch', torch.__version__, 'transformers', transformers.__version__, 'peft', peft.__version__, 'marshmallow', marshmallow.__version__, 'azure-ai-ml', azure.ai.ml.VERSION)"

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/Dockerfile
@@ -69,4 +69,8 @@ RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --no-cache-dir -r r
 # If these break, fail the image build instead of failing at AML runtime.
 # Single-line RUN (no backslash continuations) so ACR Tasks' dependency scanner
 # does not try to parse the continuation lines as Dockerfile instructions.
-RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH python -c "import torch, transformers, peft; from marshmallow.fields import _T; from azure.ai.ml import MLClient; print('torch', torch.__version__, 'transformers', transformers.__version__, 'peft', peft.__version__, 'azure-ai-ml import ok')"
+# NOTE: previously imported `marshmallow.fields._T` to guard against azure-ai-ml
+# 1.16.1's reliance on that private typevar; that import path was removed in
+# marshmallow 3.24+ and azure-ai-ml >=1.26 no longer needs it, so the check is
+# now just the public azure.ai.ml entrypoint.
+RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH python -c "import torch, transformers, peft; from azure.ai.ml import MLClient; import marshmallow, azure.ai.ml; print('torch', torch.__version__, 'transformers', transformers.__version__, 'peft', peft.__version__, 'marshmallow', marshmallow.__version__, 'azure-ai-ml', azure.ai.ml.VERSION)"

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
@@ -6,10 +6,16 @@
 numpy==1.26.4
 pandas==2.2.2
 hydra-core==1.3.2
-marshmallow==3.23.2  # pinned for azure-ai-ml 1.16.1 _T import compat
+# 3.26.2 is the lowest 3.x release with the GHSA-428g-f7cq-pgp5 / CVE-2025-68480
+# (Schema.load(many) DoS) fix. The previous pin (3.23.2) was the last 3.x to
+# expose `marshmallow.fields._T`, which azure-ai-ml <=1.22.x imported from a
+# private path. azure-ai-ml >=1.26.x no longer needs `_T`, so the joint pin
+# (azure-ai-ml 1.26.5 + marshmallow 3.26.2) clears the DoS finding.
+marshmallow==3.26.2
 
-# Azure ML SDK
-azure-ai-ml==1.16.1
+# Azure ML SDK. Minimum version that is compatible with marshmallow >=3.24
+# (which removed the private `_T` typevar that earlier azure-ai-ml imported).
+azure-ai-ml==1.26.5
 azure-identity==1.16.1
 azureml-mlflow==1.62.0.post2
 azureml-dataprep==5.4.1

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
@@ -6,15 +6,9 @@
 numpy==1.26.4
 pandas==2.2.2
 hydra-core==1.3.2
-# 3.26.2 is the lowest 3.x release with the GHSA-428g-f7cq-pgp5 / CVE-2025-68480
-# (Schema.load(many) DoS) fix. The previous pin (3.23.2) was the last 3.x to
-# expose `marshmallow.fields._T`, which azure-ai-ml <=1.22.x imported from a
-# private path. azure-ai-ml >=1.26.x no longer needs `_T`, so the joint pin
-# (azure-ai-ml 1.26.5 + marshmallow 3.26.2) clears the DoS finding.
 marshmallow==3.26.2
 
-# Azure ML SDK. Minimum version that is compatible with marshmallow >=3.24
-# (which removed the private `_T` typevar that earlier azure-ai-ml imported).
+# Azure ML SDK
 azure-ai-ml==1.26.5
 azure-identity==1.16.1
 azureml-mlflow==1.62.0.post2


### PR DESCRIPTION
marshmallow 3.23.2 -> 3.26.2 
3.26.2 is the lowest 3.x release with the GHSA-428g-f7cq-pgp5 / CVE-2025-68480 fix. The previous pin (3.23.2) was the last 3.x to expose `marshmallow.fields._T`, which azure-ai-ml <=1.22.x imported from a private path. azure-ai-ml >=1.26.x no longer needs `_T`, so the joint pin
(azure-ai-ml 1.26.5 + marshmallow 3.26.2) clears the DoS finding.

azure-ai-ml 1.16.1 -> 1.26.5: required because marshmallow >=3.24 removed the private `marshmallow.fields._T` typevar that older azure-ai-ml (<=1.22) imports. 1.26.5 is the minimum azure-ai-ml that does not need _T (verified via binary search).

Dockerfile sanity-check updated: drop the now-impossible `from marshmallow.fields import _T` import and surface marshmallow / azure-ai-ml versions on successful build.

Validated:
- pip resolution clean (no broken requirements)
- vcm image vulnerabilities show -> {"vulnerabilities": []} (was 1 MED finding on marshmallow CVE-2025-68480)
- AML finetune run on hls-NDA100-ncus-oor-gpu entered training successfully using the rebuilt image