### PR TITLE
Add Task Efficiency evaluator for Coding Agent Traces

### DIFF
--- a/assets/evaluators/builtin/task_efficiency/__init__.py
+++ b/assets/evaluators/builtin/task_efficiency/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Task efficiency evaluator init file."""

--- a/assets/evaluators/builtin/task_efficiency/asset.yaml
+++ b/assets/evaluators/builtin/task_efficiency/asset.yaml
@@ -1,0 +1,9 @@
+type: evaluator
+spec: spec.yaml
+categories:
+- Evaluator
+test:
+  pytest:
+    enabled: true
+    conda_environment: ../../tests/conda.yaml
+    tests_dir: ../../tests/test_evaluators_behavior/test_task_efficiency_evaluator_behavior.py

--- a/assets/evaluators/builtin/task_efficiency/evaluator/__init__.py
+++ b/assets/evaluators/builtin/task_efficiency/evaluator/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Task efficiency evaluator implementation init file."""

--- a/assets/evaluators/builtin/task_efficiency/evaluator/_task_efficiency.py
+++ b/assets/evaluators/builtin/task_efficiency/evaluator/_task_efficiency.py
@@ -1,0 +1,479 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+import os
+import logging
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from typing_extensions import overload, override
+
+from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
+from azure.ai.evaluation._evaluators._common import PromptyEvaluatorBase
+from azure.ai.evaluation._common.utils import reformat_tool_definitions
+from azure.ai.evaluation._common.utils import (
+    _extract_text_from_content,
+    _get_agent_response,
+    _pretty_format_conversation_history,
+)
+from azure.ai.evaluation._common._experimental import experimental
+
+
+# region Validators
+
+
+class ValidatorInterface(ABC):
+    """Abstract base class defining the interface that all validators must implement."""
+
+    @abstractmethod
+    def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
+        """Validate the evaluation input dictionary."""
+
+
+class MessageRole(str, Enum):
+    """Valid message roles in conversations."""
+
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+    TOOL = "tool"
+    DEVELOPER = "developer"
+
+
+class ContentType(str, Enum):
+    """Valid content types in messages."""
+
+    TEXT = "text"
+    INPUT_TEXT = "input_text"
+    OUTPUT_TEXT = "output_text"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    FUNCTION_CALL = "function_call"
+    FUNCTION_CALL_OUTPUT = "function_call_output"
+    MCP_APPROVAL_REQUEST = "mcp_approval_request"
+    MCP_APPROVAL_RESPONSE = "mcp_approval_response"
+    OPENAPI_CALL = "openapi_call"
+    OPENAPI_CALL_OUTPUT = "openapi_call_output"
+
+
+class MessagesValidator(ValidatorInterface):
+    """Validate that the input contains a non-empty list of message dicts."""
+
+    def __init__(self, error_target: ErrorTarget):
+        self.error_target = error_target
+
+    @override
+    def validate_eval_input(self, eval_input: Dict[str, Any]) -> bool:
+        messages = eval_input.get("messages")
+        if messages is None:
+            raise EvaluationException(
+                message="'messages' is a required input for TaskEfficiencyEvaluator.",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.MISSING_FIELD,
+                target=self.error_target,
+            )
+        if not isinstance(messages, list) or len(messages) == 0:
+            raise EvaluationException(
+                message="'messages' must be a non-empty list of message dicts.",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.INVALID_VALUE,
+                target=self.error_target,
+            )
+        for idx, msg in enumerate(messages):
+            if not isinstance(msg, dict):
+                raise EvaluationException(
+                    message=f"Message at index {idx} must be a dictionary.",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.INVALID_VALUE,
+                    target=self.error_target,
+                )
+            if "role" not in msg:
+                raise EvaluationException(
+                    message=f"Message at index {idx} must contain a 'role' field.",
+                    blame=ErrorBlame.USER_ERROR,
+                    category=ErrorCategory.MISSING_FIELD,
+                    target=self.error_target,
+                )
+        return True
+
+
+# endregion Validators
+
+
+logger = logging.getLogger(__name__)
+
+
+def _create_extended_error_target():
+    """Create an extended ErrorTarget enum that includes TASK_EFFICIENCY_EVALUATOR."""
+    existing_members = {member.name: member.value for member in ErrorTarget}
+    existing_members["TASK_EFFICIENCY_EVALUATOR"] = "TaskEfficiencyEvaluator"
+    return Enum("ExtendedErrorTarget", existing_members)
+
+
+ExtendedErrorTarget = _create_extended_error_target()
+
+
+def _drop_mcp_approval_messages(messages):
+    """Remove MCP approval request/response messages."""
+    if not isinstance(messages, list):
+        return messages
+    return [
+        msg for msg in messages
+        if not (
+            isinstance(msg, dict)
+            and isinstance(msg.get("content"), list)
+            and (
+                (msg.get("role") == "assistant" and any(
+                    isinstance(c, dict) and c.get("type") == "mcp_approval_request" for c in msg["content"]))
+                or (msg.get("role") == "tool" and any(
+                    isinstance(c, dict) and c.get("type") == "mcp_approval_response" for c in msg["content"]))
+            )
+        )
+    ]
+
+
+def _normalize_function_call_types(messages):
+    """Normalize function_call / openapi_call types to tool_call / tool_result."""
+    if not isinstance(messages, list):
+        return messages
+    for msg in messages:
+        if not isinstance(msg, dict) or not isinstance(msg.get("content"), list):
+            continue
+        for item in msg["content"]:
+            if not isinstance(item, dict):
+                continue
+            t = item.get("type")
+            if t == "function_call":
+                item["type"] = "tool_call"
+            elif t == "function_call_output":
+                item["type"] = "tool_result"
+                if "function_call_output" in item:
+                    item["tool_result"] = item.pop("function_call_output")
+            elif t == "openapi_call":
+                item["type"] = "tool_call"
+            elif t == "openapi_call_output":
+                item["type"] = "tool_result"
+                if "openapi_call_output" in item:
+                    item["tool_result"] = item.pop("openapi_call_output")
+    return messages
+
+
+def _preprocess_messages(messages):
+    """Drop MCP approval messages and normalize function call types."""
+    messages = _drop_mcp_approval_messages(messages)
+    messages = _normalize_function_call_types(messages)
+    return messages
+
+
+def _count_assistant_tool_calls(messages: List[dict]) -> int:
+    """Count assistant tool-call content items across all messages."""
+    if not isinstance(messages, list):
+        return 0
+    tool_call_types = {
+        ContentType.TOOL_CALL.value,
+        ContentType.FUNCTION_CALL.value,
+        ContentType.OPENAPI_CALL.value,
+    }
+    count = 0
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != MessageRole.ASSISTANT.value:
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if isinstance(item, dict) and item.get("type") in tool_call_types:
+                count += 1
+    return count
+
+
+def serialize_messages(messages: List[dict]) -> str:
+    """Serialize chat messages into a labeled text transcript for the multi-turn prompty."""
+    if not messages:
+        return ""
+
+    all_user_queries: List = []
+    all_agent_responses: List = []
+    cur_user_query: List = []
+    cur_agent_response: List = []
+    system_message = None
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if not role:
+            continue
+
+        normalized = msg
+        if role == MessageRole.ASSISTANT and isinstance(msg.get("content"), str):
+            normalized = {**msg, "content": [{"type": "text", "text": msg["content"]}]}
+
+        if role in (MessageRole.SYSTEM, MessageRole.DEVELOPER):
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                system_message = "\n".join(_extract_text_from_content(content))
+            else:
+                system_message = content
+
+        elif role == MessageRole.USER and "content" in msg:
+            if cur_agent_response:
+                formatted = _get_agent_response(cur_agent_response, include_tool_messages=True)
+                all_agent_responses.append([formatted])
+                cur_agent_response = []
+            content = msg["content"]
+            if isinstance(content, str):
+                text_in_msg = [content]
+            else:
+                text_in_msg = _extract_text_from_content(content)
+            if text_in_msg:
+                cur_user_query.append(text_in_msg)
+
+        elif role in (MessageRole.ASSISTANT, MessageRole.TOOL):
+            if cur_user_query:
+                all_user_queries.append(cur_user_query)
+                cur_user_query = []
+            cur_agent_response.append(normalized)
+
+    if cur_user_query:
+        all_user_queries.append(cur_user_query)
+    if cur_agent_response:
+        formatted = _get_agent_response(cur_agent_response, include_tool_messages=True)
+        all_agent_responses.append([formatted])
+
+    conversation_history: Dict = {
+        "user_queries": all_user_queries,
+        "agent_responses": all_agent_responses[:len(all_user_queries) - 1]
+        if len(all_user_queries) > 0
+        else [],
+    }
+    if system_message:
+        conversation_history["system_message"] = system_message
+
+    result = _pretty_format_conversation_history(conversation_history)
+
+    start = max(len(all_user_queries) - 1, 0)
+    for i, agent_response in enumerate(all_agent_responses[start:], start=start):
+        result += f"Agent turn {i + 1}:\n"
+        for msg_text in agent_response:
+            if isinstance(msg_text, list):
+                for submsg in msg_text:
+                    result += "  " + "\n  ".join(submsg.split("\n")) + "\n"
+            else:
+                result += "  " + "\n  ".join(msg_text.split("\n")) + "\n"
+        result += "\n"
+
+    return result.rstrip("\n")
+
+
+@experimental
+class TaskEfficiencyEvaluator(PromptyEvaluatorBase[Union[str, int]]):
+    """The Task Efficiency evaluator scores how efficient an agent's multi-turn trajectory was.
+
+    It judges the agent's tool-use process, not the correctness of the final answer or whether the
+    task was completed. It penalizes redundant tool calls, repeated reads of the same file, identical
+    failed-command retries, oscillation between targets, and dead-end exploration after the answer
+    was already in context.
+
+    Scoring is on an integer 1-5 rubric:
+
+    - 5: Highly efficient - only the strictly needed steps; nothing redundant.
+    - 4: Mostly efficient - one or two minor redundancies; no loops.
+    - 3: Moderately efficient - several redundant calls; ~15-35% of steps removable.
+    - 2: Inefficient - substantial waste; ~35-60% of steps removable.
+    - 1: Highly inefficient - severe looping or thrashing; >60% removable.
+
+    A conversation with zero assistant tool calls is reported with status ``skipped`` and score ``None``.
+
+    :param model_config: Configuration for the Azure OpenAI model used as the judge.
+    :type model_config: Union[~azure.ai.evaluation.AzureOpenAIModelConfiguration,
+        ~azure.ai.evaluation.OpenAIModelConfiguration]
+    :keyword threshold: Minimum score (1-5) to consider the trajectory a pass. Default is 3.
+    :paramtype threshold: int
+    """
+
+    _MULTI_TURN_PROMPTY_FILE = "task_efficiency_multi_turn.prompty"
+    _RESULT_KEY = "task_efficiency"
+    _OPTIONAL_PARAMS = ["tool_definitions"]
+    _MIN_SCORE = 1
+    _MAX_SCORE = 5
+
+    _validator: ValidatorInterface
+
+    id = "azureai://built-in/evaluators/task_efficiency"
+    """Evaluator identifier, experimental and to be used only with evaluation in cloud."""
+
+    @override
+    def __init__(self, model_config, *, credential=None, **kwargs):
+        current_dir = os.path.dirname(__file__)
+        prompty_path = os.path.join(current_dir, self._MULTI_TURN_PROMPTY_FILE)
+        threshold_value = kwargs.pop("threshold", 3)
+
+        self._validator = MessagesValidator(error_target=ExtendedErrorTarget.TASK_EFFICIENCY_EVALUATOR)
+
+        super().__init__(
+            model_config=model_config,
+            prompty_file=prompty_path,
+            result_key=self._RESULT_KEY,
+            credential=credential,
+            threshold=threshold_value,
+            **kwargs,
+        )
+
+    @overload
+    def __call__(
+        self,
+        *,
+        messages: List[dict],
+        tool_definitions: Optional[Union[dict, List[dict]]] = None,
+    ) -> Dict[str, Union[str, int]]:
+        """Evaluate task efficiency for a full multi-turn conversation.
+
+        :keyword messages: The full multi-turn conversation as a list of message dicts. Must contain
+            assistant tool calls; conversations without any tool-use trajectory return status ``skipped``.
+        :paramtype messages: List[dict]
+        :keyword tool_definitions: Optional list of tool definitions the agent had available.
+        :paramtype tool_definitions: Optional[Union[dict, List[dict]]]
+        :return: Dictionary with the task efficiency evaluation results.
+        :rtype: Dict[str, Union[str, int]]
+        """
+
+    @override
+    def __call__(  # pylint: disable=docstring-missing-param
+        self,
+        *args,
+        **kwargs,
+    ):
+        """Invoke the instance using the overloaded __call__ signature."""
+        return super().__call__(*args, **kwargs)
+
+    @staticmethod
+    def _get_token_metadata(prompty_output: Dict) -> Dict:
+        return {
+            "prompt_tokens": prompty_output.get("input_token_count", 0),
+            "completion_tokens": prompty_output.get("output_token_count", 0),
+            "total_tokens": prompty_output.get("total_token_count", 0),
+            "finish_reason": prompty_output.get("finish_reason", ""),
+            "model": prompty_output.get("model_id", ""),
+            "sample_input": prompty_output.get("sample_input", ""),
+            "sample_output": prompty_output.get("sample_output", ""),
+        }
+
+    def _return_not_applicable_result(self, error_message: str):
+        token_metadata = self._get_token_metadata({})
+        result = {
+            f"{self._result_key}": None,
+            f"{self._result_key}_score": None,
+            f"{self._result_key}_passed": None,
+            f"{self._result_key}_result": "not_applicable",
+            f"{self._result_key}_reason": f"Not applicable: {error_message}",
+            f"{self._result_key}_status": "skipped",
+            f"{self._result_key}_threshold": self._threshold,
+            f"{self._result_key}_properties": None,
+        }
+        result.update({f"{self._result_key}_{key}": value for key, value in token_metadata.items()})
+        return result
+
+    @override
+    async def _real_call(self, **kwargs):
+        self._validator.validate_eval_input(kwargs)
+        # Strip single-turn keys not used by this evaluator.
+        kwargs.pop("query", None)
+        kwargs.pop("response", None)
+        return await self._the_super_real_call(**kwargs)
+
+    async def _the_super_real_call(self, **kwargs):
+        try:
+            eval_input_list = self._convert_kwargs_to_eval_input(**kwargs)
+        except Exception as e:
+            logger.error(f"Error converting kwargs to eval_input_list: {e}")
+            raise
+        per_turn_results = []
+        for eval_input in eval_input_list:
+            per_turn_results.append(await self._do_eval(eval_input))
+        if len(per_turn_results) == 1:
+            return per_turn_results[0]
+        if len(per_turn_results) == 0:
+            return {}
+        return self._aggregate_results(per_turn_results=per_turn_results)
+
+    @override
+    async def _do_eval(self, eval_input: Dict) -> Dict[str, Union[int, str]]:  # type: ignore[override]
+        messages = eval_input.get("messages")
+        if not messages:
+            raise EvaluationException(
+                message="'messages' is required for TaskEfficiencyEvaluator.",
+                blame=ErrorBlame.USER_ERROR,
+                category=ErrorCategory.MISSING_FIELD,
+                target=ExtendedErrorTarget.TASK_EFFICIENCY_EVALUATOR,
+            )
+
+        messages = _preprocess_messages(messages)
+
+        # Short-circuit: efficiency is undefined when there is no tool-use trajectory.
+        if _count_assistant_tool_calls(messages) == 0:
+            return self._return_not_applicable_result(
+                "No assistant tool calls in trajectory; nothing to evaluate for efficiency."
+            )
+
+        conversation_text = serialize_messages(messages)
+        prompty_kwargs: Dict[str, Any] = {"messages": conversation_text}
+        tool_definitions = eval_input.get("tool_definitions")
+        if tool_definitions:
+            prompty_kwargs["tool_definitions"] = reformat_tool_definitions(tool_definitions, logger)
+
+        prompty_output_dict = await self._flow(timeout=self._LLM_CALL_TIMEOUT, **prompty_kwargs)
+        return self._parse_prompty_output(prompty_output_dict)
+
+    def _parse_prompty_output(self, prompty_output_dict: Dict) -> Dict[str, Union[int, str]]:
+        llm_output = prompty_output_dict.get("llm_output", prompty_output_dict)
+
+        if not isinstance(llm_output, dict):
+            raise EvaluationException(
+                message="Evaluator returned invalid output.",
+                blame=ErrorBlame.SYSTEM_ERROR,
+                category=ErrorCategory.FAILED_EXECUTION,
+                target=ExtendedErrorTarget.TASK_EFFICIENCY_EVALUATOR,
+            )
+
+        if llm_output.get("status", "completed") == "skipped":
+            return self._return_not_applicable_result(llm_output.get("reason", ""))
+
+        score_value = llm_output.get("score")
+        if score_value is None:
+            raise EvaluationException(
+                message="Evaluator returned invalid output: missing 'score'.",
+                blame=ErrorBlame.SYSTEM_ERROR,
+                category=ErrorCategory.FAILED_EXECUTION,
+                target=ExtendedErrorTarget.TASK_EFFICIENCY_EVALUATOR,
+            )
+        try:
+            score = int(round(float(score_value)))
+        except (TypeError, ValueError):
+            raise EvaluationException(
+                message=f"Evaluator returned invalid output: invalid 'score' value: {score_value}",
+                blame=ErrorBlame.SYSTEM_ERROR,
+                category=ErrorCategory.FAILED_EXECUTION,
+                target=ExtendedErrorTarget.TASK_EFFICIENCY_EVALUATOR,
+            )
+        # Clamp judge output to the declared rubric range.
+        score = max(self._MIN_SCORE, min(self._MAX_SCORE, score))
+
+        threshold = self._threshold if isinstance(self._threshold, (int, float)) else 3
+        success_result = "pass" if score >= threshold else "fail"
+        reason = llm_output.get("reason", "")
+        llm_properties = llm_output.get("properties", {}) or {}
+        token_metadata = self._get_token_metadata(prompty_output_dict)
+        llm_properties.update(token_metadata)
+        result = {
+            self._result_key: score,
+            f"{self._result_key}_score": score,
+            f"{self._result_key}_passed": success_result == "pass",
+            f"{self._result_key}_result": success_result,
+            f"{self._result_key}_reason": reason,
+            f"{self._result_key}_status": "completed",
+            f"{self._result_key}_threshold": threshold,
+            f"{self._result_key}_properties": llm_properties,
+        }
+        result.update({f"{self._result_key}_{key}": value for key, value in token_metadata.items()})
+        return result

