### PR TITLE
Add __init__.py to IFEval evaluator for multi-file package support

### DIFF
--- a/assets/benchmarkspecs/builtin/ifeval/spec.yaml
+++ b/assets/benchmarkspecs/builtin/ifeval/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.ifeval"
-version: 1
+version: 2
 display_name: "IFEval Benchmark"
 description: "Instruction-Following Eval (IFEval) is a benchmark for evaluating the instruction-following capabilities of large language models. It focuses on verifiable instructions such as word count constraints, format requirements (JSON, markdown, bullet points), keyword usage, language specifications, and case constraints. The benchmark returns both strict (exact compliance) and loose (minor tolerance) accuracy scores."
 benchmarkType: "builtin"
@@ -14,12 +14,12 @@ inference:
     max_completion_tokens: 4096
 
 evaluator:
-  id: "azureml://registries/azureml/evaluators/builtin.ifeval/versions/1"
+  id: "azureml://registries/azureml/evaluators/builtin.ifeval/versions/2"
   testingCriteria:
     type: "azure_ai_evaluator"
     name: "IFEval"
     evaluator_name: "builtin.ifeval"
-    evaluator_version: "1"
+    evaluator_version: "2"
     initialization_parameters: {}
     data_mapping:
       instruction_id_list: "{{item.instruction_id_list}}"

--- a/assets/evaluators/builtin/ifeval/evaluator/__init__.py
+++ b/assets/evaluators/builtin/ifeval/evaluator/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""IFEval evaluator package - instruction following evaluation."""

--- a/assets/evaluators/builtin/ifeval/spec.yaml
+++ b/assets/evaluators/builtin/ifeval/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.ifeval"
-version: 1
+version: 2
 displayName: "IFEval-Evaluator"
 description: "Evaluates model responses for the Instruction-Following Eval (IFEval) benchmark. Checks whether model outputs comply with verifiable instructions such as word count constraints, format requirements, keyword usage, and language specifications. Returns both strict (exact compliance) and loose (minor tolerance) accuracy scores."
 evaluatorType: "builtin"


### PR DESCRIPTION
## Summary

Adds `__init__.py` to the IFEval evaluator directory and bumps the evaluator version from 1 to 2. This enables multi-file Python package imports when the evaluator is loaded by RAISvc ACA.

## Problem

Multi-file evaluators like IFEval have multiple Python files with cross-file imports (e.g., `from _instructions import ...`). Without `__init__.py`, the directory isn't recognized as a Python package and these imports fail when loaded by RAISvc ACA's `BuiltinCodeEvaluator`.

## Changes

1. **`assets/evaluators/builtin/ifeval/evaluator/__init__.py`** (new) - marks the evaluator directory as a Python package
2. **`assets/evaluators/builtin/ifeval/spec.yaml`** - version bump 1 to 2
3. **`assets/benchmarkspecs/builtin/ifeval/spec.yaml`** - update evaluator reference to version 2

## Related

- Vienna PR [#2007622](https://msdata.visualstudio.com/Vienna/_git/vienna/pullrequest/2007622) - service-side fix for multi-file evaluator loading (merged)
- Design spec: [multi-file-evaluator-loading.md](https://msdata.visualstudio.com/Vienna/_git/evaluators?path=/specs/multi-file-evaluator-loading.md)