### PR TITLE
Rollback unreleased MMDetection component bumps

### DIFF
--- a/assets/training/finetune_acft_image/components/finetune/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/mmd_od_is/spec.yaml
@@ -1,14 +1,14 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
-version: 0.0.25
+version: 0.0.24
 name: mmdetection_image_objectdetection_instancesegmentation_finetune
 display_name: Image Object Detection and Instance Segmentation MMDetection Model Finetune
 description: Component to finetune MMDetection models for image object detection and instance segmentation.
 
 is_deterministic: false
 
-environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/86
+environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/75
 
 code: ../../../src/finetune
 

--- a/assets/training/finetune_acft_image/components/model_import/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/model_import/mmd_od_is/spec.yaml
@@ -1,14 +1,14 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 type: command
 
-version: 0.0.23
+version: 0.0.22
 name: mmdetection_image_objectdetection_instancesegmentation_model_import
 display_name: Image Object Detection and Instance Segmentation MMDetection Model Import
 description: Import PyTorch / MLflow model
 
 is_deterministic: True
 
-environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/86
+environment: azureml://registries/azureml/environments/acft-mmdetection-image-gpu/versions/75
 
 code: ../../../src/model_selector
 

--- a/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/instance_segmentation/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.28
+version: 0.0.27
 name: image_instance_segmentation_pipeline
 display_name: Image Instance Segmentation Pipeline
 description: Pipeline component for image instance segmentation.
@@ -370,7 +370,7 @@ jobs:
 
   mm_detection_model_import:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.23
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.22
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       model_family: 'MmDetectionImage'
@@ -380,7 +380,7 @@ jobs:
 
   mm_detection_finetune:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.25
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.24
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch

--- a/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/mmd_od_is/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.29
+version: 0.0.28
 name: mmdetection_image_objectdetection_instancesegmentation_pipeline
 display_name: Image Object Detection and Instance Segmentation MMDetection Pipeline
 description: Pipeline component for image object detection and instance segmentation using MMDetection models.
@@ -414,7 +414,7 @@ jobs:
 
   image_od_is_model_import:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.23
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.22
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       model_family: ${{parent.inputs.model_family}}
@@ -426,7 +426,7 @@ jobs:
 
   image_od_is_finetune:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.25
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.24
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch

--- a/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/object_detection/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 type: pipeline
 
-version: 0.0.28
+version: 0.0.27
 name: image_object_detection_pipeline
 display_name: Image Object Detection Pipeline
 description: Pipeline component for image object detection.
@@ -397,7 +397,7 @@ jobs:
 
   mm_detection_model_import:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.23
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_model_import:0.0.22
     compute: ${{parent.inputs.compute_model_import}}
     inputs:
       model_family: 'MmDetectionImage'
@@ -407,7 +407,7 @@ jobs:
 
   mm_detection_finetune:
     type: command
-    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.25
+    component: azureml:mmdetection_image_objectdetection_instancesegmentation_finetune:0.0.24
     compute: ${{parent.inputs.compute_finetune}}
     distribution:
       type: pytorch


### PR DESCRIPTION
## What
Rollback the unreleased MMDetection component and pipeline component version bumps introduced by the recent MMDetection environment fixes.

This restores:
- `mmdetection_image_objectdetection_instancesegmentation_model_import` to `0.0.22`
- `mmdetection_image_objectdetection_instancesegmentation_finetune` to `0.0.24`
- image object detection / instance segmentation / MMDetection pipeline component refs to the currently released component versions

## What this does not change
The `acft-mmdetection-image-gpu` environment asset changes are kept intact. The environment has already been released, so this PR only rolls back component source versions/refs that have not been released.

## Why
The component versions introduced by the prior PRs have not been released. Rolling them back avoids publishing a large component/runtime jump while we mitigate the customer issue separately with a pipeline override to the last known good path.
