### PR TITLE
Fix MMDetection accelerate dependency

### DIFF
--- a/assets/training/finetune_acft_image/components/finetune/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/mmd_od_is/spec.yaml
@@ -1,14 +1,14 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
-version: 0.0.24
+version: 0.0.25
 name: mmdetection_image_objectdetection_instancesegmentation_finetune
 display_name: Image Object Detection and Instance Segmentation MMDetection Model Finetune
 description: Component to finetune MMDetection models for image object detection and instance segmentation.
 
 is_deterministic: false
 
-environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/75
+environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/85
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_image/components/model_import/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/model_import/mmd_od_is/spec.yaml
@@ -1,14 +1,14 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
-version: 0.0.22
+version: 0.0.23
 name: mmdetection_image_objectdetection_instancesegmentation_model_import
 display_name: Image Object Detection and Instance Segmentation MMDetection Model Import
 description: Import PyTorch / MLflow model
 
 is_deterministic: True
 
-environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/75
+environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/85
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.27
+version: 0.0.28
 name: image_instance_segmentation_pipeline
 display_name: Image Instance Segmentation Pipeline
 description: Pipeline component for image instance segmentation.
@@ -370,7 +370,7 @@ jobs:
 
   mm_detection_model_import:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.22
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.23
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       model_family: 'MmDetectionImage'
@@ -380,7 +380,7 @@ jobs:
 
   mm_detection_finetune:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.24
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.25
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch

--- a/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.28
+version: 0.0.29
 name: mmdetection_image_objectdetection_instancesegmentation_pipeline
 display_name: Image Object Detection and Instance Segmentation MMDetection Pipeline
 description: Pipeline component for image object detection and instance segmentation using MMDetection models.
@@ -414,7 +414,7 @@ jobs:
 
   image_od_is_model_import:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.22
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.23
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       model_family: ${{parent.inputs.model_family}}
@@ -426,7 +426,7 @@ jobs:
 
   image_od_is_finetune:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.24
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.25
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch

--- a/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.27
+version: 0.0.28
 name: image_object_detection_pipeline
 display_name: Image Object Detection Pipeline
 description: Pipeline component for image object detection.
@@ -397,7 +397,7 @@ jobs:
 
   mm_detection_model_import:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.22
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.23
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       model_family: 'MmDetectionImage'
@@ -407,7 +407,7 @@ jobs:
 
   mm_detection_finetune:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.24
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.25
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch

--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/requirements.txt
@@ -8,7 +8,7 @@ requests>=2.34.0
 urllib3>=2.7.0,<3
 datasets==2.15.0
 transformers==5.5.4
-accelerate==0.27.2
+accelerate==0.32.0
 optimum==1.23.3
 diffusers==0.38.0
 huggingface-hub==1.5.0


### PR DESCRIPTION
## What
- Update the MMDetection image GPU environment to use `accelerate==0.32.0`.
- Bump the MMDetection model import and finetune component versions to reference the next environment version.
- Bump the directly consuming image object detection / instance segmentation pipeline component versions and references.

## Why
IcM 809601641 reports AutoML image object detection jobs failing at import time because PEFT imports `accelerate.utils.memory.clear_device_cache`, which is missing from the environment's current `accelerate==0.27.2` pin.

Local wheel inspection showed `clear_device_cache` is absent in `accelerate==0.27.2`, `0.28.0`, and `0.29.3`, and present from `0.32.0`.

## Validation
- Submitted AutoML image object detection repro in workspace `rtanase` on `v100-gpu-cluster`: `icm809601641-automl-mmd-20260609150630`. It reached the generated AutoML pipeline but failed before MMDetection due to unrelated EOL upstream registry environments.
- Registered a workspace import-chain smoke environment on the current ACPT base with `accelerate==0.32.0`, `peft==0.15.2`, and `transformers==5.5.4`.
- Ran standalone smoke job `icm809601641-importchain-smoke-20260609095812` on `v100-gpu-cluster`; it completed and logs show `clear_device_cache`, `peft`, and `peft.utils` imports succeeded.