### PR TITLE
Patch evaluations-built-in aiohttp HIGH vulns (GHSA-hg6j-4rv6-33pg / GHSA-jg22-mg44-37j8)

### DIFF
--- a/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
+++ b/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
@@ -9,3 +9,4 @@ croniter=={{latest-pypi-version}}
 azure-monitor-opentelemetry==1.8.0
 promptflow-azure=={{latest-pypi-version}}
 azure-identity=={{latest-pypi-version}}
+aiohttp>=3.14.0


### PR DESCRIPTION
## Summary
Patches the HIGH-risk `aiohttp` vulnerabilities flagged on the `evaluations-built-in` curated image (currently tag 40) by the `shavulnmgmtprdwus` scan.

- `requirements.txt`: pin `aiohttp>=3.14.0` to resolve:
  - [GHSA-hg6j-4rv6-33pg](https://github.com/advisories/GHSA-hg6j-4rv6-33pg) (cross-origin redirect with per-request cookies)
  - [GHSA-jg22-mg44-37j8](https://github.com/advisories/GHSA-jg22-mg44-37j8) (deserialization of untrusted data)

  Both are first fixed in `3.14.0`. `aiohttp` is a transitive dependency (azure-monitor-query / promptflow-azure / azure-ai-ml) not present in the base image, so it must be floored explicitly.

## nginx (USN-8354-1) — no change needed
The `nginx` HIGH from the work item requires **no Dockerfile change**. The `openmpi5.0-ubuntu24.04` base image already ships `nginx 1.24.0-2ubuntu7.12` (>= the USN-8354-1 fix `1.24.0-2ubuntu7.9`) as of base tag `20260621.v1`. The asset version is `auto`, so rebuilding/publishing as tag 41 on the latest base clears it automatically.

## Follow-up (separate, after tag 41 publishes)
- Vienna `src/azureml-api/src/RAISvc/EntryPoints/appsettings.json`: bump `Evaluation.RemoteEvaluationAsset` `versions/40` -> `versions/41`.
- Re-run the verification scan (expect 0 actionable rows for tag 41).
