### PR TITLE
Route documented skip cases to status=skipped for 6 evaluators (relevance, task_adherence, tool_selection, response_completeness, intent_resolution, task_completion)

### DIFF
--- a/assets/evaluators/builtin/intent_resolution/evaluator/_intent_resolution.py
+++ b/assets/evaluators/builtin/intent_resolution/evaluator/_intent_resolution.py
@@ -456,6 +456,10 @@ class ConversationValidator(ValidatorInterface):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input."""
+        # Documented skip cases (empty inputs) are surfaced as status="skipped"
+        # by _do_eval via _return_not_applicable_result; do not raise here.
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         conversation = eval_input.get("conversation")
         if conversation:
             conversation_validation_exception = self._validate_conversation(conversation)
@@ -551,6 +555,10 @@ class ToolDefinitionsValidator(ConversationValidator):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input with tool definitions."""
+        # Documented skip cases (incl. empty tool_definitions) are surfaced as
+        # status="skipped" by _do_eval via _return_not_applicable_result.
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         if super().validate_eval_input(eval_input):
             tool_definitions = eval_input.get("tool_definitions")
             tool_definitions_validation_exception = self._validate_tool_definitions(tool_definitions)
@@ -562,6 +570,38 @@ class ToolDefinitionsValidator(ConversationValidator):
 # endregion Validators
 
 logger = logging.getLogger(__name__)
+
+
+def _is_empty_input_value(value: Any) -> bool:
+    """Return True if value is None or an empty string/list/dict (documented skip case)."""
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict)) and len(value) == 0:
+        return True
+    return False
+
+
+def _documented_skip_reason(eval_input: Dict[str, Any]) -> Optional[str]:
+    """Return a reason string when eval_input matches a documented skip case, else None.
+
+    Documented skip cases for intent_resolution (per prompty's "Status: Skipped" rules
+    and PR #5042's _return_not_applicable_result helper):
+      - query or response is None / empty
+      - conversation.messages is None / empty
+      - tool_definitions is required-but-empty (no tools to evaluate against)
+    """
+    conversation = eval_input.get("conversation")
+    if isinstance(conversation, dict):
+        if _is_empty_input_value(conversation.get("messages")):
+            return "Conversation messages are empty; evaluation is not applicable."
+    if "query" in eval_input or "response" in eval_input:
+        if _is_empty_input_value(eval_input.get("query")):
+            return "Query is empty; evaluation is not applicable."
+        if _is_empty_input_value(eval_input.get("response")):
+            return "Response is empty; evaluation is not applicable."
+    if "tool_definitions" in eval_input and _is_empty_input_value(eval_input.get("tool_definitions")):
+        return "Tool definitions are empty; evaluation is not applicable."
+    return None
 
 
 def _is_intermediate_response(response):
@@ -949,6 +989,11 @@ class IntentResolutionEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         """
         # we override the _do_eval method as we want the output to be a dictionary, which is a different schema
         # than _base_prompty_eval.py
+        # Short-circuit documented skip cases (empty/missing inputs) to status="skipped"
+        # before any further processing. Matches PR #5042's design intent.
+        skip_reason = _documented_skip_reason(eval_input)
+        if skip_reason is not None:
+            return self._return_not_applicable_result(skip_reason, self._threshold)
         if "query" not in eval_input and "response" not in eval_input:
             raise EvaluationException(
                 message="Both query and response must be provided as input to the intent resolution evaluator.",

--- a/assets/evaluators/builtin/intent_resolution/spec.yaml
+++ b/assets/evaluators/builtin/intent_resolution/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.intent_resolution"
-version: 7
+version: 8
 displayName: "Intent-Resolution-Evaluator-(Preview)"
 description: "Checks whether the model correctly interprets and resolves user intent. Ensures the response aligns with what the user asked. Use this metric in conversational AI assistants, and customer support bots where understanding user intent is essential."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/relevance/evaluator/_relevance.py
+++ b/assets/evaluators/builtin/relevance/evaluator/_relevance.py
@@ -466,6 +466,11 @@ class ConversationValidator(ValidatorInterface):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate the evaluation input dictionary."""
+        # Documented skip cases (empty/None query/response/conversation messages)
+        # should not raise USER_ERROR; they are surfaced as status="skipped" by
+        # _do_eval via _return_not_applicable_result. See PR #5042.
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         conversation = eval_input.get("conversation")
         if conversation:
             conversation_validation_exception = self._validate_conversation(conversation)
