### PR TITLE
[Evaluation] Normalize evaluator validation errors to EvaluationException with USER_ERROR blame

### DIFF
--- a/assets/evaluators/builtin/bleu_score/evaluator/_bleu.py
+++ b/assets/evaluators/builtin/bleu_score/evaluator/_bleu.py
@@ -10,7 +10,7 @@ from azure.ai.evaluation._common.utils import nltk_tokenize
 
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
-from azure.ai.evaluation._exceptions import EvaluationException, ErrorCategory, ErrorTarget
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +146,7 @@ class BleuScoreEvaluator(EvaluatorBase):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/assets/evaluators/builtin/coherence/evaluator/_coherence.py
+++ b/assets/evaluators/builtin/coherence/evaluator/_coherence.py
@@ -1229,6 +1229,7 @@ class CoherenceEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/customer_satisfaction/evaluator/_customer_satisfaction.py
+++ b/assets/evaluators/builtin/customer_satisfaction/evaluator/_customer_satisfaction.py
@@ -1147,6 +1147,7 @@ class CustomerSatisfactionEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/document_retrieval/evaluator/_document_retrieval.py
+++ b/assets/evaluators/builtin/document_retrieval/evaluator/_document_retrieval.py
@@ -8,7 +8,7 @@ from itertools import starmap
 from typing import Any, Dict, List, TypedDict, Tuple, Optional
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
-from azure.ai.evaluation._exceptions import EvaluationException, ErrorCategory, ErrorTarget
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 from typing_extensions import override, overload
 
 logger = logging.getLogger(__name__)
@@ -96,14 +96,27 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
 
         if ground_truth_label_min >= ground_truth_label_max:
             raise EvaluationException(
-                "The ground truth label maximum must be strictly greater than the ground truth label minimum."
+                "The ground truth label maximum must be strictly greater than the ground truth label minimum.",
+                target=ErrorTarget.EVALUATE,
+                category=ErrorCategory.INVALID_VALUE,
+                blame=ErrorBlame.USER_ERROR,
             )
 
         if not isinstance(ground_truth_label_min, int):
-            raise EvaluationException("The ground truth label minimum must be an integer value.")
+            raise EvaluationException(
+                "The ground truth label minimum must be an integer value.",
+                target=ErrorTarget.EVALUATE,
+                category=ErrorCategory.INVALID_VALUE,
+                blame=ErrorBlame.USER_ERROR,
+            )
 
         if not isinstance(ground_truth_label_max, int):
-            raise EvaluationException("The ground truth label maximum must be an integer value.")
+            raise EvaluationException(
+                "The ground truth label maximum must be an integer value.",
+                target=ErrorTarget.EVALUATE,
+                category=ErrorCategory.INVALID_VALUE,
+                blame=ErrorBlame.USER_ERROR,
+            )
 
         self.ground_truth_label_min = ground_truth_label_min
         self.ground_truth_label_max = ground_truth_label_max
@@ -257,7 +270,13 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
                 result[f"{metric_name}_higher_is_better"] = False
 
             else:
-                raise ValueError(f"No threshold set for metric '{metric_name}'")
+                raise EvaluationException(
+                    f"No threshold set for metric '{metric_name}'",
+                    internal_message=str(metric_name),
+                    target=ErrorTarget.EVALUATE,
+                    category=ErrorCategory.FAILED_EXECUTION,
+                    blame=ErrorBlame.SYSTEM_ERROR,
+                )
 
         return result
 
@@ -281,7 +300,10 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
                 (
                     "'retrieval_ground_truth' parameter must contain at least one item. "
                     "Check your data input to be sure that each input record has ground truth defined."
-                )
+                ),
+                target=ErrorTarget.EVALUATE,
+                category=ErrorCategory.MISSING_FIELD,
+                blame=ErrorBlame.USER_ERROR,
             )
 
         qrels = []
@@ -297,11 +319,19 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
                         "Invalid input data was found in the retrieval ground truth. "
                         "Ensure that all items in the 'retrieval_ground_truth' array contain "
                         "'document_id' and 'query_relevance_label' properties."
-                    )
+                    ),
+                    target=ErrorTarget.EVALUATE,
+                    category=ErrorCategory.MISSING_FIELD,
+                    blame=ErrorBlame.USER_ERROR,
                 )
 
             if not isinstance(query_relevance_label, int):
