### PR TITLE
Add parakeet model into Foundry Local

### DIFF
--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/description.md
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of parakeet-tdt-0.6b-v2 for local inference on CUDA GPUs. This optimized model is published here in ONNX format to run on CUDA-capable GPU devices, with the precision best suited to this target.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** MIT
+- **Model Description:** This is a conversion of the parakeet-tdt-0.6b-v2 for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [parakeet-tdt-0.6b-v2](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2) for details.

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/parakeet-tdt-0.6b-v2/onnx/cuda/v1
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/spec.yaml
@@ -1,0 +1,35 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: parakeet-tdt-0.6b-v2-cuda-gpu
+version: 1
+isArchived: true
+path: ./
+tags:
+  foundryLocal: "test"
+  license: "MIT"
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2#licenseterms-of-use>."
+  author: Microsoft
+  inputModalities: "audio"
+  outputModalities: "text"
+  task: automatic-speech-recognition
+  maxOutputTokens: 2048
+  alias: parakeet-tdt-0.6b-v2
+  directoryPath: v1
+  promptTemplate: ""
+  capabilities: ""
+  supportsReasoning: ""
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 0
+  minFLVersion: "1.2.0"
+  disable-maap: "true"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/parakeet-tdt-0.6b-v2/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'gpu'
+    executionProvider: 'CUDAExecutionProvider'
+    fileSizeBytes: 725652848
+    vRamFootprintBytes: 725652848

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/description.md
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of parakeet-tdt-0.6b-v2 for local inference. Optimized models are published here in ONNX format to run on CPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** MIT
+- **Model Description:** This is a conversion of the parakeet-tdt-0.6b-v2 for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [parakeet-tdt-0.6b-v2](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2) for details.

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/parakeet-tdt-0.6b-v2/onnx/cpu_and_mobile/v1
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/spec.yaml
@@ -1,0 +1,35 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: parakeet-tdt-0.6b-v2-generic-cpu
+version: 1
+isArchived: true
+path: ./
+tags:
+  foundryLocal: "test"
+  license: "MIT"
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2#licenseterms-of-use>."
+  author: Microsoft
+  inputModalities: "audio"
+  outputModalities: "text"
+  task: automatic-speech-recognition
+  maxOutputTokens: 2048
+  alias: parakeet-tdt-0.6b-v2
+  directoryPath: v1
+  promptTemplate: ""
+  capabilities: ""
+  supportsReasoning: ""
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 0
+  minFLVersion: "1.2.0"
+  disable-maap: "true"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/parakeet-tdt-0.6b-v2/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'cpu'
+    executionProvider: 'CPUExecutionProvider'
+    fileSizeBytes: 725652479
+    vRamFootprintBytes: 725652479

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2/asset.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2/description.md
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of parakeet-tdt-0.6b-v2 for local inference. Optimized models are published here in ONNX format to run on CPU and CUDA GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** MIT
+- **Model Description:** This is a conversion of the parakeet-tdt-0.6b-v2 for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [parakeet-tdt-0.6b-v2](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2) for details.

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2/model.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/parakeet-tdt-0.6b-v2
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2/spec.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2/spec.yaml
@@ -1,0 +1,8 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: parakeet-tdt-0.6b-v2
+version: 1
+isArchived: true
+path: ./
+tags:
+  foundryLocal: ""
+type: custom_model


### PR DESCRIPTION
This PR is to add nvidia/parakeet-tdt-0.6b-v2 ONNX models into Foundry Local.

- parakeet-tdt-0.6b-v2-generic-cpu
- parakeet-tdt-0.6b-v2-cuda-gpu