--- a/assets/evaluators/builtin/task_efficiency/evaluator/task_efficiency_multi_turn.prompty
+++ b/assets/evaluators/builtin/task_efficiency/evaluator/task_efficiency_multi_turn.prompty
@@ -1,0 +1,313 @@
+---
+name: Task Efficiency
+description: Evaluates whether an agent solved the user's task efficiently across a multi-turn conversation, penalizing redundant tool calls, repeated file reads, loops, and unnecessary exploration
+model:
+  api: chat
+  parameters:
+    temperature: 0.0
+    max_tokens: 5000
+    top_p: 1.0
+    presence_penalty: 0
+    frequency_penalty: 0
+    response_format:
+      type: json_object
+inputs:
+  messages:
+    type: string
+  tool_definitions:
+    type: string
+    optional: true
+    default: ""
+---
+system:
+You are an expert evaluator who scores how efficient an AI agent's trajectory was while solving a user's task. You judge the agent's tool-use process, not the correctness of the final answer.
+
+user:
+ROLE
+====
+You are a judge on **Task Efficiency** for an AI agent (often a coding agent). Your single focus is: **Did the agent solve the task with as few wasted steps as possible, or did it perform redundant, repeated, or looping work that did not advance the task?**
+
+You are NOT evaluating:
+- Whether the final answer is correct
+- Whether the task was actually completed
+- Whether the agent picked the right tools for the job
+- The agent's tone, formatting, or style
+
+You ARE evaluating:
+- Redundant tool calls (same tool with same or near-identical arguments yielding the same information)
+- Repeated reads of the same file with no intervening edit or new context that would justify re-reading
+- Identical failed commands retried with no change in arguments
+- Oscillation between two files, searches, or directories
+- Dead-end exploration that occurs **after** the answer was already in the agent's context
+- Re-establishing context the agent already had (re-listing a directory it just listed, re-grepping for a symbol it just found)
+
+INPUT
+=====
+CONVERSATION: {{messages}}
+
+{% if tool_definitions %}
+TOOL_DEFINITIONS: {{tool_definitions}}
+{% endif %}
+
+CONVERSATION includes the full multi-turn dialogue: system messages, user queries, assistant responses, tool calls, and tool results. Tool calls and tool results are the agent's working process and are the primary input for judging efficiency.
+
+EVALUATION FRAMEWORK
+====================
+
+A. Count the trajectory:
+- `total_steps_count`: total number of assistant tool calls in the conversation.
+- A "step" is one tool call (one entry of type `tool_call`/`function_call`).
+
+B. Identify wasted steps. A step is wasted if removing it would not change the agent's eventual ability to complete the task. Common patterns:
+- **Redundant read**: reading a file whose relevant content is already in the agent's context from an earlier read, with no edit in between that would change the file.
+- **Duplicate search**: running a search/grep/list with the same or trivially-different arguments as a prior call that returned the same results.
+- **Unchanged retry**: re-issuing a failed command (same name, same arguments) without adapting based on the failure.
+- **Oscillation**: alternating between two targets (file A, file B, file A, file B) with no progress between alternations.
+- **Post-answer exploration**: continuing to explore after the agent already had everything it needed to act.
+
+C. Distinguish wasted steps from legitimate ones:
+- Re-reading a file **after editing it** to verify the change is NOT wasted.
+- Re-running a failed command **with new arguments** based on the error is NOT wasted.
+- Reading several different files to locate the right one is exploration, NOT redundancy (unless the agent re-reads the same file repeatedly).
+- Listing a directory once to discover structure is normal; listing it again with no new reason is wasted.
+
+D. Compute `wasted_steps_count` and assign a score from the rubric.
+
+RUBRIC (1-5)
+============
+
+**5 - Highly Efficient.** Trajectory contains only the steps strictly needed. Every tool call yields new information or makes concrete progress. No duplicate reads of the same file, no re-runs of identical searches, no abandoned exploration. If errors occurred, each was diagnosed in a single step and fixed. `wasted_steps_count` is 0.
+
+**4 - Mostly Efficient.** Trajectory is largely direct, with at most one or two minor redundancies (a single extra read of an already-in-context file, one slightly broader-than-needed search). No loops, no repeated failed commands. The path could be trimmed by ~1 step but the overall flow is reasonable. Roughly 1-15% of steps are wasted.
+
+**3 - Moderately Efficient.** Noticeable inefficiency: a few clearly redundant tool calls (same file read 3+ times with no intervening edits, overlapping searches that return the same results, exploring directories already listed). No tight infinite loops, but the agent is not tracking what it has already seen. Task still progresses; roughly 15-35% of steps are wasted.
+
+**2 - Inefficient.** Substantial waste: same file read 4+ times, multiple cycles of re-establishing context the agent already had, retrying the same shell command unchanged after it failed, or wide exploratory scans well after the relevant file was identified. May include short loops (read -> no edit -> read again). Roughly 35-60% of steps are wasted.
+
+**1 - Highly Inefficient.** Severe looping or thrashing: the agent repeatedly re-reads the same file 5+ times with no new edits, retries an identical failing command 3+ times without adapting, oscillates between two files/searches, or performs large dead-end exploration after the answer was already in context. More than 60% of steps could be removed without changing the outcome.
+
+OUTPUT FORMAT
+=============
+Output a JSON object with these keys:
+{
+  "reason": "<20-80 words summarizing the efficiency assessment and the main wasted patterns observed (or stating that none were observed)>",
+  "properties": {
+    "total_steps_count": <int, total assistant tool calls in the trajectory>,
+    "wasted_steps_count": <int, number of tool calls judged redundant/looping/unnecessary>,
+    "redundancy_findings": "<short text listing concrete redundant calls, e.g. 'read_file(auth.py) called 4 times across turns 2-5 with no intervening edit'. 'None' if none.>",
+    "loop_findings": "<short text listing concrete loops or unchanged retries, e.g. 'pytest run identically 3 times in turns 4, 6, 8 with no edits between'. 'None' if none.>"
+  },
+  "score": <integer 1-5, or null if status is skipped>,
+  "status": "<completed or skipped>"
+}
+
+**Status: Skipped**
+If the CONVERSATION is empty, not provided, or contains zero assistant tool calls (a pure text-only chat with no tool-use trajectory), return status "skipped" immediately without scoring:
+```json
+{"reason": "<explain why evaluation was skipped, e.g. no tool calls in trajectory>", "properties": null, "score": null, "status": "skipped"}
+```
+
+SCORING EXAMPLES
+================
+
+### SCORE: 5 - Highly Efficient
+
+CONVERSATION:
+User turn 1: Add a `--verbose` flag to our CLI.
+Agent turn 1:
+[TOOL_CALL] grep(pattern="argparse", path="src/")
+[TOOL_RESULT] src/cli.py:12: parser = argparse.ArgumentParser()
+[TOOL_CALL] read_file(path="src/cli.py")
+[TOOL_RESULT] <full cli.py content>
+[TOOL_CALL] edit_file(path="src/cli.py", change="add --verbose flag")
+[TOOL_RESULT] ok
+[TOOL_CALL] run_tests()
+[TOOL_RESULT] 42 passed
+The `--verbose` flag is added and all tests pass.
+
+EXPECTED OUTPUT:
+{
+  "reason": "Agent located argparse with one grep, read the only relevant file once, made the edit, and ran tests once. Every step contributed; nothing redundant.",
+  "properties": {
+    "total_steps_count": 4,
+    "wasted_steps_count": 0,
+    "redundancy_findings": "None",
+    "loop_findings": "None"
+  },
+  "score": 5,
+  "status": "completed"
+}
+
+### SCORE: 4 - Mostly Efficient
+
+CONVERSATION:
+User turn 1: Add a `--verbose` flag to our CLI.
+Agent turn 1:
+[TOOL_CALL] grep(pattern="argparse", path="src/")
+[TOOL_RESULT] src/cli.py:12: parser = argparse.ArgumentParser()
+[TOOL_CALL] read_file(path="src/cli.py")
+[TOOL_RESULT] <full cli.py content>
+[TOOL_CALL] grep(pattern="LOG_LEVEL", path="src/")
+[TOOL_RESULT] (no matches)
+[TOOL_CALL] edit_file(path="src/cli.py", change="add --verbose flag")
+[TOOL_RESULT] ok
+[TOOL_CALL] read_file(path="src/cli.py")
+[TOOL_RESULT] <full cli.py content with new flag>
+[TOOL_CALL] run_tests()
+[TOOL_RESULT] 42 passed
+Done. Verified the edit and tests pass.
+
+EXPECTED OUTPUT:
+{
+  "reason": "Mostly direct path. One unused grep for LOG_LEVEL and a post-edit re-read of cli.py to verify the diff are minor inefficiencies but do not constitute looping or thrashing.",
+  "properties": {
+    "total_steps_count": 6,
+    "wasted_steps_count": 1,
+    "redundancy_findings": "grep(LOG_LEVEL) returned nothing and was not acted on; post-edit re-read of cli.py is borderline (verification, not waste)",
+    "loop_findings": "None"
+  },
+  "score": 4,
+  "status": "completed"
+}
+
+### SCORE: 3 - Moderately Efficient
+
+CONVERSATION:
+User turn 1: Add a `--verbose` flag to our CLI.
+Agent turn 1:
+[TOOL_CALL] list_dir(path="src/")
+[TOOL_RESULT] cli.py, config.py, utils.py
+[TOOL_CALL] read_file(path="src/config.py")
+[TOOL_RESULT] <config.py>
+[TOOL_CALL] read_file(path="src/config.py")
+[TOOL_RESULT] <config.py>
+[TOOL_CALL] grep(pattern="argparse", path="src/")
+[TOOL_RESULT] src/cli.py:12
+[TOOL_CALL] grep(pattern="ArgumentParser", path="src/")
+[TOOL_RESULT] src/cli.py:12
+[TOOL_CALL] read_file(path="src/cli.py")
+[TOOL_RESULT] <cli.py>
+[TOOL_CALL] read_file(path="src/cli.py")
+[TOOL_RESULT] <cli.py>
+[TOOL_CALL] edit_file(path="src/cli.py", change="add --verbose flag")
+[TOOL_RESULT] ok
+[TOOL_CALL] run_tests()
+[TOOL_RESULT] 42 passed
+Flag added.
+
+EXPECTED OUTPUT:
+{
+  "reason": "Task completed but the agent did not track what it had already seen: config.py and cli.py were each read twice with no edits between, and two near-identical greps returned the same hit. About a third of the steps were removable.",
+  "properties": {
+    "total_steps_count": 9,
+    "wasted_steps_count": 3,
+    "redundancy_findings": "read_file(src/config.py) called twice with no edit between; read_file(src/cli.py) called twice with no edit between; grep(argparse) and grep(ArgumentParser) returned the same single hit",
+    "loop_findings": "None"
+  },
+  "score": 3,
+  "status": "completed"
+}
+
+### SCORE: 2 - Inefficient
+
+CONVERSATION:
+User turn 1: Fix the bug in `auth.py` that's failing the login test.
+Agent turn 1:
+[TOOL_CALL] list_dir(path="src/")
+[TOOL_RESULT] auth.py, cli.py, ...
+[TOOL_CALL] read_file(path="src/auth.py")
+[TOOL_RESULT] <auth.py>
+[TOOL_CALL] list_dir(path="src/")
+[TOOL_RESULT] auth.py, cli.py, ...
+[TOOL_CALL] read_file(path="src/auth.py")
+[TOOL_RESULT] <auth.py>
+[TOOL_CALL] run_tests()
+[TOOL_RESULT] FAIL: test_login
+[TOOL_CALL] run_tests()
+[TOOL_RESULT] FAIL: test_login
+[TOOL_CALL] read_file(path="src/auth.py")
+[TOOL_RESULT] <auth.py>
+[TOOL_CALL] grep(pattern="login", path="src/")
+[TOOL_RESULT] src/auth.py:45
+[TOOL_CALL] read_file(path="src/auth.py")
+[TOOL_RESULT] <auth.py>
+[TOOL_CALL] edit_file(path="src/auth.py", change="fix login bug")
+[TOOL_RESULT] ok
+[TOOL_CALL] run_tests()
+[TOOL_RESULT] PASS
+Fixed.
+
+EXPECTED OUTPUT:
+{
+  "reason": "Heavy churn before the one-line fix: auth.py read four times across the turn with no edits between, src/ listed twice in succession, and run_tests called twice unchanged on a failure before any edit. Roughly half the trajectory was removable.",
+  "properties": {
+    "total_steps_count": 10,
+    "wasted_steps_count": 5,
+    "redundancy_findings": "read_file(src/auth.py) called 4 times with no intervening edit; list_dir(src/) called twice in immediate succession",
+    "loop_findings": "run_tests() called twice unchanged after the first failure with no edit between"
+  },
+  "score": 2,
+  "status": "completed"
+}
+
+### SCORE: 1 - Highly Inefficient
+
+CONVERSATION:
+User turn 1: Fix the failing test in `models.py`.
+Agent turn 1:
+[TOOL_CALL] read_file(path="src/models.py")
+[TOOL_RESULT] <models.py>
+[TOOL_CALL] npm_test()
+[TOOL_RESULT] FAIL: TypeError in User
+[TOOL_CALL] read_file(path="src/models.py")
+[TOOL_RESULT] <models.py>
+[TOOL_CALL] npm_test()
+[TOOL_RESULT] FAIL: TypeError in User
+[TOOL_CALL] grep(pattern="User", path="src/")
+[TOOL_RESULT] src/models.py:23
+[TOOL_CALL] read_file(path="src/models.py")
+[TOOL_RESULT] <models.py>
+[TOOL_CALL] grep(pattern="user", path="src/")
+[TOOL_RESULT] src/models.py:23, src/auth.py:8
+[TOOL_CALL] npm_test()
+[TOOL_RESULT] FAIL: TypeError in User
+[TOOL_CALL] read_file(path="src/models.py")
+[TOOL_RESULT] <models.py>
+[TOOL_CALL] grep(pattern="User", path="src/")
+[TOOL_RESULT] src/models.py:23
+[TOOL_CALL] read_file(path="src/models.py")
+[TOOL_RESULT] <models.py>
+[TOOL_CALL] npm_test()
+[TOOL_RESULT] FAIL: TypeError in User
+[TOOL_CALL] read_file(path="src/models.py")
+[TOOL_RESULT] <models.py>
+[TOOL_CALL] edit_file(path="src/models.py", change="fix TypeError on line 23")
+[TOOL_RESULT] ok
+[TOOL_CALL] npm_test()
+[TOOL_RESULT] PASS
+
+EXPECTED OUTPUT:
+{
+  "reason": "Severe thrashing: models.py read six times with no edits between, npm_test rerun four times identically after failures with no adaptation, and grep oscillated between 'User' and 'user' returning the same hit. The eventual one-line edit was identifiable after the first read.",
+  "properties": {
+    "total_steps_count": 15,
+    "wasted_steps_count": 11,
+    "redundancy_findings": "read_file(src/models.py) called 6 times with no intervening edit; grep(User) repeated; grep(user) and grep(User) returned the same hit",
+    "loop_findings": "npm_test() rerun 4 times unchanged after identical failures with no edit between; oscillation between grep(User) and grep(user)"
+  },
+  "score": 1,
+  "status": "completed"
+}
+
+KEY PRINCIPLES
+==============
+
+1. **Process focus**: Judge the trajectory of tool calls, not the final answer or whether the task was completed.
+2. **Removability test**: A step is wasted if removing it would not have changed the agent's eventual ability to complete the task.
+3. **Verification is not waste**: A read after an edit to confirm the diff is legitimate.
+4. **Adapted retries are not waste**: A retry with new arguments after a failure is legitimate.
+5. **Exploration vs redundancy**: Reading several different files to locate the right one is exploration; reading the same file repeatedly is redundancy.
+6. **Count concretely**: Always populate `total_steps_count` and `wasted_steps_count` with concrete integers grounded in the transcript.
+7. **No correctness bias**: Do not raise the score because the agent succeeded, and do not lower it because the agent failed - this is a separate dimension from task completion.
+
+# Output

