### PR TITLE
Evaluators: stop logging customer payloads in fallback / debug paths

### DIFF
--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -1719,7 +1719,7 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         try:
             logger.debug("Extracting context from response")
             tool_calls = self._parse_tools_from_response(response=response)
-            logger.debug(f"Tool Calls parsed successfully: {tool_calls}")
+            logger.debug("Tool calls parsed successfully: count=%d", len(tool_calls) if tool_calls else 0)
 
             if not tool_calls:
                 return NO_CONTEXT

--- a/assets/evaluators/builtin/tool_call_success/evaluator/_tool_call_success.py
+++ b/assets/evaluators/builtin/tool_call_success/evaluator/_tool_call_success.py
@@ -1063,6 +1063,37 @@ def _format_status_suffix(status):
     return ""
 
 
+def _describe_response(response):
+    """Return a non-sensitive structural summary of an agent response.
+
+    The raw ``response`` may contain customer-controlled payloads (tool
+    arguments, tool results, assistant text, database rows, file content,
+    etc.) which can include credentials or PII. Logging the payload itself
+    risks leaking that data into telemetry sinks at any log level. This
+    helper returns shape-only metadata - type, length, top-level keys/roles
+    - which is sufficient to diagnose schema drift without exposing values.
+    """
+    try:
+        type_name = type(response).__name__
+        if isinstance(response, list):
+            length = len(response)
+            roles = []
+            for item in response[:10]:
+                if isinstance(item, dict):
+                    role = item.get("role")
+                    if isinstance(role, str):
+                        roles.append(role)
+            roles_summary = roles if roles else "n/a"
+            return f"response_type={type_name} len={length} roles={roles_summary}"
+        if isinstance(response, dict):
+            keys = sorted(k for k in response.keys() if isinstance(k, str))[:10]
+            return f"response_type={type_name} top_keys={keys}"
+        length = len(response) if hasattr(response, "__len__") else "n/a"
+        return f"response_type={type_name} len={length}"
+    except Exception:
+        return f"response_type={type(response).__name__} (summary unavailable)"
+
+
 def _reformat_tool_calls_results(response, logger=None):
     try:
         if response is None or response == []:
@@ -1073,8 +1104,9 @@ def _reformat_tool_calls_results(response, logger=None):
             # fallback to the original response in that case
             if logger:
                 logger.warning(
-                    f"Empty agent response extracted, likely due to input schema change. "
-                    f"Falling back to using the original response: {response}"
+                    "Empty agent response extracted, likely due to input schema change. "
+                    "Falling back to using the original response. %s",
+                    _describe_response(response),
                 )
             return response
         return "\n".join(agent_response)
@@ -1084,8 +1116,11 @@ def _reformat_tool_calls_results(response, logger=None):
         # This is a fallback to ensure that the evaluation can still proceed.
         # See comments on reformat_conversation_history for more details.
         if logger:
-            logger.warning(f"Agent response could not be parsed, falling back to original response. Error: {e}")
-            logger.debug(f"Original response: {response}")
+            logger.warning(
+                "Agent response could not be parsed, falling back to original response. Error: %s. %s",
+                e,
+                _describe_response(response),
+            )
         return response
 
 
@@ -1105,7 +1140,9 @@ def _reformat_tool_definitions(tool_definitions, logger=None):
         # See comments on reformat_conversation_history for more details.
         if logger:
             logger.warning(
-                f"Tool definitions could not be parsed, falling back to original definitions. Error: {e}"
+                "Tool definitions could not be parsed; falling back to raw definitions. "
+                "Input shape: %s. Error: %s",
+                _describe_response(tool_definitions),
+                e,
             )
-            logger.debug(f"Original tool definitions: {tool_definitions}")
         return tool_definitions

--- a/assets/evaluators/builtin/tool_input_accuracy/evaluator/_tool_input_accuracy.py
+++ b/assets/evaluators/builtin/tool_input_accuracy/evaluator/_tool_input_accuracy.py
@@ -900,7 +900,7 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
             query, include_system_messages=include_system_messages, include_tool_calls=include_tool_calls
         )
         return _pretty_format_conversation_history(conversation_history)