-                raise EvaluationException("Query relevance labels must be integer values.")
+                raise EvaluationException(
+                    "Query relevance labels must be integer values.",
+                    target=ErrorTarget.EVALUATE,
+                    category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
+                )
 
             if query_relevance_label < self.ground_truth_label_min:
                 raise EvaluationException(
@@ -309,7 +339,10 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
                         "A query relevance label less than the configured minimum value was detected in the "
                         "evaluation input data. Check the range of ground truth label values in the input data and "
                         "set the value of ground_truth_label_min to the appropriate value for your data."
-                    )
+                    ),
+                    target=ErrorTarget.EVALUATE,
+                    category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
                 )
 
             if query_relevance_label > self.ground_truth_label_max:
@@ -318,7 +351,10 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
                         "A query relevance label greater than the configured maximum value was detected in the "
                         "evaluation input data. Check the range of ground truth label values in the input data and "
                         "set the value of ground_truth_label_max to the appropriate value for your data."
-                    )
+                    ),
+                    target=ErrorTarget.EVALUATE,
+                    category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
                 )
 
             qrels.append(qrel)
@@ -337,17 +373,28 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
                             "Invalid input data was found in the retrieved documents. "
                             "Ensure that all items in the 'retrieved_documents' array contain "
                             "'document_id' and 'relevance_score' properties."
-                        )
+                        ),
+                        target=ErrorTarget.EVALUATE,
+                        category=ErrorCategory.MISSING_FIELD,
+                        blame=ErrorBlame.USER_ERROR,
                     )
 
                 if not isinstance(relevance_score, float) and not isinstance(relevance_score, int):
-                    raise EvaluationException("Retrieved document relevance score must be a numerical value.")
+                    raise EvaluationException(
+                        "Retrieved document relevance score must be a numerical value.",
+                        target=ErrorTarget.EVALUATE,
+                        category=ErrorCategory.INVALID_VALUE,
+                        blame=ErrorBlame.USER_ERROR,
+                    )
 
                 results.append(result)
 
         if len(qrels) > 10000 or len(results) > 10000:
             raise EvaluationException(
-                "'retrieval_ground_truth' and 'retrieved_documents' inputs should contain no more than 10000 items."
+                "'retrieval_ground_truth' and 'retrieved_documents' inputs should contain no more than 10000 items.",
+                target=ErrorTarget.EVALUATE,
+                category=ErrorCategory.INVALID_VALUE,
+                blame=ErrorBlame.USER_ERROR,
             )
 
         return qrels, results
@@ -513,6 +560,7 @@ class DocumentRetrievalEvaluator(EvaluatorBase):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/f1_score/evaluator/_f1_score.py
+++ b/assets/evaluators/builtin/f1_score/evaluator/_f1_score.py
@@ -8,7 +8,7 @@ from typing_extensions import overload, override
 
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
-from azure.ai.evaluation._exceptions import EvaluationException, ErrorCategory, ErrorTarget
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +205,7 @@ class F1ScoreEvaluator(EvaluatorBase):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/fluency/evaluator/_fluency.py
+++ b/assets/evaluators/builtin/fluency/evaluator/_fluency.py
@@ -875,6 +875,7 @@ class FluencyEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/gleu_score/evaluator/_gleu.py
+++ b/assets/evaluators/builtin/gleu_score/evaluator/_gleu.py
@@ -10,7 +10,7 @@ from azure.ai.evaluation._common.utils import nltk_tokenize
 
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
-from azure.ai.evaluation._exceptions import EvaluationException, ErrorCategory, ErrorTarget
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 logger = logging.getLogger(__name__)
 