--- a/assets/evaluators/builtin/task_efficiency/evaluator/task_efficiency_multi_turn.prompty
+++ b/assets/evaluators/builtin/task_efficiency/evaluator/task_efficiency_multi_turn.prompty
@@ -25,21 +25,14 @@ You are an expert evaluator who scores how efficient an AI agent's trajectory wa
 user:
 ROLE
 ====
-You are a judge on **Task Efficiency** for an AI agent (often a coding agent). Your single focus is: **Did the agent solve the task with as few wasted steps as possible, or did it perform redundant, repeated, or looping work that did not advance the task?**
+You are a judge on **Task Efficiency** for an AI coding agent. Your single focus is: **Did the agent solve the task with as few wasted steps as possible, or did it perform unnecessary, redundant, repeated, or looping work that did not advance the task?**
 
 You are NOT evaluating:
 - Whether the final answer is correct
 - Whether the task was actually completed
-- Whether the agent picked the right tools for the job
 - The agent's tone, formatting, or style
 
-You ARE evaluating:
-- Redundant tool calls (same tool with same or near-identical arguments yielding the same information)
-- Repeated reads of the same file with no intervening edit or new context that would justify re-reading
-- Identical failed commands retried with no change in arguments
-- Oscillation between two files, searches, or directories
-- Dead-end exploration that occurs **after** the answer was already in the agent's context
-- Re-establishing context the agent already had (re-listing a directory it just listed, re-grepping for a symbol it just found)
+You ARE evaluating the agent's tool-use trajectory: how much of it was wasted, looped, off-target, or required the user to clarify or correct. The specific patterns that count as wasted are defined in the EVALUATION FRAMEWORK below — use that section as the single source of truth.
 
 INPUT
 =====