@@ -486,6 +491,38 @@ class ConversationValidator(ValidatorInterface):
 # endregion Validators
 
 logger = logging.getLogger(__name__)
+
+
+def _is_empty_input_value(value: Any) -> bool:
+    """Return True if value is None or an empty string/list/dict (documented skip case)."""
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict)) and len(value) == 0:
+        return True
+    return False
+
+
+def _documented_skip_reason(eval_input: Dict[str, Any]) -> Optional[str]:
+    """Return a reason string when eval_input matches a documented skip case, else None.
+
+    Documented skip cases for the relevance evaluator (per the prompty's
+    "Status: Skipped" rules and PR #5042's _return_not_applicable_result helper):
+      - query or response is None / empty string / empty list
+      - conversation.messages is None / empty
+    These are inputs that the LLM-side prompt would itself return status="skipped"
+    for, but the SDK validators previously raised USER_ERROR before the LLM ever ran.
+    """
+    conversation = eval_input.get("conversation")
+    if isinstance(conversation, dict):
+        msgs = conversation.get("messages")
+        if _is_empty_input_value(msgs):
+            return "Conversation messages are empty; evaluation is not applicable."
+    if "query" in eval_input or "response" in eval_input:
+        if _is_empty_input_value(eval_input.get("query")):
+            return "Query is empty; evaluation is not applicable."
+        if _is_empty_input_value(eval_input.get("response")):
+            return "Response is empty; evaluation is not applicable."
+    return None
 
 
 def _is_intermediate_response(response):
@@ -840,6 +877,12 @@ class RelevanceEvaluator(PromptyEvaluatorBase):
         :return: The evaluation result.
         :rtype: Dict
         """
+        # Short-circuit documented skip cases (empty/missing inputs) to status="skipped"
+        # before any further processing. Matches PR #5042's _return_not_applicable_result
+        # design intent and the prompty's "Status: Skipped" rules.
+        skip_reason = _documented_skip_reason(eval_input)
+        if skip_reason is not None:
+            return self._return_not_applicable_result(skip_reason, self._threshold)
         if "query" not in eval_input and "response" not in eval_input:
             raise EvaluationException(
                 message="Only text conversation inputs are supported.",

--- a/assets/evaluators/builtin/relevance/spec.yaml
+++ b/assets/evaluators/builtin/relevance/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.relevance"
-version: 10
+version: 11
 displayName: "Relevance-Evaluator"
 description: "Assesses how well the response matches the user’s intent or question. Higher scores mean better alignment with the prompt. It’s best used for generative business writing such as summarizing meeting notes, creating marketing materials, and drafting email."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/response_completeness/evaluator/_response_completeness.py
+++ b/assets/evaluators/builtin/response_completeness/evaluator/_response_completeness.py
@@ -17,6 +17,30 @@ from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 logger = logging.getLogger(__name__)
 
 
+def _is_empty_input_value(value) -> bool:
+    """Return True if value is None or an empty string/list/dict (documented skip case)."""
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict)) and len(value) == 0:
+        return True
+    return False
+
+
+def _documented_skip_reason(eval_input: Dict) -> Optional[str]:
+    """Return a reason string when eval_input matches a documented skip case, else None.
+
+    Documented skip cases for response_completeness:
+      - response or ground_truth is None / empty
+    These match PR #5042's _return_not_applicable_result design intent: empty
+    inputs should yield status="skipped" rather than raise USER_ERROR.
+    """
+    if "ground_truth" in eval_input and _is_empty_input_value(eval_input.get("ground_truth")):
+        return "Ground truth is empty; evaluation is not applicable."
+    if "response" in eval_input and _is_empty_input_value(eval_input.get("response")):
+        return "Response is empty; evaluation is not applicable."
+    return None
+
+
 def _is_intermediate_response(response):
     """Check if response is intermediate (last content item is function_call or mcp_approval_request)."""
     if isinstance(response, list) and len(response) > 0:
@@ -278,6 +302,9 @@ class ResponseCompletenessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         """
         # we override the _do_eval method as we want the output to be a dictionary,
         # which is a different schema than _base_prompty_eval.py