-    except Exception:
+    except Exception as e:
         # If the conversation history cannot be parsed for whatever reason (e.g. the converter format changed),
         #  the original query is returned
         # This is a fallback to ensure that the evaluation can still proceed.
@@ -911,8 +911,41 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
         #   Lower percentage of mode in Likert scale (73.4% vs 75.4%)
         #   Lower pairwise agreement between LLMs (85% vs 90% at the pass/fail level with threshold of 3)
         if logger:
-            logger.warning(f"Conversation history could not be parsed, falling back to original query: {query}")
+            logger.warning(
+                "Conversation history could not be parsed; falling back to raw input. "
+                "Evaluator accuracy will degrade. Input shape: %s. Error: %s",
+                _describe_payload(query),
+                e,
+            )
         return query
+
+
+def _describe_payload(obj):
+    """Return a non-sensitive structural summary of a payload for safe logging.
+
+    The raw payload may contain customer-controlled data (conversation history,
+    tool arguments/results, file content, etc.) which can include credentials
+    or PII. This helper returns shape-only metadata - type, length, top-level
+    roles/keys - sufficient to diagnose schema drift without exposing values.
+    """
+    try:
+        type_name = type(obj).__name__
+        if isinstance(obj, list):
+            roles = []
+            for item in obj[:10]:
+                if isinstance(item, dict):
+                    role = item.get("role")
+                    if isinstance(role, str):
+                        roles.append(role)
+            roles_summary = roles if roles else "n/a"
+            return f"type={type_name} len={len(obj)} roles={roles_summary}"
+        if isinstance(obj, dict):
+            keys = sorted(k for k in obj.keys() if isinstance(k, str))[:10]
+            return f"type={type_name} top_keys={keys}"
+        length = len(obj) if hasattr(obj, "__len__") else "n/a"
+        return f"type={type_name} len={length}"
+    except Exception:
+        return f"type={type(obj).__name__} (summary unavailable)"
 
 
 def _is_intermediate_response(response):

--- a/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
+++ b/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
@@ -716,8 +716,12 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
         #   Lower percentage of mode in Likert scale (73.4% vs 75.4%)
         #   Lower pairwise agreement between LLMs (85% vs 90% at the pass/fail level with threshold of 3)
         if logger:
-            logger.warning(f"Conversation history could not be parsed, falling back to original query: {query}")
-            print(e)
+            logger.warning(
+                "Conversation history could not be parsed; falling back to raw input. "
+                "Evaluator accuracy will degrade. Input shape: %s. Error: %s",
+                _describe_payload(query),
+                e,
+            )
         return query
 
 
@@ -823,10 +827,41 @@ def reformat_tool_definitions(tool_definitions, logger=None):
         # See comments on reformat_conversation_history for more details.
         if logger:
             logger.warning(
-                "Tool definitions could not be parsed, falling back to original definitions"
-                f": {tool_definitions}. Error: {e}"
+                "Tool definitions could not be parsed; falling back to raw definitions. "
+                "Input shape: %s. Error: %s",
+                _describe_payload(tool_definitions),
+                e,
             )
         return tool_definitions
+
+
+def _describe_payload(obj):
+    """Return a non-sensitive structural summary of a payload for safe logging.
+
+    The raw payload may contain customer-controlled data (conversation history,
+    tool definitions, tool arguments/results, file content, etc.) which can
+    include credentials or PII. This helper returns shape-only metadata - type,
+    length, top-level roles/keys - sufficient to diagnose schema drift without
+    exposing values.
+    """
+    try:
+        type_name = type(obj).__name__
+        if isinstance(obj, list):
+            roles = []
+            for item in obj[:10]:
+                if isinstance(item, dict):
+                    role = item.get("role")
+                    if isinstance(role, str):
+                        roles.append(role)
+            roles_summary = roles if roles else "n/a"
+            return f"type={type_name} len={len(obj)} roles={roles_summary}"
+        if isinstance(obj, dict):
+            keys = sorted(k for k in obj.keys() if isinstance(k, str))[:10]
+            return f"type={type_name} top_keys={keys}"
+        length = len(obj) if hasattr(obj, "__len__") else "n/a"
+        return f"type={type_name} len={length}"
+    except Exception:
+        return f"type={type(obj).__name__} (summary unavailable)"
 
 
 # ```

