### PR TITLE
Update OpenVINO model's npu configuration in Foundry Local

### DIFF
--- a/assets/models/foundrylocal/DeepSeek-R1-Distill-Qwen-7B-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/DeepSeek-R1-Distill-Qwen-7B-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/DeepSeek-R1-Distill-Qwen-7B/onnx/openvino_npu/v3
+  container_path: foundrylocal/models/DeepSeek-R1-Distill-Qwen-7B/onnx/openvino_npu/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/DeepSeek-R1-Distill-Qwen-7B-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/DeepSeek-R1-Distill-Qwen-7B-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: DeepSeek-R1-Distill-Qwen-7B-openvino-npu
-version: 3
+version: 4
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: deepseek-r1-7b
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"assistant\": \"{Content}\", \"prompt\": \"\\\\u003C\\\\uFF5CUser\\\\uFF5C\\\\u003E{Content}\\\\u003C\\\\uFF5CAssistant\\\\uFF5C\\\\u003E\"}"
   capabilities: "reasoning"
   supportsReasoning: "true"
@@ -31,5 +31,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'npu'
     executionProvider: 'OpenVINOExecutionProvider'
-    fileSizeBytes: 4478241107
-    vRamFootprintBytes: 4478241107
+    fileSizeBytes: 4478240898
+    vRamFootprintBytes: 4478240898

--- a/assets/models/foundrylocal/Mistral-7B-Instruct-v0-2-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/Mistral-7B-Instruct-v0-2-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/Mistral-7B-Instruct-v0-2/onnx/openvino_npu/v2
+  container_path: foundrylocal/models/Mistral-7B-Instruct-v0-2/onnx/openvino_npu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/Mistral-7B-Instruct-v0-2-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/Mistral-7B-Instruct-v0-2-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Mistral-7B-Instruct-v0-2-openvino-npu
-version: 2
+version: 3
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: mistral-7b-v0.2
-  directoryPath: v2
+  directoryPath: v3
   promptTemplate: "{\"system\": \"<s>\", \"user\": \"[INST]\\n{Content}\\n[/INST]\", \"assistant\": \"{Content}</s>\", \"prompt\": \"[INST]\\n{Content}\\n[/INST]\"}"
   contextLength: 4224
   capabilities: ""

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/Phi-4-mini-reasoning/onnx/openvino_npu/v3
+  container_path: foundrylocal/models/Phi-4-mini-reasoning/onnx/openvino_npu/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/Phi-4-mini-reasoning-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/Phi-4-mini-reasoning-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: Phi-4-mini-reasoning-openvino-npu
-version: 3
+version: 4
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: phi-4-mini-reasoning
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"system\": \"<|system|>Your name is Phi, an AI math expert developed by Microsoft. {Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   supportsToolCalling: ""
   toolCallStart: "<|tool_call|>"
@@ -38,5 +38,5 @@ variantInfo:
     quantization: ['QuaRot', 'GPTQ']
     device: 'npu'
     executionProvider: 'OpenVINOExecutionProvider'
-    fileSizeBytes: 2313243100
-    vRamFootprintBytes: 2313243100
+    fileSizeBytes: 2313243099
+    vRamFootprintBytes: 2313243099

--- a/assets/models/foundrylocal/phi-4-mini-instruct-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/phi-4-mini-instruct/onnx/openvino_npu/v3
+  container_path: foundrylocal/models/phi-4-mini-instruct/onnx/openvino_npu/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/phi-4-mini-instruct-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/phi-4-mini-instruct-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: phi-4-mini-instruct-openvino-npu
-version: 3
+version: 4
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: phi-4-mini
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"system\": \"<|system|>{Content}<|end|>\", \"user\": \"<|user|>{Content}<|end|>\", \"assistant\": \"<|assistant|>{Content}<|end|>\", \"prompt\": \"<|user|>{Content}<|end|><|assistant|>\"}"
   supportsToolCalling: "true"
   toolCallStart: "<|tool_call|>"

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen2.5-0.5b-instruct/onnx/openvino_npu/v4
+  container_path: foundrylocal/models/qwen2.5-0.5b-instruct/onnx/openvino_npu/v5
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-0.5b-instruct-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-0.5b-instruct-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-0.5b-instruct-openvino-npu
-version: 4
+version: 5
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: qwen2.5-0.5b
-  directoryPath: v4
+  directoryPath: v5
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.8}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
   supportsToolCalling: "true"

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen2.5-1.5b-instruct/onnx/openvino_npu/v4
+  container_path: foundrylocal/models/qwen2.5-1.5b-instruct/onnx/openvino_npu/v5
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-1.5b-instruct-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-1.5b-instruct-openvino-npu
-version: 4
+version: 5
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: qwen2.5-1.5b
-  directoryPath: v4
+  directoryPath: v5
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"
@@ -38,5 +38,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'npu'
     executionProvider: 'OpenVINOExecutionProvider'
