### PR TITLE
Fix LLM evaluator skip-handling: status-first guard + pre-validation

### DIFF
--- a/assets/evaluators/builtin/coherence/evaluator/_coherence.py
+++ b/assets/evaluators/builtin/coherence/evaluator/_coherence.py
@@ -1279,6 +1279,12 @@ class CoherenceEvaluator(PromptyEvaluatorBase[Union[str, float]]):
 
         result = await self._the_super_do_eval(eval_input)
 
+        # Honor explicit skip status before any numeric validation. This is structurally safer
+        # than relying solely on the None-guard below: if the base helper already produced a
+        # not-applicable record, propagate it as-is and never run math.isnan on its None score.
+        if result.get(f"{self._result_key}_status") == "skipped":
+            return result
+
         # Check if base returned nan (invalid output case); None means not-applicable/skipped
         _score = result.get(self._result_key, 0)
         if _score is not None and math.isnan(_score):

--- a/assets/evaluators/builtin/fluency/evaluator/_fluency.py
+++ b/assets/evaluators/builtin/fluency/evaluator/_fluency.py
@@ -921,6 +921,12 @@ class FluencyEvaluator(PromptyEvaluatorBase[Union[str, float]]):
 
         result = await self._the_super_do_eval(eval_input)
 
+        # Honor explicit skip status before any numeric validation. This is structurally safer
+        # than relying solely on the None-guard below: if the base helper already produced a
+        # not-applicable record, propagate it as-is and never run math.isnan on its None score.
+        if result.get(f"{self._result_key}_status") == "skipped":
+            return result
+
         # Check if base returned nan (invalid output case); None means not-applicable/skipped
         _score = result.get(self._result_key, 0)
         if _score is not None and math.isnan(_score):

--- a/assets/evaluators/builtin/retrieval/evaluator/_retrieval.py
+++ b/assets/evaluators/builtin/retrieval/evaluator/_retrieval.py
@@ -374,6 +374,11 @@ class RetrievalEvaluator(PromptyEvaluatorBase[Union[str, float]]):
             eval_input["query"] = _preprocess_messages(eval_input["query"])
 
         result = await self._the_super_do_eval(eval_input)
+        # Honor explicit skip status before any numeric validation. This is structurally safer
+        # than relying solely on the None-guard below: if the base helper already produced a
+        # not-applicable record, propagate it as-is and never run math.isnan on its None score.
+        if result.get(f"{self._result_key}_status") == "skipped":
+            return result
         # Check if base returned nan (invalid output case); None means not-applicable/skipped
         _score = result.get(self._result_key, 0)
         if _score is not None and math.isnan(_score):
@@ -385,6 +390,29 @@ class RetrievalEvaluator(PromptyEvaluatorBase[Union[str, float]]):
             )
         return result
 
+    def _validate_required_inputs(self, **kwargs) -> None:
+        """Pre-validate inputs to raise a clean USER_ERROR for missing/empty fields.
+
+        When ``conversation`` is provided the multi-turn path handles validation internally,
+        so this check only applies to the single-turn ``query``/``context`` path. Raising here
+        (before the LLM is ever invoked) turns silent ``not_applicable`` rows into proactive
+        user-error signals and avoids burning model calls on inputs that cannot be evaluated.
+        """
+        if kwargs.get("conversation"):
+            return
+        query = kwargs.get("query")
+        context = kwargs.get("context")
+        if (not query) or (not context):
+            raise EvaluationException(
+                message=(
+                    f"{type(self).__name__}: Either 'conversation' or both 'query' and 'context' "
+                    "must be provided as non-empty inputs."
+                ),
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.MISSING_FIELD,
+                target=ErrorTarget.RETRIEVAL_EVALUATOR,
+            )
+
     @override
     async def _real_call(self, **kwargs):
         """Perform the asynchronous call where real end-to-end evaluation logic runs.
@@ -394,6 +422,9 @@ class RetrievalEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :return: The evaluation result.
         :rtype: Union[DoEvalResult[T_EvalValue], AggregateResult[T_EvalValue]]
         """
+        # Pre-validate before invoking the LLM so missing/empty inputs surface a clean
+        # USER_ERROR instead of either crashing later or being silently demoted to a skipped row.
+        self._validate_required_inputs(**kwargs)
         # Convert inputs into list of evaluable inputs.
         try:
             eval_input_list = self._convert_kwargs_to_eval_input(**kwargs)


### PR DESCRIPTION
## Summary

Two related defects across the LLM-based evaluators were identified through end-to-end testing against the `np-canary` Foundry project (using minimal_repro_dataset.jsonl and minimal_repro_dataset_empty.jsonl):

1. **Skip-handling fragility** — `coherence` / `fluency` / `retrieval` post-process the dict returned by `_the_super_do_eval` and then run `math.isnan(result.get(self._result_key, 0))`. PR #5107 added the `_score is not None` guard that prevents the production `TypeError: must be real number, not NoneType`, but the structure is fragile: any future override that forgets the guard re-introduces the bug. `task_completion` (and `relevance`) avoid this entire class of defect by checking `status == "skipped"` *before* any numeric coercion runs.

2. **No input pre-validation on `retrieval`** — empty/missing `query`/`context` is silently sent to the LLM, which returns `status: skipped`, demoting the row to `not_applicable` instead of raising a clean `USER_ERROR`. (`groundedness`/`coherence`/`fluency`/`relevance` already have this via `self._validator`.)

## Changes (3 files, +43 lines)

| File | Change |
|---|---|
| `coherence/evaluator/_coherence.py` | Add status-first early-return in `_do_eval` before `math.isnan` |
| `fluency/evaluator/_fluency.py` | Same |
| `retrieval/evaluator/_retrieval.py` | Same + new `_validate_required_inputs` invoked at top of `_real_call` |

The status-first pattern (the canonical example lives in `task_completion._parse_prompty_output`):

`python
result = await self._the_super_do_eval(eval_input)
# Honor explicit skip status before any numeric validation. Structurally safer
# than relying solely on the None-guard below.
if result.get(f"{self._result_key}_status") == "skipped":
    return result
_score = result.get(self._result_key, 0)
if _score is not None and math.isnan(_score):
    raise EvaluationException(...)
`

The None-guard from #5107 is retained as a backstop. The skipped path can no longer reach `math.isnan` at all.

## Out of scope

- `relevance` — already has both patterns inline. No change required.
- `groundedness` — has the same outer post-check shape as `coherence`/`fluency`/`retrieval` and would benefit from the same W4 refactor; left out per agreed scope (this PR is the four highest-risk evaluators only).
- The remaining ~14 LLM evaluators in the catalog need pre-validation as well; tracked separately.
- Republishing fixed evaluators to the `azureml` registry (operational, not a code change).
- Math-based evaluators (`bleu`/`gleu`/`meteor`/`rouge`/`f1`/`task_navigation_efficiency`) need typed input validation; tracked separately.

## Validation

- `python scripts/validation/code_health.py -i assets/evaluators/builtin` — clean.
- `pytest` on `test_coherence_evaluator_behavior.py` + `test_fluency_evaluator_behavior.py` + `test_relevance_evaluator_behavior.py` — **199 passed**.
