### PR TITLE
Fix non-ACFT image vulnerabilities

### DIFF
--- a/assets/training/aoai/proxy_components/environments/context/Dockerfile
+++ b/assets/training/aoai/proxy_components/environments/context/Dockerfile
@@ -1,5 +1,9 @@
 FROM mcr.microsoft.com/azureml/openmpi5.0-ubuntu24.04:{{latest-image-tag}}
 
+RUN apt-get update \
+    && apt-get install -y --only-upgrade --no-install-recommends libgnutls30t64 \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 
 RUN pip install -r requirements.txt --no-cache-dir

--- a/assets/training/aoai/proxy_components/environments/context/requirements.txt
+++ b/assets/training/aoai/proxy_components/environments/context/requirements.txt
@@ -1,26 +1,14 @@
 openai==1.28.0
 pandas==2.2.0
-azureml-mlflow==1.56.0
+azureml-mlflow==1.62.0.post2
 azure-mgmt-cognitiveservices==13.5.0
 azure-identity>=1.16.1
 jsonlines==4.0.0
-azureml-telemetry==1.56.0
+azureml-telemetry==1.62.0
 pydantic==2.7.0
 azure-keyvault-secrets==4.8.0
-requests==2.33.0
-urllib3==2.7.0
-# cryptography is pulled in transitively by azure-identity / msal /
-# azure-keyvault-secrets, none of which pin a fixed minimum. The base
-# image (openmpi5.0-ubuntu24.04) currently ships cryptography 44.0.3,
-# which is vulnerable to GHSA-r6ph-v2qm-q3c2 (CVE-2026-26007) and
-# GHSA-m959-cc7f-wv43 (CVE-2026-34073). Override to >=46.0.7 (latest
-# fixed line) until the base image upgrades.
-cryptography>=46.0.7
-# idna is shipped by the base image (openmpi5.0-ubuntu24.04) at 3.13, which is
-# vulnerable to GHSA-65pc-fj4g-8rjx (CVE-2026-45409). The "parent" here is the
-# base image itself - no upstream Python package brings idna into our context;
-# it is a transitive dep of requests/httpx already installed in the base.
-# We cannot bump the base image to a tag that contains idna>=3.15 (none is
-# published as of 2026-05-23), so we pin idna directly here as the only
-# available remediation.
+requests==2.34.2
+# idna is brought in by requests (directly and via azure-core/msal) and by
+# httpx (via openai). Current parent releases still allow vulnerable idna
+# versions instead of requiring idna>=3.15, so keep this direct override.
 idna>=3.15

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/Dockerfile
@@ -27,51 +27,51 @@ RUN pip install \
     deepspeed~=0.15.1
 
 # Override transformers to fix GHSA-69w3-r845-3855
-# Root cause: azureml-automl-dnn-nlp==1.62.0 (latest) pins transformers==4.53.0; cannot upgrade parent
+# Root cause: azureml-automl-dnn-nlp==1.62.0 is the latest release as of
+# 2026-05-26 and pins transformers==4.53.0, so direct override is required.
 RUN pip install --no-cache-dir --no-deps 'transformers[sentencepiece,torch]==5.5.4'
 
 # Vulnerability patches for ptca environment (python 3.10 at /opt/conda/envs/ptca)
-# pip 26.0.1 -> >=26.1.1 (GHSA-jp4c-xjxw-mgf9, CVE-2026-6357): pip is base infra;
-#   no parent package brings it, so a direct upgrade is the only fix. The stale
+# pip 26.0.1 -> >=26.1.1 (GHSA-jp4c-xjxw-mgf9, CVE-2026-6357): no parent
+#   package controls pip here, so direct upgrade is required. The stale
 #   conda-meta JSON for pip-26.0.1 is removed so scanners do not re-flag it.
 # setuptools 81.0.0 -> >=82.0.1 (GHSA-58pv-8j8x-9vj2 in vendored jaraco.context):
 #   setuptools is a build dependency with no parent that pins it.
-# pytest >=9.0.3 (GHSA-6w46-j5rx-g56g): ACPT base ptca env not yet patched.
 # Override onnx to fix GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6,
 #   GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m.
-#   Root cause: azureml-automl-runtime==1.62.0 (latest) pins onnx<=1.17.0; cannot upgrade parent.
+#   Root cause: azureml-automl-runtime==1.62.0 is the latest release as of
+#   2026-05-26 and pins onnx<=1.17.0, so direct override is required.
 # bokeh 2.4.3 -> >=3.8.2 (GHSA-793v-589g-574v, CVE-2026-21883) and distributed
 #   2023.2.0 -> >=2026.1.0 (GHSA-c336-7962-wfj2, CVE-2026-23528) are pulled in by
-#   azureml-automl-runtime==1.62.0 which pins bokeh==2.4.3 and distributed==2023.2.0;
-#   no newer azureml-automl-runtime release exists, so direct override is required.
+#   azureml-train-automl-runtime==1.62.0, which requires bokeh<3.0.0 and
+#   dask[complete]<=2023.2.0. Latest AzureML parents remain at 1.62.0 as of
+#   2026-05-26, so direct override is required.
 RUN /opt/conda/envs/ptca/bin/pip install --upgrade \
     'pip>=26.1.1' \
     'setuptools>=82.0.1' \
-    'pytest>=9.0.3' \
     'onnx>=1.21.0' \
     'bokeh>=3.8.2' \
     'distributed>=2026.1.0' && \
     rm -f /opt/conda/envs/ptca/conda-meta/pip-26.0.1-*.json
 
 # Vulnerability patches for conda base env (python 3.13 at /opt/conda)
-# pip 26.0.1 -> >=26.1.1 (GHSA-jp4c-xjxw-mgf9, CVE-2026-6357): pip is base infra;
-#   no parent package brings it, so a direct upgrade is the only fix.
+# pip 26.0.1 -> >=26.1.1 (GHSA-jp4c-xjxw-mgf9, CVE-2026-6357): no parent
+#   package controls pip here, so direct upgrade is required.
 # urllib3 2.6.3 -> >=2.7.0 (GHSA-qccp-gfcp-xxvc / CVE-2026-44431, GHSA-mf9v-mfxr-j63j