@@ -51,60 +44,131 @@ TOOL_DEFINITIONS: {{tool_definitions}}
 
 CONVERSATION includes the full multi-turn dialogue: system messages, user queries, assistant responses, tool calls, and tool results. Tool calls and tool results are the agent's working process and are the primary input for judging efficiency.
 
+SERIALIZATION MARKERS
+=====================
+The transcript may contain these markers inserted by our preprocessor. They are NOT agent output:
+- `(result #N)` tags a tool-result body so it can be back-referenced.
+- `[same result as result #N | M chars]` means this tool call returned a body byte-identical to result #N. This IS strong evidence of a redundant call: the agent re-fetched information it already had. Count it as such unless the call is a clear post-edit verification.
+- `[X chars elided of Y total]` means the result body was head/tail truncated for length. Elision is NOT agent behavior; do not penalize it.
+Tool calls (name + arguments) are always verbatim and complete; never assume a call was truncated.
+
+PROCEDURE
+=========
+Follow in order; do not skip steps:
+1. Scan the ENTIRE conversation end-to-end, step-by-step. Do not base your judgment on the last turn alone — long trajectories must be assessed in full.
+2. For each tool call, decide if it is wasted using sections A and B below. Track concrete findings as you scan.
+3. Count user turns that re-state, rephrase, or correct a prior request — these are `user_repetition_count`.
+4. Choose a score from the rubric using your findings; think proportionally to the trajectory length, not in absolute counts.
+
 EVALUATION FRAMEWORK
 ====================
 
-A. Count the trajectory:
-- `total_steps_count`: total number of assistant tool calls in the conversation.
-- A "step" is one tool call (one entry of type `tool_call`/`function_call`).
-
-B. Identify wasted steps. A step is wasted if removing it would not change the agent's eventual ability to complete the task. Common patterns:
+A. Identify wasted steps. A step is wasted if removing it would not change the agent's eventual ability to complete the task, OR if the step is unnecessary or irrelevant to what the user actually asked for. Common patterns:
 - **Redundant read**: reading a file whose relevant content is already in the agent's context from an earlier read, with no edit in between that would change the file.
+- **Off-target read**: reading a file or running a command whose subject has no plausible connection to the user's request, when the relevant target was already identifiable from the user's request or prior context (e.g. user says "fix `auth.py`" but the agent reads several unrelated files before opening `auth.py`).
 - **Duplicate search**: running a search/grep/list with the same or trivially-different arguments as a prior call that returned the same results.
 - **Unchanged retry**: re-issuing a failed command (same name, same arguments) without adapting based on the failure.
 - **Oscillation**: alternating between two targets (file A, file B, file A, file B) with no progress between alternations.
 - **Post-answer exploration**: continuing to explore after the agent already had everything it needed to act.
+- **User request repetition**: user having to repeat the same request across multiple turns, indicating the agent did not act on or misunderstood the initial instruction.
+- **Agent rework**: user having to fix, correct, or redo the agent's work in subsequent turns, indicating the agent made errors that required user correction.
 
-C. Distinguish wasted steps from legitimate ones:
+B. Distinguish wasted steps from legitimate ones:
 - Re-reading a file **after editing it** to verify the change is NOT wasted.
 - Re-running a failed command **with new arguments** based on the error is NOT wasted.
 - Reading several different files to locate the right one is exploration, NOT redundancy (unless the agent re-reads the same file repeatedly).
+- Reading unrelated files is NOT off-target if the user's request was ambiguous about which file to modify, or if the agent had no way to identify the target without exploration. Only flag off-target reads when the correct target was clearly identifiable from the request or earlier context.
 - Listing a directory once to discover structure is normal; listing it again with no new reason is wasted.
 
-D. Compute `wasted_steps_count` and assign a score from the rubric.
+C. Note approximately how much of the trajectory is wasted (a small minority, a noticeable share, most, etc.) and assign a score from the rubric.
 
 RUBRIC (1-5)
 ============
+Score each trajectory along four axes, then take the WORST axis as the score (efficiency failures do not compensate). Reason proportionally to trajectory length — bands below describe shares, not absolute counts.
 
-**5 - Highly Efficient.** Trajectory contains only the steps strictly needed. Every tool call yields new information or makes concrete progress. No duplicate reads of the same file, no re-runs of identical searches, no abandoned exploration. If errors occurred, each was diagnosed in a single step and fixed. `wasted_steps_count` is 0.
+Axes:
+- **Redundancy & off-target density**: share of steps that are redundant, irrelevant, or off-target.
+- **Loops & retries**: presence of unchanged retries, oscillation, or repeated context re-establishment.
+- **On-targetness**: whether the agent stayed focused on what the user asked for.
+- **User burden**: whether the user had to clarify, repeat, or correct.
 
-**4 - Mostly Efficient.** Trajectory is largely direct, with at most one or two minor redundancies (a single extra read of an already-in-context file, one slightly broader-than-needed search). No loops, no repeated failed commands. The path could be trimmed by ~1 step but the overall flow is reasonable. Roughly 1-15% of steps are wasted.
+**5 — Highly Efficient.**
+- Redundancy: none.
+- Loops/retries: none; any error diagnosed and fixed in a single step.
+- On-target: fully focused; every step advances the request.
+- User burden: user stated the request once; no clarification or correction needed.
 
-**3 - Moderately Efficient.** Noticeable inefficiency: a few clearly redundant tool calls (same file read 3+ times with no intervening edits, overlapping searches that return the same results, exploring directories already listed). No tight infinite loops, but the agent is not tracking what it has already seen. Task still progresses; roughly 15-35% of steps are wasted.
+**4 — Mostly Efficient.**
+- Redundancy: small minority of stray steps (e.g. one re-read of an already-in-context file, one slightly broader-than-needed search).
+- Loops/retries: no loops; no repeated failed commands.
+- On-target: mostly focused; at most one minor detour.
+- User burden: at most one clarification, and only in a long conversation.
 
-**2 - Inefficient.** Substantial waste: same file read 4+ times, multiple cycles of re-establishing context the agent already had, retrying the same shell command unchanged after it failed, or wide exploratory scans well after the relevant file was identified. May include short loops (read -> no edit -> read again). Roughly 35-60% of steps are wasted.
+**3 — Partially Inefficient.**
+- Redundancy: a noticeable share of steps are redundant or irrelevant (e.g. the same file read several times with no intervening edit, overlapping searches returning the same results, exploration of files unrelated to the request).
+- Loops/retries: at most one isolated unchanged retry; no sustained loop.
+- On-target: visibly drifts; some exploration of unrelated targets, though the core request is still pursued.
+- User burden: user had to clarify or repeat more than once relative to conversation length.
+- This trajectory does not meet the bar for an efficient agent, even if the task progressed.
 
-**1 - Highly Inefficient.** Severe looping or thrashing: the agent repeatedly re-reads the same file 5+ times with no new edits, retries an identical failing command 3+ times without adapting, oscillates between two files/searches, or performs large dead-end exploration after the answer was already in context. More than 60% of steps could be removed without changing the outcome.
+**2 — Substantially Inefficient.**
+- Redundancy: most steps are redundant or off-target; useful work is the minority.
+- Loops/retries: short loops present (e.g. read → no edit → read again; test → no edit → test).
+- On-target: significant off-target exploration competes with the actual task.
+- User burden: user repeatedly redirects or corrects the agent.
+
+**1 — Highly Inefficient.**
+- Redundancy: trajectory is overwhelmingly redundant, looping, or off-target; useful work is buried in churn.
+- Loops/retries: sustained loops, oscillation between targets, or repeated unadapted retries.
+- On-target: dominated by irrelevant or off-target work.
+- User burden: user must drag the task forward turn after turn.
+
+**Anchor:** repeated identical retries of a failed command without adapting arguments is automatically score 1, regardless of trajectory length.
 
 OUTPUT FORMAT
 =============
-Output a JSON object with these keys:
+Return exactly one JSON object. Do not wrap it in markdown. Fields must appear in the order listed, and `final_label` must be LAST so you commit to a score only after weighing the evidence.
+
 {
-  "reason": "<20-80 words summarizing the efficiency assessment and the main wasted patterns observed (or stating that none were observed)>",
+  "evidence_for": [{"claim": "<concise factual statement>", "trace_ref": "turn N, source", "weight": "strong|moderate|weak"}],
+  "evidence_against": [{"claim": "<concise factual statement>", "trace_ref": "turn N, source", "weight": "strong|moderate|weak"}],
+  "weighing": "<one short paragraph reconciling evidence_for and evidence_against>",
   "properties": {
-    "total_steps_count": <int, total assistant tool calls in the trajectory>,
-    "wasted_steps_count": <int, number of tool calls judged redundant/looping/unnecessary>,
-    "redundancy_findings": "<short text listing concrete redundant calls, e.g. 'read_file(auth.py) called 4 times across turns 2-5 with no intervening edit'. 'None' if none.>",
-    "loop_findings": "<short text listing concrete loops or unchanged retries, e.g. 'pytest run identically 3 times in turns 4, 6, 8 with no edits between'. 'None' if none.>"
+    "redundancy_band": "<one of: none | small minority | noticeable share | most | overwhelming>",
+    "loops_band": "<one of: none | isolated retry | short loop | sustained loop>",
+    "on_target_band": "<one of: focused | minor detour | some drift | significant off-target | dominated off-target>",
+    "user_burden_band": "<one of: none | one clarification | repeated clarification | repeated redirect | user drives task>",
+    "user_repetition_count": <int, number of user turns that restate, rephrase, or correct a prior request>,
+    "redundancy_findings": "<short text listing concrete redundant or off-target calls, or 'None'>",
+    "loop_findings": "<short text listing concrete loops or unchanged retries, or 'None'>",
+    "user_repetition_findings": "<short text describing user repetitions/corrections, or 'None'>"
   },
+  "reason": "<20-80 words summarizing the efficiency assessment and main wasted patterns (or stating none were observed)>",
+  "efficiency_suggestion": "<if the agent could have been more efficient, one short sentence describing concretely what to drop or change (e.g. 'Skip the second read of cli.py; the file was unchanged'). Use the exact string \"None\" if the trajectory was already efficient and there is no useful suggestion to make>",
+  "status": "<completed or skipped>",
   "score": <integer 1-5, or null if status is skipped>,
-  "status": "<completed or skipped>"
+  "confidence": <float 0.0-1.0. 1.0 unambiguous, 0.6 likely, 0.4 borderline, <=0.2 a guess. Do not default to 0.7>,
+  "confidence_reason": "<one short sentence explaining the confidence>",
+  "final_label": "<single-token symbol mirroring score: must be one of 1, 2, 3, 4, 5; null if status is skipped>"
 }
+
+Field rules:
+- `evidence_for` and `evidence_against` are required arrays. Use [] only if you genuinely found no evidence for that side.
+- `trace_ref` must point to a turn or event visible in the conversation (for example: "turn 7, assistant", "turn 12, tool_result").
+- The four `*_band` fields are the four rubric axes — fill each independently, then derive `score` by taking the WORST band across the four (mapped to the matching rubric level).
+- `efficiency_suggestion` is a single short sentence. Set it to the literal string "None" when there is no meaningful change to suggest (typically score 5, but score 4 may still warrant a suggestion). Set it to `null` only when status is "skipped".
+- `final_label` is a string and must equal the string form of `score` (e.g. score 4 → final_label "4"). It is `null` only when status is "skipped".
+
+Band-to-score mapping (worst axis wins):
+- redundancy_band: none→5, small minority→4, noticeable share→3, most→2, overwhelming→1.
+- loops_band: none→5/4, isolated retry→3, short loop→2, sustained loop→1.
+- on_target_band: focused→5, minor detour→4, some drift→3, significant off-target→2, dominated off-target→1.
+- user_burden_band: none→5, one clarification→4, repeated clarification→3, repeated redirect→2, user drives task→1.
 
 **Status: Skipped**
 If the CONVERSATION is empty, not provided, or contains zero assistant tool calls (a pure text-only chat with no tool-use trajectory), return status "skipped" immediately without scoring:
 ```json
-{"reason": "<explain why evaluation was skipped, e.g. no tool calls in trajectory>", "properties": null, "score": null, "status": "skipped"}
+{"evidence_for": [], "evidence_against": [], "weighing": "<why no trajectory to evaluate>", "properties": null, "reason": "<explain why evaluation was skipped>", "efficiency_suggestion": null, "status": "skipped", "score": null, "confidence": 1.0, "confidence_reason": "Absence of tool calls is directly observable.", "final_label": null}
 ```
 
 SCORING EXAMPLES
