### PR TITLE
Remove test tag from Parakeet model

### DIFF
--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-cuda-gpu/spec.yaml
@@ -4,7 +4,7 @@ version: 1
 isArchived: true
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "MIT"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2#licenseterms-of-use>."
   author: Microsoft

--- a/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/parakeet-tdt-0.6b-v2-generic-cpu/spec.yaml
@@ -4,7 +4,7 @@ version: 1
 isArchived: true
 path: ./
 tags:
-  foundryLocal: "test"
+  foundryLocal: ""
   license: "MIT"
   licenseDescription: "This model is provided under the License Terms available at <https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2#licenseterms-of-use>."
   author: Microsoft


### PR DESCRIPTION
This pull request makes a minor update to the metadata of two model spec files. The only change is the removal of the `"test"` value from the `foundryLocal` tag, leaving it empty. No other changes were made.