-#   / CVE-2026-44432): pulled in transitively by `requests` and many conda CLI deps
-#   (anaconda-cloud-auth, conda, pip itself). `requests` has no upper bound on urllib3
-#   (Requires-Dist: urllib3<3,>=1.21.1), and none of the conda parents pin urllib3
-#   tightly, so no parent upgrade can force >=2.7.0 -- direct override required.
-# idna >=3.15 (GHSA-65pc-fj4g-8rjx): base env parents (`requests`, `anyio`,
-#   `httpx`, `yarl`) declare loose idna requirements, so direct override is required.
-# click >=8.3.3 (GHSA-47fr-3ffg-hgmw): base env CLI parents use loose click floors,
-#   so direct override is required.
+#   / CVE-2026-44432): requests 2.34.2 is the latest release as of 2026-05-26 and
+#   still allows urllib3<3,>=1.26; conda CLI parents also use loose urllib3 ranges,
+#   so no parent upgrade can force >=2.7.0 and direct override is required.
+# idna >=3.15 (GHSA-65pc-fj4g-8rjx): parents (`requests`, `anyio`, `httpx`,
+#   `yarl`) declare loose idna requirements, so direct override is required.
+# click >=8.3.3 (GHSA-47fr-3ffg-hgmw): CLI parents use loose click floors, so
+#   direct override is required.
 # setuptools 82.0.0 -> >=82.0.1 (GHSA-58pv-8j8x-9vj2 in vendored jaraco.context):
 #   no parent package pins setuptools.
 # python-dotenv 1.2.1 -> >=1.2.2 (GHSA-mf9w-mj56-hr94): brought in transitively by
-#   anaconda-auth==0.14.2 (Requires-Dist: python-dotenv with no version pin) and
+#   anaconda-auth==0.14.4 (Requires-Dist: python-dotenv with no version pin) and
 #   pydantic-settings==2.12.0 (python-dotenv>=0.21.0, via anaconda-cli-base ->
-#   anaconda-auth). Latest releases on PyPI as of 2026-05-19 (anaconda-auth==0.14.4,
-#   pydantic-settings==2.14.0) still use the same loose floors, so a parent upgrade
+#   anaconda-auth). Latest releases on PyPI as of 2026-05-26 (anaconda-auth==0.15.0,
+#   pydantic-settings==2.14.1) still use the same loose floors, so a parent upgrade
 #   cannot force >=1.2.2 -- direct override required.
 RUN /opt/conda/bin/pip install --upgrade \
     'pip>=26.1.1' \

--- a/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-text-gpu/context/Dockerfile
@@ -7,8 +7,6 @@ ENV PATH=$AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
 COPY --from=mcr.microsoft.com/azureml/mlflow-ubuntu20.04-py38-cpu-inference:20250506.v1 /var/mlflow_resources/ /var/mlflow_resources/
 
 ENV MLFLOW_MODEL_FOLDER="mlflow-model"
-# ENV AML_APP_ROOT="/var/mlflow_resources"
-# ENV AZUREML_ENTRY_SCRIPT="mlflow_score_script.py"
 
 # Inference requirements
 COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20250310.v1 /artifacts /var/
@@ -40,17 +38,11 @@ EXPOSE 5001 8883 8888
 
 ENV ENABLE_METADATA=true
 
-# try updating pip for base and ptca env using conda
-RUN conda install pip -n base -y 
-RUN conda install pip -n ptca -y
-
 # Security: upgrade pip in /opt/conda (base, py3.13) and /opt/conda/envs/ptca (py3.10)
 # to fix CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9 (vulnerable self-update behaviour in
-# pip < 26.1). The `conda install pip -n {base,ptca}` lines above resolve to
-# pip==26.0.1 from conda-forge, so an explicit follow-up pip upgrade is required.
-# pip is its own parent — no upstream package can ship a fixed pip — so explicit
-# upgrades are the only available remediation. Kept as its own RUN (no co-installed
-# packages) to avoid the documented pip self-upgrade race.
+# pip < 26.1). Current base tag biweekly.202605.2 ships pip==26.0.1 in both
+# envs. pip is its own parent, so no upstream package can ship a fixed pip.
+# Keep this as its own RUN to avoid the documented pip self-upgrade race.
 RUN /opt/conda/bin/pip install --no-cache-dir --upgrade 'pip>=26.1' && \
     /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade 'pip>=26.1'
 
@@ -63,8 +55,8 @@ RUN conda create -p $AZUREML_CONDA_ENVIRONMENT_PATH \
     numpy~=1.23.5\
     scikit-learn=1.5.1 \
     pandas~=1.5.3 \
-    setuptools \
-    wheel=0.46.2 \
+    setuptools=82.0.1 \
+    wheel=0.46.3 \
     scipy=1.10.1 \
     pybind11=2.10.1 \
     # end conda dependencies
@@ -99,68 +91,69 @@ RUN pip install --no-cache-dir \
 # Doing it  separately from pip install above to avoid conflict with other packages
 # We should aim for this list to be empty with new and patched releases
 # by fixing dependencies in the base packages
-RUN pip list && \
-    pip install pyarrow==14.0.2 \
+RUN pip install pyarrow==14.0.2 \
                 accelerate==1.12.0 
 
 # Override transformers to fix GHSA-69w3-r845-3855
-# Root cause: azureml-automl-dnn-nlp==1.62.0 (latest) pins transformers==4.53.0; cannot upgrade parent
+# Root cause: azureml-automl-dnn-nlp==1.62.0 (latest as of 2026-05-26)
+# pins transformers==4.53.0; cannot upgrade parent.
 RUN pip install --no-cache-dir --no-deps 'transformers[sentencepiece,torch]==5.5.4'
 
 
 # Security: upgrade pip to fix CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9 (vulnerable
 # self-update behaviour in pip < 26.1) in the AZUREML conda env. The `conda create`
-# above seeds the env with pip==26.0.1 from conda-forge. pip is its own parent —
-# no upstream package can bring in a patched pip — so an explicit upgrade is the
+# above seeds the env with pip==26.0.1 from conda-forge. pip is its own parent,
+# so no upstream package can bring in a patched pip; an explicit upgrade is the
 # only remediation. Kept as its own RUN to avoid the pip self-upgrade race.
 RUN pip install --no-cache-dir --upgrade 'pip>=26.1'
 
-# Upgrade bokeh, cryptography, onnx in the AZUREML conda env (py3.10).
-# NOTE: azureml-mlflow==1.62.0.post2 (latest as of 2026-05-19) pins
-# cryptography<47.0.0; we use >=46.0.5 (compatible) to fix prior CVEs.
+# Upgrade bokeh, cryptography, and onnx in the AZUREML conda env (py3.10).
+# NOTE: azureml-mlflow==1.62.0.post2 (latest as of 2026-05-26) caps
+# cryptography<47.0.0 but does not force the fixed floor; use >=46.0.5.
 # Override onnx to fix GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6, GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m
 # Root cause: azureml-automl-runtime==1.62.0 (latest) pins onnx<=1.17.0; cannot upgrade parent
-RUN pip install --upgrade 'distributed>=2026.1.0' 'cryptography>=46.0.5' 'setuptools>=82.0.1' 'wheel>=0.46.2' 'bokeh>=3.8.2' 'onnx>=1.21.0'
+RUN pip install --upgrade 'distributed>=2026.1.0' 'cryptography>=46.0.5' 'bokeh>=3.8.2' 'onnx>=1.21.0'
 