@@ -127,15 +191,30 @@ The `--verbose` flag is added and all tests pass.
 
 EXPECTED OUTPUT:
 {
-  "reason": "Agent located argparse with one grep, read the only relevant file once, made the edit, and ran tests once. Every step contributed; nothing redundant.",
+  "evidence_for": [
+    {"claim": "Located argparse with a single grep before reading any file", "trace_ref": "turn 1, assistant tool_call grep", "weight": "strong"},
+    {"claim": "Read cli.py exactly once, then edited it", "trace_ref": "turn 1, assistant tool_calls read_file and edit_file", "weight": "strong"},
+    {"claim": "Ran tests once after the edit and stopped", "trace_ref": "turn 1, assistant tool_call run_tests", "weight": "moderate"}
+  ],
+  "evidence_against": [],
+  "weighing": "Every tool call advances the task; no redundancy, no loops, no off-target reads.",
   "properties": {
-    "total_steps_count": 4,
-    "wasted_steps_count": 0,
+    "redundancy_band": "none",
+    "loops_band": "none",
+    "on_target_band": "focused",
+    "user_burden_band": "none",
+    "user_repetition_count": 0,
     "redundancy_findings": "None",
-    "loop_findings": "None"
+    "loop_findings": "None",
+    "user_repetition_findings": "None"
   },
+  "reason": "Agent located argparse with one grep, read the only relevant file once, made the edit, and ran tests once. Every step contributed; nothing redundant.",
+  "efficiency_suggestion": "None",
+  "status": "completed",
   "score": 5,
-  "status": "completed"
+  "confidence": 0.95,
+  "confidence_reason": "Trajectory is short and the absence of redundancy or loops is directly observable.",
+  "final_label": "5"
 }
 
 ### SCORE: 4 - Mostly Efficient
@@ -159,18 +238,35 @@ Done. Verified the edit and tests pass.
 
 EXPECTED OUTPUT:
 {
-  "reason": "Mostly direct path. One unused grep for LOG_LEVEL and a post-edit re-read of cli.py to verify the diff are minor inefficiencies but do not constitute looping or thrashing.",
+  "evidence_for": [
+    {"claim": "grep(LOG_LEVEL) returned no matches and was not followed by any LOG_LEVEL-related edit", "trace_ref": "turn 1, assistant tool_call grep LOG_LEVEL", "weight": "moderate"},
+    {"claim": "cli.py read again after edit_file", "trace_ref": "turn 1, assistant tool_call read_file post-edit", "weight": "weak"}
+  ],
+  "evidence_against": [
+    {"claim": "Core path (grep argparse, read cli.py, edit, run tests) is direct", "trace_ref": "turn 1, assistant tool_calls", "weight": "strong"},
+    {"claim": "Post-edit re-read is a legitimate verification", "trace_ref": "turn 1, assistant tool_call read_file after edit", "weight": "moderate"}
+  ],
+  "weighing": "One unused exploratory grep and one verification re-read are minor inefficiencies. No loops, no off-target work that drives the task. Worst axis is on_target_band (minor detour) → 4.",
   "properties": {
-    "total_steps_count": 6,
-    "wasted_steps_count": 1,
+    "redundancy_band": "small minority",
+    "loops_band": "none",
+    "on_target_band": "minor detour",
+    "user_burden_band": "none",
+    "user_repetition_count": 0,
     "redundancy_findings": "grep(LOG_LEVEL) returned nothing and was not acted on; post-edit re-read of cli.py is borderline (verification, not waste)",
-    "loop_findings": "None"
+    "loop_findings": "None",
+    "user_repetition_findings": "None"
   },
+  "reason": "Mostly direct path. One unused grep for LOG_LEVEL and a post-edit re-read of cli.py to verify the diff are minor inefficiencies but do not constitute looping or thrashing.",
+  "efficiency_suggestion": "Skip the speculative grep for LOG_LEVEL when nothing in the request points to it, and rely on the edit tool's diff instead of re-reading cli.py after the edit.",
+  "status": "completed",
   "score": 4,
-  "status": "completed"
+  "confidence": 0.85,
+  "confidence_reason": "Bands are clearly bounded; only borderline call is the verification re-read.",
+  "final_label": "4"
 }
 
-### SCORE: 3 - Moderately Efficient
+### SCORE: 3 - Partially Inefficient
 
 CONVERSATION:
 User turn 1: Add a `--verbose` flag to our CLI.
@@ -197,18 +293,35 @@ Flag added.
 
 EXPECTED OUTPUT:
 {
-  "reason": "Task completed but the agent did not track what it had already seen: config.py and cli.py were each read twice with no edits between, and two near-identical greps returned the same hit. About a third of the steps were removable.",
+  "evidence_for": [
+    {"claim": "read_file(src/config.py) called twice in succession with no edit between", "trace_ref": "turn 1, assistant tool_calls read_file config.py", "weight": "strong"},
+    {"claim": "read_file(src/cli.py) called twice with no edit between", "trace_ref": "turn 1, assistant tool_calls read_file cli.py", "weight": "strong"},
+    {"claim": "grep(argparse) and grep(ArgumentParser) returned the same single hit", "trace_ref": "turn 1, assistant tool_calls grep", "weight": "moderate"}
+  ],
+  "evidence_against": [
+    {"claim": "Final edit and test run are correct and on target", "trace_ref": "turn 1, assistant tool_calls edit_file and run_tests", "weight": "moderate"}
+  ],
+  "weighing": "A noticeable share of steps are removable duplicates of reads and overlapping greps, though there are no sustained loops or off-target detours. Worst axis is redundancy_band (noticeable share) → 3.",
   "properties": {
-    "total_steps_count": 9,
-    "wasted_steps_count": 3,
+    "redundancy_band": "noticeable share",
+    "loops_band": "none",
+    "on_target_band": "focused",
+    "user_burden_band": "none",
+    "user_repetition_count": 0,
     "redundancy_findings": "read_file(src/config.py) called twice with no edit between; read_file(src/cli.py) called twice with no edit between; grep(argparse) and grep(ArgumentParser) returned the same single hit",
-    "loop_findings": "None"
+    "loop_findings": "None",
+    "user_repetition_findings": "None"
   },
+  "reason": "Task completed but the agent did not track what it had already seen: config.py and cli.py were each read twice with no edits between, and two near-identical greps returned the same hit. About a third of the steps were removable.",
+  "efficiency_suggestion": "Read each file only once when nothing changed in between, and collapse grep(argparse) and grep(ArgumentParser) into a single search.",
+  "status": "completed",
   "score": 3,
-  "status": "completed"
+  "confidence": 0.85,
+  "confidence_reason": "Duplicate reads and overlapping greps are directly observable in the transcript.",
+  "final_label": "3"
 }
 
-### SCORE: 2 - Inefficient
+### SCORE: 2 - Substantially Inefficient
 
 CONVERSATION:
 User turn 1: Fix the bug in `auth.py` that's failing the login test.
@@ -239,15 +352,32 @@ Fixed.
 
 EXPECTED OUTPUT:
 {
-  "reason": "Heavy churn before the one-line fix: auth.py read four times across the turn with no edits between, src/ listed twice in succession, and run_tests called twice unchanged on a failure before any edit. Roughly half the trajectory was removable.",
+  "evidence_for": [
+    {"claim": "read_file(src/auth.py) called 4 times with no intervening edit", "trace_ref": "turn 1, assistant tool_calls read_file auth.py", "weight": "strong"},
+    {"claim": "list_dir(src/) called twice in immediate succession", "trace_ref": "turn 1, assistant tool_calls list_dir", "weight": "moderate"},
+    {"claim": "run_tests() called twice unchanged after first failure before any edit", "trace_ref": "turn 1, assistant tool_calls run_tests", "weight": "strong"}
+  ],
+  "evidence_against": [
+    {"claim": "Agent stayed on the file the user identified (auth.py)", "trace_ref": "turn 1, assistant tool_calls", "weight": "moderate"}
+  ],
+  "weighing": "Most steps before the edit are redundant reads or unchanged retest cycles; on_target is fine but redundancy is 'most' and loops_band is 'short loop'. Worst axis → 2.",
   "properties": {
-    "total_steps_count": 10,
-    "wasted_steps_count": 5,
+    "redundancy_band": "most",
+    "loops_band": "short loop",
+    "on_target_band": "focused",
+    "user_burden_band": "none",
+    "user_repetition_count": 0,
     "redundancy_findings": "read_file(src/auth.py) called 4 times with no intervening edit; list_dir(src/) called twice in immediate succession",
-    "loop_findings": "run_tests() called twice unchanged after the first failure with no edit between"
+    "loop_findings": "run_tests() called twice unchanged after the first failure with no edit between",
+    "user_repetition_findings": "None"
   },
+  "reason": "Heavy churn before the one-line fix: auth.py read four times across the turn with no edits between, src/ listed twice in succession, and run_tests called twice unchanged on a failure before any edit. Roughly half the trajectory was removable.",
+  "efficiency_suggestion": "After the first read of auth.py and the first failing run_tests, go straight to diagnosing and editing instead of re-reading auth.py three more times and re-running the unchanged test.",
+  "status": "completed",
   "score": 2,
-  "status": "completed"
+  "confidence": 0.9,
+  "confidence_reason": "Repeat counts and unchanged retries are directly visible in the transcript.",
+  "final_label": "2"
 }
 
 ### SCORE: 1 - Highly Inefficient
@@ -288,15 +418,30 @@ Agent turn 1:
 
 EXPECTED OUTPUT:
 {
-  "reason": "Severe thrashing: models.py read six times with no edits between, npm_test rerun four times identically after failures with no adaptation, and grep oscillated between 'User' and 'user' returning the same hit. The eventual one-line edit was identifiable after the first read.",
+  "evidence_for": [
+    {"claim": "read_file(src/models.py) called 6 times with no intervening edit", "trace_ref": "turn 1, assistant tool_calls read_file models.py", "weight": "strong"},
+    {"claim": "npm_test() rerun 4 times unchanged after identical failures before any edit", "trace_ref": "turn 1, assistant tool_calls npm_test", "weight": "strong"},
+    {"claim": "grep(User) and grep(user) oscillate and return the same hit", "trace_ref": "turn 1, assistant tool_calls grep", "weight": "moderate"}
+  ],
+  "evidence_against": [],
+  "weighing": "Overwhelming redundancy and a sustained loop of unchanged retests dominate the trajectory. Worst axis is loops_band (sustained loop) → 1.",
   "properties": {
-    "total_steps_count": 15,
-    "wasted_steps_count": 11,
+    "redundancy_band": "overwhelming",
+    "loops_band": "sustained loop",
+    "on_target_band": "focused",
+    "user_burden_band": "none",
+    "user_repetition_count": 0,
     "redundancy_findings": "read_file(src/models.py) called 6 times with no intervening edit; grep(User) repeated; grep(user) and grep(User) returned the same hit",
-    "loop_findings": "npm_test() rerun 4 times unchanged after identical failures with no edit between; oscillation between grep(User) and grep(user)"
+    "loop_findings": "npm_test() rerun 4 times unchanged after identical failures with no edit between; oscillation between grep(User) and grep(user)",
+    "user_repetition_findings": "None"
   },
+  "reason": "Severe thrashing: models.py read six times with no edits between, npm_test rerun four times identically after failures with no adaptation, and grep oscillated between 'User' and 'user' returning the same hit. The eventual one-line edit was identifiable after the first read.",
+  "efficiency_suggestion": "Edit models.py after the first read and the first failing npm_test instead of re-running the unchanged test four times and oscillating between grep(User) and grep(user).",
+  "status": "completed",
   "score": 1,
-  "status": "completed"
+  "confidence": 0.97,
+  "confidence_reason": "Repeat counts and identical unchanged retests are directly visible.",
+  "final_label": "1"
 }
 
 KEY PRINCIPLES
