### PR TITLE
Fms10 release

### DIFF
--- a/assets/training/model_management/environments/foundation-model-serve/context/Dockerfile
+++ b/assets/training/model_management/environments/foundation-model-serve/context/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azureml/openmpi5.0-cuda13.1-ubuntu24.04:latest
+FROM mcr.microsoft.com/azureml/openmpi5.0-cuda13.1-ubuntu24.04:{{latest-image-tag}}
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -47,8 +47,7 @@ COPY . .
 RUN python3.12 -m pip install -e ./ --no-cache-dir && \
     rm -rf ~/.cache/pip
 
-# services there for its built-in scoring stack; we want only our api_server supervised.
-# The MCR base ships its legacy AzureML scoring services (gunicorn/nginx/rsyslog)
+# The MCR base ships its AzureML scoring services (gunicorn/nginx/rsyslog)
 # under /var/runit; remove them so only our api_server is supervised.
 RUN rm -rf /var/runit/gunicorn /var/runit/nginx /var/runit/rsyslog
 ADD runit_folder/api_server /var/runit/api_server

--- a/assets/training/model_management/environments/foundation-model-serve/context/Dockerfile
+++ b/assets/training/model_management/environments/foundation-model-serve/context/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azureml/openmpi5.0-cuda13.1-ubuntu24.04:{{latest-image-tag}}
+FROM mcr.microsoft.com/azureml/openmpi5.0-cuda13.1-ubuntu24.04:latest
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -47,18 +47,18 @@ COPY . .
 RUN python3.12 -m pip install -e ./ --no-cache-dir && \
     rm -rf ~/.cache/pip
 
-# Install our api_server service under /etc/service (empty in the base image).
-# IMPORTANT: do NOT use /var/runit here — the MCR base ships gunicorn/nginx/rsyslog
 # services there for its built-in scoring stack; we want only our api_server supervised.
-ADD runit_folder/api_server /etc/service/api_server
-RUN sed -i 's/\r$//g' /etc/service/api_server/run && \
-    chmod +x /etc/service/api_server/run
+# The MCR base ships its legacy AzureML scoring services (gunicorn/nginx/rsyslog)
+# under /var/runit; remove them so only our api_server is supervised.
+RUN rm -rf /var/runit/gunicorn /var/runit/nginx /var/runit/rsyslog
+ADD runit_folder/api_server /var/runit/api_server
+RUN sed -i 's/\r$//g' /var/runit/api_server/run && \
+    chmod +x /var/runit/api_server/run
 
-ENV SVDIR=/etc/service \
+ENV SVDIR=/var/runit \
     WORKER_TIMEOUT=3600
 
-# install runit as the CMD below depends on `runsvdir`).
 RUN command -v runsvdir >/dev/null || { echo 'runsvdir missing in base image'; exit 1; }
 
 EXPOSE 5001
-CMD ["runsvdir", "/etc/service"]
+CMD ["runsvdir", "/var/runit"]

--- a/assets/training/model_management/environments/foundation-model-serve/context/requirements.txt
+++ b/assets/training/model_management/environments/foundation-model-serve/context/requirements.txt
@@ -2,7 +2,7 @@ azure-ai-contentsafety==1.0.0b1
 azure-ai-ml==1.13.0
 azureml-mlflow==1.60.0
 azure-identity==1.23.0
-fastapi==0.120.4
+fastapi==0.136.3
 pandas==2.2.3
 transformers==5.0.0
 uvicorn==0.38.0


### PR DESCRIPTION
The MCR base image (openmpi5.0-cuda13.1-ubuntu24.04) ships the built-in
AzureML scoring stack (gunicorn, nginx, rsyslog) as runit services under
/var/runit. 

Consolidate everything under /var/runit so there is one — and only one —
supervised service:

- Remove /var/runit/{gunicorn,nginx,rsyslog} from the base image.
- Install api_server at /var/runit/api_server (was /etc/service/api_server).
- Update SVDIR and the CMD to `runsvdir /var/runit`.

No changes to api_server itself; this only touches container service
supervision. After the change, the container starts cleanly with a single
api_server process listening on 5001, with no leftover services from the
base image.