-# Fix vendored jaraco.context (GHSA-58pv-8j8x-9vj2) and wheel (GHSA-8rrh-rw8j-w5fx) in ptca/base setuptools.
+# Fix vulnerable vendored dependencies in base and ptca setuptools.
 # setuptools vendors jaraco.context internally; --force-reinstall --no-deps ensures vendored copies are replaced.
-# Base image biweekly.202605.2 ships: base=82.0.0, ptca=81.0.0 (verified via probe build).
-# Both are below 82.0.1 (which carries the vendored fix), so both overrides are required.
-RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
+# Current base tag biweekly.202605.2 ships: base=82.0.0, ptca=81.0.0.
+# Both are below 82.0.1, so direct overrides are still required.
+RUN /opt/conda/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1' && \
+    /opt/conda/envs/ptca/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
 
-# Security: upgrade urllib3 in base (py3.13) and ptca (py3.10) envs to fix
+# Security: upgrade urllib3 in the base env (py3.13) to fix
 # CVE-2026-44431 / GHSA-qccp-gfcp-xxvc and CVE-2026-44432 / GHSA-mf9v-mfxr-j63j
-# (urllib3 < 2.7.0). Base image biweekly.202605.1 ships urllib3 2.6.3 in both
-# envs. Parents: `requests` (urllib3<3,>=1.21.1) and `torchdata` (urllib3, no
-# pin) — both accept 2.7.0+, but neither pins forward, so a parent upgrade
-# cannot force the fix; direct override is the only remediation.
+# (urllib3 < 2.7.0). Current base tag biweekly.202605.2 ships urllib3 2.6.3
+# in base; ptca already ships urllib3 2.7.0, so no ptca override is needed.
+# Latest parents (`requests==2.34.2`, `distributed==2026.3.0`) still use loose
+# urllib3 ranges, so parent upgrades cannot force urllib3>=2.7.0.
 #
-# Security: upgrade idna in base (py3.13) and ptca (py3.10) envs to fix
-# CVE-2026-45409 / GHSA-65pc-fj4g-8rjx (idna < 3.15). Base image ships
-# idna 3.11 (base) and 3.13 (ptca). Parents: `requests`, `anyio`, `httpx`,
-# `yarl` — all use loose `idna` requirements with no upper pin, so parent
-# upgrade cannot force the fix; direct override is the only remediation.
+# Security: upgrade idna in the base env (py3.13) to fix CVE-2026-45409 /
+# GHSA-65pc-fj4g-8rjx (idna < 3.15). Current base tag biweekly.202605.2 ships
+# idna 3.11 in base; ptca already ships idna 3.15. Latest parents
+# (`requests==2.34.2`, `anyio==4.13.0`, `httpx==0.28.1`, `yarl==1.24.2`)
+# still use loose idna ranges, so parent upgrades cannot force idna>=3.15.
 #
 # Security: upgrade click in base env (py3.13) to fix CVE-2026-7246 /
 # GHSA-47fr-3ffg-hgmw (click.edit() command injection in click < 8.3.3).
-# Base image ships click 8.2.1. Parents: `typer`, `typer-slim`,
-# `anaconda-cli-base` — they require click with loose floors only, so parent
-# upgrade cannot force 8.3.3; direct override is the only remediation.
-RUN /opt/conda/bin/pip install --no-cache-dir --upgrade 'urllib3>=2.7.0' 'idna>=3.15' 'click>=8.3.3' && \
-    /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade 'urllib3>=2.7.0' 'idna>=3.15'
+# Current base tag biweekly.202605.2 ships click 8.2.1. Latest parents
+# (`typer==0.25.1`, `anaconda-cli-base==0.8.2`, and httpx's CLI extra)
+# still use loose click ranges, so parent upgrades cannot force click>=8.3.3.
+RUN /opt/conda/bin/pip install --no-cache-dir --upgrade 'urllib3>=2.7.0' 'idna>=3.15' 'click>=8.3.3'
 
 # Security: python-dotenv 1.2.1 -> >=1.2.2 fixes GHSA-mf9w-mj56-hr94 (set_key()/
 # unset_key() follow symlinks on cross-device .env writes -> arbitrary file
-# overwrite). Lives in /opt/conda/lib/python3.13/site-packages of the BASE conda
-# env (shipped by the ACPT base image biweekly.202605.1). It is pulled in
+# overwrite). Lives in /opt/conda/lib/python3.13/site-packages of the base conda
+# env (shipped by the current ACPT base image biweekly.202605.2). It is pulled in
 # transitively by anaconda-auth (Requires-Dist: python-dotenv with no version pin)
 # and pydantic-settings (python-dotenv>=0.21.0, via anaconda-cli-base ->
-# anaconda-auth). Latest releases on PyPI as of 2026-05-12 (anaconda-auth==0.14.4,
-# pydantic-settings==2.14.0) still use the same loose floors, so a parent upgrade
-# cannot force >=1.2.2 — direct override is the only remediation.
+# anaconda-auth). Latest releases on PyPI as of 2026-05-26 (anaconda-auth==0.15.0,
+# pydantic-settings==2.14.1) still use the same loose floors, so a parent upgrade
+# cannot force >=1.2.2; direct override is the only remediation.
 RUN conda run -n base pip install --no-cache-dir --upgrade 'python-dotenv>=1.2.2'
 
-RUN /opt/conda/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
+# Apply the same setuptools vendored-dependency fix in the AzureML conda env.
+RUN pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
 
 RUN /bin/bash -c "source activate $AZUREML_CONDA_ENVIRONMENT_PATH && \
  export CUDACXX=/usr/local/cuda/bin/nvcc && \

--- a/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn-vision-gpu/context/Dockerfile
@@ -10,18 +10,9 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 
 # Inference requirements
 COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20250310.v1 /artifacts /var/
-# USN-8222-1 (CVE-2026-35385/35386/35387/35388/35414): openssh-client must be
-# >= 1:8.9p1-3ubuntu0.15. openssh-client is shipped by the Ubuntu 22.04 ACPT base
-# image (no pip parent in this asset's context); the only fix path is the OS package
-# manager. `apt-get upgrade` alone has been observed to leave the held openssh
-# version in place when an older base layer is cached, so reinstall openssh-client
-# explicitly to force pickup of the patched version. Only openssh-client is
-# pre-installed in this base image — openssh-server / openssh-sftp-server are not
-# present (and would pull in systemd and fail postinst inside docker build).
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-        libcurl4 \
         liblttng-ust1 \
         libunwind8 \
         libxml++2.6-2v5 \
@@ -30,7 +21,6 @@ RUN apt-get update && \
         rsyslog \
         runit \
         unzip && \
-    apt-get install --reinstall -y openssh-client && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     cp /var/configuration/rsyslog.conf /etc/rsyslog.conf && \
     cp /var/configuration/nginx.conf /etc/nginx/sites-available/app && \
