### PR TITLE
Add isArchived: true to retired Phi-3 and Phi-3.5 models

### DIFF
--- a/assets/models/system/phi-3-medium-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-medium-128k-instruct/spec.yaml
@@ -1,6 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-3-medium-128k-instruct
 path: ./
+isArchived: true
 properties:
   SharedComputeCapacityEnabled: "True"
   languages: en

--- a/assets/models/system/phi-3-medium-4k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-medium-4k-instruct/spec.yaml
@@ -1,6 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-3-medium-4k-instruct
 path: ./
+isArchived: true
 properties:
   SharedComputeCapacityEnabled: "True"
   languages: en

--- a/assets/models/system/phi-3-mini-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-mini-128k-instruct/spec.yaml
@@ -1,6 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-3-mini-128k-instruct
 path: ./
+isArchived: true
 properties:
   SharedComputeCapacityEnabled: "True"
   languages: en

--- a/assets/models/system/phi-3-mini-4k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-mini-4k-instruct/spec.yaml
@@ -1,6 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-3-mini-4k-instruct
 path: ./
+isArchived: true
 properties:
   SharedComputeCapacityEnabled: "True"
   languages: en

--- a/assets/models/system/phi-3-small-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3-small-128k-instruct/spec.yaml
@@ -1,6 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-3-small-128k-instruct
 path: ./
+isArchived: true
 properties:
   SharedComputeCapacityEnabled: "True"
   languages: en

--- a/assets/models/system/phi-3.5-mini-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3.5-mini-128k-instruct/spec.yaml
@@ -1,6 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-3.5-mini-instruct
 path: ./
+isArchived: true
 properties:
   SharedComputeCapacityEnabled: "True"
   languages: en

--- a/assets/models/system/phi-3.5-moe-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3.5-moe-128k-instruct/spec.yaml
@@ -1,6 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-3.5-MoE-instruct
 path: ./
+isArchived: true
 properties:
   SharedComputeCapacityEnabled: "True"
   languages: en

--- a/assets/models/system/phi-3.5-vision-128k-instruct/spec.yaml
+++ b/assets/models/system/phi-3.5-vision-128k-instruct/spec.yaml
@@ -1,6 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-3.5-vision-instruct
 path: ./
+isArchived: true
 properties:
   SharedComputeCapacityEnabled: "True"
   languages: en


### PR DESCRIPTION
All 8 models have InferenceRetirementDate of 2025-08-30 (already past). Adding isArchived: true for consistency with other retired models.