### PR TITLE
Update qwen3.5-2b-text webgpu to v3

### DIFF
--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-2b-text/onnx/webgpu/v2
+  container_path: foundrylocal/models/qwen3.5-2b-text/onnx/webgpu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen3.5-2b-text-generic-gpu
-version: 2
+version: 3
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: qwen3.5-2b-text
-  directoryPath: v2
+  directoryPath: v3
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"
@@ -38,5 +38,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'gpu'
     executionProvider: 'WebGPUExecutionProvider'
-    fileSizeBytes: 2164370322
-    vRamFootprintBytes: 2164370322
+    fileSizeBytes: 1417201353
+    vRamFootprintBytes: 1417201353


### PR DESCRIPTION
This pull request updates the `qwen3.5-2b-text-generic-gpu` model asset to version 3, reflecting a new model directory and significantly reduced file size and VRAM footprint. These changes ensure the asset points to the latest model files and improve resource efficiency.

Model version and path updates:
* Updated the model version from 2 to 3 in `spec.yaml` and switched the model directory from `v2` to `v3` in both `spec.yaml` and `model.yaml`, ensuring the asset references the latest model files. [[1]](diffhunk://#diff-5d1c705d97d75567cd9a59b340a1870fef7446b59c784dd63e1cac936edd6112L3-R3) [[2]](diffhunk://#diff-5d1c705d97d75567cd9a59b340a1870fef7446b59c784dd63e1cac936edd6112L16-R16)
* Changed the `container_path` in `model.yaml` to use the new `v3` directory.

Resource usage improvements:
* Reduced `fileSizeBytes` and `vRamFootprintBytes` in the `variantInfo` section, lowering the model's storage and memory requirements.