### PR TITLE
Fix S360 vulnerabilities in evaluations-built-in environment

### DIFF
--- a/assets/evaluation_on_cloud/environments/evaluations-built-in/context/Dockerfile
+++ b/assets/evaluation_on_cloud/environments/evaluations-built-in/context/Dockerfile
@@ -1,7 +1,13 @@
 FROM mcr.microsoft.com/azureml/openmpi5.0-ubuntu24.04:{{latest-image-tag}}
 
+# Fix S360 vulnerabilities: update OS packages (openssh, curl, kmod, sed, nghttp2, dpkg)
+RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt /app/requirements.txt
 RUN pip install -r /app/requirements.txt
+
+# Upgrade pip and GitPython to fix known CVEs (after requirements to avoid downgrade)
+RUN pip install --upgrade "pip==26.1" "GitPython==3.1.50"
 
 # Copy your Python file into the image
 COPY evaluate_on_data.py /app/evaluate_on_data.py


### PR DESCRIPTION
Update Dockerfile to fix 10 identified vulnerabilities (ICM 805974566):

OS packages (apt-get upgrade):
- openssh (USN-8222-1) - HIGH, due Jun 3
- kmod (USN-8226-1) - HIGH, due Jun 4
- curl (USN-8227-1) - HIGH, due Jun 5
- sed (USN-8229-1) - MEDIUM, due Jun 5
- nghttp2 (USN-8233-1) - HIGH, due Jun 5
- dpkg (USN-8249-1) - HIGH, due Jun 10

Python packages (pip install --upgrade):
- pip 26.0.1 -> 26.1 (GHSA-jp4c-xjxw-mgf9) - HIGH
- GitPython 3.1.47 -> 3.1.50 (GHSA-v87r-6q3f-2j67, GHSA-7545-fcxq-7j24, GHSA-mv93-w799-cj2w)