--- a/assets/evaluators/builtin/tool_selection/evaluator/_tool_selection.py
+++ b/assets/evaluators/builtin/tool_selection/evaluator/_tool_selection.py
@@ -921,7 +921,7 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
             query, include_system_messages=include_system_messages, include_tool_calls=include_tool_calls
         )
         return _pretty_format_conversation_history(conversation_history)
-    except Exception:
+    except Exception as e:
         # If the conversation history cannot be parsed for whatever reason (e.g. the converter format change),
         # the original query is returned
         # This is a fallback to ensure that the evaluation can still proceed.
@@ -932,8 +932,41 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
         #   Lower percentage of mode in Likert scale (73.4% vs 75.4%)
         #   Lower pairwise agreement between LLMs (85% vs 90% at the pass/fail level with threshold of 3)
         if logger:
-            logger.warning(f"Conversation history could not be parsed, falling back to original query: {query}")
+            logger.warning(
+                "Conversation history could not be parsed; falling back to raw input. "
+                "Evaluator accuracy will degrade. Input shape: %s. Error: %s",
+                _describe_payload(query),
+                e,
+            )
         return query
+
+
+def _describe_payload(obj):
+    """Return a non-sensitive structural summary of a payload for safe logging.
+
+    The raw payload may contain customer-controlled data (conversation history,
+    tool arguments/results, file content, etc.) which can include credentials
+    or PII. This helper returns shape-only metadata - type, length, top-level
+    roles/keys - sufficient to diagnose schema drift without exposing values.
+    """
+    try:
+        type_name = type(obj).__name__
+        if isinstance(obj, list):
+            roles = []
+            for item in obj[:10]:
+                if isinstance(item, dict):
+                    role = item.get("role")
+                    if isinstance(role, str):
+                        roles.append(role)
+            roles_summary = roles if roles else "n/a"
+            return f"type={type_name} len={len(obj)} roles={roles_summary}"
+        if isinstance(obj, dict):
+            keys = sorted(k for k in obj.keys() if isinstance(k, str))[:10]
+            return f"type={type_name} top_keys={keys}"
+        length = len(obj) if hasattr(obj, "__len__") else "n/a"
+        return f"type={type_name} len={length}"
+    except Exception:
+        return f"type={type(obj).__name__} (summary unavailable)"
 
 
 def _is_intermediate_response(response):

