### PR TITLE
fix(automl): update pyarrow in automl image

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
@@ -102,12 +102,17 @@ RUN pip install \
 #   mlflow-skinny declares python-dotenv<2,>=0.19.0 but the pinned mlflow-skinny==2.16.0
 #   does not; it is brought in by another transitive path). No parent constraint
 #   blocks 1.2.2, so override directly.
+#
+# pyarrow>=23.0.1 (GHSA-rgxp-2hwp-jwgg / CVE-2026-25087): use-after-free
+#   in Apache Arrow C++. Parent packages still resolve pyarrow 17.0.0 in this
+#   image, so override directly until upstream pins move to a patched version.
 RUN pip install --upgrade \
     'distributed>=2026.1.0' \
     'bokeh>=3.8.2' \
     'onnx>=1.21.0' \
     'pillow>=12.2.0' \
-    'python-dotenv>=1.2.2'
+    'python-dotenv>=1.2.2' \
+    'pyarrow>=23.0.1'
 RUN pip install --no-deps --force-reinstall 'skl2onnx==1.19.1'
 RUN pip install --no-deps --force-reinstall 'onnxconverter-common==1.16.0'
 RUN pip install --no-deps --force-reinstall 'onnxmltools==1.14.0'


### PR DESCRIPTION
## Summary
- Add `pyarrow>=23.0.1` to the `ai-ml-automl` image Python security override block.
- Addresses GHSA-rgxp-2hwp-jwgg / CVE-2026-25087 reported against pyarrow 17.0.0 in the image.

## Context
The pandas 2 sparse compatibility patch is already present on `main`. A subsequent image build reported a Qualys SCA finding for pyarrow 17.0.0. This PR adds the pyarrow security override until upstream package pins move to a patched version.

## Validation
- ACR test image build with `pyarrow>=23.0.1` succeeded.
- Live AML setup rerun using the pyarrow-included image completed successfully:
  - `joyful_melon_gx3dq4zvj4` → Completed