@@ -307,7 +452,8 @@ KEY PRINCIPLES
 3. **Verification is not waste**: A read after an edit to confirm the diff is legitimate.
 4. **Adapted retries are not waste**: A retry with new arguments after a failure is legitimate.
 5. **Exploration vs redundancy**: Reading several different files to locate the right one is exploration; reading the same file repeatedly is redundancy.
-6. **Count concretely**: Always populate `total_steps_count` and `wasted_steps_count` with concrete integers grounded in the transcript.
+6. **Ground in evidence**: Each band and finding must be grounded in concrete observations from the transcript, not in vibes.
 7. **No correctness bias**: Do not raise the score because the agent succeeded, and do not lower it because the agent failed - this is a separate dimension from task completion.
+8. **Multi-turn impact**: In multi-turn conversations, penalize trajectories where the user must repeat requests or fix agent mistakes—these indicate core efficiency failures that compound over turns, regardless of final success.
 
 # Output

--- a/assets/evaluators/builtin/task_efficiency/spec.yaml
+++ b/assets/evaluators/builtin/task_efficiency/spec.yaml
@@ -1,0 +1,39 @@
+type: "evaluator"
+name: "builtin.task_efficiency"
+version: 1
+displayName: "Task-Efficiency-Evaluator-(Preview)"
+description: "Evaluates whether an AI agent (especially a coding agent) solved the user's task efficiently by analyzing its multi-turn trajectory of tool calls and tool results. Penalizes redundant work such as repeated reads of the same file, identical tool calls with identical arguments, retrying a failed command unchanged, oscillation between targets, and dead-end exploration after the answer was already in context. This evaluator is useful for assessing agent quality in tool-using and code-generating scenarios where minimizing unnecessary steps matters."
+evaluatorType: "builtin"
+evaluatorSubType: "code"
+categories: ["agents", "business"]
+tags:
+  is_continuous_scenario: "true"
+  provider: "Microsoft"
+supportedEvaluationLevels: ["conversation"]
+initParameterSchema:
+  type: "object"
+  properties:
+    deployment_name:
+      type: "string"
+  required: ["deployment_name"]
+dataMappingSchema:
+  type: "object"
+  properties:
+    messages:
+      type: "array"
+      items:
+        type: "object"
+    tool_definitions:
+      anyOf:
+        - type: "object"
+        - type: "array"
+          items:
+            type: "object"
+  required: ["messages"]
+outputSchema:
+  task_efficiency:
+    type: "integer"
+    desirable_direction: "increase"
+    min_value: 1
+    max_value: 5
+path: ./evaluator

