### PR TITLE
Evaluators: stop logging customer payloads in fallback / debug paths

### DIFF
--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -1719,7 +1719,7 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         try:
             logger.debug("Extracting context from response")
             tool_calls = self._parse_tools_from_response(response=response)
-            logger.debug(f"Tool Calls parsed successfully: {tool_calls}")
+            logger.debug("Tool calls parsed successfully: count=%d", len(tool_calls) if tool_calls else 0)
 
             if not tool_calls:
                 return NO_CONTEXT

--- a/assets/evaluators/builtin/quality_grader/evaluator/_quality_grader.py
+++ b/assets/evaluators/builtin/quality_grader/evaluator/_quality_grader.py
@@ -600,6 +600,35 @@ _GROUNDEDNESS_THRESHOLD = 2.5
 _CONTEXT_COVERAGE_THRESHOLD = 1.5
 
 
+def _log_safe_summary(obj):
+    """Return a non-sensitive structural summary of a payload for safe logging.
+
+    The raw payload may contain customer-controlled data (LLM output text,
+    conversation history, tool arguments/results, etc.) which can include
+    credentials or PII. This helper returns shape-only metadata - type,
+    length, top-level keys/roles - sufficient to diagnose schema drift
+    without exposing values.
+    """
+    try:
+        type_name = type(obj).__name__
+        if isinstance(obj, list):
+            roles = []
+            for item in obj[:10]:
+                if isinstance(item, dict):
+                    role = item.get("role")
+                    if isinstance(role, str):
+                        roles.append(role)
+            roles_summary = roles if roles else "n/a"
+            return f"type={type_name} len={len(obj)} roles={roles_summary}"
+        if isinstance(obj, dict):
+            keys = sorted(k for k in obj.keys() if isinstance(k, str))[:10]
+            return f"type={type_name} top_keys={keys}"
+        length = len(obj) if hasattr(obj, "__len__") else "n/a"
+        return f"type={type_name} len={length}"
+    except Exception:
+        return f"type={type(obj).__name__} (summary unavailable)"
+
+
 class QualityGraderEvaluator(PromptyEvaluatorBase[Union[str, float]]):
     """Evaluates overall response quality using a two-stage grading pipeline.
 
@@ -901,8 +930,12 @@ class QualityGraderEvaluator(PromptyEvaluatorBase[Union[str, float]]):
             return llm_output
         try:
             return json.loads(llm_output)
-        except (json.JSONDecodeError, TypeError):
-            logger.warning("Failed to parse LLM output as JSON: %s", llm_output)
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.warning(
+                "Failed to parse LLM output as JSON. Output shape: %s. Error: %s",
+                _log_safe_summary(llm_output),
+                e,
+            )
             return {}
 
     def _build_result(

--- a/assets/evaluators/builtin/tool_call_success/evaluator/_tool_call_success.py
+++ b/assets/evaluators/builtin/tool_call_success/evaluator/_tool_call_success.py
@@ -1294,6 +1294,37 @@ def _get_tool_calls_results(agent_response_msgs):
     return agent_response_text
 
 
+def _describe_response(response):
+    """Return a non-sensitive structural summary of an agent response.
+
+    The raw ``response`` may contain customer-controlled payloads (tool
+    arguments, tool results, assistant text, database rows, file content,
+    etc.) which can include credentials or PII. Logging the payload itself
+    risks leaking that data into telemetry sinks at any log level. This
+    helper returns shape-only metadata - type, length, top-level keys/roles
+    - which is sufficient to diagnose schema drift without exposing values.
+    """
+    try:
+        type_name = type(response).__name__
+        if isinstance(response, list):
+            length = len(response)
+            roles = []
+            for item in response[:10]:
+                if isinstance(item, dict):
+                    role = item.get("role")
+                    if isinstance(role, str):
+                        roles.append(role)
+            roles_summary = roles if roles else "n/a"
+            return f"response_type={type_name} len={length} roles={roles_summary}"
+        if isinstance(response, dict):
+            keys = sorted(k for k in response.keys() if isinstance(k, str))[:10]
+            return f"response_type={type_name} top_keys={keys}"
+        length = len(response) if hasattr(response, "__len__") else "n/a"
+        return f"response_type={type_name} len={length}"
+    except Exception:
+        return f"response_type={type(response).__name__} (summary unavailable)"
+
+
 def _reformat_tool_calls_results(response, logger=None):
     try:
         if response is None or response == []:
@@ -1304,8 +1335,9 @@ def _reformat_tool_calls_results(response, logger=None):
             # fallback to the original response in that case
             if logger:
                 logger.warning(
-                    f"Empty agent response extracted, likely due to input schema change. "
-                    f"Falling back to using the original response: {response}"
+                    "Empty agent response extracted, likely due to input schema change. "
+                    "Falling back to using the original response. %s",
+                    _describe_response(response),
                 )
             return response
         return "\n".join(agent_response)
@@ -1316,9 +1348,10 @@ def _reformat_tool_calls_results(response, logger=None):
         # See comments on reformat_conversation_history for more details.
         if logger:
             logger.warning(
-                f"Agent response could not be parsed, falling back to original response. Error: {e}"
+                "Agent response could not be parsed, falling back to original response. Error: %s. %s",
+                e,
+                _describe_response(response),
             )
-            logger.debug(f"Original response: {response}")
         return response
 
 
@@ -1338,7 +1371,9 @@ def _reformat_tool_definitions(tool_definitions, logger=None):
         # See comments on reformat_conversation_history for more details.
         if logger:
             logger.warning(
-                f"Tool definitions could not be parsed, falling back to original definitions. Error: {e}"
+                "Tool definitions could not be parsed; falling back to raw definitions. "
+                "Input shape: %s. Error: %s",
+                _describe_response(tool_definitions),
+                e,
             )
-            logger.debug(f"Original tool definitions: {tool_definitions}")
         return tool_definitions

--- a/assets/evaluators/builtin/tool_call_success/evaluator/_tool_call_success.py
+++ b/assets/evaluators/builtin/tool_call_success/evaluator/_tool_call_success.py
@@ -1294,35 +1294,34 @@ def _get_tool_calls_results(agent_response_msgs):
     return agent_response_text
 
 
-def _describe_response(response):
-    """Return a non-sensitive structural summary of an agent response.
+def _log_safe_summary(obj):
+    """Return a non-sensitive structural summary of a payload for safe logging.
 
-    The raw ``response`` may contain customer-controlled payloads (tool
-    arguments, tool results, assistant text, database rows, file content,
-    etc.) which can include credentials or PII. Logging the payload itself
-    risks leaking that data into telemetry sinks at any log level. This
-    helper returns shape-only metadata - type, length, top-level keys/roles
-    - which is sufficient to diagnose schema drift without exposing values.
+    The raw payload may contain customer-controlled data (tool arguments,
+    tool results, assistant text, database rows, file content, etc.) which
+    can include credentials or PII. Logging the payload itself risks leaking
+    that data into telemetry sinks at any log level. This helper returns
+    shape-only metadata - type, length, top-level keys/roles - which is
+    sufficient to diagnose schema drift without exposing values.
     """
     try:
-        type_name = type(response).__name__
-        if isinstance(response, list):
-            length = len(response)
+        type_name = type(obj).__name__
+        if isinstance(obj, list):
             roles = []
-            for item in response[:10]:
+            for item in obj[:10]:
                 if isinstance(item, dict):
                     role = item.get("role")
                     if isinstance(role, str):
                         roles.append(role)
             roles_summary = roles if roles else "n/a"
-            return f"response_type={type_name} len={length} roles={roles_summary}"
-        if isinstance(response, dict):
-            keys = sorted(k for k in response.keys() if isinstance(k, str))[:10]
-            return f"response_type={type_name} top_keys={keys}"
-        length = len(response) if hasattr(response, "__len__") else "n/a"
-        return f"response_type={type_name} len={length}"
+            return f"type={type_name} len={len(obj)} roles={roles_summary}"
+        if isinstance(obj, dict):
+            keys = sorted(k for k in obj.keys() if isinstance(k, str))[:10]
+            return f"type={type_name} top_keys={keys}"
+        length = len(obj) if hasattr(obj, "__len__") else "n/a"
+        return f"type={type_name} len={length}"
     except Exception:
-        return f"response_type={type(response).__name__} (summary unavailable)"
+        return f"type={type(obj).__name__} (summary unavailable)"
 
 
 def _reformat_tool_calls_results(response, logger=None):
@@ -1337,7 +1336,7 @@ def _reformat_tool_calls_results(response, logger=None):
                 logger.warning(
                     "Empty agent response extracted, likely due to input schema change. "
                     "Falling back to using the original response. %s",
-                    _describe_response(response),
+                    _log_safe_summary(response),
                 )
             return response
         return "\n".join(agent_response)
@@ -1350,7 +1349,7 @@ def _reformat_tool_calls_results(response, logger=None):
             logger.warning(
                 "Agent response could not be parsed, falling back to original response. Error: %s. %s",
                 e,
-                _describe_response(response),
+                _log_safe_summary(response),
             )
         return response
 
@@ -1373,7 +1372,7 @@ def _reformat_tool_definitions(tool_definitions, logger=None):
             logger.warning(
                 "Tool definitions could not be parsed; falling back to raw definitions. "
                 "Input shape: %s. Error: %s",
-                _describe_response(tool_definitions),
+                _log_safe_summary(tool_definitions),
                 e,
             )
         return tool_definitions

--- a/assets/evaluators/builtin/tool_input_accuracy/evaluator/_tool_input_accuracy.py
+++ b/assets/evaluators/builtin/tool_input_accuracy/evaluator/_tool_input_accuracy.py
@@ -914,13 +914,13 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
             logger.warning(
                 "Conversation history could not be parsed; falling back to raw input. "
                 "Evaluator accuracy will degrade. Input shape: %s. Error: %s",
-                _describe_payload(query),
+                _log_safe_summary(query),
                 e,
             )
         return query
 
 