+        skip_reason = _documented_skip_reason(eval_input)
+        if skip_reason is not None:
+            return self._return_not_applicable_result(skip_reason, self._threshold)
         if "ground_truth" not in eval_input or "response" not in eval_input:
             raise EvaluationException(
                 message="Both ground_truth and response must be provided as input to the completeness evaluator.",

--- a/assets/evaluators/builtin/response_completeness/spec.yaml
+++ b/assets/evaluators/builtin/response_completeness/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.response_completeness"
-version: 8
+version: 9
 displayName: "Response-Completeness-Evaluator-(Preview)"
 description: "Assesses whether the response covers all key aspects of the question. Higher scores indicate more thorough and complete answers. This evaluator is useful when evaluating chatbots, virtual assistants, and QA systems where full and informative responses are critical."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/task_adherence/evaluator/_task_adherence.py
+++ b/assets/evaluators/builtin/task_adherence/evaluator/_task_adherence.py
@@ -524,6 +524,8 @@ class ConversationValidator(ValidatorInterface):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input."""
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         conversation = eval_input.get("conversation")
         if conversation:
             conversation_validation_exception = self._validate_conversation(conversation)
@@ -619,6 +621,8 @@ class ToolDefinitionsValidator(ConversationValidator):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input with tool definitions."""
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         if super().validate_eval_input(eval_input):
             tool_definitions = eval_input.get("tool_definitions")
             tool_definitions_validation_exception = self._validate_tool_definitions(tool_definitions)
@@ -633,6 +637,8 @@ class MessagesOrQueryResponseInputValidator(ToolDefinitionsValidator):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input, supporting messages as an alternative to query/response."""
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         messages = eval_input.get("messages")
         if messages is not None:
             if not isinstance(messages, list):
@@ -816,6 +822,39 @@ def serialize_messages(messages: List[dict]) -> str:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _is_empty_input_value(value: Any) -> bool:
+    """Return True if value is None or an empty string/list/dict (documented skip case)."""
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict)) and len(value) == 0:
+        return True
+    return False
+
+
+def _documented_skip_reason(eval_input: Dict[str, Any]) -> Optional[str]:
+    """Return a reason string when eval_input matches a documented skip case, else None.
+
+    Documented skip cases for task_adherence (per prompty's "Status: Skipped" rules
+    and PR #5042's _return_not_applicable_result helper):
+      - query, response, conversation.messages, or messages is None/empty
+      - tool_definitions is present-but-empty (no tools to evaluate against)
+    """
+    conversation = eval_input.get("conversation")
+    if isinstance(conversation, dict):
+        if _is_empty_input_value(conversation.get("messages")):
+            return "Conversation messages are empty; evaluation is not applicable."
+    if "messages" in eval_input and _is_empty_input_value(eval_input.get("messages")):
+        return "Messages are empty; evaluation is not applicable."
+    if "query" in eval_input or "response" in eval_input:
+        if _is_empty_input_value(eval_input.get("query")):
+            return "Query is empty; evaluation is not applicable."
+        if _is_empty_input_value(eval_input.get("response")):
+            return "Response is empty; evaluation is not applicable."
+    if "tool_definitions" in eval_input and _is_empty_input_value(eval_input.get("tool_definitions")):
+        return "Tool definitions are empty; evaluation is not applicable."
+    return None
 
 
 def _is_intermediate_response(response):
@@ -1266,6 +1305,9 @@ class TaskAdherenceEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :return: The evaluation result.
         :rtype: Dict
         """
+        skip_reason = _documented_skip_reason(eval_input)
+        if skip_reason is not None:
+            return self._return_not_applicable_result(skip_reason, self._threshold)
         if self._should_use_conversation_level(eval_input):
             return await self._do_eval_conversation(eval_input)
         if "query" not in eval_input or "response" not in eval_input:

--- a/assets/evaluators/builtin/task_adherence/spec.yaml
+++ b/assets/evaluators/builtin/task_adherence/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.task_adherence"
-version: 13
+version: 14
 displayName: "Task-Adherence-Evaluator-(Preview)"
 description: "Evaluates whether the agent completed the task within the confines of the instructions given to the agentic system. Higher scores indicate better compliance with the instructions. This evaluator is useful when useful for end-to-end system-level task evaluation for agents. Example outputs include actions such as updating a database and textual responses such as writing a report."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
+++ b/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
@@ -535,6 +535,8 @@ class ConversationValidator(ValidatorInterface):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input."""
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         conversation = eval_input.get("conversation")
         if conversation:
             conversation_validation_exception = self._validate_conversation(conversation)
@@ -630,6 +632,8 @@ class ToolDefinitionsValidator(ConversationValidator):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input with tool definitions."""
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         if super().validate_eval_input(eval_input):
             tool_definitions = eval_input.get("tool_definitions")
             tool_definitions_validation_exception = self._validate_tool_definitions(tool_definitions)
@@ -648,6 +652,8 @@ class MessagesOrQueryResponseInputValidator(ToolDefinitionsValidator):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input, supporting messages as an alternative to query/response."""
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         messages = eval_input.get("messages")
         if messages is not None:
             if not isinstance(messages, list):
@@ -879,6 +885,39 @@ def _create_extended_error_target():
 
 
 ExtendedErrorTarget = _create_extended_error_target()
+
+
+def _is_empty_input_value(value: Any) -> bool:
+    """Return True if value is None or an empty string/list/dict (documented skip case)."""
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict)) and len(value) == 0:
+        return True
+    return False
+
+
+def _documented_skip_reason(eval_input: Dict[str, Any]) -> Optional[str]:
+    """Return a reason string when eval_input matches a documented skip case, else None.
+
+    Documented skip cases for task_completion (per prompty's "Status: Skipped" rules
+    and PR #5042's _return_not_applicable_result helper):
+      - query, response, conversation.messages, or messages is None/empty
+      - tool_definitions is present-but-empty
+    """
+    conversation = eval_input.get("conversation")
+    if isinstance(conversation, dict):
+        if _is_empty_input_value(conversation.get("messages")):
+            return "Conversation messages are empty; evaluation is not applicable."
+    if "messages" in eval_input and _is_empty_input_value(eval_input.get("messages")):
+        return "Messages are empty; evaluation is not applicable."
+    if "query" in eval_input or "response" in eval_input:
+        if _is_empty_input_value(eval_input.get("query")):
+            return "Query is empty; evaluation is not applicable."
+        if _is_empty_input_value(eval_input.get("response")):
+            return "Response is empty; evaluation is not applicable."
+    if "tool_definitions" in eval_input and _is_empty_input_value(eval_input.get("tool_definitions")):
+        return "Tool definitions are empty; evaluation is not applicable."
+    return None
 
 
 def _is_intermediate_response(response):
@@ -1393,6 +1432,9 @@ class TaskCompletionEvaluator(PromptyEvaluatorBase[Union[str, int]]):
         :return: The evaluation result.
         :rtype: Dict
         """
+        skip_reason = _documented_skip_reason(eval_input)
+        if skip_reason is not None:
+            return self._return_not_applicable_result(skip_reason, self._threshold)
         if self._should_use_conversation_level(eval_input):
             return await self._do_eval_conversation_level(eval_input)
 

--- a/assets/evaluators/builtin/task_completion/spec.yaml
+++ b/assets/evaluators/builtin/task_completion/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.task_completion"
-version: 16
+version: 17
 displayName: "Task-Completion-Evaluator-(Preview)"
 description: "Evaluates whether an AI agent successfully completed the requested task end to end by analyzing the conversation history and agent response to determine if all task requirements were met, ignoring rule adherence or intent understanding. This evaluator is useful for assessing agent effectiveness in task-oriented scenarios, workflow automation, and goal-oriented AI interactions."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/tool_selection/evaluator/_tool_selection.py
+++ b/assets/evaluators/builtin/tool_selection/evaluator/_tool_selection.py
@@ -453,6 +453,8 @@ class ConversationValidator(ValidatorInterface):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input."""
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         conversation = eval_input.get("conversation")
         if conversation:
             conversation_validation_exception = self._validate_conversation(conversation)
@@ -548,6 +550,8 @@ class ToolDefinitionsValidator(ConversationValidator):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate evaluation input with tool definitions."""
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         if super().validate_eval_input(eval_input):
             tool_definitions = eval_input.get("tool_definitions")
             tool_definitions_validation_exception = self._validate_tool_definitions(tool_definitions)
@@ -605,6 +609,8 @@ class ToolCallsValidator(ToolDefinitionsValidator):
     @override
     def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
         """Validate the evaluation input dictionary."""
+        if _documented_skip_reason(eval_input) is not None:
+            return True
         query = eval_input.get("query")
         query_validation_exception = self._validate_query(query)
         if query_validation_exception:
@@ -637,6 +643,40 @@ class ToolCallsValidator(ToolDefinitionsValidator):
 # endregion Validators
 
 logger = logging.getLogger(__name__)
+
+
+def _is_empty_input_value(value: Any) -> bool:
+    """Return True if value is None or an empty string/list/dict (documented skip case)."""
+    if value is None:
+        return True
+    if isinstance(value, (str, list, dict)) and len(value) == 0:
+        return True
+    return False
+
+
+def _documented_skip_reason(eval_input: Dict[str, Any]) -> Optional[str]:
+    """Return a reason string when eval_input matches a documented skip case, else None.
+
+    Documented skip cases for tool_selection (per prompty's "Status: Skipped" rules
+    and PR #5042's _return_not_applicable_result helper):
+      - query, response, or conversation.messages is None/empty
+      - tool_definitions is None / missing / empty (no tools to evaluate against)
+      - tool_calls is None / empty (no tool calls to score)
+    """
+    conversation = eval_input.get("conversation")
+    if isinstance(conversation, dict):
+        if _is_empty_input_value(conversation.get("messages")):
+            return "Conversation messages are empty; evaluation is not applicable."
+    if "query" in eval_input and _is_empty_input_value(eval_input.get("query")):
+        return "Query is empty; evaluation is not applicable."
+    if "response" in eval_input and _is_empty_input_value(eval_input.get("response")):
+        return "Response is empty; evaluation is not applicable."
+    if _is_empty_input_value(eval_input.get("tool_definitions")):
+        return "Tool definitions are empty; evaluation is not applicable."
+    if "tool_calls" in eval_input and _is_empty_input_value(eval_input.get("tool_calls")):
+        return "No tool calls to evaluate; evaluation is not applicable."
+    return None
+
 
 T_EvalValue = TypeVar("T_EvalValue")
 
@@ -1186,6 +1226,9 @@ class ToolSelectionEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :return: A dictionary containing the result of the evaluation.
         :rtype: Dict[str, Union[str, float]]
         """
+        skip_reason = _documented_skip_reason(eval_input)
+        if skip_reason is not None:
+            return self._return_not_applicable_result(skip_reason, self._threshold)
         if eval_input.get("query") is None:
             raise EvaluationException(
                 message=(

--- a/assets/evaluators/builtin/tool_selection/spec.yaml
+++ b/assets/evaluators/builtin/tool_selection/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.tool_selection"
-version: 10
+version: 11
 displayName: "Tool-Selection-Evaluator"
 description: "Evaluates whether an AI agent selected the most appropriate and efficient tools for a given task, avoiding redundancy or missing essentials. Use it to assess tool choice quality in agent-based systems, orchestration platforms, and AI assistants that must pick the right tools from available options."
 evaluatorType: "builtin"


### PR DESCRIPTION
## Summary

Route documented skip cases (empty/None query, response, conversation.messages, messages, tool_definitions, tool_calls) to `status="skipped"` for **six evaluators** I own:

- `relevance`
- `task_adherence`
- `tool_selection`
- `response_completeness`
- `intent_resolution`
- `task_completion`

## Background

PR #5042 introduced `status="skipped"` / `result="not_applicable"` and the `_return_not_applicable_result()` helper. Each of these six evaluators already:

- Defines `_return_not_applicable_result()` locally.
- Has the Python-side intermediate-response skip path wired (`_is_intermediate_response()` → `_return_not_applicable_result()`).
- Has the LLM-prompt-driven skip path wired (prompty says "return status: skipped on empty inputs"; Python wrapper catches `llm_status == "skipped"` → `_return_not_applicable_result()`).

PR #5107 added a `math.isnan(None)` guard for **5 other** evaluators (groundedness/coherence/fluency/retrieval/similarity). My 6 don't have that exact pattern, so #5107 itself didn't help them.

## The bug

For my 6 evaluators, the `validate_eval_input` method (called by the base `PromptyEvaluatorBase._real_call` **before** `_do_eval`) raises `EvaluationException(USER_ERROR)` for exactly the inputs the prompts say should return `status="skipped"`. The row dies with `status="error"` before either skip path can fire.

Concrete raise sites:

| Evaluator | Raise site | Message |
|---|---|---|
| relevance | `_validate_input_messages_list` | `"{input_name} string cannot be empty"`, `"{input_name} list cannot be empty"` |
| intent_resolution | same + `_validate_tool_definitions` | `"Tool definitions input is required but not provided"` |
| task_adherence | same | (same family) |
| task_completion | same | also `'NoneType' object is not iterable` (separate iteration bug — see note below) |
| tool_selection | `validate_eval_input` (ToolCallsValidator) | `"Tool definitions input is required but not provided"`, `"Query is a required input"` |
| response_completeness | `_do_eval` directly | `"Both ground_truth and response must be provided..."` |

This is the **exact** signal Kavitha's KQL on `EvalAcaLogs` is finding (`"must be real number, not NoneType"`, `"math.isnan"`, `"TypeError" + "NoneType"`).

## The fix

For each evaluator, add a small module-level helper:

```python
def _documented_skip_reason(eval_input: Dict[str, Any]) -> Optional[str]:
    """Return a reason string when eval_input matches a documented skip case."""
    ...
```

It returns a human-readable reason if `eval_input` matches a documented skip case (empty/None query, response, conversation.messages, messages, tool_definitions, tool_calls — varying per evaluator).

It is called:

1. **At the top of each `validate_eval_input` override** — suppresses the USER_ERROR raise for these specific cases (returns `True` immediately so `_do_eval` can run).
2. **At the top of each `_do_eval`** — short-circuits to `self._return_not_applicable_result(reason, self._threshold)`.

Non-documented validation failures (wrong type, malformed message dict, missing required fields) continue to raise as before.

## Reproduction

In project `ilmat-0277`, with literal-string `"empty query"`/`"empty response"` inputs, all 6 evaluators correctly return `status="skipped"` today — proving the LLM-skip pipeline end-to-end works once the validators are bypassed. With actual `""` empty strings or missing fields, the row errors instead.

KQL signal:

```kusto
EvalAcaLogs
| where timestamp > ago(15d)
| where Message has "must be real number, not NoneType"
   or Message has "math.isnan"
   or Message has "TypeError" and Message has "NoneType"
| summarize Count=count() by bin(timestamp, 1d)
| order by timestamp desc
```

## Version bumps

Each modified evaluator's `spec.yaml` version bumped by 1:

- relevance: 10 → 11
- intent_resolution: 7 → 8
- task_adherence: 13 → 14
- task_completion: 16 → 17
- tool_selection: 10 → 11
- response_completeness: 8 → 9

## Notes / follow-ups (NOT in this PR)

1. **task_completion `'NoneType' object is not iterable`** — when `messages[i].content` is `None`, downstream iteration in `_do_eval_conversation_level` crashes. The validator currently rejects this with USER_ERROR, but if it slips through (e.g., conversation-level path or service-level shape), it raises a raw `TypeError`. Should be a separate PR with explicit None-handling.
2. **`tool_call_accuracy` inconsistency** — outside the scope of my 6, but worth flagging: it currently returns `label="pass"` while `status="skipped"`. `tool_selection` correctly returns `label="not_applicable"`. Different owner should fix.
3. **Service-level validators** (which reject `content: null` and `content: ""` in `conversation_messages` dataKind before the evaluator code even runs) are independent of this PR.

## Related

- #5042 — added `status="skipped"` + `_return_not_applicable_result` helper
- #5107 — `math.isnan(None)` guard for 5 other evaluators
