### PR TITLE
Remove azureml-defaults from conda dependencies

### DIFF
--- a/assets/inference/environments/minimal-py311-inference/context/conda_dependencies.yaml
+++ b/assets/inference/environments/minimal-py311-inference/context/conda_dependencies.yaml
@@ -6,7 +6,6 @@ dependencies:
 - python=3.11
 - pip
 - pip:
-  - azureml-defaults=={{latest-pypi-version}}
   - azureml-inference-server-http=={{latest-pypi-version}}
   - azure-storage-blob=={{latest-pypi-version}}
   - azure-identity=={{latest-pypi-version}}


### PR DESCRIPTION
Remove azureml-defaults from minimal-py311-inference environment to remediate pyarrow security vulnerability