### PR TITLE
Add ministral-3-3b-2512 model into Foundry Local

### DIFF
--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/description.md
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/description.md
@@ -1,9 +1,8 @@
-This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference. Optimized models are published here in ONNX format to run on CPU and GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs, with the precision best suited to each of these targets.
+This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference on CUDA GPUs. This optimized model is published here in ONNX format to run on CUDA-capable GPU devices, with the precision best suited to this target.
 
 # ONNX Models
 Here are some of the optimized configurations we have added:
-1. ONNX model for CPU and mobile using RTN quantization.
-2. ONNX model for GPU using RTN quantization.
+1. ONNX model for CUDA GPU using RTN quantization.
 
 # Model Description
 - **Developed by:** Microsoft

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/description.md
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/description.md
@@ -1,0 +1,16 @@
+This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference. Optimized models are published here in ONNX format to run on CPU and GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs, with the precision best suited to each of these targets.
+
+# ONNX Models
+Here are some of the optimized configurations we have added:
+1. ONNX model for CPU and mobile using RTN quantization.
+2. ONNX model for GPU using RTN quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of Ministral-3-3B-Instruct-2512 for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Ministral-3-3B-Instruct-2512](https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512) for details.

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512/onnx/cuda/v1
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/spec.yaml
@@ -1,0 +1,42 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: ministral-3-3b-instruct-2512-cuda-gpu
+version: 1
+isArchived: true
+path: ./
+tags:
+  foundryLocal: ""
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://www.apache.org/licenses/LICENSE-2.0.html>."
+  author: Microsoft
+  inputModalities: "text,image"
+  outputModalities: "text"
+  task: vision-language-chat
+  maxOutputTokens: 2048
+  alias: ministral-3-3b-instruct-2512
+  directoryPath: v1
+  promptTemplate: "{\"system\": \"[SYSTEM_PROMPT]{Content}[/SYSTEM_PROMPT]\", \"user\": \"[INST]{Content}[/INST]\", \"assistant\": \"{Content}</s>\", \"prompt\": \"[INST]{Content}[/INST]\"}"
+  supportsToolCalling: "true"
+  toolCallStart: "[TOOL_CALLS]"
+  toolCallEnd: "</s>"
+  toolRegisterStart: "[AVAILABLE_TOOLS]"
+  toolRegisterEnd: "[/AVAILABLE_TOOLS]"
+  toolResponseStart: "[TOOL_RESULTS]"
+  toolResponseEnd: "[/TOOL_RESULTS]"
+  capabilities: "tool-calling"
+  supportsReasoning: ""
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 262144
+  minFLVersion: "1.2.0"
+  disable-maap: "true"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/ministral-3-3b-instruct-2512/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'gpu'
+    executionProvider: 'CUDAExecutionProvider'
+    fileSizeBytes: 3857772715
+    vRamFootprintBytes: 3857772715

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/description.md
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/description.md
@@ -1,9 +1,8 @@
-This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference. Optimized models are published here in ONNX format to run on CPU and GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs, with the precision best suited to each of these targets.
+This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference on CPU and mobile devices. This optimized model is published here in ONNX format to run on CPU and mobile targets, with the precision best suited to this target.
 
 # ONNX Models
 Here are some of the optimized configurations we have added:
 1. ONNX model for CPU and mobile using RTN quantization.