-def _describe_payload(obj):
+def _log_safe_summary(obj):
     """Return a non-sensitive structural summary of a payload for safe logging.
 
     The raw payload may contain customer-controlled data (conversation history,

--- a/assets/evaluators/builtin/tool_input_accuracy/evaluator/_tool_input_accuracy.py
+++ b/assets/evaluators/builtin/tool_input_accuracy/evaluator/_tool_input_accuracy.py
@@ -900,7 +900,7 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
             query, include_system_messages=include_system_messages, include_tool_calls=include_tool_calls
         )
         return _pretty_format_conversation_history(conversation_history)
-    except Exception:
+    except Exception as e:
         # If the conversation history cannot be parsed for whatever reason (e.g. the converter format changed),
         #  the original query is returned
         # This is a fallback to ensure that the evaluation can still proceed.
@@ -911,8 +911,41 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
         #   Lower percentage of mode in Likert scale (73.4% vs 75.4%)
         #   Lower pairwise agreement between LLMs (85% vs 90% at the pass/fail level with threshold of 3)
         if logger:
-            logger.warning(f"Conversation history could not be parsed, falling back to original query: {query}")
+            logger.warning(
+                "Conversation history could not be parsed; falling back to raw input. "
+                "Evaluator accuracy will degrade. Input shape: %s. Error: %s",
+                _describe_payload(query),
+                e,
+            )
         return query
+
+
+def _describe_payload(obj):
+    """Return a non-sensitive structural summary of a payload for safe logging.
+
+    The raw payload may contain customer-controlled data (conversation history,
+    tool arguments/results, file content, etc.) which can include credentials
+    or PII. This helper returns shape-only metadata - type, length, top-level
+    roles/keys - sufficient to diagnose schema drift without exposing values.
+    """
+    try:
+        type_name = type(obj).__name__
+        if isinstance(obj, list):
+            roles = []
+            for item in obj[:10]:
+                if isinstance(item, dict):
+                    role = item.get("role")
+                    if isinstance(role, str):
+                        roles.append(role)
+            roles_summary = roles if roles else "n/a"
+            return f"type={type_name} len={len(obj)} roles={roles_summary}"
+        if isinstance(obj, dict):
+            keys = sorted(k for k in obj.keys() if isinstance(k, str))[:10]
+            return f"type={type_name} top_keys={keys}"
+        length = len(obj) if hasattr(obj, "__len__") else "n/a"
+        return f"type={type_name} len={length}"
+    except Exception:
+        return f"type={type(obj).__name__} (summary unavailable)"
 
 
 def _is_intermediate_response(response):

--- a/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
+++ b/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
@@ -716,8 +716,12 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
         #   Lower percentage of mode in Likert scale (73.4% vs 75.4%)
         #   Lower pairwise agreement between LLMs (85% vs 90% at the pass/fail level with threshold of 3)
         if logger:
-            logger.warning(f"Conversation history could not be parsed, falling back to original query: {query}")
-            print(e)
+            logger.warning(
+                "Conversation history could not be parsed; falling back to raw input. "
+                "Evaluator accuracy will degrade. Input shape: %s. Error: %s",
+                _describe_payload(query),
+                e,
+            )
         return query
 
 
@@ -823,10 +827,41 @@ def reformat_tool_definitions(tool_definitions, logger=None):
         # See comments on reformat_conversation_history for more details.
         if logger:
             logger.warning(
-                "Tool definitions could not be parsed, falling back to original definitions"
-                f": {tool_definitions}. Error: {e}"
+                "Tool definitions could not be parsed; falling back to raw definitions. "
+                "Input shape: %s. Error: %s",
+                _describe_payload(tool_definitions),
+                e,
             )
         return tool_definitions
+
+
+def _describe_payload(obj):
+    """Return a non-sensitive structural summary of a payload for safe logging.
+
+    The raw payload may contain customer-controlled data (conversation history,
+    tool definitions, tool arguments/results, file content, etc.) which can
+    include credentials or PII. This helper returns shape-only metadata - type,
+    length, top-level roles/keys - sufficient to diagnose schema drift without
+    exposing values.
+    """
+    try:
+        type_name = type(obj).__name__
+        if isinstance(obj, list):
+            roles = []
+            for item in obj[:10]:
+                if isinstance(item, dict):
+                    role = item.get("role")
+                    if isinstance(role, str):
+                        roles.append(role)
+            roles_summary = roles if roles else "n/a"
+            return f"type={type_name} len={len(obj)} roles={roles_summary}"
+        if isinstance(obj, dict):
+            keys = sorted(k for k in obj.keys() if isinstance(k, str))[:10]
+            return f"type={type_name} top_keys={keys}"
+        length = len(obj) if hasattr(obj, "__len__") else "n/a"
+        return f"type={type_name} len={length}"
+    except Exception:
+        return f"type={type(obj).__name__} (summary unavailable)"
 
 
 # ```

--- a/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
+++ b/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
@@ -719,7 +719,7 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
             logger.warning(
                 "Conversation history could not be parsed; falling back to raw input. "
                 "Evaluator accuracy will degrade. Input shape: %s. Error: %s",
-                _describe_payload(query),
+                _log_safe_summary(query),
                 e,
             )
         return query
@@ -829,13 +829,13 @@ def reformat_tool_definitions(tool_definitions, logger=None):
             logger.warning(
                 "Tool definitions could not be parsed; falling back to raw definitions. "
                 "Input shape: %s. Error: %s",
-                _describe_payload(tool_definitions),
+                _log_safe_summary(tool_definitions),
                 e,
             )
         return tool_definitions
 
 
-def _describe_payload(obj):
+def _log_safe_summary(obj):
     """Return a non-sensitive structural summary of a payload for safe logging.
 
     The raw payload may contain customer-controlled data (conversation history,

--- a/assets/evaluators/builtin/tool_selection/evaluator/_tool_selection.py
+++ b/assets/evaluators/builtin/tool_selection/evaluator/_tool_selection.py
@@ -935,13 +935,13 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
             logger.warning(
                 "Conversation history could not be parsed; falling back to raw input. "
                 "Evaluator accuracy will degrade. Input shape: %s. Error: %s",
-                _describe_payload(query),
+                _log_safe_summary(query),
                 e,
             )
         return query
 
 
-def _describe_payload(obj):
+def _log_safe_summary(obj):
     """Return a non-sensitive structural summary of a payload for safe logging.
 
     The raw payload may contain customer-controlled data (conversation history,

--- a/assets/evaluators/builtin/tool_selection/evaluator/_tool_selection.py
+++ b/assets/evaluators/builtin/tool_selection/evaluator/_tool_selection.py
@@ -921,7 +921,7 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
             query, include_system_messages=include_system_messages, include_tool_calls=include_tool_calls
         )
         return _pretty_format_conversation_history(conversation_history)
-    except Exception:
+    except Exception as e:
         # If the conversation history cannot be parsed for whatever reason (e.g. the converter format change),
         # the original query is returned
         # This is a fallback to ensure that the evaluation can still proceed.
@@ -932,8 +932,41 @@ def reformat_conversation_history(query, logger=None, include_system_messages=Fa
         #   Lower percentage of mode in Likert scale (73.4% vs 75.4%)
         #   Lower pairwise agreement between LLMs (85% vs 90% at the pass/fail level with threshold of 3)
         if logger:
-            logger.warning(f"Conversation history could not be parsed, falling back to original query: {query}")
+            logger.warning(
+                "Conversation history could not be parsed; falling back to raw input. "
+                "Evaluator accuracy will degrade. Input shape: %s. Error: %s",
+                _describe_payload(query),
+                e,
+            )
         return query
+
+
+def _describe_payload(obj):
+    """Return a non-sensitive structural summary of a payload for safe logging.
+
+    The raw payload may contain customer-controlled data (conversation history,
+    tool arguments/results, file content, etc.) which can include credentials
+    or PII. This helper returns shape-only metadata - type, length, top-level
+    roles/keys - sufficient to diagnose schema drift without exposing values.
+    """
+    try:
+        type_name = type(obj).__name__
+        if isinstance(obj, list):
+            roles = []
+            for item in obj[:10]:
+                if isinstance(item, dict):
+                    role = item.get("role")
+                    if isinstance(role, str):
+                        roles.append(role)
+            roles_summary = roles if roles else "n/a"
+            return f"type={type_name} len={len(obj)} roles={roles_summary}"
+        if isinstance(obj, dict):
+            keys = sorted(k for k in obj.keys() if isinstance(k, str))[:10]
+            return f"type={type_name} top_keys={keys}"
+        length = len(obj) if hasattr(obj, "__len__") else "n/a"
+        return f"type={type_name} len={length}"
+    except Exception:
+        return f"type={type(obj).__name__} (summary unavailable)"
 
 
 def _is_intermediate_response(response):

--- a/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
@@ -1,0 +1,265 @@
+"""Regression tests guarding against credential / PII leaks via response logging.
+
+Several evaluator fallback paths previously logged the full raw payload
+(``response``, ``query``, ``tool_definitions``, parsed ``tool_calls``) at
+WARNING or DEBUG level. Those payloads are customer-controlled - they carry
+tool arguments, tool results, user-pasted text, system prompts, file content,
+database rows, and other data that can include credentials or PII. Logging
+them - even at ``debug`` level - leaks that data into any sink that captures
+the corresponding log level (CI logs, Azure ML run logs, App Insights, OTel
+exporters, customer telemetry).
+
+These tests assert that for each known fallback / debug path, the raw payload
+never appears in captured log output at any level. They cover one file per
+leak site; the synthetic ``SECRET`` placeholder stands in for any sensitive
+substring that might be present in real customer payloads.
+"""
+
+import logging
+
+import pytest
+
+from ...builtin.tool_call_success.evaluator._tool_call_success import (
+    _reformat_tool_calls_results,
+    _reformat_tool_definitions as _tcs_reformat_tool_definitions,
+    _describe_response,
+)
+from ...builtin.tool_selection.evaluator._tool_selection import (
+    reformat_conversation_history as _ts_reformat_conversation_history,
+    _describe_payload as _ts_describe_payload,
+)
+from ...builtin.tool_input_accuracy.evaluator._tool_input_accuracy import (
+    reformat_conversation_history as _tia_reformat_conversation_history,
+    _describe_payload as _tia_describe_payload,
+)
+from ...builtin.tool_output_utilization.evaluator._tool_output_utilization import (
+    reformat_conversation_history as _tou_reformat_conversation_history,
+    reformat_tool_definitions as _tou_reformat_tool_definitions,
+    _describe_payload as _tou_describe_payload,
+)
+
+
+SECRET = "sk-SUPERSECRET-API-KEY-DO-NOT-LOG"
+
+
+def _assert_secret_not_logged(caplog):
+    leaks = [r for r in caplog.records if SECRET in r.getMessage()]
+    assert not leaks, (
+        "Payload was written to logs - this leaks credentials / PII. "
+        f"Offending records: {[(r.levelname, r.getMessage()) for r in leaks]}"
+    )
+
+
+# region tool_call_success._reformat_tool_calls_results
+
+
+def test_tcs_exception_branch_does_not_log_response(caplog):
+    """Parsing error in tool_call_success must not log the raw response."""
+
+    class Boom:
+        """Response that triggers a TypeError inside _get_tool_calls_results."""
+
+        def __repr__(self):
+            return f"<Response token={SECRET}>"
+
+        def __iter__(self):
+            raise TypeError("cannot iterate")
+
+    logger = logging.getLogger("test_tcs_exception_branch_does_not_log_response")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = _reformat_tool_calls_results(Boom(), logger=logger)
+
+    assert isinstance(result, Boom)
+    _assert_secret_not_logged(caplog)
+
+
+def test_tcs_empty_extraction_branch_does_not_log_response(caplog):
+    """Empty-extraction fallback in tool_call_success must not log the raw response."""
+    response = [
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": f"my key is {SECRET}"}],
+        }
+    ]
+
+    logger = logging.getLogger("test_tcs_empty_extraction_branch_does_not_log_response")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = _reformat_tool_calls_results(response, logger=logger)
+
+    assert result is response
+    _assert_secret_not_logged(caplog)
+
+
+def test_tcs_tool_definitions_exception_does_not_log_payload(caplog):
+    """Parsing error in tool_call_success._reformat_tool_definitions must not log the raw definitions."""
+
+    class BoomDefs:
+        def __repr__(self):
+            return f"<ToolDefs secret={SECRET}>"
+
+        def __iter__(self):
+            raise TypeError("cannot iterate")
+
+    logger = logging.getLogger("test_tcs_tool_definitions_exception_does_not_log_payload")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = _tcs_reformat_tool_definitions(BoomDefs(), logger=logger)
+
+    assert isinstance(result, BoomDefs)
+    _assert_secret_not_logged(caplog)
+
+
+# endregion
+
+
+# region reformat_conversation_history (three siblings)
+
+
+def _make_unparseable_query():
+    """A query object whose iteration raises - reliably triggers the except branch
+    of ``reformat_conversation_history`` across all three evaluator copies."""
+
+    class BoomQuery:
+        def __repr__(self):
+            return f"<Query password='{SECRET}'>"
+
+        def __iter__(self):
+            raise TypeError("cannot iterate")
+
+    return BoomQuery()
+
+
+@pytest.mark.parametrize(
+    "name,reformat",
+    [
+        ("tool_selection", _ts_reformat_conversation_history),
+        ("tool_input_accuracy", _tia_reformat_conversation_history),
+        ("tool_output_utilization", _tou_reformat_conversation_history),
+    ],
+)
+def test_reformat_conversation_history_does_not_log_query(name, reformat, caplog):
+    """All three reformat_conversation_history copies must not log the raw query."""
+    query = _make_unparseable_query()
+    logger = logging.getLogger(f"test_reformat_conversation_history_does_not_log_query[{name}]")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = reformat(query, logger=logger)
+
+    assert result is query
+    _assert_secret_not_logged(caplog)
+
+
+# endregion
+
+
+# region tool_output_utilization._reformat_tool_definitions
+
+
+def test_tou_tool_definitions_exception_does_not_log_payload(caplog):
+    """Parsing error in tool_output_utilization._reformat_tool_definitions must not log the raw definitions."""
+
+    class BoomDefs:
+        def __repr__(self):
+            return f"<ToolDefs secret={SECRET}>"
+
+        def __iter__(self):
+            raise TypeError("cannot iterate")
+
+    logger = logging.getLogger("test_tou_tool_definitions_exception_does_not_log_payload")
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        result = _tou_reformat_tool_definitions(BoomDefs(), logger=logger)
+
+    assert isinstance(result, BoomDefs)
+    _assert_secret_not_logged(caplog)
+
+
+# endregion
+
+
+# region _describe_payload / _describe_response adversarial robustness
+
+
+# All four describe-helper copies must behave identically under hostile input:
+# they must never raise, must never include the original value's repr, and
+# must always produce a short, structural-only string. Parametrize over each
+# helper so a regression in any one copy is caught.
+DESCRIBE_HELPERS = [
+    ("tool_call_success._describe_response", _describe_response),
+    ("tool_selection._describe_payload", _ts_describe_payload),
+    ("tool_input_accuracy._describe_payload", _tia_describe_payload),
+    ("tool_output_utilization._describe_payload", _tou_describe_payload),
+]
+
+
+class _BadLen(list):
+    def __len__(self):
+        raise RuntimeError(f"len boom containing {SECRET}")
+
+
+class _BadDict(dict):
+    def keys(self):
+        raise RuntimeError(f"keys boom containing {SECRET}")
+
+
+class _BadObj:
+    def __len__(self):
+        raise ValueError(f"len boom containing {SECRET}")
+
+    def __repr__(self):
+        return f"<BadObj {SECRET}>"
+
+
+def _adversarial_inputs():
+    """Inputs that historically broke naive describe-by-repr implementations."""
+    rec = {}
+    rec["self"] = rec  # recursive dict - would blow up json.dumps / repr
+    return [
+        ("none", None),
+        ("empty_list", []),
+        ("empty_dict", {}),
+        ("list_of_strings", [f"payload {SECRET}", "x"]),
+        ("list_of_ints", [1, 2, 3]),
+        ("list_of_mixed", [{"role": "user"}, f"stray {SECRET}", 42, None]),
+        ("list_with_non_string_roles", [{"role": 1}, {"role": None}, {"role": ["weird"]}]),
+        ("dict_with_int_keys", {1: f"value {SECRET}", 2: "b"}),
+        ("dict_with_mixed_keys", {"a": 1, 2: f"value {SECRET}", (1, 2): "c"}),
+        ("recursive_dict", rec),
+        ("bytes_payload", f"sk-{SECRET}".encode("utf-8")),
+        ("bytearray_payload", bytearray(SECRET.encode("utf-8"))),
+        ("set_payload", {f"a {SECRET}", "b"}),
+        ("tuple_payload", (f"a {SECRET}", "b")),
+        ("huge_list", [{"role": "user"}] * 10_000),
+        ("bad_len_list", _BadLen([1, 2, 3])),
+        ("bad_dict_keys", _BadDict({"a": SECRET})),
+        ("bad_obj_with_len_raising", _BadObj()),
+    ]
+
+
+@pytest.mark.parametrize("helper_name,helper", DESCRIBE_HELPERS)
+@pytest.mark.parametrize("label,value", _adversarial_inputs())
+def test_describe_helper_never_raises_and_never_leaks(helper_name, helper, label, value):
+    """Every describe helper must (1) never raise and (2) never include SECRET."""
+    try:
+        out = helper(value)
+    except Exception as e:  # pragma: no cover - defensive
+        pytest.fail(f"{helper_name} raised on input {label!r}: {type(e).__name__}: {e}")
+
+    assert isinstance(out, str), f"{helper_name} returned non-str for {label!r}: {type(out)}"
+    assert SECRET not in out, (
+        f"{helper_name} leaked SECRET in output for input {label!r}: {out!r}"
+    )
+
+
+@pytest.mark.parametrize("helper_name,helper", DESCRIBE_HELPERS)
+def test_describe_helper_truncates_long_role_lists(helper_name, helper):
+    """A 10k-message conversation must not produce a 10k-long roles string."""
+    huge = [{"role": "user"}] * 10_000
+    out = helper(huge)
+    # Cap chosen generously - real shape descriptions stay well under 256 chars.
+    assert len(out) < 512, f"{helper_name} produced unbounded output ({len(out)} chars): {out[:200]}..."
+    assert "len=10000" in out, f"{helper_name} did not report true length: {out}"
+
+
+# endregion
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
@@ -118,8 +118,11 @@ def test_tcs_tool_definitions_exception_does_not_log_payload(caplog):
 
 
 def _make_unparseable_query():
-    """A query object whose iteration raises - reliably triggers the except branch
-    of ``reformat_conversation_history`` across all three evaluator copies."""
+    """Build a query object that triggers the except branch.
+
+    Iteration raises ``TypeError``, which reliably triggers the except branch
+    of ``reformat_conversation_history`` across all three evaluator copies.
+    """
 
     class BoomQuery:
         def __repr__(self):
@@ -211,7 +214,7 @@ class _BadObj:
 
 
 def _adversarial_inputs():
-    """Inputs that historically broke naive describe-by-repr implementations."""
+    """Return inputs that historically broke naive describe-by-repr implementations."""
     rec = {}
     rec["self"] = rec  # recursive dict - would blow up json.dumps / repr
     return [

--- a/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
@@ -11,7 +11,7 @@ exporters, customer telemetry).
 
 These tests assert that for each known fallback / debug path, the raw payload
 never appears in captured log output at any level. They cover one file per
-leak site; the synthetic ``SECRET`` placeholder stands in for any sensitive
+leak site; the synthetic ``LEAK_CANARY`` placeholder stands in for any sensitive
 substring that might be present in real customer payloads.
 """
 
@@ -39,11 +39,11 @@ from ...builtin.tool_output_utilization.evaluator._tool_output_utilization impor
 )
 
 