@@ -147,6 +147,7 @@ class GleuScoreEvaluator(EvaluatorBase):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -1622,6 +1622,7 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/assets/evaluators/builtin/intent_resolution/evaluator/_intent_resolution.py
+++ b/assets/evaluators/builtin/intent_resolution/evaluator/_intent_resolution.py
@@ -909,6 +909,7 @@ class IntentResolutionEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/assets/evaluators/builtin/meteor_score/evaluator/_meteor.py
+++ b/assets/evaluators/builtin/meteor_score/evaluator/_meteor.py
@@ -10,7 +10,7 @@ from typing_extensions import overload, override
 from azure.ai.evaluation._common.utils import nltk_tokenize, ensure_nltk_data_downloaded
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
-from azure.ai.evaluation._exceptions import EvaluationException, ErrorCategory, ErrorTarget
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +172,7 @@ class MeteorScoreEvaluator(EvaluatorBase):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/relevance/evaluator/_relevance.py
+++ b/assets/evaluators/builtin/relevance/evaluator/_relevance.py
@@ -802,6 +802,7 @@ class RelevanceEvaluator(PromptyEvaluatorBase):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/assets/evaluators/builtin/response_completeness/evaluator/_response_completeness.py
+++ b/assets/evaluators/builtin/response_completeness/evaluator/_response_completeness.py
@@ -379,6 +379,7 @@ class ResponseCompletenessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/assets/evaluators/builtin/retrieval/evaluator/_retrieval.py
+++ b/assets/evaluators/builtin/retrieval/evaluator/_retrieval.py
@@ -426,6 +426,7 @@ class RetrievalEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/rouge_score/evaluator/_rouge.py
+++ b/assets/evaluators/builtin/rouge_score/evaluator/_rouge.py
@@ -10,7 +10,7 @@ from typing_extensions import overload, override
 from azure.ai.evaluation._vendor.rouge_score import rouge_scorer
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
-from azure.ai.evaluation._exceptions import EvaluationException, ErrorCategory, ErrorTarget
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 import math
 
 logger = logging.getLogger(__name__)
@@ -129,7 +129,12 @@ class RougeScoreEvaluator(EvaluatorBase):
             ("f1_score_threshold", f1_score_threshold),
         ]:
             if not isinstance(value, float):
-                raise TypeError(f"{name} must be a float, got {type(value)}")
+                raise EvaluationException(
+                    message=f"{name} must be a float, got {type(value)}",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=ErrorTarget.EVALUATE,
+                )
 
         self._threshold = {
             "precision": precision_threshold,
@@ -277,6 +282,7 @@ class RougeScoreEvaluator(EvaluatorBase):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/similarity/evaluator/_similarity.py
+++ b/assets/evaluators/builtin/similarity/evaluator/_similarity.py
@@ -441,6 +441,7 @@ class SimilarityEvaluator(PromptyEvaluatorBase):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value

--- a/assets/evaluators/builtin/task_adherence/evaluator/_task_adherence.py
+++ b/assets/evaluators/builtin/task_adherence/evaluator/_task_adherence.py
@@ -1228,6 +1228,7 @@ class TaskAdherenceEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
+++ b/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
@@ -1352,6 +1352,7 @@ class TaskCompletionEvaluator(PromptyEvaluatorBase[Union[str, int]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/assets/evaluators/builtin/task_navigation_efficiency/evaluator/_task_navigation_efficiency.py
+++ b/assets/evaluators/builtin/task_navigation_efficiency/evaluator/_task_navigation_efficiency.py
@@ -463,9 +463,13 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
             try:
                 self.matching_mode = TaskNavigationEfficiencyMatchingMode(matching_mode)
             except ValueError:
-                raise ValueError(
+                raise EvaluationException(
                     f"matching_mode must be one of {[m.value for m in TaskNavigationEfficiencyMatchingMode]}, "
-                    f"got '{matching_mode}'"
+                    f"got '{matching_mode}'",
+                    internal_message=str(matching_mode),
+                    target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
                 )
         elif isinstance(matching_mode, TaskNavigationEfficiencyMatchingMode):
             self.matching_mode = matching_mode
@@ -476,6 +480,7 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
                 internal_message=str(matching_mode),
                 target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
                 category=ErrorCategory.INVALID_VALUE,
+                blame=ErrorBlame.USER_ERROR,
             )
 
         # Initialize input validator
@@ -537,6 +542,7 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
                             if not contains_threshold_key:
                                 result[threshold_key] = threshold_value
@@ -752,7 +758,8 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
                     "Tool call must be a dictionary.",
                     internal_message=str(tool_call),
                     target=ErrorTarget.EVALUATE,
-                    category=ErrorCategory.UNKNOWN,
+                    category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
                 )
             if tool_call.get("type") != "tool_call":
                 raise EvaluationException(
@@ -760,6 +767,7 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
                     internal_message=str(tool_call),
                     target=ErrorTarget.EVALUATE,
                     category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
                 )
 
             if "name" not in tool_call:
@@ -768,6 +776,7 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
                     internal_message=str(tool_call),
                     target=ErrorTarget.EVALUATE,
                     category=ErrorCategory.MISSING_FIELD,
+                    blame=ErrorBlame.USER_ERROR,
                 )
 
             tool_name = str(tool_call["name"]).strip()
@@ -790,6 +799,7 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
                             internal_message=str(tool_call),
                             target=ErrorTarget.EVALUATE,
                             category=ErrorCategory.INVALID_VALUE,
+                            blame=ErrorBlame.USER_ERROR,
                         )
 
             tool_name_param_pairs.append((tool_name, parameters))
