### PR TITLE
Add Nemotron multilingual ASR model to Foundry Local

### DIFF
--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-generic-cpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-generic-cpu/description.md
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-generic-cpu/description.md
@@ -1,0 +1,13 @@
+This model is an optimized version of nemotron-3.5-asr-streaming-0.6b to enable local inference on CPUs. This model uses RTN quantization.
+
+# Model Description
+
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** MIT
+- **Model Description:** This is an optimized version of the nemotron-3.5-asr-streaming-0.6b model for local inference on CPUs.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+
+See Hugging Face model [nemotron-3.5-asr-streaming-0.6b](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b) for details.

--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-generic-cpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/nemotron-3.5-asr-streaming-0.6b/onnx/cpu_and_mobile/v1
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-generic-cpu/spec.yaml
@@ -1,0 +1,35 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: nemotron-3.5-asr-streaming-0.6b-generic-cpu
+version: 1
+isArchived: true
+path: ./
+tags:
+  foundryLocal: "test"
+  license: "MIT"
+  licenseDescription: "This model is provided under the License Terms available at <https://github.com/microsoft/Foundry-Local/blob/main/licenses/nemotron-speech-streaming.md>."
+  author: Microsoft
+  inputModalities: "audio"
+  outputModalities: "text"
+  task: automatic-speech-recognition
+  maxOutputTokens: 2048
+  alias: nemotron-3.5-asr-streaming-0.6b
+  directoryPath: v1
+  promptTemplate: ""
+  capabilities: ""
+  supportsReasoning: ""
+  reasoningStart: ""
+  reasoningEnd: ""
+  contextLength: 0
+  minFLVersion: "1.2.1"
+  disable-maap: "true"
+type: custom_model
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/nemotron-3.5-asr-streaming-0.6b/versions/1
+  variantMetadata:
+    modelType: 'ONNX'
+    quantization: ['RTN']
+    device: 'cpu'
+    executionProvider: 'CPUExecutionProvider'
+    fileSizeBytes: 793345330
+    vRamFootprintBytes: 793345330

--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b/asset.yaml
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b/description.md
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b/description.md
@@ -1,0 +1,11 @@
+This model is an optimized version of nemotron-3.5-asr-streaming-0.6b for local inference. Optimized models are published here in ONNX format to run on CPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs.
+
+# Model Description
+- **Developed by:** Microsoft
+- **Model type:** ONNX
+- **License:** MIT
+- **Model Description:** This is a conversion of the nemotron-3.5-asr-streaming-0.6b for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [nemotron-3.5-asr-streaming-0.6b](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b) for details.

--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b/model.yaml
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/nemotron-3.5-asr-streaming-0.6b
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b/spec.yaml
@@ -1,0 +1,8 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: nemotron-3.5-asr-streaming-0.6b
+version: 1
+isArchived: true
+path: ./
+tags:
+  foundryLocal: ""
+type: custom_model


### PR DESCRIPTION
This PR is to add Nemotron 3.5 multilingual ASR model into Foundry Local. We publish CPU ONNX model first.

- nemotron-3.5-asr-streaming-0.6b-generic-cpu