### PR TITLE
Update metadata of qwen3.5-2b-text Foundry Local models

### DIFF
--- a/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/spec.yaml
@@ -4,7 +4,7 @@ version: 1
 isArchived: true
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-cuda-gpu/spec.yaml
@@ -27,7 +27,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "1.1.0"
+  minFLVersion: "1.2.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/spec.yaml
@@ -4,7 +4,7 @@ version: 1
 isArchived: true
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE>."
   author: Microsoft

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-cpu/spec.yaml
@@ -27,7 +27,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "1.1.0"
+  minFLVersion: "1.2.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
@@ -27,7 +27,7 @@ tags:
   reasoningStart: "<think>"
   reasoningEnd: "</think>"
   contextLength: 262144
-  minFLVersion: "1.1.0"
+  minFLVersion: "1.2.0"
   disable-maap: "true"
 type: custom_model
 variantInfo:

--- a/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-text-generic-gpu/spec.yaml
@@ -4,7 +4,7 @@ version: 3
 isArchived: true
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "apache-2.0"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/Qwen3.5-2B/blob/main/LICENSE>."
   author: Microsoft


### PR DESCRIPTION
This PR is to remove "test" tag from qwen3.5-2b text models in Foundry Local Catalog and to update minFLVersion to "1.2.0".