@@ -819,7 +829,12 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
 
         # Value and type checking for expected actions steps
         if not expected_actions:
-            raise ValueError("expected_actions cannot be empty")
+            raise EvaluationException(
+                "expected_actions cannot be empty",
+                target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                category=ErrorCategory.INVALID_VALUE,
+                blame=ErrorBlame.USER_ERROR,
+            )
 
         # Check if expected_actions is a tuple (tool names + parameters) or list (tool names only)
         use_parameter_matching = False
@@ -837,36 +852,65 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
             tool_names_list, params_dict = expected_actions
 
             if not isinstance(tool_names_list, list) or not all(isinstance(name, str) for name in tool_names_list):
-                raise TypeError("expected_actions tuple first element must be a list of strings (tool names)")
+                raise EvaluationException(
+                    "expected_actions tuple first element must be a list of strings (tool names)",
+                    target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
+                )
 
             if not isinstance(params_dict, dict):
-                raise TypeError(
-                    "expected_actions tuple second element must be a dictionary mapping tool names to parameters"
+                raise EvaluationException(
+                    "expected_actions tuple second element must be a dictionary mapping tool names to parameters",
+                    target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    blame=ErrorBlame.USER_ERROR,
                 )
 
             # Validate that all values in params_dict are dictionaries with string keys and values
             for tool_name, params in params_dict.items():
                 if not isinstance(tool_name, str):
-                    raise TypeError("expected_actions parameters dictionary keys must be strings (tool names)")
+                    raise EvaluationException(
+                        "expected_actions parameters dictionary keys must be strings (tool names)",
+                        target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                        category=ErrorCategory.INVALID_VALUE,
+                        blame=ErrorBlame.USER_ERROR,
+                    )
                 if not isinstance(params, dict):
-                    raise TypeError(f"expected_actions parameters for tool '{tool_name}' must be a dictionary")
+                    raise EvaluationException(
+                        f"expected_actions parameters for tool '{tool_name}' must be a dictionary",
+                        target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                        category=ErrorCategory.INVALID_VALUE,
+                        blame=ErrorBlame.USER_ERROR,
+                    )
                 for k, v in params.items():
                     if not isinstance(k, str):
-                        raise TypeError(f"expected_actions parameters for tool '{tool_name}' must have string keys")
+                        raise EvaluationException(
+                            f"expected_actions parameters for tool '{tool_name}' must have string keys",
+                            target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                            category=ErrorCategory.INVALID_VALUE,
+                            blame=ErrorBlame.USER_ERROR,
+                        )
                     try:
                         json.dumps(v)
                     except (TypeError, ValueError):
-                        raise TypeError(
+                        raise EvaluationException(
                             f"expected_actions parameters for tool '{tool_name}' must have JSON-serializable values "
-                            f"(got type {type(v)} for key '{k}')"
+                            f"(got type {type(v)} for key '{k}')",
+                            target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                            category=ErrorCategory.INVALID_VALUE,
+                            blame=ErrorBlame.USER_ERROR,
                         )
 
             expected_actions_names = [name.strip() for name in tool_names_list]
             expected_actions_params_dict = params_dict
             use_parameter_matching = True
         else:
-            raise TypeError(
-                "expected_actions must be a list of strings or a tuple of (list[str], dict[str, dict[str, str]])"
+            raise EvaluationException(
+                "expected_actions must be a list of strings or a tuple of (list[str], dict[str, dict[str, str]])",
+                target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
+                category=ErrorCategory.INVALID_VALUE,
+                blame=ErrorBlame.USER_ERROR,
             )
 
         # Extract tool information from the actions
@@ -909,6 +953,7 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
                 internal_message=str(self.matching_mode),
                 target=ErrorTarget.TASK_NAVIGATION_EFFICIENCY_EVALUATOR,
                 category=ErrorCategory.INVALID_VALUE,
+                blame=ErrorBlame.USER_ERROR,
             )
 
     @overload

--- a/assets/evaluators/builtin/tool_call_success/evaluator/_tool_call_success.py
+++ b/assets/evaluators/builtin/tool_call_success/evaluator/_tool_call_success.py
@@ -842,6 +842,7 @@ class ToolCallSuccessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
+++ b/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
@@ -1061,6 +1061,7 @@ class ToolOutputUtilizationEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                                     internal_message=str(threshold_value),
                                     target=ErrorTarget.EVALUATE,
                                     category=ErrorCategory.INVALID_VALUE,
+                                    blame=ErrorBlame.USER_ERROR,
                                 )
 
                             if not contains_threshold_key:

--- a/assets/evaluators/tests/test_evaluators_behavior/test_rouge_score_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_rouge_score_evaluator_behavior.py
@@ -13,6 +13,7 @@ except ImportError:
     from typing_extensions import override
 from ..common.base_code_evaluator_runner import BaseCodeEvaluatorRunner
 from ...builtin.rouge_score.evaluator._rouge import RougeScoreEvaluator, RougeType
+from azure.ai.evaluation._exceptions import EvaluationException
 
 
 @pytest.mark.unittest
@@ -647,7 +648,7 @@ class TestRougeScoreEvaluatorBehavior(BaseCodeEvaluatorRunner):
 
     def test_invalid_threshold_type_int(self):
         """Test with invalid threshold type (int instead of float)."""
-        with pytest.raises(TypeError):
+        with pytest.raises(EvaluationException):
             self._init_evaluator(
                 rouge_type=RougeType.ROUGE_1,
                 precision_threshold=1,  # int instead of float
@@ -655,7 +656,7 @@ class TestRougeScoreEvaluatorBehavior(BaseCodeEvaluatorRunner):
 
     def test_invalid_threshold_type_string(self):
         """Test with invalid threshold type (string)."""
-        with pytest.raises(TypeError):
+        with pytest.raises(EvaluationException):
             self._init_evaluator(
                 rouge_type=RougeType.ROUGE_1,
                 recall_threshold="0.5",  # string instead of float

--- a/assets/evaluators/tests/test_evaluators_behavior/test_task_navigation_efficiency_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_task_navigation_efficiency_evaluator_behavior.py
@@ -502,7 +502,7 @@ class TestTaskNavigationEfficiencyEvaluatorBehavior(BaseCodeEvaluatorRunner):
 
     def test_invalid_matching_mode_string(self):
         """Test with invalid matching mode string."""
-        with pytest.raises(ValueError):
+        with pytest.raises(EvaluationException):
             self._init_evaluator(matching_mode="invalid_mode")
 
     def test_invalid_matching_mode_type(self):


### PR DESCRIPTION
## Description
Normalizes evaluator error handling so that input/configuration validation failures consistently raise `EvaluationException` with `blame=ErrorBlame.USER_ERROR` (plus an appropriate `category` and `target`), instead of bare `ValueError`/`TypeError` or `EvaluationException` with no blame.

This mirrors the upstream SDK change in Azure/azure-sdk-for-python#47735.

## Changes
- **DocumentRetrievalEvaluator**: constructor and input-data validations now use `EvaluationException` + `USER_ERROR`; the internal `No threshold set for metric` check uses `SYSTEM_ERROR`/`FAILED_EXECUTION`.
- **RougeScoreEvaluator**: threshold-type `TypeError` -> `EvaluationException` + `USER_ERROR`.
- **TaskNavigationEfficiencyEvaluator**: `matching_mode` / `expected_actions` / tool-call `ValueError`/`TypeError` -> `EvaluationException` + `USER_ERROR`; `UNKNOWN` category corrected to `INVALID_VALUE`.
- **All builtin evaluators**: the shared `Threshold value must be a number.` check now sets `blame=ErrorBlame.USER_ERROR` (and `ErrorBlame` imported where missing).
- **Tests**: behavior tests updated to expect `EvaluationException`.

## Validation
- `code_health` lint passes on `assets/evaluators`.
- Behavior tests pass for the affected evaluators (rouge, task_navigation_efficiency, document_retrieval).