### PR TITLE
[fix]: Fix slime image for dependencies

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
@@ -81,10 +81,13 @@ RUN python -m pip install --no-cache-dir \
     python -m pip install --no-cache-dir \
         'nvidia-modelopt[torch]>=0.37.0' --no-build-isolation
 
-RUN python -m pip install --no-cache-dir transformer-engine-cu12==2.15.0 && \
-    MAX_JOBS=32 NVTE_FRAMEWORK=pytorch TORCH_CUDA_ARCH_LIST=8.0 \
-        python -m pip install --no-cache-dir --no-build-isolation transformer-engine-torch==2.15.0 && \
-    python -m pip install --no-cache-dir transformer-engine==2.15.0
+# The PyTorch extension has no public wheel for this image's torch/CUDA stack.
+# Install the hosted wheel extracted from the tested canary image instead of
+# building transformer-engine-torch from source in the release pipeline.
+RUN python -m pip install --no-cache-dir transformer-engine-cu12==2.10.0 && \
+    python -m pip install --no-cache-dir \
+        https://github.com/yeshsurya/TransformerEngine/releases/download/transformer_engine_torch-2.10.0/transformer_engine_torch-2.10.0-cp310-cp310-linux_x86_64.whl && \
+    python -m pip install --no-cache-dir transformer-engine==2.10.0
 
 COPY requirements.txt /tmp/slime-requirements.txt
 RUN python -m pip install --no-cache-dir -r /tmp/slime-requirements.txt && \

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
@@ -81,6 +81,11 @@ RUN python -m pip install --no-cache-dir \
     python -m pip install --no-cache-dir \
         'nvidia-modelopt[torch]>=0.37.0' --no-build-isolation
 
+RUN python -m pip install --no-cache-dir transformer-engine-cu12==2.15.0 && \
+    MAX_JOBS=32 NVTE_FRAMEWORK=pytorch TORCH_CUDA_ARCH_LIST=8.0 \
+        python -m pip install --no-cache-dir --no-build-isolation transformer-engine-torch==2.15.0 && \
+    python -m pip install --no-cache-dir transformer-engine==2.15.0
+
 COPY requirements.txt /tmp/slime-requirements.txt
 RUN python -m pip install --no-cache-dir -r /tmp/slime-requirements.txt && \
     rm /tmp/slime-requirements.txt
@@ -105,6 +110,10 @@ RUN LOG4J_VERSION=${LOG4J_VERSION} \
 
 RUN cd /opt/slime && \
     python -m pip install --no-cache-dir -e . --no-deps
+
+COPY patch_slime_rft_fixes.py /tmp/patch_slime_rft_fixes.py
+RUN python /tmp/patch_slime_rft_fixes.py && \
+    rm /tmp/patch_slime_rft_fixes.py
 
 RUN cd /opt/slime/slime/backends/megatron_utils/kernels/int4_qat && \
     python -m pip install --no-cache-dir . --no-build-isolation

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
@@ -86,7 +86,7 @@ RUN python -m pip install --no-cache-dir \
 # building transformer-engine-torch from source in the release pipeline.
 RUN python -m pip install --no-cache-dir transformer-engine-cu12==2.10.0 && \
     python -m pip install --no-cache-dir \
-        https://github.com/yeshsurya/TransformerEngine/releases/download/transformer_engine_torch-2.10.0/transformer_engine_torch-2.10.0-cp310-cp310-linux_x86_64.whl && \
+        https://github.com/yeshsurya/TransformerEngine/releases/download/transformer_engine-2.10.0%2B769ed77-cp312-cp312-linux_x86_64/transformer_engine-2.10.0+769ed77-cp312-cp312-linux_x86_64.whl && \
     python -m pip install --no-cache-dir transformer-engine==2.10.0
 
 COPY requirements.txt /tmp/slime-requirements.txt

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
@@ -84,7 +84,8 @@ RUN python -m pip install --no-cache-dir \
 # The PyTorch extension has no public wheel for this image's torch/CUDA stack.
 # Install the hosted wheel extracted from the tested canary image instead of
 # building transformer-engine-torch from source in the release pipeline.
-RUN python -m pip install --no-cache-dir transformer-engine-cu12==2.10.0 && \
+RUN python -m pip install --no-cache-dir \
+        https://github.com/yeshsurya/TransformerEngine/releases/download/transformer_engine_cu12-2.10.0-py3-none-manylinux_2_28_x86_64/transformer_engine_cu12-2.10.0-py3-none-manylinux_2_28_x86_64.whl && \
     python -m pip install --no-cache-dir \
         https://github.com/yeshsurya/TransformerEngine/releases/download/transformer_engine-2.10.0%2B769ed77-cp312-cp312-linux_x86_64/transformer_engine-2.10.0+769ed77-cp312-cp312-linux_x86_64.whl && \
     python -m pip install --no-cache-dir transformer-engine==2.10.0

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/patch_slime_rft_fixes.py
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/patch_slime_rft_fixes.py
@@ -1,0 +1,53 @@
+"""Apply Retail RFT compatibility patches to the slime image."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SLIME_ROOT = Path("/opt/slime")
+
+
+def replace_once(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if new in text:
+        return
+    if old not in text:
+        raise RuntimeError(f"Expected text not found in {path}: {old!r}")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+def patch_numpy_guard() -> None:
+    path = SLIME_ROOT / "slime" / "backends" / "megatron_utils" / "initialize.py"
+    replace_once(
+        path,
+        '    assert np.__version__.startswith("1."), "Megatron does not support numpy 2.x"\n',
+        "    # This image builds Megatron extensions against numpy 2.x, so the\n"
+        "    # conservative slime numpy 1.x guard is not needed here.\n",
+    )
+
+
+def patch_attention_backend_propagation() -> None:
+    path = SLIME_ROOT / "slime" / "backends" / "megatron_utils" / "model_provider.py"
+    text = path.read_text(encoding="utf-8")
+    marker = "        provider.context_parallel_size = args.context_parallel_size\n"
+    patch = (
+        marker
+        +
+        "        if hasattr(args, \"attention_backend\") and args.attention_backend is not None:\n"
+        "            provider.attention_backend = args.attention_backend\n"
+    )
+    if patch in text:
+        return
+    if marker not in text:
+        raise RuntimeError(f"Expected provider marker not found in {path}")
+    path.write_text(text.replace(marker, patch, 1), encoding="utf-8")
+
+
+def main() -> None:
+    patch_numpy_guard()
+    patch_attention_backend_propagation()
+
+
+if __name__ == "__main__":
+    main()

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/patch_slime_rft_fixes.py
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/patch_slime_rft_fixes.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Apply Retail RFT compatibility patches to the slime image."""
 
 from __future__ import annotations

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/patch_slime_rft_fixes.py
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/patch_slime_rft_fixes.py
@@ -12,6 +12,7 @@ SLIME_ROOT = Path("/opt/slime")
 
 
 def replace_once(path: Path, old: str, new: str) -> None:
