### PR TITLE
acft-medimageparse-3d-finetune: bump azure-ai-ml to latest stable (1.33.0)

### DIFF
--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
@@ -9,7 +9,7 @@ hydra-core==1.3.2
 marshmallow==3.26.2
 
 # Azure ML SDK
-azure-ai-ml==1.26.5
+azure-ai-ml==1.33.0
 azure-identity==1.16.1
 azureml-mlflow==1.62.0.post2
 azureml-dataprep==5.4.1
@@ -20,10 +20,6 @@ mlflow-skinny==3.9.0
 # DL training stack
 timm==0.9.16
 opencv-python-headless==4.11.0.86
-# deepspeed: not used by MIP-3D training path. Active Lightning strategy in
-# olympus_biomed_parse_3d/configs/trainer/biomedparse_trainer.yaml is
-# "ddp_find_unused_parameters_true"; deepspeed strategy + optimizer configs are
-# all commented out. Dropping saves ~200MB and avoids JIT-compile risk.
 transformers>=5.0.0,<6.0.0
 open-clip-torch==2.26.1
 sentencepiece==0.2.1
@@ -46,8 +42,6 @@ mup==1.0.0
 arrow==1.3.0
 dotmap==1.3.30
 appdirs==1.4.4
-# ffmpeg python wrapper dropped: no video codepaths in MIP3D (NIFTI/DICOM only)
-# and the OS ffmpeg pkg accounts for 11/12 scan findings.
 filelock>=3.20.1
 
 # Build tooling pins (CVE / compatibility)


### PR DESCRIPTION
Follow-up to #5069 (marshmallow CVE-2025-68480 fix). That PR pinned `azure-ai-ml` to the minimum version compatible with `marshmallow>=3.24` (1.26.5). Bumping to the latest stable so we don't sit on a stale SDK unnecessarily.

`azure-ai-ml 1.33.0` requires `marshmallow>=3.5,<4.0`, so the existing `marshmallow==3.26.2` pin remains compatible.

### Validation

- `pip` resolution clean (no broken requirements)
- Local build pushed to staging ACR; `vcm image vulnerabilities show` -> **0 findings**
- AML finetune smoke run on `hls-NDA100-ncus-oor-gpu` against the rebuilt image entered training successfully (`frank_tangelo_7vs8tx0h1x`)

### Diff
Single line change:
```diff
- azure-ai-ml==1.26.5
+ azure-ai-ml==1.33.0
```