### PR TITLE
Update or add new QNN models in Foundry Local

### DIFF
--- a/assets/models/foundrylocal/DeepSeek-R1-Distill-Qwen-1.5B-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/DeepSeek-R1-Distill-Qwen-1.5B-qnn-npu/spec.yaml
@@ -32,4 +32,5 @@ variantInfo:
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
     fileSizeBytes: 1632077086
-    vRamFootprintBytes: 1336043110
+    vRamFootprintBytes: 1632077086
+

--- a/assets/models/foundrylocal/DeepSeek-R1-Distill-Qwen-7B-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/DeepSeek-R1-Distill-Qwen-7B-qnn-npu/spec.yaml
@@ -32,4 +32,5 @@ variantInfo:
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
     fileSizeBytes: 3987199754
-    vRamFootprintBytes: 3301640765
+    vRamFootprintBytes: 3987199754
+

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-qnn-npu/spec.yaml
@@ -39,4 +39,5 @@ variantInfo:
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
     fileSizeBytes: 2982936576
-    vRamFootprintBytes: 1749486141
+    vRamFootprintBytes: 2982936576
+

--- a/assets/models/foundrylocal/deepseek-r1-distill-qwen-14b-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/deepseek-r1-distill-qwen-14b-qnn-npu/spec.yaml
@@ -32,4 +32,5 @@ variantInfo:
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
     fileSizeBytes: 7644884500
-    vRamFootprintBytes: 6667276124
+    vRamFootprintBytes: 7644884500
+

--- a/assets/models/foundrylocal/phi-3-mini-128k-instruct-qnn-npu/model.yaml
+++ b/assets/models/foundrylocal/phi-3-mini-128k-instruct-qnn-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/phi-3-mini-128k-instruct/onnx/qnn_npu/v3
+  container_path: foundrylocal/models/phi-3-mini-128k-instruct/onnx/qnn_npu/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/phi-3-mini-128k-instruct-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/phi-3-mini-128k-instruct-qnn-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: phi-3-mini-128k-instruct-qnn-npu
-version: 3
+version: 4
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: phi-3-mini-128k
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"system\": \"<|system|>Your name is Phi, an AI math expert developed by Microsoft. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   contextLength: 131072
   capabilities: ""
@@ -31,6 +31,7 @@ variantInfo:
     quantization: ['QuaRot', 'GPTQ']
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
-    fileSizeBytes: 2982936576
-    vRamFootprintBytes: 1749486141
+    fileSizeBytes: 3799254479
+    vRamFootprintBytes: 3799254479
+
 

--- a/assets/models/foundrylocal/phi-3-mini-4k-instruct-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/phi-3-mini-4k-instruct-qnn-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: phi-3-mini-4k-instruct-qnn-npu
-version: 3
+version: 4
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: phi-3-mini-4k
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"system\": \"<|system|>Your name is Phi, an AI math expert developed by Microsoft. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   contextLength: 4096
   capabilities: ""
@@ -31,6 +31,7 @@ variantInfo:
     quantization: ['QuaRot', 'GPTQ']
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
-    fileSizeBytes: 2982936576
-    vRamFootprintBytes: 1749486141
+    fileSizeBytes: 3799250963
+    vRamFootprintBytes: 3799250963
+
 

--- a/assets/models/foundrylocal/phi-3.5-mini-128k-instruct-qnn-npu/model.yaml
+++ b/assets/models/foundrylocal/phi-3.5-mini-128k-instruct-qnn-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/phi-3.5-mini-instruct/onnx/qnn_npu/v2
+  container_path: foundrylocal/models/phi-3.5-mini-instruct/onnx/qnn_npu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/phi-3.5-mini-128k-instruct-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/phi-3.5-mini-128k-instruct-qnn-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: phi-3.5-mini-instruct-qnn-npu
-version: 2
+version: 3
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: phi-3.5-mini
-  directoryPath: v2
+  directoryPath: v3
   promptTemplate: "{\"system\": \"<|system|>Your name is Phi, an AI math expert developed by Microsoft. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   contextLength: 131072
   capabilities: ""
