### PR TITLE
Add agent category for CSAT evaluator and fix task completion error message

### DIFF
--- a/assets/evaluators/builtin/customer_satisfaction/spec.yaml
+++ b/assets/evaluators/builtin/customer_satisfaction/spec.yaml
@@ -5,7 +5,7 @@ displayName: "Customer-Satisfaction-Evaluator"
 description: "Evaluates the predicted customer satisfaction level of an AI agent interaction on a 1-5 Likert scale. This evaluator assesses whether the agent's response would likely result in a satisfied customer based on helpfulness, completeness, tone, and resolution of the user's needs. Useful for measuring customer support quality, chatbot effectiveness, and overall user experience."
 evaluatorType: "builtin"
 evaluatorSubType: "code"
-categories: ["business"]
+categories: ["agents", "business"]
 tags:
   provider: "Microsoft"
   is_continuous_scenario: "true"

--- a/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
+++ b/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
@@ -725,7 +725,7 @@ class MessagesOrQueryResponseInputValidator(ToolDefinitionsValidator):
                 if not has_text:
                     raise EvaluationException(
                         message=(
-                            "The last assistant message must contain text content, "
+                            "The last message must contain text content, "
                             "not only tool calls. The conversation appears to be "
                             "mid-execution — provide the agent's final text response."
                         ),


### PR DESCRIPTION
## Changes

- **Customer Satisfaction evaluator**: Added `agents` to the categories list alongside `business` in `spec.yaml`
- **Task Completion evaluator**: Fixed error message in `_task_completion.py`  changed *'The last assistant message'* to *'The last message'* for accuracy when the final message isn't from the assistant