### PR TITLE
Use MMDetection image environment 86

### DIFF
--- a/assets/training/finetune_acft_image/components/finetune/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/mmd_od_is/spec.yaml
@@ -8,7 +8,7 @@ description: Component to finetune MMDetection models for image object detection
 
 is_deterministic: false
 
-environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/85
+environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/86
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_image/components/model_import/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/model_import/mmd_od_is/spec.yaml
@@ -8,7 +8,7 @@ description: Import PyTorch / MLflow model
 
 is_deterministic: True
 
-environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/85
+environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/86
 
 code: ../../../src/model_selector
 


### PR DESCRIPTION
## What
- Point the MMDetection model import and finetune components at `acft-mmdetection-image-gpu` version `86`.

## Why
`image_object_detection()` is the Azure ML SDK factory; the runtime environment is pinned in the azureml-assets MMDetection component specs. Environment `86` is the intended latest MMDetection image environment for the AutoML image object detection fix.

## Notes
- The component versions introduced by #5125 are not tagged yet, so this keeps those component versions and corrects only their environment reference from `85` to `86`.
- `refs/tags/environment/acft-mmdetection-image-gpu/86` exists in azureml-assets.

## Validation
- The probe job was canceled after confirming override behavior to avoid unnecessary compute use.