@@ -31,6 +31,7 @@ variantInfo:
     quantization: ['QuaRot', 'GPTQ']
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
-    fileSizeBytes: 2982936576
-    vRamFootprintBytes: 1749486141
+    fileSizeBytes: 2164067858
+    vRamFootprintBytes: 2164067858
+
 

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-qnn-npu/asset.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-qnn-npu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-qnn-npu/description.md
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-qnn-npu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of qwen2.5-0.5b-instruct to enable local inference on QNN NPUs.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** MIT
+- **Model Description:** This is a conversion of the qwen2.5-0.5b-instruct for local inference on QNN NPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [qwen2.5-0.5b-instruct](https://huggingface.co/Qwen/qwen2.5-0.5b-instruct) for details.

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-qnn-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-qnn-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/phi-3-mini-4k-instruct/onnx/qnn_npu/v4
+  container_path: foundrylocal/models/qwen2.5-0.5b-instruct/onnx/qnn_npu/v1
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-qnn-npu/spec.yaml
@@ -1,19 +1,19 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
-name: qwen2.5-7b-instruct-qnn-npu
-version: 3
+name: qwen2.5-0.5b-instruct-qnn-npu
+version: 1
 isArchived: true
 path: ./
 tags:
   foundryLocal: ""
   license: "MIT"
-  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/qwen2.5-7b-instruct/blob/main/LICENSE>."
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/qwen2.5-0.5b-instruct/blob/main/LICENSE>."
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
   task: chat-completion
   maxOutputTokens: 2048
-  alias: qwen2.5-7b
-  directoryPath: v3
+  alias: qwen2.5-0.5b
+  directoryPath: v1
   promptTemplate: "{\"system\": \"<|system|>You are Qwen, an AI assistant developed by Alibaba. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"
@@ -32,13 +32,11 @@ tags:
 type: custom_model
 variantInfo:
   parents:
-  - assetId: azureml://registries/azureml/models/qwen2.5-7b-instruct/versions/1
+  - assetId: azureml://registries/azureml/models/qwen2.5-0.5b-instruct/versions/1
   variantMetadata:
     modelType: 'ONNX'
     quantization: ['QuaRot', 'GPTQ']
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
-    fileSizeBytes: 7316493941
-    vRamFootprintBytes: 7316493941
-
-
+    fileSizeBytes: 463732157
+    vRamFootprintBytes: 463732157

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/tool_calling/qwen2.5-1.5b-instruct-qnn-npu/v2
+  container_path: foundrylocal/models/qwen2.5-1.5b-instruct/onnx/qnn_npu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-qnn-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-1.5b-instruct-qnn-npu
-version: 2
+version: 3
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: qwen2.5-1.5b
-  directoryPath: v2
+  directoryPath: v3
   promptTemplate: "{\"system\": \"<|system|>You are Qwen, an AI assistant developed by Alibaba. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"
@@ -38,6 +38,7 @@ variantInfo:
     quantization: ['QuaRot', 'GPTQ']
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
-    fileSizeBytes: 2982936576
-    vRamFootprintBytes: 1749486141
+    fileSizeBytes: 1139116915
+    vRamFootprintBytes: 1139116915
+
 

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-qnn-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-qnn-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/tool_calling/qwen2.5-7b-instruct-qnn-npu/v2
+  container_path: foundrylocal/models/qwen2.5-7b-instruct/onnx/qnn_npu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-qnn-npu/asset.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-qnn-npu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-qnn-npu/description.md
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-qnn-npu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of qwen2.5-coder-0.5b-instruct to enable local inference on QNN NPUs.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** MIT
+- **Model Description:** This is a conversion of the qwen2.5-coder-0.5b-instruct for local inference on QNN NPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [qwen2.5-coder-0.5b-instruct](https://huggingface.co/Qwen/qwen2.5-coder-0.5b-instruct) for details.

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-qnn-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-qnn-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/phi-3-mini-4k-instruct/onnx/qnn_npu/v4
+  container_path: foundrylocal/models/qwen2.5-coder-0.5b-instruct/onnx/qnn_npu/v1
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-qnn-npu/spec.yaml
@@ -1,19 +1,19 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
-name: qwen2.5-7b-instruct-qnn-npu
-version: 3
+name: qwen2.5-coder-0.5b-instruct-qnn-npu
+version: 1
 isArchived: true
 path: ./
 tags:
   foundryLocal: ""
   license: "MIT"
-  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/qwen2.5-7b-instruct/blob/main/LICENSE>."
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/qwen2.5-coder-0.5b-instruct/blob/main/LICENSE>."
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
   task: chat-completion
   maxOutputTokens: 2048
-  alias: qwen2.5-7b
-  directoryPath: v3
+  alias: qwen2.5-coder-0.5b
+  directoryPath: v1
   promptTemplate: "{\"system\": \"<|system|>You are Qwen, an AI assistant developed by Alibaba. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"
@@ -32,13 +32,11 @@ tags:
 type: custom_model
 variantInfo:
   parents:
-  - assetId: azureml://registries/azureml/models/qwen2.5-7b-instruct/versions/1
+  - assetId: azureml://registries/azureml/models/qwen2.5-coder-0.5b-instruct/versions/1
   variantMetadata:
     modelType: 'ONNX'
     quantization: ['QuaRot', 'GPTQ']
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
-    fileSizeBytes: 7316493941
-    vRamFootprintBytes: 7316493941
-
-
+    fileSizeBytes: 463732157
+    vRamFootprintBytes: 463732157

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-qnn-npu/asset.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-qnn-npu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-qnn-npu/description.md
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-qnn-npu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of qwen2.5-coder-1.5b-instruct to enable local inference on QNN NPUs.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** MIT
+- **Model Description:** This is a conversion of the qwen2.5-coder-1.5b-instruct for local inference on QNN NPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [qwen2.5-coder-1.5b-instruct](https://huggingface.co/Qwen/qwen2.5-coder-1.5b-instruct) for details.

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-qnn-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-qnn-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/phi-3-mini-4k-instruct/onnx/qnn_npu/v4
+  container_path: foundrylocal/models/qwen2.5-coder-1.5b-instruct/onnx/qnn_npu/v1
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-qnn-npu/spec.yaml
@@ -1,19 +1,19 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
-name: qwen2.5-7b-instruct-qnn-npu
-version: 3
+name: qwen2.5-coder-1.5b-instruct-qnn-npu
+version: 1
 isArchived: true
 path: ./
 tags:
   foundryLocal: ""
   license: "MIT"
-  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/qwen2.5-7b-instruct/blob/main/LICENSE>."
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/qwen2.5-coder-1.5b-instruct/blob/main/LICENSE>."
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
   task: chat-completion
   maxOutputTokens: 2048
-  alias: qwen2.5-7b
-  directoryPath: v3
+  alias: qwen2.5-coder-1.5b
+  directoryPath: v1
   promptTemplate: "{\"system\": \"<|system|>You are Qwen, an AI assistant developed by Alibaba. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"
@@ -32,13 +32,11 @@ tags:
 type: custom_model
 variantInfo:
   parents:
-  - assetId: azureml://registries/azureml/models/qwen2.5-7b-instruct/versions/1
+  - assetId: azureml://registries/azureml/models/qwen2.5-coder-1.5b-instruct/versions/1
   variantMetadata:
     modelType: 'ONNX'
     quantization: ['QuaRot', 'GPTQ']
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
-    fileSizeBytes: 7316493941
-    vRamFootprintBytes: 7316493941
-
-
+    fileSizeBytes: 1139120923
+    vRamFootprintBytes: 1139120923

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-qnn-npu/asset.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-qnn-npu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-qnn-npu/description.md
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-qnn-npu/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of qwen2.5-coder-7b-instruct to enable local inference on QNN NPUs.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** MIT
+- **Model Description:** This is a conversion of the qwen2.5-coder-7b-instruct for local inference on QNN NPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [qwen2.5-coder-7b-instruct](https://huggingface.co/Qwen/qwen2.5-coder-7b-instruct) for details.

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-qnn-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-qnn-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/phi-3-mini-4k-instruct/onnx/qnn_npu/v4
+  container_path: foundrylocal/models/qwen2.5-coder-7b-instruct/onnx/qnn_npu/v1
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-qnn-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-qnn-npu/spec.yaml
@@ -1,19 +1,19 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
-name: qwen2.5-7b-instruct-qnn-npu
-version: 3
+name: qwen2.5-coder-7b-instruct-qnn-npu
+version: 1
 isArchived: true
 path: ./
 tags:
   foundryLocal: ""
   license: "MIT"
-  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/qwen2.5-7b-instruct/blob/main/LICENSE>."
+  licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/Qwen/qwen2.5-coder-7b-instruct/blob/main/LICENSE>."
   author: Microsoft
   inputModalities: "text"
   outputModalities: "text"
   task: chat-completion
   maxOutputTokens: 2048
-  alias: qwen2.5-7b
-  directoryPath: v3
+  alias: qwen2.5-coder-7b
+  directoryPath: v1
   promptTemplate: "{\"system\": \"<|system|>You are Qwen, an AI assistant developed by Alibaba. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"
@@ -32,13 +32,11 @@ tags:
 type: custom_model
 variantInfo:
   parents:
-  - assetId: azureml://registries/azureml/models/qwen2.5-7b-instruct/versions/1
+  - assetId: azureml://registries/azureml/models/qwen2.5-coder-7b-instruct/versions/1
   variantMetadata:
     modelType: 'ONNX'
     quantization: ['QuaRot', 'GPTQ']
     device: 'npu'
     executionProvider: 'QNNExecutionProvider'
-    fileSizeBytes: 7316493941
-    vRamFootprintBytes: 7316493941
-
-
+    fileSizeBytes: 7606003998
+    vRamFootprintBytes: 7606003998


### PR DESCRIPTION
This PR is to update QNN models in Foundry Local

- phi-3-mini-128k-instruct-qnn-npu: v4
- phi-3-mini-4k-instruct-qnn-npu: v4
- qwen2.5-1.5b-instruct-qnn-npu: v3
- qwen2.5-7b-instruct-qnn-npu: v3

and to add following QNN models into Foundry Local

- qwen2.5-0.5b-instruct-qnn-npu: v1
- qwen2.5-coder-0.5b-instruct-qnn-npu: v1
- qwen2.5-coder-1.5b-instruct-qnn-npu: v1
- qwen2.5-coder-7b-instruct-qnn-npu: v1

All models were tested locally.