@@ -91,9 +81,11 @@ RUN pip install --no-cache-dir \
                 azureml-train-automl-client=={{latest-pypi-version}} \
                 azureml-train-automl-runtime=={{latest-pypi-version}} \
                 azureml-automl-dnn-vision=={{latest-pypi-version}}
-                
+
 # Vulnerability patches for conda environment
-# NOTE: azureml-mlflow~=1.62.0 pins cryptography<46.0.0; upgrading anyway for CVE fix
+# NOTE: azureml-mlflow==1.62.0.post2 allows cryptography<47.0.0; upgrading within
+#       that parent constraint for CVE fixes because AzureML parents only set loose
+#       cryptography lower bounds.
 # NOTE: azureml-automl-runtime pins onnx<=1.17.0,>=1.16.1; force-installing onnx>=1.21.0 to fix
 #       GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6, GHSA-p433-9wv8-28xj,
 #       GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m. Parent azureml-automl-runtime (1.62.0) cannot
@@ -117,16 +109,10 @@ RUN pip install --no-cache-dir --upgrade \
 # pip>=26.1 (CVE-2026-6357 / GHSA-jp4c-xjxw-mgf9): pip < 26.1 deferred imports of
 #   well-known module names until after wheel install, allowing a freshly-installed
 #   wheel to be imported during the self-update check. ptca env ships pip 26.0.1
-#   from the ACPT base image; pip is its own parent (no upstream package can pull
-#   in a fixed pip via dependency resolution), so explicit override is required.
-# urllib3>=2.7.0 (GHSA-qccp-gfcp-xxvc, GHSA-mf9v-mfxr-j63j): urllib3 2.6.3 ships in the
-#   ptca env (py3.10) via the ACPT base image as a transitive dep of requests/botocore.
-#   urllib3 is its own root for security purposes — requests pins urllib3>=1.21.1,<3 and
-#   botocore pins urllib3>=1.25.4,<2.5 (py<3.10) or <3 (py>=3.10), so no parent release
-#   forces urllib3>=2.7.0. Explicit override is the only fix path.
+#   in biweekly.202605.2; pip is its own parent (no upstream package can pull in a
+#   fixed pip via dependency resolution), so explicit override is required.
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade \
-                'pillow==12.2.0' 'filelock>=3.20.3' 'cryptography>=46.0.7' 'protobuf>=6.33.5' 'wheel>=0.46.2' \
-                'pytest>=9.0.3' 'pip>=26.1' 'urllib3>=2.7.0' 'requests>=2.33.0' 'idna>=3.15' 'pyOpenSSL>=26.0.0'
+                'pip>=26.1'
 # setuptools resolver picks wrong version due to dep conflicts; force install to fix jaraco.context vuln (GHSA-58pv-8j8x-9vj2)
 # setuptools vendors jaraco.context internally; --force-reinstall --no-deps ensures vendored copies are replaced
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'
@@ -148,18 +134,17 @@ RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --force-reinstall --no-d
 #   package — its parents (requests pins urllib3>=1.21.1,<3; botocore pins
 #   urllib3>=1.25.4,<3) do not bound it tightly enough to force 2.7.0, so no parent
 #   upgrade can pull in the fix. Explicit override required.
+# click>=8.3.3 (GHSA-47fr-3ffg-hgmw / CVE-2026-7246): metadata probe of the
+#   resolved base image (biweekly.202605.2) found click 8.2.1 in /opt/conda via
+#   anaconda-cli-base==0.8.2 (`click`) and typer==0.25.1 (`click>=8.2.1`).
+#   Current published parent metadata still has loose floors only, so no parent
+#   upgrade can force the patched click version; explicit override is required.
 RUN conda run -n base pip install --no-cache-dir --upgrade \
-                'cryptography>=46.0.7' \
-                'wheel>=0.46.2' \
-                'PyJWT>=2.12.0' \
-                'aiohttp>=3.13.4' \
                 'python-dotenv>=1.2.2' \
                 'pip>=26.1' \
                 'urllib3>=2.7.0' \
-                'requests>=2.33.0' \
                 'idna>=3.15' \
-                'pyOpenSSL>=26.0.0'
-# PyJWT 2.10.1 (CVE-2026-32597) is installed in the base conda env (python3.13) from ACPT base image; manually upgrading since base image hasn't been patched yet
+                'click>=8.3.3'
 # Fix vendored jaraco.context (GHSA-58pv-8j8x-9vj2) and wheel (GHSA-8rrh-rw8j-w5fx) in base setuptools
 # setuptools vendors jaraco.context internally; --force-reinstall --no-deps ensures vendored copies are replaced
 RUN /opt/conda/bin/pip install --no-cache-dir --force-reinstall --no-deps 'setuptools==82.0.1'

--- a/assets/training/automl/environments/ai-ml-automl-dnn/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn/context/Dockerfile
@@ -10,26 +10,18 @@ ENV MLFLOW_MODEL_FOLDER="mlflow-model"
 
 ENV ENABLE_METADATA=true
 
-# Security: upgrade all OS packages to pick up the latest Ubuntu security errata
-# (covers USN-8222 openssh, USN-8226 kmod, USN-8227 curl, USN-8229 sed,
-#  USN-8233 nghttp2, USN-8249 dpkg, etc.). --fix-missing tolerates mirror sync gaps.
+# Upgrade OS packages to pick up current Ubuntu security errata.
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade --fix-missing && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Security: upgrade pip in the base miniconda (/opt/miniconda) to fix
-# GHSA-jp4c-xjxw-mgf9 (pip < 26.1 self-update behaviour). The base image ships
-# pip 26.0.1 in /opt/miniconda; pip is its own parent so the only remediation
-# is an explicit upgrade. Done before the conda env is created.
-RUN /opt/miniconda/bin/pip install --no-cache-dir --upgrade 'pip>=26.1'
-
-# Security: upgrade urllib3 in the base miniconda (/opt/miniconda) to >=2.7.0 for
-# GHSA-mf9v-mfxr-j63j and GHSA-qccp-gfcp-xxvc. Base miniconda ships urllib3 2.6.3.
-# urllib3 is a transitive dep of `requests` (which is pulled by conda/anaconda
-# client tooling); the latest `requests` (2.32.5) only requires urllib3<3, so
-# upgrading the parent `requests` cannot raise the urllib3 floor — direct
-# override is the only remediation for the /opt/miniconda site-packages copy.
-RUN /opt/miniconda/bin/pip install --no-cache-dir --upgrade 'urllib3>=2.7.0'
+# Security: idna>=3.16 fixes GHSA-65pc-fj4g-8rjx / CVE-2026-45409 in
+# /opt/miniconda. Parent research (2026-05-26): base requests 2.34.1 requires
+# idna<4,>=2.5; latest public requests 2.32.5, observed internal requests 2.34.2,
+# and yarl 1.22.0 still keep loose idna ranges, so parent upgrades cannot force
+# idna>=3.15. Direct override required for the base miniconda copy.
+RUN /opt/miniconda/bin/pip install --no-cache-dir --upgrade 'idna>=3.16' && \
+    /opt/miniconda/bin/python -c "import idna; version=tuple(map(int, idna.__version__.split('.'))); assert version >= (3, 16), idna.__version__"
 
 # begin conda create
 # Create conda environment (minimal — packages installed via pip to avoid solver OOM)