+    """Replace one expected text block in a file."""
     text = path.read_text(encoding="utf-8")
     if new in text:
         return
@@ -21,6 +22,7 @@ def replace_once(path: Path, old: str, new: str) -> None:
 
 
 def patch_numpy_guard() -> None:
+    """Remove slime's conservative numpy 1.x startup assertion."""
     path = SLIME_ROOT / "slime" / "backends" / "megatron_utils" / "initialize.py"
     replace_once(
         path,
@@ -31,6 +33,7 @@ def patch_numpy_guard() -> None:
 
 
 def patch_attention_backend_propagation() -> None:
+    """Propagate CLI attention backend selection into Megatron Bridge config."""
     path = SLIME_ROOT / "slime" / "backends" / "megatron_utils" / "model_provider.py"
     text = path.read_text(encoding="utf-8")
     marker = "        provider.context_parallel_size = args.context_parallel_size\n"
@@ -48,6 +51,7 @@ def patch_attention_backend_propagation() -> None:
 
 
 def main() -> None:
+    """Apply all Retail RFT compatibility patches."""
     patch_numpy_guard()
     patch_attention_backend_propagation()
 

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/smoke_test.py
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/smoke_test.py
@@ -12,6 +12,7 @@ import ray
 import sglang
 import slime
 import torch
+import transformer_engine.pytorch as te
 
 
 LOG4J_ARTIFACTS = ("log4j-api", "log4j-core", "log4j-slf4j-impl")
@@ -69,6 +70,7 @@ assert torch.__version__.startswith("2.9.1")
 assert Version(PIL.__version__) >= Version("12.2.0")
 assert sglang
 assert slime
+assert te
 
 # AML/Singularity jobs run as uid 9000 (aiscuser); /root is mode 700 so
 # slime must be editable-installed from a non-/root location. Pin the
@@ -85,6 +87,13 @@ for path in (
 slime_init = EXPECTED_SLIME_ROOT / "slime" / "__init__.py"
 if slime_init.exists():
     assert_world_accessible(slime_init)
+
+initialize_py = EXPECTED_SLIME_ROOT / "slime" / "backends" / "megatron_utils" / "initialize.py"
+model_provider_py = EXPECTED_SLIME_ROOT / "slime" / "backends" / "megatron_utils" / "model_provider.py"
+assert "Megatron does not support numpy 2.x" not in initialize_py.read_text(encoding="utf-8")
+assert "provider.attention_backend = args.attention_backend" in model_provider_py.read_text(
+    encoding="utf-8"
+)
 
 ray_dist = find_ray_dist()
 for artifact in LOG4J_ARTIFACTS:


### PR DESCRIPTION
This pull request updates the `slime-pytorch-2.9-cuda12.8` environment with new dependencies and applies compatibility patches to support Retail RFT. The main changes include installing the latest `transformer-engine` packages, introducing a patch script to modify `slime` source files for compatibility with numpy 2.x and attention backend propagation, and updating the smoke test to verify these patches and the new dependency.

**Dependency updates:**
- Added installation of `transformer-engine-cu12`, `transformer-engine-torch`, and `transformer-engine` version 2.15.0 in the `Dockerfile` to ensure compatibility with CUDA 12 and PyTorch.

**Compatibility patches:**
- Introduced a new script `patch_slime_rft_fixes.py` that:
  - Removes the numpy 2.x guard in `initialize.py` to allow usage with numpy 2.x.
  - Propagates the `attention_backend` argument in `model_provider.py` if present.
- Updated the `Dockerfile` to copy and execute this patch script during the image build process.

**Testing and validation:**
- Updated `smoke_test.py` to:
  - Import and assert the presence of the `transformer_engine.pytorch` module.
  - Check that the numpy guard is removed from `initialize.py` and that attention backend propagation is present in `model_provider.py`, verifying the patch was applied successfully. [[1]](diffhunk://#diff-65ea28ad890182554c8299f89c48a36ca5a5cb8839b816816d60925efb2e7ae3R15) [[2]](diffhunk://#diff-65ea28ad890182554c8299f89c48a36ca5a5cb8839b816816d60925efb2e7ae3R73) [[3]](diffhunk://#diff-65ea28ad890182554c8299f89c48a36ca5a5cb8839b816816d60925efb2e7ae3R91-R97)