--- a/assets/evaluators/tests/test_evaluators_behavior/test_task_efficiency_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_task_efficiency_evaluator_behavior.py
@@ -1,0 +1,292 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Behavioral tests for Task Efficiency Evaluator."""
+
+import os
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from azure.ai.evaluation import AzureOpenAIModelConfiguration
+from azure.ai.evaluation._exceptions import EvaluationException
+
+from ...builtin.task_efficiency.evaluator._task_efficiency import (
+    TaskEfficiencyEvaluator,
+    serialize_messages,
+    _count_assistant_tool_calls,
+)
+from ..common.evaluator_mock_config import get_flow_side_effect_for_evaluator
+
+
+def _create_mocked_evaluator(**init_kwargs):
+    """Create a TaskEfficiencyEvaluator with its _flow mocked."""
+    model_config = AzureOpenAIModelConfiguration(
+        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT", "https://Sanitized.api.cognitive.microsoft.com"),
+        azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT", "aoai-deployment"),
+    )
+    evaluator = TaskEfficiencyEvaluator(model_config=model_config, **init_kwargs)
+    evaluator._flow = MagicMock(side_effect=get_flow_side_effect_for_evaluator("task_efficiency"))
+    return evaluator
+
+
+# A trajectory with a single assistant tool call - enough to exercise the LLM path.
+VALID_MESSAGES_WITH_TOOLS: List[Dict[str, Any]] = [
+    {"role": "user", "content": [{"type": "text", "text": "Add a --verbose flag to the CLI."}]},
+    {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_call",
+                "tool_call_id": "call_1",
+                "name": "read_file",
+                "arguments": {"path": "src/cli.py"},
+            }
+        ],
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": [{"type": "tool_result", "tool_result": "parser = argparse.ArgumentParser()"}],
+    },
+    {"role": "assistant", "content": [{"type": "text", "text": "Added the --verbose flag."}]},
+]
+
+VALID_TOOL_DEFINITIONS: List[Dict[str, Any]] = [
+    {
+        "name": "read_file",
+        "description": "Read a file from disk.",
+        "parameters": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+        },
+    }
+]
+
+
+@pytest.mark.unittest
+class TestTaskEfficiencyEvaluatorBehavior:
+    """Behavioral tests for the multi-turn (messages) path of TaskEfficiencyEvaluator."""
+
+    def test_messages_valid_input_returns_expected_fields(self):
+        evaluator = _create_mocked_evaluator()
+        result = evaluator(messages=VALID_MESSAGES_WITH_TOOLS)
+
+        for key in (
+            "task_efficiency",
+            "task_efficiency_score",
+            "task_efficiency_result",
+            "task_efficiency_reason",
+            "task_efficiency_status",
+            "task_efficiency_threshold",
+            "task_efficiency_passed",
+            "task_efficiency_properties",
+        ):
+            assert key in result
+        assert result["task_efficiency_status"] == "completed"
+        assert isinstance(result["task_efficiency"], int)
+        assert 1 <= result["task_efficiency"] <= 5
+
+    def test_messages_with_tool_definitions(self):
+        evaluator = _create_mocked_evaluator()
+        result = evaluator(messages=VALID_MESSAGES_WITH_TOOLS, tool_definitions=VALID_TOOL_DEFINITIONS)
+
+        assert result["task_efficiency_status"] == "completed"
+        call_kwargs = evaluator._flow.call_args
+        assert "tool_definitions" in call_kwargs.kwargs
+
+    def test_messages_without_tool_definitions_does_not_pass_them(self):
+        evaluator = _create_mocked_evaluator()
+        evaluator(messages=VALID_MESSAGES_WITH_TOOLS)
+
+        call_kwargs = evaluator._flow.call_args
+        assert "tool_definitions" not in call_kwargs.kwargs
+
+    def test_threshold_default_is_three(self):
+        evaluator = _create_mocked_evaluator()
+        result = evaluator(messages=VALID_MESSAGES_WITH_TOOLS)
+        assert result["task_efficiency_threshold"] == 3
+
+    def test_threshold_override(self):
+        evaluator = _create_mocked_evaluator(threshold=5)
+        result = evaluator(messages=VALID_MESSAGES_WITH_TOOLS)
+        # Mock returns GRADERS_SUCCESS_SCORE=5, so score=5 >= threshold=5 -> pass.
+        assert result["task_efficiency_threshold"] == 5
+        assert result["task_efficiency_passed"] is True
+        assert result["task_efficiency_result"] == "pass"
+
+    def test_threshold_above_score_fails(self):
+        # Force a low score from the mock by patching the flow directly.
+        evaluator = _create_mocked_evaluator(threshold=4)
+
+        async def low_score_flow(timeout, **kwargs):
+            return {
+                "llm_output": {
+                    "score": 2,
+                    "reason": "Lots of repeated reads.",
+                    "status": "completed",
+                    "properties": {
+                        "total_steps_count": 10,
+                        "wasted_steps_count": 6,
+                        "redundancy_findings": "auth.py read 4x",
+                        "loop_findings": "None",
+                    },
+                }
+            }
+
+        evaluator._flow = MagicMock(side_effect=low_score_flow)
+        result = evaluator(messages=VALID_MESSAGES_WITH_TOOLS)
+        assert result["task_efficiency"] == 2
+        assert result["task_efficiency_passed"] is False
+        assert result["task_efficiency_result"] == "fail"
+
+    def test_score_is_clamped_to_rubric_range(self):
+        evaluator = _create_mocked_evaluator()
+
+        async def out_of_range_flow(timeout, **kwargs):
+            return {
+                "llm_output": {
+                    "score": 9,
+                    "reason": "Out of range.",
+                    "status": "completed",
+                    "properties": {},
+                }
+            }
+
+        evaluator._flow = MagicMock(side_effect=out_of_range_flow)
+        result = evaluator(messages=VALID_MESSAGES_WITH_TOOLS)
+        assert result["task_efficiency"] == 5
+
+    def test_no_tool_calls_returns_skipped(self):
+        """A text-only conversation has no trajectory; result is not_applicable / skipped."""
+        evaluator = _create_mocked_evaluator()
+        text_only_messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Hi."}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
+        ]
+        result = evaluator(messages=text_only_messages)
+
+        assert result["task_efficiency"] is None
+        assert result["task_efficiency_score"] is None
+        assert result["task_efficiency_status"] == "skipped"
+        assert result["task_efficiency_result"] == "not_applicable"
+        assert result["task_efficiency_passed"] is None
+        evaluator._flow.assert_not_called()
+
+    def test_judge_skipped_status_propagates(self):
+        evaluator = _create_mocked_evaluator()
+
+        async def skipped_flow(timeout, **kwargs):
+            return {
+                "llm_output": {
+                    "score": None,
+                    "reason": "Not enough trajectory.",
+                    "status": "skipped",
+                    "properties": None,
+                }
+            }
+
+        evaluator._flow = MagicMock(side_effect=skipped_flow)
+        result = evaluator(messages=VALID_MESSAGES_WITH_TOOLS)
+        assert result["task_efficiency_status"] == "skipped"
+        assert result["task_efficiency"] is None
+
+    def test_messages_empty_list_raises_error(self):
+        evaluator = _create_mocked_evaluator()
+        with pytest.raises(EvaluationException):
+            evaluator(messages=[])
+
+    def test_messages_missing_raises_error(self):
+        evaluator = _create_mocked_evaluator()
+        with pytest.raises(EvaluationException):
+            evaluator()
+
+    def test_messages_invalid_type_raises_error(self):
+        evaluator = _create_mocked_evaluator()
+        with pytest.raises(EvaluationException):
+            evaluator(messages="not a list")
+
+    def test_messages_non_dict_items_raises_error(self):
+        evaluator = _create_mocked_evaluator()
+        with pytest.raises(EvaluationException):
+            evaluator(messages=[{"role": "user", "content": "hi"}, "not a dict"])
+
+    def test_messages_missing_role_raises_error(self):
+        evaluator = _create_mocked_evaluator()
+        with pytest.raises(EvaluationException):
+            evaluator(messages=[{"content": [{"type": "text", "text": "no role"}]}])
+
+    def test_function_call_normalized_to_tool_call(self):
+        """function_call content should be recognized as a tool-use trajectory."""
+        evaluator = _create_mocked_evaluator()
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Do X."}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "function_call",
+                        "tool_call_id": "call_1",
+                        "name": "do_x",
+                        "arguments": {},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": [{"type": "function_call_output", "function_call_output": "ok"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": "Done."}]},
+        ]
+        result = evaluator(messages=messages)
+        assert result["task_efficiency_status"] == "completed"
+
+
+@pytest.mark.unittest
+class TestTaskEfficiencyHelpers:
+    """Unit tests for helper functions in _task_efficiency."""
+
+    def test_count_assistant_tool_calls_zero(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+        ]
+        assert _count_assistant_tool_calls(msgs) == 0
+
+    def test_count_assistant_tool_calls_counts_tool_call_types(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_call", "name": "a", "tool_call_id": "1", "arguments": {}},
+                    {"type": "function_call", "name": "b", "tool_call_id": "2", "arguments": {}},
+                    {"type": "openapi_call", "name": "c", "tool_call_id": "3", "arguments": {}},
+                    {"type": "text", "text": "not a tool call"},
+                ],
+            }
+        ]
+        assert _count_assistant_tool_calls(msgs) == 3
+
+    def test_count_assistant_tool_calls_ignores_tool_role(self):
+        msgs = [
+            {
+                "role": "tool",
+                "tool_call_id": "1",
+                "content": [{"type": "tool_call", "name": "x", "tool_call_id": "1", "arguments": {}}],
+            }
+        ]
+        assert _count_assistant_tool_calls(msgs) == 0
+
+    def test_serialize_messages_empty(self):
+        assert serialize_messages([]) == ""
+
+    def test_serialize_messages_includes_user_and_agent_text(self):
+        msgs = [
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "world"}]},
+        ]
+        text = serialize_messages(msgs)
+        assert "hello" in text
+        assert "world" in text

--- a/assets/evaluators/tests/test_evaluators_quality/test_task_efficiency_evaluator_quality_multi_turn.py
+++ b/assets/evaluators/tests/test_evaluators_quality/test_task_efficiency_evaluator_quality_multi_turn.py
@@ -1,0 +1,600 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Quality tests for Task Efficiency Evaluator - realistic multi-turn coding agent trajectories.
+
+Each test crafts a GitHub-Copilot-style coding agent transcript (using realistic tools
+such as ``read_file``, ``grep_search``, ``list_dir``, ``replace_string_in_file``,
+``run_in_terminal``, ``get_errors``) and asserts that the LLM judge places it in the
+expected efficiency band.
+
+Default threshold is 3, so:
+- Scores 4-5 (highly / mostly efficient) -> ``pass``
+- Score 3 (moderately efficient) -> borderline ``pass``
+- Scores 1-2 (inefficient / highly inefficient) -> ``fail``
+- No assistant tool calls -> ``skipped`` (short-circuit, no LLM call)
+"""
+
+import pytest
+
+from ..common.base_quality_evaluator_runner import BaseQualityEvaluatorRunner, ExpectedResult
+from ...builtin.task_efficiency.evaluator._task_efficiency import TaskEfficiencyEvaluator
+
+
+# region Reusable tool definitions for a coding agent
+
+CODING_AGENT_TOOL_DEFINITIONS = [
+    {
+        "name": "read_file",
+        "description": "Read the contents of a file from the workspace.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Absolute or workspace-relative path"},
+                "start_line": {"type": "integer"},
+                "end_line": {"type": "integer"},
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "grep_search",
+        "description": "Search the workspace for a regex pattern.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pattern": {"type": "string"},
+                "path": {"type": "string"},
+            },
+            "required": ["pattern"],
+        },
+    },
+    {
+        "name": "list_dir",
+        "description": "List the entries in a directory.",
+        "parameters": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "replace_string_in_file",
+        "description": "Replace an exact string in a file with new text.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "old": {"type": "string"},
+                "new": {"type": "string"},
+            },
+            "required": ["path", "old", "new"],
+        },
+    },
+    {
+        "name": "run_in_terminal",
+        "description": "Run a shell command and return its output.",
+        "parameters": {
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"],
+        },
+    },
+    {
+        "name": "get_errors",
+        "description": "Return compile/lint errors for the given files.",
+        "parameters": {
+            "type": "object",
+            "properties": {"paths": {"type": "array", "items": {"type": "string"}}},
+            "required": ["paths"],
+        },
+    },
+]
+
+
+def _tc(call_id: str, name: str, arguments: dict) -> dict:
+    """Build an assistant tool_call content block."""
+    return {"type": "tool_call", "tool_call_id": call_id, "name": name, "arguments": arguments}
+
+
+def _tr(call_id: str, result) -> dict:
+    """Build a tool message wrapping a tool_result."""
+    return {
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": [{"type": "tool_result", "tool_result": result}],
+    }
+
+
+def _user(text: str) -> dict:
+    return {"role": "user", "content": [{"type": "text", "text": text}]}
+
+
+def _assistant_text(text: str) -> dict:
+    return {"role": "assistant", "content": [{"type": "text", "text": text}]}
+
+
+def _assistant_calls(*calls) -> dict:
+    return {"role": "assistant", "content": list(calls)}
+
+
+# endregion
+
+
+@pytest.mark.quality
+class TestTaskEfficiencyEvaluatorQualityMultiTurn(BaseQualityEvaluatorRunner):
+    """Multi-turn quality tests for Task Efficiency Evaluator.
+
+    Realistic GitHub-Copilot-style coding agent sessions across the full 1-5 rubric.
+    """
+
+    evaluator_type = TaskEfficiencyEvaluator
+
+    # ==================== PASS: Highly Efficient (expect 4-5) ====================
+
+    def test_pass_highly_efficient_add_cli_flag(self) -> None:
+        """PASS - direct, minimal trajectory: locate, read once, edit once, verify once.
+
+        The agent adds a ``--verbose`` flag to a CLI. Each tool call yields new
+        information or makes concrete progress; nothing is read twice, no command
+        is repeated, no dead-end exploration. Expected score: 4 or 5.
+        """
+        self.run_quality_test(
+            test_label="PASS-highly-efficient-add-cli-flag",
+            expected=ExpectedResult.PASS,
+            messages=[
+                _user("Add a `--verbose` flag to our CLI in src/cli.py that enables debug logging."),
+                _assistant_calls(
+                    _tc("c1", "grep_search", {"pattern": "argparse.ArgumentParser", "path": "src/"}),
+                ),
+                _tr("c1", "src/cli.py:14: parser = argparse.ArgumentParser(description='myapp')"),
+                _assistant_calls(
+                    _tc("c2", "read_file", {"path": "src/cli.py", "start_line": 1, "end_line": 60}),
+                ),
+                _tr(
+                    "c2",
+                    (
+                        "1  import argparse\n"
+                        "2  import logging\n"
+                        "...\n"
+                        "14 parser = argparse.ArgumentParser(description='myapp')\n"
+                        "15 parser.add_argument('--config', type=str, required=True)\n"
+                        "16 args = parser.parse_args()\n"
+                        "17 logging.basicConfig(level=logging.INFO)\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc(
+                        "c3",
+                        "replace_string_in_file",
+                        {
+                            "path": "src/cli.py",
+                            "old": "parser.add_argument('--config', type=str, required=True)\nargs = parser.parse_args()\nlogging.basicConfig(level=logging.INFO)",  # noqa: E501
+                            "new": "parser.add_argument('--config', type=str, required=True)\nparser.add_argument('--verbose', action='store_true', help='Enable debug logging')\nargs = parser.parse_args()\nlogging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)",  # noqa: E501
+                        },
+                    ),
+                ),
+                _tr("c3", "ok"),
+                _assistant_calls(
+                    _tc("c4", "run_in_terminal", {"command": "pytest tests/test_cli.py -q"}),
+                ),
+                _tr("c4", "42 passed in 0.8s"),
+                _assistant_text(
+                    "Added the `--verbose` flag in src/cli.py. It toggles the root logger between INFO "
+                    "and DEBUG. All 42 CLI tests pass."
+                ),
+            ],
+            tool_definitions=CODING_AGENT_TOOL_DEFINITIONS,
+        )
+
+    def test_pass_mostly_efficient_fix_off_by_one(self) -> None:
+        """PASS - mostly efficient: one acceptable post-edit verification read.
+
+        The agent fixes an off-by-one bug in a pagination helper. It performs one
+        extra read of the file after the edit to verify the diff, which is legitimate
+        verification, not redundancy. Expected score: 4 (occasionally 5).
+        """
+        self.run_quality_test(
+            test_label="PASS-mostly-efficient-fix-off-by-one",
+            expected=ExpectedResult.PASS,
+            messages=[
+                _user("test_pagination is failing - the last page is missing one row. Fix it in src/pagination.py."),
+                _assistant_calls(
+                    _tc("c1", "run_in_terminal", {"command": "pytest tests/test_pagination.py -q"}),
+                ),
+                _tr(
+                    "c1",
+                    (
+                        "FAILED tests/test_pagination.py::test_paginate_last_page\n"
+                        "AssertionError: expected 5 items on last page, got 4\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc("c2", "read_file", {"path": "src/pagination.py", "start_line": 1, "end_line": 40}),
+                ),
+                _tr(
+                    "c2",
+                    (
+                        "def paginate(items, page_size):\n"
+                        "    total = len(items)\n"
+                        "    pages = total // page_size  # bug: drops the partial last page\n"
+                        "    for i in range(pages):\n"
+                        "        yield items[i * page_size:(i + 1) * page_size]\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc(
+                        "c3",
+                        "replace_string_in_file",
+                        {
+                            "path": "src/pagination.py",
+                            "old": "pages = total // page_size  # bug: drops the partial last page",
+                            "new": "pages = (total + page_size - 1) // page_size  # ceil to include the partial last page",  # noqa: E501
+                        },
+                    ),
+                ),
+                _tr("c3", "ok"),
+                _assistant_calls(
+                    _tc("c4", "read_file", {"path": "src/pagination.py", "start_line": 1, "end_line": 10}),
+                ),
+                _tr(
+                    "c4",
+                    (
+                        "def paginate(items, page_size):\n"
+                        "    total = len(items)\n"
+                        "    pages = (total + page_size - 1) // page_size  # ceil to include the partial last page\n"
+                        "    for i in range(pages):\n"
+                        "        yield items[i * page_size:(i + 1) * page_size]\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc("c5", "run_in_terminal", {"command": "pytest tests/test_pagination.py -q"}),
+                ),
+                _tr("c5", "8 passed in 0.3s"),
+                _assistant_text(
+                    "Fixed the off-by-one by switching the page count to ceiling division. All 8 "
+                    "pagination tests now pass."
+                ),
+            ],
+            tool_definitions=CODING_AGENT_TOOL_DEFINITIONS,
+        )
+
+    # ==================== BORDERLINE: Moderately Efficient (expect ~3) ====================
+
+    def test_borderline_moderately_efficient_add_method(self) -> None:
+        """BORDERLINE - moderately efficient: a few redundant reads/searches, no loops.
+
+        Agent adds a ``to_dict`` method to a ``User`` class. It re-reads the same
+        file twice with no edit between, runs two nearly-identical greps that return
+        the same hit, and lists ``src/`` twice. Roughly a third of steps are wasted.
+        Expected score: 3 (sometimes 2 or 4 depending on judge).
+        """
+        self.run_quality_test(
+            test_label="BORDERLINE-moderately-efficient-add-to_dict",
+            expected=ExpectedResult.PASS_OR_FAIL,
+            messages=[
+                _user("Add a `to_dict()` method to the User class so we can JSON-serialize it."),
+                _assistant_calls(
+                    _tc("c1", "list_dir", {"path": "src/"}),
+                ),
+                _tr("c1", "models.py  views.py  utils.py  __init__.py"),
+                _assistant_calls(
+                    _tc("c2", "grep_search", {"pattern": "class User", "path": "src/"}),
+                ),
+                _tr("c2", "src/models.py:12: class User:"),
+                _assistant_calls(
+                    _tc("c3", "grep_search", {"pattern": "class User\\b", "path": "src/"}),
+                ),
+                _tr("c3", "src/models.py:12: class User:"),
+                _assistant_calls(
+                    _tc("c4", "list_dir", {"path": "src/"}),
+                ),
+                _tr("c4", "models.py  views.py  utils.py  __init__.py"),
+                _assistant_calls(
+                    _tc("c5", "read_file", {"path": "src/models.py", "start_line": 1, "end_line": 60}),
+                ),
+                _tr(
+                    "c5",
+                    (
+                        "class User:\n"
+                        "    def __init__(self, id, name, email):\n"
+                        "        self.id = id\n"
+                        "        self.name = name\n"
+                        "        self.email = email\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc("c6", "read_file", {"path": "src/models.py", "start_line": 1, "end_line": 60}),
+                ),
+                _tr(
+                    "c6",
+                    (
+                        "class User:\n"
+                        "    def __init__(self, id, name, email):\n"
+                        "        self.id = id\n"
+                        "        self.name = name\n"
+                        "        self.email = email\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc(
+                        "c7",
+                        "replace_string_in_file",
+                        {
+                            "path": "src/models.py",
+                            "old": "        self.email = email\n",
+                            "new": (
+                                "        self.email = email\n\n"
+                                "    def to_dict(self):\n"
+                                "        return {'id': self.id, 'name': self.name, 'email': self.email}\n"
+                            ),
+                        },
+                    ),
+                ),
+                _tr("c7", "ok"),
+                _assistant_calls(
+                    _tc("c8", "run_in_terminal", {"command": "pytest tests/test_models.py -q"}),
+                ),
+                _tr("c8", "15 passed in 0.2s"),
+                _assistant_text("Added `to_dict()` to the User class. Tests pass."),
+            ],
+            tool_definitions=CODING_AGENT_TOOL_DEFINITIONS,
+        )
+
+    # ==================== FAIL: Inefficient (expect 1-2) ====================
+
+    def test_fail_inefficient_repeated_reads_and_retries(self) -> None:
+        """FAIL - inefficient: file read 4+ times, unchanged retries on failing tests.
+
+        The agent's actual fix is one line. Around it, the agent reads ``auth.py``
+        four separate times with no edit between, lists ``src/`` twice in immediate
+        succession, and runs ``pytest`` twice unchanged after the same failure
+        before doing any work. Roughly half the trajectory is removable. Expected
+        score: 1 or 2.
+        """
+        self.run_quality_test(
+            test_label="FAIL-inefficient-repeated-reads-and-retries",
+            expected=ExpectedResult.FAIL,
+            messages=[
+                _user("test_login is failing - the user lookup returns None. Fix it in src/auth.py."),
+                _assistant_calls(_tc("c1", "list_dir", {"path": "src/"})),
+                _tr("c1", "auth.py  cli.py  models.py"),
+                _assistant_calls(_tc("c2", "list_dir", {"path": "src/"})),
+                _tr("c2", "auth.py  cli.py  models.py"),
+                _assistant_calls(
+                    _tc("c3", "read_file", {"path": "src/auth.py", "start_line": 1, "end_line": 80}),
+                ),
+                _tr(
+                    "c3",
+                    (
+                        "def lookup_user(username):\n"
+                        "    rows = db.query('SELECT * FROM users WHERE name = ?', username)\n"
+                        "    if rows:\n"
+                        "        return rows[0]\n"
+                        "    return None\n"
+                        "\n"
+                        "def login(username, password):\n"
+                        "    user = lookup_user(username.lower())  # bug: db stores names case-sensitively\n"
+                        "    if user and check_password(user, password):\n"
+                        "        return user\n"
+                        "    return None\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc("c4", "run_in_terminal", {"command": "pytest tests/test_auth.py -q"}),
+                ),
+                _tr("c4", "FAILED tests/test_auth.py::test_login - AssertionError: expected user, got None"),
+                _assistant_calls(
+                    _tc("c5", "run_in_terminal", {"command": "pytest tests/test_auth.py -q"}),
+                ),
+                _tr("c5", "FAILED tests/test_auth.py::test_login - AssertionError: expected user, got None"),
+                _assistant_calls(
+                    _tc("c6", "read_file", {"path": "src/auth.py", "start_line": 1, "end_line": 80}),
+                ),
+                _tr(
+                    "c6",
+                    (
+                        "def lookup_user(username):\n"
+                        "    rows = db.query('SELECT * FROM users WHERE name = ?', username)\n"
+                        "    ...\n"
+                        "def login(username, password):\n"
+                        "    user = lookup_user(username.lower())\n"
+                        "    ...\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc("c7", "grep_search", {"pattern": "lookup_user", "path": "src/"}),
+                ),
+                _tr("c7", "src/auth.py:1: def lookup_user(username):\nsrc/auth.py:8: user = lookup_user(username.lower())"),  # noqa: E501
+                _assistant_calls(
+                    _tc("c8", "read_file", {"path": "src/auth.py", "start_line": 1, "end_line": 80}),
+                ),
+                _tr(
+                    "c8",
+                    (
+                        "def lookup_user(username):\n"
+                        "    rows = db.query('SELECT * FROM users WHERE name = ?', username)\n"
+                        "    ...\n"
+                        "def login(username, password):\n"
+                        "    user = lookup_user(username.lower())\n"
+                        "    ...\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc("c9", "read_file", {"path": "src/auth.py", "start_line": 1, "end_line": 80}),
+                ),
+                _tr(
+                    "c9",
+                    (
+                        "def lookup_user(username):\n"
+                        "    ...\n"
+                        "    user = lookup_user(username.lower())\n"
+                        "    ...\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc(
+                        "c10",
+                        "replace_string_in_file",
+                        {
+                            "path": "src/auth.py",
+                            "old": "user = lookup_user(username.lower())  # bug: db stores names case-sensitively",
+                            "new": "user = lookup_user(username)",
+                        },
+                    ),
+                ),
+                _tr("c10", "ok"),
+                _assistant_calls(
+                    _tc("c11", "run_in_terminal", {"command": "pytest tests/test_auth.py -q"}),
+                ),
+                _tr("c11", "12 passed in 0.4s"),
+                _assistant_text("Removed the unintended `.lower()` so the lookup uses the original casing. Tests pass."),
+            ],
+            tool_definitions=CODING_AGENT_TOOL_DEFINITIONS,
+        )
+
+    def test_fail_highly_inefficient_thrashing(self) -> None:
+        """FAIL - highly inefficient: severe thrashing, repeated identical failed retries, oscillation.
+
+        The agent re-reads ``models.py`` six times with no edits, retries the same
+        failing ``npm test`` command four times unchanged, and oscillates between
+        ``grep "User"`` and ``grep "user"`` that return the same hit. The final fix
+        is a one-line change identifiable after the first read. Expected score: 1.
+        """
+        self.run_quality_test(
+            test_label="FAIL-highly-inefficient-thrashing",
+            expected=ExpectedResult.FAIL,
+            messages=[
+                _user("Fix the failing User test in src/models.js - it's throwing a TypeError."),
+                _assistant_calls(
+                    _tc("c1", "read_file", {"path": "src/models.js", "start_line": 1, "end_line": 40}),
+                ),
+                _tr(
+                    "c1",
+                    (
+                        "class User {\n"
+                        "  constructor(id, name) {\n"
+                        "    this.id = id;\n"
+                        "    this.name = name;\n"
+                        "  }\n"
+                        "  greet() {\n"
+                        "    return 'Hello, ' + this.Name;  // bug: should be this.name\n"
+                        "  }\n"
+                        "}\n"
+                    ),
+                ),
+                _assistant_calls(_tc("c2", "run_in_terminal", {"command": "npm test"})),
+                _tr("c2", "FAIL  models.test.js > greet > TypeError: Cannot read properties of undefined"),
+                _assistant_calls(
+                    _tc("c3", "read_file", {"path": "src/models.js", "start_line": 1, "end_line": 40}),
+                ),
+                _tr(
+                    "c3",
+                    (
+                        "class User {\n"
+                        "  constructor(id, name) { this.id = id; this.name = name; }\n"
+                        "  greet() { return 'Hello, ' + this.Name; }\n"
+                        "}\n"
+                    ),
+                ),
+                _assistant_calls(_tc("c4", "run_in_terminal", {"command": "npm test"})),
+                _tr("c4", "FAIL  models.test.js > greet > TypeError: Cannot read properties of undefined"),
+                _assistant_calls(_tc("c5", "grep_search", {"pattern": "User", "path": "src/"})),
+                _tr("c5", "src/models.js:1: class User {"),
+                _assistant_calls(
+                    _tc("c6", "read_file", {"path": "src/models.js", "start_line": 1, "end_line": 40}),
+                ),
+                _tr(
+                    "c6",
+                    (
+                        "class User {\n"
+                        "  constructor(id, name) { this.id = id; this.name = name; }\n"
+                        "  greet() { return 'Hello, ' + this.Name; }\n"
+                        "}\n"
+                    ),
+                ),
+                _assistant_calls(_tc("c7", "grep_search", {"pattern": "user", "path": "src/"})),
+                _tr("c7", "src/models.js:1: class User {"),
+                _assistant_calls(_tc("c8", "run_in_terminal", {"command": "npm test"})),
+                _tr("c8", "FAIL  models.test.js > greet > TypeError: Cannot read properties of undefined"),
+                _assistant_calls(
+                    _tc("c9", "read_file", {"path": "src/models.js", "start_line": 1, "end_line": 40}),
+                ),
+                _tr(
+                    "c9",
+                    (
+                        "class User {\n"
+                        "  constructor(id, name) { this.id = id; this.name = name; }\n"
+                        "  greet() { return 'Hello, ' + this.Name; }\n"
+                        "}\n"
+                    ),
+                ),
+                _assistant_calls(_tc("c10", "grep_search", {"pattern": "User", "path": "src/"})),
+                _tr("c10", "src/models.js:1: class User {"),
+                _assistant_calls(
+                    _tc("c11", "read_file", {"path": "src/models.js", "start_line": 1, "end_line": 40}),
+                ),
+                _tr(
+                    "c11",
+                    (
+                        "class User {\n"
+                        "  constructor(id, name) { this.id = id; this.name = name; }\n"
+                        "  greet() { return 'Hello, ' + this.Name; }\n"
+                        "}\n"
+                    ),
+                ),
+                _assistant_calls(_tc("c12", "run_in_terminal", {"command": "npm test"})),
+                _tr("c12", "FAIL  models.test.js > greet > TypeError: Cannot read properties of undefined"),
+                _assistant_calls(
+                    _tc("c13", "read_file", {"path": "src/models.js", "start_line": 1, "end_line": 40}),
+                ),
+                _tr(
+                    "c13",
+                    (
+                        "class User {\n"
+                        "  constructor(id, name) { this.id = id; this.name = name; }\n"
+                        "  greet() { return 'Hello, ' + this.Name; }\n"
+                        "}\n"
+                    ),
+                ),
+                _assistant_calls(
+                    _tc(
+                        "c14",
+                        "replace_string_in_file",
+                        {
+                            "path": "src/models.js",
+                            "old": "return 'Hello, ' + this.Name;",
+                            "new": "return 'Hello, ' + this.name;",
+                        },
+                    ),
+                ),
+                _tr("c14", "ok"),
+                _assistant_calls(_tc("c15", "run_in_terminal", {"command": "npm test"})),
+                _tr("c15", "PASS  models.test.js (1 test)"),
+                _assistant_text("Fixed - `this.Name` should have been `this.name`. Tests pass."),
+            ],
+            tool_definitions=CODING_AGENT_TOOL_DEFINITIONS,
+        )
+
+    # ==================== SKIPPED: No tool-use trajectory ====================
+
+    def test_skipped_no_tool_calls(self) -> None:
+        """SKIPPED - a text-only chat has no trajectory to score for efficiency.
+
+        Should short-circuit to ``not_applicable`` / ``skipped`` without making an
+        LLM call.
+        """
+        self.run_quality_test(
+            test_label="SKIPPED-no-tool-calls",
+            expected=ExpectedResult.SKIPPED,
+            messages=[
+                _user("What's the difference between `is` and `==` in Python?"),
+                _assistant_text(
+                    "`is` checks identity (same object in memory); `==` checks equality (values compare "
+                    "equal via `__eq__`). For small ints and interned strings they often coincide, but "
+                    "you should generally use `==` for value comparison and `is` only for identity checks "
+                    "such as `x is None`."
+                ),
+            ],
+            tool_definitions=CODING_AGENT_TOOL_DEFINITIONS,
+        )


### PR DESCRIPTION
Introduces a new LLM-as-judge evaluator that scores how efficiently an AI coding agent used tools to complete a user's coding task across a multi-turn conversation.

**What it evaluates:**

  - Redundant or repeated tool calls (same file read multiple times with no intervening edit)
  - Off-target reads (exploring irrelevant files when the target was clearly identifiable)
  - Unchanged retries of failed commands
  - Oscillation and post-answer exploration
  - User burden: whether the user had to repeat, clarify, or correct the agent across turns

**Key design decisions:**

  - Scores 1–5 across four independent axes (redundancy density, loops/retries, on-targetness, user burden); worst axis wins
  - Output is structured JSON with evidence_for/evidence_against, per-axis band fields, efficiency_suggestion, and a confidence score — making evaluations interpretable and debuggable
  - Serialization markers ((result #N), [same result as result #N]) allow the model to detect byte-identical repeated fetches without re-reading full content
  - Skips scoring cleanly when the conversation has no tool-use trajectory
  - Five annotated scoring examples (1–5) calibrate the rubric with concrete tool traces