--- a/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
@@ -1,0 +1,265 @@
+"""Regression tests guarding against credential / PII leaks via response logging.
+
+Several evaluator fallback paths previously logged the full raw payload
+(``response``, ``query``, ``tool_definitions``, parsed ``tool_calls``) at
+WARNING or DEBUG level. Those payloads are customer-controlled - they carry
+tool arguments, tool results, user-pasted text, system prompts, file content,
+database rows, and other data that can include credentials or PII. Logging
+them - even at ``debug`` level - leaks that data into any sink that captures
+the corresponding log level (CI logs, Azure ML run logs, App Insights, OTel
+exporters, customer telemetry).
+
+These tests assert that for each known fallback / debug path, the raw payload
+never appears in captured log output at any level. They cover one file per
+leak site; the synthetic ``SECRET`` placeholder stands in for any sensitive
+substring that might be present in real customer payloads.
+"""
+
+import logging
+
+import pytest
+
+from ...builtin.tool_call_success.evaluator._tool_call_success import (
+    _reformat_tool_calls_results,
+    _reformat_tool_definitions as _tcs_reformat_tool_definitions,
+    _describe_response,
+)
+from ...builtin.tool_selection.evaluator._tool_selection import (
+    reformat_conversation_history as _ts_reformat_conversation_history,
+    _describe_payload as _ts_describe_payload,
+)
+from ...builtin.tool_input_accuracy.evaluator._tool_input_accuracy import (
+    reformat_conversation_history as _tia_reformat_conversation_history,
+    _describe_payload as _tia_describe_payload,
+)
+from ...builtin.tool_output_utilization.evaluator._tool_output_utilization import (
+    reformat_conversation_history as _tou_reformat_conversation_history,
+    reformat_tool_definitions as _tou_reformat_tool_definitions,
+    _describe_payload as _tou_describe_payload,
+)
+
+
+SECRET = "sk-SUPERSECRET-API-KEY-DO-NOT-LOG"
+
+
+def _assert_secret_not_logged(caplog):
+    leaks = [r for r in caplog.records if SECRET in r.getMessage()]
+    assert not leaks, (
+        "Payload was written to logs - this leaks credentials / PII. "
+        f"Offending records: {[(r.levelname, r.getMessage()) for r in leaks]}"
+    )
+
+
+# region tool_call_success._reformat_tool_calls_results
+
+
+def test_tcs_exception_branch_does_not_log_response(caplog):
+    """Parsing error in tool_call_success must not log the raw response."""
+
+    class Boom:
+        """Response that triggers a TypeError inside _get_tool_calls_results."""
+
+        def __repr__(self):
+            return f"<Response token={SECRET}>"
+
+        def __iter__(self):
+            raise TypeError("cannot iterate")
+
+    logger = logging.getLogger("test_tcs_exception_branch_does_not_log_response")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = _reformat_tool_calls_results(Boom(), logger=logger)
+
+    assert isinstance(result, Boom)
+    _assert_secret_not_logged(caplog)
+
+
+def test_tcs_empty_extraction_branch_does_not_log_response(caplog):
+    """Empty-extraction fallback in tool_call_success must not log the raw response."""
+    response = [
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": f"my key is {SECRET}"}],
+        }
+    ]
+
+    logger = logging.getLogger("test_tcs_empty_extraction_branch_does_not_log_response")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = _reformat_tool_calls_results(response, logger=logger)
+
+    assert result is response
+    _assert_secret_not_logged(caplog)
+
+
+def test_tcs_tool_definitions_exception_does_not_log_payload(caplog):
+    """Parsing error in tool_call_success._reformat_tool_definitions must not log the raw definitions."""
+
+    class BoomDefs:
+        def __repr__(self):
+            return f"<ToolDefs secret={SECRET}>"
+
+        def __iter__(self):
+            raise TypeError("cannot iterate")
+
+    logger = logging.getLogger("test_tcs_tool_definitions_exception_does_not_log_payload")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = _tcs_reformat_tool_definitions(BoomDefs(), logger=logger)
+
+    assert isinstance(result, BoomDefs)
+    _assert_secret_not_logged(caplog)
+
+
+# endregion
+
+
+# region reformat_conversation_history (three siblings)
+
+
+def _make_unparseable_query():
+    """A query object whose iteration raises - reliably triggers the except branch
+    of ``reformat_conversation_history`` across all three evaluator copies."""
+
+    class BoomQuery:
+        def __repr__(self):
+            return f"<Query password='{SECRET}'>"
+
+        def __iter__(self):
+            raise TypeError("cannot iterate")
+
+    return BoomQuery()
+
+
+@pytest.mark.parametrize(
+    "name,reformat",
+    [
+        ("tool_selection", _ts_reformat_conversation_history),
+        ("tool_input_accuracy", _tia_reformat_conversation_history),
+        ("tool_output_utilization", _tou_reformat_conversation_history),
+    ],
+)
+def test_reformat_conversation_history_does_not_log_query(name, reformat, caplog):
+    """All three reformat_conversation_history copies must not log the raw query."""
+    query = _make_unparseable_query()
+    logger = logging.getLogger(f"test_reformat_conversation_history_does_not_log_query[{name}]")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = reformat(query, logger=logger)
+
+    assert result is query
+    _assert_secret_not_logged(caplog)
+
+
+# endregion
+
+
+# region tool_output_utilization._reformat_tool_definitions
+
+
+def test_tou_tool_definitions_exception_does_not_log_payload(caplog):
+    """Parsing error in tool_output_utilization._reformat_tool_definitions must not log the raw definitions."""
+
+    class BoomDefs:
+        def __repr__(self):
+            return f"<ToolDefs secret={SECRET}>"
+
+        def __iter__(self):
+            raise TypeError("cannot iterate")
+
+    logger = logging.getLogger("test_tou_tool_definitions_exception_does_not_log_payload")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = _tou_reformat_tool_definitions(BoomDefs(), logger=logger)
+
+    assert isinstance(result, BoomDefs)
+    _assert_secret_not_logged(caplog)
+
+
+# endregion
+
+
+# region _describe_payload / _describe_response adversarial robustness
+
+
+# All four describe-helper copies must behave identically under hostile input:
+# they must never raise, must never include the original value's repr, and
+# must always produce a short, structural-only string. Parametrize over each
+# helper so a regression in any one copy is caught.
+DESCRIBE_HELPERS = [
+    ("tool_call_success._describe_response", _describe_response),
+    ("tool_selection._describe_payload", _ts_describe_payload),
+    ("tool_input_accuracy._describe_payload", _tia_describe_payload),
+    ("tool_output_utilization._describe_payload", _tou_describe_payload),
+]
+
+
+class _BadLen(list):
+    def __len__(self):
+        raise RuntimeError(f"len boom containing {SECRET}")
+
+
+class _BadDict(dict):
+    def keys(self):
+        raise RuntimeError(f"keys boom containing {SECRET}")
+
+
+class _BadObj:
+    def __len__(self):
+        raise ValueError(f"len boom containing {SECRET}")
+
+    def __repr__(self):
+        return f"<BadObj {SECRET}>"
+
+
+def _adversarial_inputs():
+    """Inputs that historically broke naive describe-by-repr implementations."""
+    rec = {}
+    rec["self"] = rec  # recursive dict - would blow up json.dumps / repr
+    return [
+        ("none", None),
+        ("empty_list", []),
+        ("empty_dict", {}),
+        ("list_of_strings", [f"payload {SECRET}", "x"]),
+        ("list_of_ints", [1, 2, 3]),
+        ("list_of_mixed", [{"role": "user"}, f"stray {SECRET}", 42, None]),
+        ("list_with_non_string_roles", [{"role": 1}, {"role": None}, {"role": ["weird"]}]),
+        ("dict_with_int_keys", {1: f"value {SECRET}", 2: "b"}),
+        ("dict_with_mixed_keys", {"a": 1, 2: f"value {SECRET}", (1, 2): "c"}),
+        ("recursive_dict", rec),
+        ("bytes_payload", f"sk-{SECRET}".encode("utf-8")),
+        ("bytearray_payload", bytearray(SECRET.encode("utf-8"))),
+        ("set_payload", {f"a {SECRET}", "b"}),
+        ("tuple_payload", (f"a {SECRET}", "b")),
+        ("huge_list", [{"role": "user"}] * 10_000),
+        ("bad_len_list", _BadLen([1, 2, 3])),
+        ("bad_dict_keys", _BadDict({"a": SECRET})),
+        ("bad_obj_with_len_raising", _BadObj()),
+    ]
+
+
+@pytest.mark.parametrize("helper_name,helper", DESCRIBE_HELPERS)
+@pytest.mark.parametrize("label,value", _adversarial_inputs())
+def test_describe_helper_never_raises_and_never_leaks(helper_name, helper, label, value):
+    """Every describe helper must (1) never raise and (2) never include SECRET."""
+    try:
+        out = helper(value)
+    except Exception as e:  # pragma: no cover - defensive
+        pytest.fail(f"{helper_name} raised on input {label!r}: {type(e).__name__}: {e}")
+
+    assert isinstance(out, str), f"{helper_name} returned non-str for {label!r}: {type(out)}"
+    assert SECRET not in out, (
+        f"{helper_name} leaked SECRET in output for input {label!r}: {out!r}"
+    )
+
+
+@pytest.mark.parametrize("helper_name,helper", DESCRIBE_HELPERS)
+def test_describe_helper_truncates_long_role_lists(helper_name, helper):
+    """A 10k-message conversation must not produce a 10k-long roles string."""
+    huge = [{"role": "user"}] * 10_000
+    out = helper(huge)
+    # Cap chosen generously - real shape descriptions stay well under 256 chars.
+    assert len(out) < 512, f"{helper_name} produced unbounded output ({len(out)} chars): {out[:200]}..."
+    assert "len=10000" in out, f"{helper_name} did not report true length: {out}"
+
+
+# endregion
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Several evaluator fallback and debug paths were logging the raw input payload (`response`, `query`, `tool_definitions`, parsed `tool_calls`) at WARNING or DEBUG level. These payloads are customer-controlled — they carry tool arguments, tool results, user-pasted text, system prompts, file content, and database rows that can include credentials or PII. WARNING-level entries reach default sinks (Azure ML run logs, App Insights); DEBUG-level entries reach any sink that opts into debug capture.