-2. ONNX model for GPU using RTN quantization.
 
 # Model Description
 - **Developed by:** Microsoft

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/description.md
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/description.md
@@ -1,0 +1,16 @@
+This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference. Optimized models are published here in ONNX format to run on CPU and GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs, with the precision best suited to each of these targets.
+
+# ONNX Models
+Here are some of the optimized configurations we have added:
+1. ONNX model for CPU and mobile using RTN quantization.
+2. ONNX model for GPU using RTN quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of Ministral-3-3B-Instruct-2512 for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Ministral-3-3B-Instruct-2512](https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512) for details.

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512/onnx/cpu_and_mobile/v1
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/spec.yaml
@@ -1,0 +1,42 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: ministral-3-3b-instruct-2512-generic-cpu
+version: 1
+isArchived: true
+path: ./
+tags:
+  foundryLocal: ""
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://www.apache.org/licenses/LICENSE-2.0.html>."
+  author: Microsoft
+  inputModalities: "text,image"
+  outputModalities: "text"
+  task: vision-language-chat
+  maxOutputTokens: 2048
+  alias: ministral-3-3b-instruct-2512
+  directoryPath: v1
+  promptTemplate: "{\"system\": \"[SYSTEM_PROMPT]{Content}[/SYSTEM_PROMPT]\", \"user\": \"[INST]{Content}[/INST]\", \"assistant\": \"{Content}</s>\", \"prompt\": \"[INST]{Content}[/INST]\"}"
+  supportsToolCalling: "true"
+  toolCallStart: "[TOOL_CALLS]"
+  toolCallEnd: "</s>"
+  toolRegisterStart: "[AVAILABLE_TOOLS]"
+  toolRegisterEnd: "[/AVAILABLE_TOOLS]"
+  toolResponseStart: "[TOOL_RESULTS]"
+  toolResponseEnd: "[/TOOL_RESULTS]"
+  capabilities: "tool-calling"
+  supportsReasoning: ""
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 262144
+  minFLVersion: "1.2.0"
+  disable-maap: "true"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/ministral-3-3b-instruct-2512/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'cpu'
+    executionProvider: 'CPUExecutionProvider'
+    fileSizeBytes: 4919876920
+    vRamFootprintBytes: 4919876920

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/asset.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/description.md
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/description.md
@@ -1,0 +1,16 @@
+This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference. Optimized models are published here in ONNX format to run on CPU and GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs, with the precision best suited to each of these targets.
+
+# ONNX Models
+Here are some of the optimized configurations we have added:
+1. ONNX model for CPU and mobile using RTN quantization.
+2. ONNX model for GPU using RTN quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of Ministral-3-3B-Instruct-2512 for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Ministral-3-3B-Instruct-2512](https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512) for details.

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/description.md
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/description.md
@@ -1,9 +1,8 @@
-This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference. Optimized models are published here in ONNX format to run on CPU and GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs, with the precision best suited to each of these targets.
+This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference on WebGPU-capable devices. This optimized model is published here in ONNX format to run with the WebGPU execution provider, with the precision best suited to this target.
 
 # ONNX Models
 Here are some of the optimized configurations we have added:
-1. ONNX model for CPU and mobile using RTN quantization.
-2. ONNX model for GPU using RTN quantization.
+1. ONNX model for WebGPU using RTN quantization.
 
 # Model Description
 - **Developed by:** Microsoft

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512/onnx/webgpu/v1
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/spec.yaml
@@ -1,0 +1,42 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: ministral-3-3b-instruct-2512-generic-gpu
+version: 1
+isArchived: true
+path: ./
+tags:
+  foundryLocal: ""
+  license: "apache-2.0"
+  licenseDescription: "This model is provided under the License Terms available at <https://www.apache.org/licenses/LICENSE-2.0.html>."
+  author: Microsoft
+  inputModalities: "text,image"
+  outputModalities: "text"
+  task: vision-language-chat
+  maxOutputTokens: 2048
+  alias: ministral-3-3b-instruct-2512
+  directoryPath: v1
+  promptTemplate: "{\"system\": \"[SYSTEM_PROMPT]{Content}[/SYSTEM_PROMPT]\", \"user\": \"[INST]{Content}[/INST]\", \"assistant\": \"{Content}</s>\", \"prompt\": \"[INST]{Content}[/INST]\"}"
+  supportsToolCalling: "true"
+  toolCallStart: "[TOOL_CALLS]"
+  toolCallEnd: "</s>"
+  toolRegisterStart: "[AVAILABLE_TOOLS]"
+  toolRegisterEnd: "[/AVAILABLE_TOOLS]"
+  toolResponseStart: "[TOOL_RESULTS]"
+  toolResponseEnd: "[/TOOL_RESULTS]"
+  capabilities: "tool-calling"
+  supportsReasoning: ""
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 262144
+  minFLVersion: "1.2.0"
+  disable-maap: "true"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/ministral-3-3b-instruct-2512/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'gpu'
+    executionProvider: 'WebGPUExecutionProvider'
+    fileSizeBytes: 3857775303
+    vRamFootprintBytes: 3857775303

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512/asset.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512/description.md
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512/description.md
@@ -1,0 +1,16 @@
+This model is an optimized version of Ministral-3-3B-Instruct-2512 for local inference. Optimized models are published here in ONNX format to run on CPU and GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs, with the precision best suited to each of these targets.
+
+# ONNX Models
+Here are some of the optimized configurations we have added:
+1. ONNX model for CPU and mobile using RTN quantization.
+2. ONNX model for GPU using RTN quantization.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of Ministral-3-3B-Instruct-2512 for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Ministral-3-3B-Instruct-2512](https://huggingface.co/mistralai/Ministral-3-3B-Instruct-2512) for details.

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512/model.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512/spec.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512/spec.yaml
@@ -1,0 +1,8 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: ministral-3-3b-instruct-2512
+version: 1
+isArchived: true
+path: ./
+tags:
+  foundryLocal: ""
+type: custom_model


### PR DESCRIPTION
This PR is to add ministral-3-3b-instruct-2512 cpu/cuda/webgpu models into Foundry Local. Models are tested locally with onnxruntime-genai 0.14.0.