@@ -96,25 +88,30 @@ RUN pip install \
                 # end pypi dependencies
 # end pip install
 
-# Fix vulnerabilities - security overrides for transitive dependencies
+# Fix vulnerabilities - security overrides for transitive dependencies.
+# Parent research refreshed 2026-05-26; direct floors are kept only where the
+# current parent packages still allow vulnerable lower versions.
 #
 # distributed>=2026.1.0    CVE-2026-23528  XSS-to-RCE via Dask dashboard proxy
-#                          Chain (L1): prophet -> distributed
-#                          Chain (L1): xgboost -> distributed
-#                          Chain (L2): prophet -> dask -> distributed
+#                          Chain: azureml-train-automl-runtime 1.62.0 ->
+#                          dask[complete]<=2023.2.0 -> distributed. Latest dask
+#                          only aligns distributed to the dask release; it does
+#                          not force this security floor.
 #
 # protobuf>=5.29.6         CVE-2025-4565   DoS via recursive protobuf messages (pure-Python)
-#                          Chain (L1): mlflow-skinny -> protobuf
+#                          Chain (L1): mlflow-skinny -> protobuf. Latest
+#                          mlflow-skinny 3.12.0 still allows protobuf>=3.12.0.
 #                          Chain (L2): azureml-automl-runtime -> onnxruntime -> protobuf
 #
 # cryptography>=46.0.5     CVE-2026-26007  EC subgroup validation bypass (ECDH key leak)
-#                          Chain (L1): azureml-mlflow -> cryptography
 #                          Chain (L1): mltable -> cryptography
-#                          Chain (L2): azureml-core -> paramiko -> cryptography
+#                          Chain (L2): azureml-core -> paramiko -> cryptography.
+#                          Latest mltable 1.6.3 and paramiko 3.5.1 keep loose
+#                          cryptography floors.
 #
 # bokeh>=3.8.2             GHSA-793v-589g-574v  conda env installs 2.4.3, pip can't auto-upgrade
-#                          Chain (L1): azureml-train-automl-runtime -> bokeh
-#                          Chain (L2): prophet -> dask -> bokeh
+#                          Chain (L1): azureml-train-automl-runtime 1.62.0 ->
+#                          bokeh<3.0.0 and dask[complete]<=2023.2.0.
 #
 # onnx>=1.21.0             GHSA-cmw6-hcpp-c6jp, GHSA-538c-55jv-c5g9, GHSA-q56x-g2fj-4rj6,
 #                          GHSA-p433-9wv8-28xj, GHSA-3r9x-f23j-gc73, GHSA-hqmj-h5c6-369m
@@ -130,12 +127,9 @@ RUN pip install \
 #                          intermediate parent cannot raise the floor.  Direct override required.
 #
 # ujson>=5.12.1            GHSA-c38f-wx89-p2xg  (decode buffer overflow)
-#                          Chain (L1): azureml-defaults -> azureml-inference-server-http ->
-#                                       gunicorn / flask / werkzeug helpers that pull ujson
-#                          Chain (L1): mlflow-skinny -> databricks-sdk -> ujson (optional)
-#                          ujson 5.12.1 is the only release with the patch and no parent
-#                          declares a tight pin on ujson, so the floor can only be raised
-#                          via a direct override here.
+#                          Current parent metadata does not declare a tight ujson
+#                          floor, so the floor can only be raised via a direct
+#                          override here.
 RUN pip install --upgrade 'distributed>=2026.1.0' 'protobuf>=5.29.6' 'cryptography>=46.0.5' \
     'bokeh>=3.8.2' \
     'onnx>=1.21.0' \

--- a/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
@@ -1,26 +1,18 @@
-FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu118-py310-torch271:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
+FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
-# Upgrade pip in base conda env (CVE-2026-1703 requires pip>=26.0)
-RUN conda install -n base -c conda-forge 'pip>=26.0' -y
-
-# Security upgrades in BASE conda env (Python 3.13). Parent packages in base image
-# (anaconda-auth, anaconda-cli-base, conda, conda-content-trust, requests, typer, yarl,
-#  SecretStorage) do not yet pin to patched versions; direct overrides required.
-RUN conda run -n base python -m pip install --upgrade \
-    'wheel>=0.46.2' \
-    'cryptography>=46.0.7,<47.0.0' \
-    'setuptools>=82.0.1' \
-    'PyJWT>=2.12.0' \
-    'aiohttp>=3.13.4' \
-    'urllib3>=2.7.0' \
-    'requests>=2.33.0' \
-    'python-dotenv>=1.2.2' \
-    'idna>=3.15' \
-    'click>=8.3.3'
-
-# Upgrade pip in ptca conda env (CVE-2026-1703 requires pip>=26.0)
-RUN conda install -c conda-forge 'pip>=26.0' -y && \
-    conda clean -a -y
+# Base conda env (Python 3.13) security floors. Tool-based parent checks on 2026-05-26
+# showed requests only requires urllib3<3/idna<4, pydantic-settings only requires
+# python-dotenv>=0.21.0, and click parents do not require a CVE-safe floor yet.
+# pip is a root packaging tool and VCM also scans the ptca conda-meta record.
+RUN conda install -n ptca -c conda-forge -y 'pip>=26.1' && \
+    conda install -n base -c conda-forge -y 'pip>=26.1' 'conda=26.3.2' && \
+    conda run -n base python -m pip install --upgrade --no-cache-dir \
+        'python-dotenv>=1.2.2' \
+        'urllib3>=2.7.0' \
+        'idna>=3.15' \
+        'click>=8.3.3' && \
+    conda clean -a -y && \
+    rm -rf /opt/conda/pkgs
 
 # Install pip dependencies (runs in default PTCA conda env)
 COPY requirements.txt .
@@ -28,7 +20,6 @@ RUN pip install -r requirements.txt --no-cache-dir
 
 
 # Inference requirements
-# libcurl4, liblttng-ust1, openssh-client are already installed by the base image -- omitted.
 COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20230419.v1 /artifacts /var/
 RUN apt-get update && \
     apt-get upgrade -y && \