-    fileSizeBytes: 928062117
-    vRamFootprintBytes: 928062117
+    fileSizeBytes: 928062219
+    vRamFootprintBytes: 928062219

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen2.5-7b-instruct/onnx/openvino_npu/v3
+  container_path: foundrylocal/models/qwen2.5-7b-instruct/onnx/openvino_npu/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-7b-instruct-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-7b-instruct-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-7b-instruct-openvino-npu
-version: 3
+version: 4
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: qwen2.5-7b
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen2.5-coder-0.5b-instruct/onnx/openvino_npu/v4
+  container_path: foundrylocal/models/qwen2.5-coder-0.5b-instruct/onnx/openvino_npu/v5
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-0.5b-instruct-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-0.5b-instruct-openvino-npu
-version: 4
+version: 5
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: qwen2.5-coder-0.5b
-  directoryPath: v4
+  directoryPath: v5
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.9}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
   supportsToolCalling: "true"

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen2.5-coder-1.5b-instruct/onnx/openvino_npu/v4
+  container_path: foundrylocal/models/qwen2.5-coder-1.5b-instruct/onnx/openvino_npu/v5
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-1.5b-instruct-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-1.5b-instruct-openvino-npu
-version: 4
+version: 5
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: qwen2.5-coder-1.5b
-  directoryPath: v4
+  directoryPath: v5
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   parameterSchema: "{\"enabled\": [{\"name\": \"temperature\", \"default\": 1.0}, {\"name\": \"top_p\", \"default\": 0.9}, {\"name\": \"top_k\", \"default\": 40}, {\"name\": \"presence_penalty\", \"default\": 1.1}]}"
   supportsToolCalling: "true"
@@ -39,5 +39,5 @@ variantInfo:
     quantization: ['RTN']
     device: 'npu'
     executionProvider: 'OpenVINOExecutionProvider'
-    fileSizeBytes: 935989770
-    vRamFootprintBytes: 935989770
+    fileSizeBytes: 935989886
+    vRamFootprintBytes: 935989886

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-openvino-npu/model.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-openvino-npu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen2.5-coder-7b-instruct/onnx/openvino_npu/v3
+  container_path: foundrylocal/models/qwen2.5-coder-7b-instruct/onnx/openvino_npu/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-openvino-npu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-7b-instruct-openvino-npu/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
 name: qwen2.5-coder-7b-instruct-openvino-npu
-version: 3
+version: 4
 isArchived: true
 path: ./
 tags:
@@ -13,7 +13,7 @@ tags:
   task: chat-completion
   maxOutputTokens: 2048
   alias: qwen2.5-coder-7b
-  directoryPath: v3
+  directoryPath: v4
   promptTemplate: "{\"system\": \"<|im_start|>system\\n{Content}<|im_end|>\", \"user\": \"<|im_start|>user\\n{Content}<|im_end|>\", \"assistant\": \"<|im_start|>assistant\\n{Content}<|im_end|>\", \"prompt\": \"<|im_start|>user\\n{Content}<|im_end|>\\n<|im_start|>assistant\"}"
   supportsToolCalling: "true"
   toolCallStart: "<tool_call>"


### PR DESCRIPTION
OpenVINO models' genai_config.json are not fully synced with Olive recipes. This PR is to fix this issue to unblock EPCert failures. The affected models are

- DeepSeek-R1-Distill-Qwen-7B
- Mistral-7B-Instruct-v0-2
- phi-4-mini-instruct
- Phi-4-mini-reasoning
- qwen2.5-0.5b-instruct
- qwen2.5-1.5b-instruct
- qwen2.5-7b-instruct
- qwen2.5-coder-0.5b-instruct
- qwen2.5-coder-1.5b-instruct
- qwen2.5-coder-7b-instruct