### PR TITLE
Fix pyarrow vulnerability in RAI tabular image

### DIFF
--- a/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
@@ -42,7 +42,7 @@ RUN pip install 'azureml-telemetry==1.60.0' --no-deps \
 
 # azureml-dataset-runtime[fuse] upper bound for pyarrow is 11.0.0
 # so we install pyarrow in extra step to avoid conflict
-RUN pip install 'pyarrow>=14.0.1'
+RUN pip install 'pyarrow>=23.0.1'
 
 # To resolve vulnerability issue regarding cryptography
 RUN pip install 'cryptography>=46.0.5'
@@ -60,7 +60,7 @@ RUN pip install 'requests>=2.32.4'
 RUN pip install 'mcp>=1.23.0'
 # vulnerability fixes for skops (GHSA-m7f4-hrc6-fwg3, GHSA-4v6w-xpmh-gfgp, GHSA-378x-6p4f-8jgm)
 # --no-deps to prevent skops from upgrading numpy (skops>=0.13.0 requires numpy>=1.25 but we pin numpy<1.24)
-RUN pip install --no-deps 'skops>=0.13.0'
+RUN pip install --no-deps 'skops>=0.13.0,<0.14.0'
 
 # clean conda and pip caches
 RUN conda run -p $CONDA_PREFIX pip cache purge && \


### PR DESCRIPTION
- pyarrow: bump to >=23.0.1 (GHSA-rgxp-2hwp-jwgg, CVE-2026-25087)