### PR TITLE
Remove a test tag from nemotron Spanish model at Foundry Local

### DIFF
--- a/assets/models/foundrylocal/nemotron-speech-streaming-es-0.6b-ft-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-es-0.6b-ft-generic-cpu/spec.yaml
@@ -4,7 +4,7 @@ version: 1
 isArchived: true
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "MIT"
   licenseDescription: "This model is provided under the License Terms available at <https://github.com/microsoft/Foundry-Local/blob/main/licenses/nemotron-speech-streaming.md>."
   author: Microsoft


### PR DESCRIPTION
nemotron-speech-streaming-es-0.6b-ft, which is a fine-turned model from nemotron-speech-streaming-en-0.6b model to support Spanish. Since this model is well tested locally with Foundry Local, this PR will make the model visible at Foundry Local model list.