This PR removes the payload from every leak site and replaces it with a small `_describe_payload` helper that emits structural-only metadata (type, length, top-level roles/keys) — sufficient to diagnose schema drift without exposing values.

## Related

- Bug: https://msdata.visualstudio.com/Vienna/_workitems/edit/5048434
- Supersedes / completes #5108 (which only demoted one site `warning`→`debug`; the payload was still logged).

## Sites fixed

| File | Site | Was | Now |
|---|---|---|---|
| `tool_call_success/_tool_call_success.py` | `_reformat_tool_calls_results` (the ICM site) | `f"...: {response}"` WARNING + `f"...: {response}"` DEBUG | shape-only |
| `tool_call_success/_tool_call_success.py` | `_reformat_tool_definitions` | DEBUG `f"...: {tool_definitions}"` | shape-only |
| `tool_selection/_tool_selection.py` | `reformat_conversation_history` | WARNING `f"...: {query}"` | shape-only |
| `tool_input_accuracy/_tool_input_accuracy.py` | `reformat_conversation_history` | WARNING `f"...: {query}"` | shape-only |
| `tool_output_utilization/_tool_output_utilization.py` | `reformat_conversation_history` | WARNING `f"...: {query}"` + stray `print(e)` | shape-only, `print` removed |
| `tool_output_utilization/_tool_output_utilization.py` | `reformat_tool_definitions` | WARNING `f"...: {tool_definitions}"` | shape-only |
| `groundedness/_groundedness.py` | `_get_context_from_agent_response` | DEBUG `f"...: {tool_calls}"` (happy path; arguments + tool_result included) | `count=N` only |