@@ -52,20 +43,3 @@ EXPOSE 5001 8883 8888
 
 # Deepspeed launcher requires passwordless ssh; server side not in base image
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
-
-# PTCA env post-install: azureml-mlflow pulls cryptography (must be >=46.0.7 for CVE coverage;
-# azureml-mlflow caps at <47.0.0). setuptools vendors jaraco.context (CVE-2026-23949) and
-# also fixes wheel CVE-2026-24049; --force-reinstall --no-deps replaces the vendored copies.
-RUN pip install --upgrade --no-cache-dir 'cryptography>=46.0.7,<47.0.0'
-RUN pip install --force-reinstall --no-deps 'setuptools>=82.0.1'
-
-# torch 2.7.1+cu118: GHSA-887c-mr87-cxwp / CVE-2025-3730 (local DoS in ctc_loss; fixed in torch 2.8.0).
-# Override NOT possible:
-#   1. PyTorch upstream dropped CUDA 11.8 wheels starting with torch 2.8.0. The cu118 wheel index
-#      (https://download.pytorch.org/whl/cu118/torch/) lists 2.7.1 as the highest stable release;
-#      only a 2.8.0.dev* nightly exists for cu118 and PEP 440 dev versions still satisfy <2.8.0.
-#   2. Installing the PyPI default torch 2.8.0 wheel (bundled cu126) would mismatch the rest of the
-#      cu118-built GPU stack baked into the base image (DeepSpeed, onnxruntime-training-gpu,
-#      torch-ort), breaking ABI / CUDA compatibility.
-#   3. No cu118-patched base image is published (latest tag biweekly.202601.1 still ships torch 2.7.1+cu118).
-# Permanent fix path: migrate workloads to acpt-pytorch-2.8-cuda12.6 (cu126 + torch 2.8.0).

--- a/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/requirements.txt
+++ b/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/requirements.txt
@@ -7,13 +7,13 @@ azureml-mlflow=={{latest-pypi-version}}
 azureml-contrib-services=={{latest-pypi-version}}
 azureml-contrib-services=={{latest-pypi-version}}
 azureml-inference-server-http
+# azureml-inference-server-http 1.5.1 pins opentelemetry-api/sdk==1.33.0
+# while newer exporter betas require newer OpenTelemetry and/or psutil>=5.9.
+azure-monitor-opentelemetry-exporter==1.0.0b23
 inference-schema
 MarkupSafe==2.1.2
 regex
 pybind11
-urllib3>=2.7.0
-idna>=3.15
-requests>=2.33.0
 pillow>=12.2.0
 # GHSA-69w3-r845-3855 requires transformers>=5.0.0rc3; upgrading to stable 5.x
 transformers>=5.0.0
@@ -35,6 +35,5 @@ py-cpuinfo==5.0.0
 torch-tb-profiler~=0.4.0
 starlette>=0.49.1
 filelock>=3.20.1
-wheel>=0.46.2
 jaraco.context>=6.1.0
 protobuf>=6.33.5

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -33,41 +33,29 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Fix security vulnerabilities in ptca conda env (python 3.10, active)
-# setuptools>=82.0.1: GHSA-58pv-8j8x-9vj2, GHSA-8rrh-rw8j-w5fx
-# urllib3>=2.7.0: GHSA-mf9v-mfxr-j63j (CVE-2026-44432), GHSA-qccp-gfcp-xxvc
-#   (CVE-2026-44431). Transitive via requests<=2.34.2 (urllib3<3,>=1.26) and
-#   botocore<=1.43.14 (urllib3!=2.2.0,<3,>=1.25.4); neither parent pins a safe
-#   floor as of 2026-05-23, so direct override required.
-RUN pip install --upgrade 'setuptools>=82.0.1' 'urllib3>=2.7.0'
+# Fix ptca conda env vulnerabilities (python 3.10, active).
+# pip>=26.1.1: GHSA-jp4c-xjxw-mgf9. pip is a root tool with no parent package,
+# and VCM reads the ptca conda-meta record, so conda must update it. The current
+# base plus requirements dry-run already keep urllib3 at 2.7.0.
+# setuptools>=82.0.1: GHSA-58pv-8j8x-9vj2, GHSA-8rrh-rw8j-w5fx.
+RUN conda install -n ptca -c conda-forge -y 'pip>=26.1.1' 'setuptools>=82.0.1'
 
-# pip>=26.1: CVE-2026-6357 (GHSA-jp4c-xjxw-mgf9). pip is a root tool with no
-# parent package. Scanner reads opt/conda/envs/ptca/conda-meta/pip-*.json which
-# is only updated by conda, so we must use `conda install` (a plain
-# `pip install --upgrade pip` leaves the conda-meta record stale).
-RUN conda install -n ptca -c conda-forge -y 'pip>=26.1'
-
-# Fix security vulnerabilities in base conda env (python 3.13)
-# setuptools>=82.0.1: same advisories as ptca env above.
-# python-dotenv>=1.2.2: CVE-2026-28684 (GHSA-mf9w-mj56-hr94). Transitive via
-#   azureml-defaults -> azureml-inference-server-http -> pydantic-settings
-#   (<=2.14.0 requires python-dotenv>=0.21.0, no safe floor); direct override
-#   required.
-# urllib3>=2.7.0: see ptca env block above; same parent analysis.
-# idna>=3.15: GHSA-65pc-fj4g-8rjx (CVE-2026-45409). Transitive via
-#   requests<=2.34.2 (idna<4,>=2.5); parent does not pin a safe floor as of
-#   2026-05-23, so direct override required.
-# click>=8.3.3: GHSA-47fr-3ffg-hgmw (CVE-2026-7246). Transitive via
-#   mlflow-skinny<=3.12.0 (click<9,>=7.0), flask<=3.1.3 (click>=8.1.3),
-#   uvicorn<=0.47.0 (click>=7.0), typer<=0.25.1 (click>=8.2.1); none pin a
-#   safe floor as of 2026-05-23, so direct override required.
+# Fix base conda env vulnerabilities (python 3.13). Parent packages still expose
+# loose floors as of 2026-05-25, so these direct floors are required:
+# setuptools>=82.0.1: conda 26.3.2 requires setuptools>=60.0.0 only.
+# python-dotenv>=1.2.2: pydantic-settings 2.14.1 requires >=0.21.0.
+# urllib3>=2.7.0: requests 2.34.2 requires <3,>=1.26.
+# idna>=3.15: requests 2.34.2 requires <4,>=2.5.
+# click>=8.3.3: typer 0.25.1 requires >=8.2.1; mlflow-skinny 3.12.0 requires
+#   <9,>=7.0.
 RUN conda run -n base python -m pip install --upgrade \
     'setuptools>=82.0.1' 'python-dotenv>=1.2.2' \
     'urllib3>=2.7.0' 'idna>=3.15' 'click>=8.3.3'
 