-SECRET = "sk-SUPERSECRET-API-KEY-DO-NOT-LOG"
+LEAK_CANARY = "leak-canary-xyzzy-do-not-log"
 
 
 def _assert_secret_not_logged(caplog):
-    leaks = [r for r in caplog.records if SECRET in r.getMessage()]
+    leaks = [r for r in caplog.records if LEAK_CANARY in r.getMessage()]
     assert not leaks, (
         "Payload was written to logs - this leaks credentials / PII. "
         f"Offending records: {[(r.levelname, r.getMessage()) for r in leaks]}"
@@ -60,7 +60,7 @@ def test_tcs_exception_branch_does_not_log_response(caplog):
         """Response that triggers a TypeError inside _get_tool_calls_results."""
 
         def __repr__(self):
-            return f"<Response token={SECRET}>"
+            return f"<Response marker={LEAK_CANARY}>"
 
         def __iter__(self):
             raise TypeError("cannot iterate")
@@ -78,7 +78,7 @@ def test_tcs_empty_extraction_branch_does_not_log_response(caplog):
     response = [
         {
             "role": "assistant",
-            "content": [{"type": "text", "text": f"my key is {SECRET}"}],
+            "content": [{"type": "text", "text": f"observed value {LEAK_CANARY}"}],
         }
     ]
 
@@ -95,7 +95,7 @@ def test_tcs_tool_definitions_exception_does_not_log_payload(caplog):
 
     class BoomDefs:
         def __repr__(self):
-            return f"<ToolDefs secret={SECRET}>"
+            return f"<ToolDefs marker={LEAK_CANARY}>"
 
         def __iter__(self):
             raise TypeError("cannot iterate")
@@ -120,7 +120,7 @@ def _make_unparseable_query():
 
     class BoomQuery:
         def __repr__(self):
-            return f"<Query password='{SECRET}'>"
+            return f"<Query marker='{LEAK_CANARY}'>"
 
         def __iter__(self):
             raise TypeError("cannot iterate")
@@ -158,7 +158,7 @@ def test_tou_tool_definitions_exception_does_not_log_payload(caplog):
 
     class BoomDefs:
         def __repr__(self):
-            return f"<ToolDefs secret={SECRET}>"
+            return f"<ToolDefs marker={LEAK_CANARY}>"
 
         def __iter__(self):
             raise TypeError("cannot iterate")
@@ -191,20 +191,20 @@ DESCRIBE_HELPERS = [
 
 class _BadLen(list):
     def __len__(self):
-        raise RuntimeError(f"len boom containing {SECRET}")
+        raise RuntimeError(f"len boom containing {LEAK_CANARY}")
 
 
 class _BadDict(dict):
     def keys(self):
-        raise RuntimeError(f"keys boom containing {SECRET}")
+        raise RuntimeError(f"keys boom containing {LEAK_CANARY}")
 
 
 class _BadObj:
     def __len__(self):
-        raise ValueError(f"len boom containing {SECRET}")
+        raise ValueError(f"len boom containing {LEAK_CANARY}")
 
     def __repr__(self):
-        return f"<BadObj {SECRET}>"
+        return f"<BadObj marker={LEAK_CANARY}>"
 
 
 def _adversarial_inputs():
@@ -215,20 +215,20 @@ def _adversarial_inputs():
         ("none", None),
         ("empty_list", []),
         ("empty_dict", {}),
-        ("list_of_strings", [f"payload {SECRET}", "x"]),
+        ("list_of_strings", [f"payload {LEAK_CANARY}", "x"]),
         ("list_of_ints", [1, 2, 3]),
-        ("list_of_mixed", [{"role": "user"}, f"stray {SECRET}", 42, None]),
+        ("list_of_mixed", [{"role": "user"}, f"stray {LEAK_CANARY}", 42, None]),
         ("list_with_non_string_roles", [{"role": 1}, {"role": None}, {"role": ["weird"]}]),
-        ("dict_with_int_keys", {1: f"value {SECRET}", 2: "b"}),
-        ("dict_with_mixed_keys", {"a": 1, 2: f"value {SECRET}", (1, 2): "c"}),
+        ("dict_with_int_keys", {1: f"value {LEAK_CANARY}", 2: "b"}),
+        ("dict_with_mixed_keys", {"a": 1, 2: f"value {LEAK_CANARY}", (1, 2): "c"}),
         ("recursive_dict", rec),
-        ("bytes_payload", f"sk-{SECRET}".encode("utf-8")),
-        ("bytearray_payload", bytearray(SECRET.encode("utf-8"))),
-        ("set_payload", {f"a {SECRET}", "b"}),
-        ("tuple_payload", (f"a {SECRET}", "b")),
+        ("bytes_payload", f"prefix-{LEAK_CANARY}".encode("utf-8")),
+        ("bytearray_payload", bytearray(LEAK_CANARY.encode("utf-8"))),
+        ("set_payload", {f"a {LEAK_CANARY}", "b"}),
+        ("tuple_payload", (f"a {LEAK_CANARY}", "b")),
         ("huge_list", [{"role": "user"}] * 10_000),
         ("bad_len_list", _BadLen([1, 2, 3])),
-        ("bad_dict_keys", _BadDict({"a": SECRET})),
+        ("bad_dict_keys", _BadDict({"a": LEAK_CANARY})),
         ("bad_obj_with_len_raising", _BadObj()),
     ]
 
@@ -236,15 +236,15 @@ def _adversarial_inputs():
 @pytest.mark.parametrize("helper_name,helper", DESCRIBE_HELPERS)
 @pytest.mark.parametrize("label,value", _adversarial_inputs())
 def test_describe_helper_never_raises_and_never_leaks(helper_name, helper, label, value):
-    """Every describe helper must (1) never raise and (2) never include SECRET."""
+    """Every describe helper must (1) never raise and (2) never include the canary marker."""
     try:
         out = helper(value)
     except Exception as e:  # pragma: no cover - defensive
         pytest.fail(f"{helper_name} raised on input {label!r}: {type(e).__name__}: {e}")
 
     assert isinstance(out, str), f"{helper_name} returned non-str for {label!r}: {type(out)}"
-    assert SECRET not in out, (
-        f"{helper_name} leaked SECRET in output for input {label!r}: {out!r}"
+    assert LEAK_CANARY not in out, (
+        f"{helper_name} leaked the canary marker in output for input {label!r}: {out!r}"
     )
 
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 """Regression tests guarding against credential / PII leaks via response logging.
 
 Several evaluator fallback paths previously logged the full raw payload

--- a/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py
@@ -25,20 +25,24 @@ import pytest
 from ...builtin.tool_call_success.evaluator._tool_call_success import (
     _reformat_tool_calls_results,
     _reformat_tool_definitions as _tcs_reformat_tool_definitions,
-    _describe_response,
+    _log_safe_summary as _tcs_log_safe_summary,
 )
 from ...builtin.tool_selection.evaluator._tool_selection import (
     reformat_conversation_history as _ts_reformat_conversation_history,
-    _describe_payload as _ts_describe_payload,
+    _log_safe_summary as _ts_log_safe_summary,
 )
 from ...builtin.tool_input_accuracy.evaluator._tool_input_accuracy import (
     reformat_conversation_history as _tia_reformat_conversation_history,
-    _describe_payload as _tia_describe_payload,
+    _log_safe_summary as _tia_log_safe_summary,
 )
 from ...builtin.tool_output_utilization.evaluator._tool_output_utilization import (
     reformat_conversation_history as _tou_reformat_conversation_history,
     reformat_tool_definitions as _tou_reformat_tool_definitions,
-    _describe_payload as _tou_describe_payload,
+    _log_safe_summary as _tou_log_safe_summary,
+)
+from ...builtin.quality_grader.evaluator._quality_grader import (
+    QualityGraderEvaluator,
+    _log_safe_summary as _qg_log_safe_summary,
 )
 
 
@@ -180,7 +184,35 @@ def test_tou_tool_definitions_exception_does_not_log_payload(caplog):
 # endregion
 
 
-# region _describe_payload / _describe_response adversarial robustness
+# region quality_grader._parse_prompty_json_output
+
+
+def test_quality_grader_json_parse_failure_does_not_log_llm_output(caplog):
+    """JSON parse failure in quality_grader must not log the raw LLM output.
+
+    ``llm_output`` is the judge LLM's freeform text, which routinely echoes
+    customer input (questions, responses, tool results) inside its
+    explanation fields. Logging it on parse failure leaks that content.
+    """
+    leaky_llm_output = (
+        f"Sure! Here is my analysis of the request involving {LEAK_CANARY}:\n\n"
+        '{"properties": {"relevance": 5'  # truncated, will fail json.loads
+    )
+    # Realistic prompty wrapper - the function unwraps via .get("llm_output", ...)
+    prompty_output = {"llm_output": leaky_llm_output}
+
+    with caplog.at_level(logging.DEBUG, logger="root"):
+        result = QualityGraderEvaluator._parse_prompty_json_output(prompty_output)
+
+    # Fallback contract: empty dict returned on parse failure.
+    assert result == {}
+    _assert_secret_not_logged(caplog)
+
+
+# endregion
+
+
+# region _log_safe_summary adversarial robustness
 
 
 # All four describe-helper copies must behave identically under hostile input:
@@ -188,10 +220,11 @@ def test_tou_tool_definitions_exception_does_not_log_payload(caplog):
 # must always produce a short, structural-only string. Parametrize over each
 # helper so a regression in any one copy is caught.
 DESCRIBE_HELPERS = [
-    ("tool_call_success._describe_response", _describe_response),
-    ("tool_selection._describe_payload", _ts_describe_payload),
-    ("tool_input_accuracy._describe_payload", _tia_describe_payload),
-    ("tool_output_utilization._describe_payload", _tou_describe_payload),
+    ("tool_call_success._log_safe_summary", _tcs_log_safe_summary),
+    ("tool_selection._log_safe_summary", _ts_log_safe_summary),
+    ("tool_input_accuracy._log_safe_summary", _tia_log_safe_summary),
+    ("tool_output_utilization._log_safe_summary", _tou_log_safe_summary),
+    ("quality_grader._log_safe_summary", _qg_log_safe_summary),
 ]
 
 


### PR DESCRIPTION
## Summary

Several evaluator fallback and debug paths were logging the raw input payload (`response`, `query`, `tool_definitions`, parsed `tool_calls`) at WARNING or DEBUG level. These payloads are customer-controlled — they carry tool arguments, tool results, user-pasted text, system prompts, file content, and database rows that can include credentials or PII. WARNING-level entries reach default sinks (Azure ML run logs, App Insights); DEBUG-level entries reach any sink that opts into debug capture.

This PR removes the payload from every leak site and replaces it with a small `_describe_payload` helper that emits structural-only metadata (type, length, top-level roles/keys) — sufficient to diagnose schema drift without exposing values.

## Related

- Bug: https://msdata.visualstudio.com/Vienna/_workitems/edit/5048434
- Supersedes / completes #5108 (which only demoted one site `warning`→`debug`; the payload was still logged).

## Sites fixed

| File | Site | Was | Now |
|---|---|---|---|
| `tool_call_success/_tool_call_success.py` | `_reformat_tool_calls_results` (the ICM site) | `f"...: {response}"` WARNING + `f"...: {response}"` DEBUG | shape-only |
| `tool_call_success/_tool_call_success.py` | `_reformat_tool_definitions` | DEBUG `f"...: {tool_definitions}"` | shape-only |
| `tool_selection/_tool_selection.py` | `reformat_conversation_history` | WARNING `f"...: {query}"` | shape-only |
| `tool_input_accuracy/_tool_input_accuracy.py` | `reformat_conversation_history` | WARNING `f"...: {query}"` | shape-only |
| `tool_output_utilization/_tool_output_utilization.py` | `reformat_conversation_history` | WARNING `f"...: {query}"` + stray `print(e)` | shape-only, `print` removed |
| `tool_output_utilization/_tool_output_utilization.py` | `reformat_tool_definitions` | WARNING `f"...: {tool_definitions}"` | shape-only |
| `groundedness/_groundedness.py` | `_get_context_from_agent_response` | DEBUG `f"...: {tool_calls}"` (happy path; arguments + tool_result included) | `count=N` only |

The diagnostic message is preserved (e.g. "Conversation history could not be parsed; falling back to raw input. Evaluator accuracy will degrade."). The reproducibility use case is served by asking customers for a repro on demand rather than harvesting payloads pre-emptively.

## Tests

New file: `tests/test_evaluators_behavior/test_tool_call_success_no_response_logging.py` — **83 tests**.

- **7 leak-site regression tests** (one per fixed site). Each triggers the fallback / debug path with a payload containing a `SECRET` marker and asserts the marker is absent from `caplog.records` at any log level.
- **72 adversarial robustness tests** — 18 hostile inputs × 4 describe-helper copies. Inputs include `bytes` payloads, recursive dicts, mixed-type lists, dicts with non-string keys, objects with `__len__` / `keys()` raising (with the SECRET embedded in the exception message), `__repr__`-overriding objects, etc. Each asserts the helper (1) never raises and (2) never produces output containing the marker.
- **4 truncation tests** — assert a 10,000-entry list produces bounded output (<512 chars) while still reporting the true length.

If a future refactor swaps `_describe_payload` for `repr()` / `str()` / `json.dumps()`, dozens of tests fail.

## Verification

- ✅ All **316 affected behavior tests** pass on Python 3.10 across the 5 modified evaluator suites + status passthrough + 83 new regression/adversarial tests.
- ✅ `flake8` / `scripts/validation/code_health.py -i assets/evaluators` clean.
- ⚠️ 5 pre-existing failures in `test_groundedness_evaluator_behavior.py` (`test_file_search`, `test_image_generation`, `test_memory_search`, `test_kb_mcp`, `test_mcp`) are present on `main` without these changes — unrelated, separate issue.

## Why not just demote `warning → debug` (as in #5108)?

`debug` is one config flip away from being on. Customers and support engineers routinely raise log level when something goes wrong — exactly when payloads are most likely to contain real secrets. Microsoft SDL guidance treats "log untrusted, unbounded customer payloads" as a defect at any level. Demoting reduces blast radius but does not eliminate the data-flow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