The diagnostic message is preserved (e.g. "Conversation history could not be parsed; falling back to raw input. Evaluator accuracy will degrade."). The reproducibility use case is served by asking customers for a repro on demand rather than harvesting payloads pre-emptively.

## Tests

New file: `tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py` — **83 tests**.

- **7 leak-site regression tests** (one per fixed site). Each triggers the fallback / debug path with a payload containing a `SECRET` marker and asserts the marker is absent from `caplog.records` at any log level.
- **72 adversarial robustness tests** — 18 hostile inputs × 4 describe-helper copies. Inputs include `bytes` payloads, recursive dicts, mixed-type lists, dicts with non-string keys, objects with `__len__` / `keys()` raising (with the SECRET embedded in the exception message), `__repr__`-overriding objects, etc. Each asserts the helper (1) never raises and (2) never produces output containing the marker.
- **4 truncation tests** — assert a 10,000-entry list produces bounded output (<512 chars) while still reporting the true length.

If a future refactor swaps `_describe_payload` for `repr()` / `str()` / `json.dumps()`, dozens of tests fail.

## Verification

- ✅ All **316 affected behavior tests** pass on Python 3.10 across the 5 modified evaluator suites + status passthrough + 83 new regression/adversarial tests.
- ✅ `flake8` / `scripts/validation/code_health.py -i assets/evaluators` clean.
- ⚠️ 5 pre-existing failures in `test_groundedness_evaluator_behavior.py` (`test_file_search`, `test_image_generation`, `test_memory_search`, `test_kb_mcp`, `test_mcp`) are present on `main` without these changes — unrelated, separate issue.

## Why not just demote `warning → debug` (as in #5108)?

`debug` is one config flip away from being on. Customers and support engineers routinely raise log level when something goes wrong — exactly when payloads are most likely to contain real secrets. Microsoft SDL guidance treats "log untrusted, unbounded customer payloads" as a defect at any level. Demoting reduces blast radius but does not eliminate the data-flow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