-# pip>=26.1 in base env: CVE-2026-6357 (GHSA-jp4c-xjxw-mgf9). Same reasoning as
-# ptca env: conda-managed pip needs `conda install` so conda-meta and the
-# matching dist-info are updated together.
-RUN conda install -n base -c conda-forge -y 'pip>=26.1'
+# pip>=26.1.1 in base env: GHSA-jp4c-xjxw-mgf9. pip is a root tool with no
+# parent package. Pin conda to the base version because an unconstrained
+# conda-forge solve upgrades conda and installs py-rattler 0.23.2, which brings
+# the Rust vulnerabilities reported in VCM under rattler/rattler.abi3.so.
+RUN conda install -n base -c conda-forge -y 'pip>=26.1.1' 'conda=26.3.2'
 
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/requirements.txt
@@ -20,15 +20,16 @@ tqdm
 py-cpuinfo
 torch-tb-profiler
 # starlette: transitive dep of azureml-inference-server-http -> fastapi -> starlette.
-#   Not pre-installed in base ptca env; fastapi uses loose floor.
+#   fastapi 0.136.3 still uses a loose floor (starlette>=0.46.0), so keep a
+#   direct safe floor.
 starlette>=0.49.1
 # python-dotenv: transitive dep chain: azureml-defaults -> azureml-inference-server-http
-#   -> pydantic-settings -> python-dotenv>=0.21.0. pydantic-settings (all versions through
-#   2.14.0) only requires >=0.21.0 which does not constrain to a CVE-safe version.
-#   No parent upgrade resolves this. Floor pin required to fix CVE-2026-28684 (GHSA-mf9w-mj56-hr94).
+#   -> pydantic-settings -> python-dotenv>=0.21.0. pydantic-settings 2.14.1 and
+#   mlflow-skinny 3.12.0 still do not constrain to a CVE-safe version.
+#   Floor pin required to fix CVE-2026-28684 (GHSA-mf9w-mj56-hr94).
 python-dotenv>=1.2.2
 # GitPython: transitive dep chain: azureml-mlflow -> mlflow-skinny -> GitPython (>=3.1.9,<4).
-#   mlflow-skinny (all versions through 3.11.1) only requires >=3.1.9,<4 which does not
-#   constrain to a CVE-safe floor. No parent upgrade resolves this.
+#   azureml-mlflow 1.62.0.post2 caps mlflow-skinny at <=3.9.0, and latest
+#   mlflow-skinny 3.12.0 still does not constrain to a CVE-safe floor.
 #   Floor pin required to fix GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4.
 GitPython>=3.1.47

--- a/assets/training/vision/environments/automl-dnn-vision-gpu/context/Dockerfile
+++ b/assets/training/vision/environments/automl-dnn-vision-gpu/context/Dockerfile
@@ -14,36 +14,12 @@ COPY --from=mcr.microsoft.com/azureml/o16n-base/python-assets:20250310.v1 /artif
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
-        libcurl4 \
-        liblttng-ust1 \
         libunwind8 \
         libxml++2.6-2v5 \
         nginx-light \
         psmisc \
         rsyslog \
         runit \
-        libc-bin \
-        dpkg-dev \
-        libssl-dev \
-        dpkg \
-        dotnet-hostfxr-8.0 \
-        dotnet-host-8.0 \
-        dotnet-runtime-8.0 \
-        binutils \
-        binutils-common \
-        binutils-x86-64-linux-gnu \
-        libbinutils \
-        libctf0 \
-        libctf-nobfd0 \
-        libc6 \
-        libc6-dev \
-        libc-dev-bin \
-        libssh-4 \
-        libxml2 \
-        linux-libc-dev \
-        linux-headers-generic \
-        locales \
-        openssl \
         unzip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*&& \
     cp /var/configuration/rsyslog.conf /etc/rsyslog.conf && \
@@ -76,23 +52,25 @@ RUN pip install --no-cache-dir --upgrade 'urllib3>=2.7.0'
 # Security: fix onnx (multiple CVEs) — transitive dep of azureml-automl-runtime via onnxruntime; parent pinned, cannot upgrade
 RUN pip install --no-cache-dir --upgrade 'onnx>=1.21.0'
 
-# Security: fix base conda env (python 3.13) — packages present in base image at vulnerable versions.
-# Base image (probed) contains: aiohttp 3.12.14, cryptography 44.0.1, pip 25.3, PyJWT 2.10.1,
-# python-dotenv 1.1.0, requests 2.32.4, setuptools 80.9.0, urllib3 2.5.0, wheel 0.45.1.
+# Security: fix base conda env (python 3.13).
 # python-dotenv>=1.2.2: CVE-2026-28684 (GHSA-mf9w-mj56-hr94); transitive chain in inference layer:
 #   azureml-defaults -> azureml-inference-server-http -> pydantic-settings -> python-dotenv>=0.21.0;
 #   pydantic-settings (<=2.14.0) only requires >=0.21.0, no parent upgrade resolves this.
-# idna>=3.15 and click>=8.3.3 are pulled by base-env HTTP/CLI parents with loose
-# requirements, so parent upgrades cannot force the fixed versions.
+# idna>=3.15 (GHSA-65pc-fj4g-8rjx): base has idna 3.11 from requests 2.32.4 (idna<4,>=2.5)
+# and yarl 1.22.0 (idna>=2.0). As of 2026-05-25, latest requests/yarl keep the same loose
+# idna ranges, so parent upgrades cannot force the fixed idna version.
+# click>=8.3.3 (GHSA-47fr-3ffg-hgmw): base has click 8.2.1 from anaconda-cli-base/typer
+# parents. As of 2026-05-25, latest anaconda-cli-base, typer, and python-dotenv still require
+# click without a >=8.3.3 floor, so direct override is required.
 RUN /opt/conda/bin/conda install -n base -c conda-forge 'pip>=26.1' -y && \
     /opt/conda/bin/pip install --no-cache-dir --upgrade 'requests>=2.33.0' 'urllib3>=2.7.0' 'aiohttp>=3.13.4' 'wheel>=0.46.2' \
     'setuptools>=82.0.1' 'cryptography>=46.0.7' 'PyJWT>=2.12.0' \
     'python-dotenv>=1.2.2' 'idna>=3.15' 'click>=8.3.3'
-# Security: fix ptca conda env (python 3.10) — packages present in base image at vulnerable versions.
-# Base image (probed) contains: aiohttp 3.13.3, filelock 3.20.0, onnx 1.20.1, pillow 12.1.0,
-# pip 25.3, protobuf 6.33.3, pytest 7.4.3, requests 2.32.5, setuptools 80.9.0, urllib3 2.6.3,
-# wheel 0.41.2, torch 2.7.1+cu118, torchvision 0.22.1+cu118.
+# Security: fix ptca conda env (python 3.10).
 RUN /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade torch==2.8.0 torchvision==0.23.0
+# idna>=3.15 (GHSA-65pc-fj4g-8rjx): ptca has idna 3.11 from requests 2.32.5 (idna<4,>=2.5)
+# and yarl 1.22.0 (idna>=2.0). As of 2026-05-25, latest requests/yarl keep the same loose
+# idna ranges, so parent upgrades cannot force the fixed idna version.
 RUN /opt/conda/bin/conda install -n ptca -c conda-forge 'pip>=26.1' -y && \
     /opt/conda/envs/ptca/bin/pip install --no-cache-dir --upgrade 'filelock>=3.20.3' \
     'wheel>=0.46.2' 'setuptools>=82.0.1' 'protobuf>=6.33.5' \
@@ -100,15 +78,15 @@ RUN /opt/conda/bin/conda install -n ptca -c conda-forge 'pip>=26.1' -y && \
     'aiohttp>=3.13.4' 'pytest>=9.0.3' 'idna>=3.15'
 
 # Fix security vulnerabilities in active conda env (azureml-automl-dnn-vision-gpu, python 3.10)
-# aiohttp, bokeh, distributed, protobuf, cryptography, filelock, wheel, setuptools, PyJWT,
-# urllib3, pillow, onnx, requests, python-dotenv — all transitive deps of azureml SDK packages
-# pinned with template versions (cannot upgrade parent during template rendering).
+# aiohttp, bokeh, distributed, protobuf, cryptography, filelock, setuptools, PyJWT, urllib3, pillow, onnx,
+# requests, python-dotenv — all transitive deps of azureml SDK packages pinned with template
+# versions (cannot upgrade parent during template rendering).
+# cryptography>=46.0.7: azure-identity (via azureml-dataprep) only requires cryptography>=2.5.
 # python-dotenv>=1.2.2: CVE-2026-28684; pydantic-settings (<=2.14.0) requires >=0.21.0 only.
-# idna>=3.15 and click>=8.3.3 are direct overrides because parent packages keep
-# loose dependency ranges that allow the vulnerable base versions.
-RUN conda install -p $AZUREML_CONDA_ENVIRONMENT_PATH -c conda-forge 'pip>=26.1' -y && \
-    pip install --no-cache-dir --upgrade 'aiohttp>=3.13.4' 'distributed>=2026.1.0' 'protobuf>=6.33.5' 'cryptography>=46.0.7' \
-    'filelock>=3.20.3' 'wheel>=0.46.2' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'urllib3>=2.7.0' 'pillow>=12.2.0' \
+# idna>=3.15 and click>=8.3.3 are direct overrides because requests/yarl/dask parents keep
+# loose dependency ranges that allow vulnerable versions.
+RUN pip install --no-cache-dir --upgrade 'aiohttp>=3.13.4' 'distributed>=2026.1.0' 'protobuf>=6.33.5' 'cryptography>=46.0.7' \
+    'filelock>=3.20.3' 'setuptools>=82.0.1' 'PyJWT>=2.12.0' 'urllib3>=2.7.0' 'pillow>=12.2.0' \
     'onnx>=1.21.0' 'requests>=2.33.0' 'python-dotenv>=1.2.2' \
     'bokeh>=3.8.2' 'idna>=3.15' 'click>=8.3.3'
 # Remove stale vendored metadata that scanners pick up


### PR DESCRIPTION
This pull request applies a series of security and dependency updates across multiple Dockerfiles and requirements for AzureML training environments. The main focus is on remediating vulnerabilities in Python packages and system libraries, aligning pinned versions with the latest available parent package releases, and improving documentation of dependency override rationales. The changes ensure that patched versions are installed even when upstream parents do not yet enforce secure minimum versions.

**Dependency and Security Updates**

* **Python package upgrades and vulnerability patches:**
  - Updated `azureml-mlflow` and `azureml-telemetry` to `1.62.0.post2` and `1.62.0` respectively in `requirements.txt` to match latest releases.
  - Upgraded `requests` to `2.34.2` and ensured `idna>=3.15` is directly pinned to mitigate known CVEs, since parent packages still allow vulnerable versions.
  - Updated and clarified direct overrides for `pip`, `setuptools`, `wheel`, `bokeh`, `onnx`, `cryptography`, `urllib3`, `idna`, `click`, and `python-dotenv` in various Dockerfiles to ensure patched versions are installed regardless of parent package constraints. [[1]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631L30-R74) [[2]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL66-R59) [[3]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL102-R156) [[4]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L96-R88) [[5]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L120-R115) [[6]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97R137-R147)

* **System library and OS package updates:**
  - Added an explicit upgrade for `libgnutls30t64` in the AOAI proxy component Dockerfile to address potential security issues.
  - Removed unnecessary or redundant OS package installations (e.g., `libcurl4`, explicit `openssh-client` reinstall) from the DNN vision GPU Dockerfile, relying on upstream base image patching. [[1]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L13-L24) [[2]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L33)

**Documentation and Maintenance Improvements**

* **Enhanced comments and rationale:**
  - Clarified in Dockerfile comments which vulnerabilities are being addressed, the reasoning behind direct overrides, and the status of parent package releases to aid future maintenance. [[1]](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631L30-R74) [[2]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL102-R156) [[3]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L96-R88) [[4]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L120-R115) [[5]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97R137-R147)

* **Consolidation and cleanup:**
  - Removed redundant or unnecessary Dockerfile commands and updated comments to reflect the current state of base images and dependency management. [[1]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL10-L11) [[2]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL43-R45) [[3]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL66-R59) [[4]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L13-L24) [[5]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L33)

These updates collectively strengthen the security posture of the training environments and ensure better alignment with current best practices for dependency management.

**References:**
- [assets/training/aoai/proxy_components/environments/context/requirements.txtL3-R13](diffhunk://#diff-923e0d019cb2afbcd664e9ae7ac1d1b8f5816275fe4b6239da3a10a70b715ce6L3-R13)
- [assets/training/aoai/proxy_components/environments/context/DockerfileR3-R6](diffhunk://#diff-2bc04e7a267272d500ee38ea26c83fa2ecf9b5bac1e98a2bfd1753960b80c5fbR3-R6)
- [assets/training/automl/environments/ai-ml-automl-dnn-text-gpu-ptca/context/DockerfileL30-R74](diffhunk://#diff-7dcea02849ca1747df34544577a9d65029a7b790298a79dc9a7b03ae95655631L30-R74)
- [[1]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL10-L11) [[2]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL43-R45) [[3]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL66-R59) [[4]](diffhunk://#diff-3b8b4937909f914c6a917a3fb78fea846d5b5950f552c427cb03410491e4da2fL102-R156)
- [[1]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L13-L24) [[2]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L33) [[3]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L96-R88) [[4]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97L120-R115) [[5]](diffhunk://#diff-946203079cb31586a3672f895968d3391509cb47c0ac0e9c27db03fa8f66ac97R137-R147)