### PR TITLE
Remove mid-execution text guard; adopt azure-ai-evaluation 1.18.0

### DIFF
--- a/assets/evaluators/builtin/coherence/evaluator/_coherence.py
+++ b/assets/evaluators/builtin/coherence/evaluator/_coherence.py
@@ -645,26 +645,6 @@ class MessagesOrQueryResponseInputValidator(ConversationValidator):
                     target=self.error_target,
                 )
 
-            # The final assistant message must contain text
-            last_content = messages[-1].get("content", "")
-            if isinstance(last_content, list):
-                has_text = any(
-                    isinstance(c, dict) and c.get("type") in ("text",)
-                    or isinstance(c, str)
-                    for c in last_content
-                )
-                if not has_text:
-                    raise EvaluationException(
-                        message=(
-                            "The last message must contain text content, "
-                            "not only tool calls. The conversation appears to be "
-                            "mid-execution — provide the agent's final text response."
-                        ),
-                        blame=ErrorBlame.USER_ERROR,
-                        category=ErrorCategory.INVALID_VALUE,
-                        target=self.error_target,
-                    )
-
             return True
         return super().validate_eval_input(eval_input)
 

--- a/assets/evaluators/builtin/customer_satisfaction/evaluator/_customer_satisfaction.py
+++ b/assets/evaluators/builtin/customer_satisfaction/evaluator/_customer_satisfaction.py
@@ -623,26 +623,6 @@ class ConversationValidator(ValidatorInterface):
                     target=self.error_target,
                 )
 
-            # The final assistant message must contain text
-            last_content = messages[-1].get("content", "")
-            if isinstance(last_content, list):
-                has_text = any(
-                    isinstance(c, dict) and c.get("type") in ("text",)
-                    or isinstance(c, str)
-                    for c in last_content
-                )
-                if not has_text:
-                    raise EvaluationException(
-                        message=(
-                            "The last message must contain text content, "
-                            "not only tool calls. The conversation appears to be "
-                            "mid-execution — provide the agent's final text response."
-                        ),
-                        blame=ErrorBlame.USER_ERROR,
-                        category=ErrorCategory.INVALID_VALUE,
-                        target=self.error_target,
-                    )
-
             return True
 
         # Legacy conversation path

--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -650,25 +650,6 @@ class MessagesOrQueryResponseInputValidator(ConversationValidator):
                     category=ErrorCategory.INVALID_VALUE,
                     target=self.error_target,
                 )
-            # The final assistant message must contain text
-            last_content = messages[-1].get("content", "")
-            if isinstance(last_content, list):
-                has_text = any(
-                    isinstance(c, dict) and c.get("type") in ("text",)
-                    or isinstance(c, str)
-                    for c in last_content
-                )
-                if not has_text:
-                    raise EvaluationException(
-                        message=(
-                            "The last message must contain text content, "
-                            "not only tool calls. The conversation appears to be "
-                            "mid-execution — provide the agent's final text response."
-                        ),
-                        blame=ErrorBlame.USER_ERROR,
-                        category=ErrorCategory.INVALID_VALUE,
-                        target=self.error_target,
-                    )
             return True
         return super().validate_eval_input(eval_input)
 

--- a/assets/evaluators/builtin/task_adherence/evaluator/_task_adherence.py
+++ b/assets/evaluators/builtin/task_adherence/evaluator/_task_adherence.py
@@ -697,31 +697,6 @@ class MessagesOrQueryResponseInputValidator(ToolDefinitionsValidator):
                     category=ErrorCategory.INVALID_VALUE,
                     target=self.error_target,
                 )
-            last_content = messages[-1].get("content", "")
-            if isinstance(last_content, list):
-                has_text = any(
-                    (
-                        isinstance(content_item, dict)
-                        and content_item.get("type") in (
-                            ContentType.TEXT,
-                            ContentType.INPUT_TEXT,
-                            ContentType.OUTPUT_TEXT,
-                        )
-                    )
-                    or isinstance(content_item, str)
-                    for content_item in last_content
-                )
-                if not has_text:
-                    raise EvaluationException(
-                        message=(
-                            "The last message must contain text content, "
-                            "not only tool calls. The conversation appears to be "
-                            "mid-execution — provide the agent's final text response."
-                        ),
-                        blame=ErrorBlame.USER_ERROR,
-                        category=ErrorCategory.INVALID_VALUE,
-                        target=self.error_target,
-                    )
 
             for message in messages:
                 error = self._validate_message_dict(message)

--- a/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
+++ b/assets/evaluators/builtin/task_completion/evaluator/_task_completion.py
@@ -714,25 +714,6 @@ class MessagesOrQueryResponseInputValidator(ToolDefinitionsValidator):
                     category=ErrorCategory.INVALID_VALUE,
                     target=self.error_target,
                 )
-            # The final assistant message must contain text
-            last_content = messages[-1].get("content", "")
-            if isinstance(last_content, list):
-                has_text = any(
-                    isinstance(c, dict) and c.get("type") in ("text",)
-                    or isinstance(c, str)
-                    for c in last_content
-                )
-                if not has_text:
-                    raise EvaluationException(
-                        message=(
-                            "The last message must contain text content, "
-                            "not only tool calls. The conversation appears to be "
-                            "mid-execution — provide the agent's final text response."
-                        ),
-                        blame=ErrorBlame.USER_ERROR,
-                        category=ErrorCategory.INVALID_VALUE,
-                        target=self.error_target,
-                    )
 
             tool_definitions = eval_input.get("tool_definitions")
             tool_definitions_error = self._validate_tool_definitions(tool_definitions)

--- a/assets/evaluators/tests/requirements.txt
+++ b/assets/evaluators/tests/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-evaluation==1.11.1
+azure-ai-evaluation==1.18.0
 azure-ai-projects==2.0.0b2
 azureml-mlflow
 azure-ai-ml

--- a/assets/evaluators/tests/test_evaluators_behavior/base_validator_unit_test.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/base_validator_unit_test.py
@@ -1333,7 +1333,12 @@ class MessagesOrQueryResponseUnitTests(_ValidatorUnitTestSupport):
             validator.validate_eval_input({"messages": [{"role": "user", "content": "x"}]})
 
     def test_mqr_last_message_no_text(self):
-        """Reject input whose last message has no text content."""
+        """Accept input whose last message has no text content.
+
+        The mid-execution text guard (which rejected a final assistant message
+        lacking text content, e.g. a trailing tool_call) has been removed, so
+        such mid-execution inputs are now valid.
+        """
         validator = self._messages_or_query_response_validator()
         msgs = [
             {"role": "user", "content": [{"type": "text", "text": "hi"}]},
@@ -1342,8 +1347,7 @@ class MessagesOrQueryResponseUnitTests(_ValidatorUnitTestSupport):
                 "content": [{"type": "tool_call", "name": "f", "arguments": {}, "tool_call_id": "c1"}],
             },
         ]
-        with pytest.raises(EvaluationException):
-            validator.validate_eval_input({"messages": msgs})
+        assert validator.validate_eval_input({"messages": msgs}) is True
 
     def test_mqr_valid_messages(self):
         """Accept a well-formed messages list."""

--- a/assets/evaluators/tests/test_evaluators_behavior/common_tool_test_data.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/common_tool_test_data.py
@@ -2244,16 +2244,18 @@ WEB_SEARCH_EXPECTED_FLOW_QUERY = (
 )
 
 BROWSER_AUTOMATION_EXPECTED_FLOW_QUERY = (
-                                         "SYSTEM_PROMPT:\n  You are an Agent helping with browser automation tasks. "
-                                         "You can answer questions, provide information, and assist with various "
-                                         "tasks related to web browsing using the Browser Automation tool available "
-                                         "to you.\n\nUser turn 1:\n  Your goal is to report the percent of Microsoft "
-                                         "year-to-date stock price change.\nTo do that, go to the website "
-                                         "finance.yahoo.com.\nAt the top of the page, you will find a search "
-                                         "bar.\nEnter the value 'MSFT', to get information about the Microsoft stock "
-                                         "price.\nAt the top of the resulting page you will see a default chart of "
-                                         "Microsoft stock price.\nClick on 'YTD' at the top of that chart, and report "
-                                         "the percent value that shows up just below it.\n\n"
+    "SYSTEM_PROMPT:\n"
+    "  You are an Agent helping with browser automation tasks. You can answer questions, provide information, and assi"
+    "st with various tasks related to web browsing using the Browser Automation tool available to you.\n"
+    "\n"
+    "User turn 1:\n"
+    "  Your goal is to report the percent of Microsoft year-to-date stock price change.\n"
+    "  To do that, go to the website finance.yahoo.com.\n"
+    "  At the top of the page, you will find a search bar.\n"
+    "  Enter the value 'MSFT', to get information about the Microsoft stock price.\n"
+    "  At the top of the resulting page you will see a default chart of Microsoft stock price.\n"
+    "  Click on 'YTD' at the top of that chart, and report the percent value that shows up just below it.\n"
+    "\n"
 )
 
 # TS processes multi-line user content differently (indents continuation lines)
@@ -2321,13 +2323,14 @@ OPENAPI_IR_EXPECTED_FLOW_QUERY = "User turn 1:\n  What's the weather like in Cai
 WEB_SEARCH_IR_EXPECTED_FLOW_QUERY = "User turn 1:\n  what's the weather like in Napoli, Italy?\n\n"
 
 BROWSER_AUTOMATION_IR_EXPECTED_FLOW_QUERY = (
-                                            "User turn 1:\n  Your goal is to report the percent of Microsoft "
-                                            "year-to-date stock price change.\nTo do that, go to the website "
-                                            "finance.yahoo.com.\nAt the top of the page, you will find a search "
-                                            "bar.\nEnter the value 'MSFT', to get information about the Microsoft "
-                                            "stock price.\nAt the top of the resulting page you will see a default "
-                                            "chart of Microsoft stock price.\nClick on 'YTD' at the top of that "
-                                            "chart, and report the percent value that shows up just below it.\n\n"
+    "User turn 1:\n"
+    "  Your goal is to report the percent of Microsoft year-to-date stock price change.\n"
+    "  To do that, go to the website finance.yahoo.com.\n"
+    "  At the top of the page, you will find a search bar.\n"
+    "  Enter the value 'MSFT', to get information about the Microsoft stock price.\n"
+    "  At the top of the resulting page you will see a default chart of Microsoft stock price.\n"
+    "  Click on 'YTD' at the top of that chart, and report the percent value that shows up just below it.\n"
+    "\n"
 )
 
 IMAGE_GEN_IR_EXPECTED_FLOW_QUERY = "User turn 1:\n  Generate an image of Microsoft logo.\n\n"
@@ -2392,17 +2395,18 @@ BING_CUSTOM_SEARCH_EXPECTED_FLOW_RESPONSE = (
 )
 
 FILE_SEARCH_EXPECTED_FLOW_RESPONSE = (
-                                     "[TOOL_CALL] file_search_call(queries=\"['good restaurant recommendation', 'best "
-                                     "restaurant', 'top rated restaurant', 'recommended restaurants', \"what's a good "
-                                     "restaurant\"]\")\n[TOOL_RESULT] [{'attributes': {}, 'file_id': "
-                                     "'assistant-StE61XCSBRyLv11Ytyckea', 'filename': 'french_cafe_menu.md', 'score': "
-                                     "0.0333, 'text': '# Le Jardin de Paris', 'vector_store_id': ''}, {'attributes': "
-                                     "{}, 'file_id': 'assistant-Xpu5yP1AQZiB86Hz5iG4uv', 'filename': "
-                                     "'italian_diner_menu.md', 'score': 0.0328, 'text': '# Trattoria Bella Notte', "
-                                     "'vector_store_id': ''}]\nIf you're looking for a good restaurant, here are two "
-                                     "tasty options based on the menus provided:\n\n1. **Le Jardin de Paris** (French "
-                                     "Café)\n2. **Trattoria Bella Notte** (Italian Diner)\n\nBoth are excellent "
-                                     "choices—pick based on whether you’re in the mood for French or Italian!"
+    "[TOOL_CALL] file_search_call(queries=['good restaurant recommendation', 'best restaurant', 'top rated restaurant'"
+    ", 'recommended restaurants', \"what's a good restaurant\"])\n"
+    "[TOOL_RESULT] [{'attributes': {}, 'file_id': 'assistant-StE61XCSBRyLv11Ytyckea', 'filename': 'french_cafe_menu.md"
+    "', 'score': 0.0333, 'text': '# Le Jardin de Paris', 'vector_store_id': ''}, {'attributes': {}, 'file_id': 'assist"
+    "ant-Xpu5yP1AQZiB86Hz5iG4uv', 'filename': 'italian_diner_menu.md', 'score': 0.0328, 'text': '# Trattoria Bella Not"
+    "te', 'vector_store_id': ''}]\n"
+    "If you're looking for a good restaurant, here are two tasty options based on the menus provided:\n"
+    "\n"
+    "1. **Le Jardin de Paris** (French Caf\u00e9)\n"
+    "2. **Trattoria Bella Notte** (Italian Diner)\n"
+    "\n"
+    "Both are excellent choices\u2014pick based on whether you\u2019re in the mood for French or Italian!"
 )
 
 AZURE_AI_SEARCH_EXPECTED_FLOW_RESPONSE = (
@@ -2460,9 +2464,10 @@ OPENAPI_EXPECTED_FLOW_RESPONSE = (
 )
 
 WEB_SEARCH_EXPECTED_FLOW_RESPONSE = (
-                                    '[TOOL_CALL] web_search(query="current weather Napoli Italy", type="search", '
-                                    'queries="[\'current weather Napoli Italy\']")\nThe current weather in Napoli, '
-                                    'Italy is partly cloudy with a temperature of around 10°C, feeling like 7°C.'
+    "[TOOL_CALL] web_search(query=\"current weather Napoli Italy\", type=\"search\", queries=['current weather Napoli "
+    "Italy'])\n"
+    "The current weather in Napoli, Italy is partly cloudy with a temperature of around 10\u00b0C, feeling like 7"
+    "\u00b0C."
 )
 
 BROWSER_AUTOMATION_EXPECTED_FLOW_RESPONSE = (
@@ -2496,10 +2501,21 @@ MEMORY_SEARCH_EXPECTED_FLOW_RESPONSE = (
 )
 
 KB_MCP_EXPECTED_FLOW_RESPONSE = (
-                                "[TOOL_CALL] knowledge_base_retrieve(request=\"{'knowledgeAgentIntents': ['Provide "
-                                "general information about the Earth.']}\")\n[TOOL_RESULT] Retrieved 11 "
-                                "documents.\nHere's an interesting overview about Earth from space, focusing on "
-                                "nighttime images and what they tell us about our planet and humanity."
+    "[TOOL_CALL] knowledge_base_retrieve(request={'knowledgeAgentIntents': ['Provide general information about the Ear"
+    "th.']})\n"
+    "[TOOL_RESULT] Retrieved 11 documents.\n"
+    "Here's an interesting overview about Earth from space, focusing on nighttime images and what they tell us about o"
+    "ur planet and humanity."
+)
+
+# tool_output_utilization keeps its own _get_agent_response (_stringify_tool_result), which
+# still quotes the tool-call arguments payload; the SDK path used by TA/TC dropped that
+# quoting in azure-ai-evaluation 1.18.0, so kb_mcp now needs a TOU-specific expected value.
+KB_MCP_TOU_EXPECTED_FLOW_RESPONSE = (
+    "[TOOL_CALL] knowledge_base_retrieve(request=\"{'knowledgeAgentIntents': ['Provide "
+    "general information about the Earth.']}\")\n[TOOL_RESULT] Retrieved 11 "
+    "documents.\nHere's an interesting overview about Earth from space, focusing on "
+    "nighttime images and what they tell us about our planet and humanity."
 )
 
 MCP_EXPECTED_FLOW_RESPONSE = (
@@ -3011,24 +3027,6 @@ FILE_SEARCH_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
                         "what's a good restaurant",
                     ],
                 },
-                "tool_result": [
-                    {
-                        "attributes": {},
-                        "file_id": "assistant-StE61XCSBRyLv11Ytyckea",
-                        "filename": "french_cafe_menu.md",
-                        "score": 0.0333,
-                        "text": "# Le Jardin de Paris",
-                        "vector_store_id": "",
-                    },
-                    {
-                        "attributes": {},
-                        "file_id": "assistant-Xpu5yP1AQZiB86Hz5iG4uv",
-                        "filename": "italian_diner_menu.md",
-                        "score": 0.0328,
-                        "text": "# Trattoria Bella Notte",
-                        "vector_store_id": "",
-                    },
-                ],
             },
         ],
     },
@@ -3063,10 +3061,9 @@ FILE_SEARCH_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
     {
         "role": "assistant",
         "content": [
-            "If you're looking for a good restaurant, here are two tasty options based on the menus "
-            "provided:\n\n1. **Le Jardin de Paris** (French Caf\u00e9)\n2. **Trattoria Bella Notte** "
-            "(Italian Diner)\n\nBoth are excellent choices\u2014pick based on whether you\u2019re in "
-            "the mood for French or Italian!",
+            "If you're looking for a good restaurant, here are two tasty options based on the menus provided:\n\n1. **"
+            "Le Jardin de Paris** (French Caf\u00e9)\n2. **Trattoria Bella Notte** (Italian Diner)\n\nBoth are excelle"
+            "nt choices\u2014pick based on whether you\u2019re in the mood for French or Italian!",
         ],
     },
 ]
@@ -3094,7 +3091,6 @@ IMAGE_GEN_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
                     "size": "1024x1024",
                     "revised_prompt": "Microsoft logo on a white background",
                 },
-                "tool_result": "<generated_image_data>",
             },
         ],
     },
@@ -3111,7 +3107,9 @@ IMAGE_GEN_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
     },
     {
         "role": "assistant",
-        "content": ["Here is an image of the Microsoft logo."],
+        "content": [
+            "Here is an image of the Microsoft logo.",
+        ],
     },
 ]
 
@@ -3132,33 +3130,6 @@ MEMORY_SEARCH_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
                 "tool_call_id": "memupdateo_2f31edffff39a63f00699441f5791081909eaae75cd08dd354",
                 "name": "memory_search",
                 "arguments": {},
-                "tool_result": [
-                    {
-                        "content": "User prefers dark roast coffee.",
-                        "kind": "user_profile",
-                        "memory_id": "3a353f9202ca41bf95a4a9ef21d90d41",
-                        "scope": "user_123",
-                        "updated_at": 1771323829,
-                    },
-                    {
-                        "content": "User prefers dark roast coffee.",
-                        "kind": "user_profile",
-                        "memory_id": "3a353f9202ca41bf95a4a9ef21d90d41",
-                        "scope": "user_123",
-                        "updated_at": 1771323829,
-                    },
-                    {
-                        "content": (
-                            "The user stated a preference for dark roast coffee. Dark roast coffee is "
-                            "characterized by a bold flavor, rich aroma, and lower acidity compared to "
-                            "lighter roasts."
-                        ),
-                        "kind": "chat_summary",
-                        "memory_id": "9117c9f9d7424f0290c523d1cd3de45a",
-                        "scope": "user_123",
-                        "updated_at": 1771323829,
-                    },
-                ],
             },
         ],
     },
@@ -3185,11 +3156,8 @@ MEMORY_SEARCH_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
                         "updated_at": 1771323829,
                     },
                     {
-                        "content": (
-                            "The user stated a preference for dark roast coffee. Dark roast coffee is "
-                            "characterized by a bold flavor, rich aroma, and lower acidity compared to "
-                            "lighter roasts."
-                        ),
+                        "content": "The user stated a preference for dark roast coffee. Dark roast coffee is character"
+                        "ized by a bold flavor, rich aroma, and lower acidity compared to lighter roasts.",
                         "kind": "chat_summary",
                         "memory_id": "9117c9f9d7424f0290c523d1cd3de45a",
                         "scope": "user_123",
@@ -3202,8 +3170,8 @@ MEMORY_SEARCH_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
     {
         "role": "assistant",
         "content": [
-            "Sure! I'll order your usual\u2014one dark roast coffee. Would you like any specific "
-            "size or extras (milk, sugar, etc.) with that?",
+            "Sure! I'll order your usual\u2014one dark roast coffee. Would you like any specific size or extras (milk,"
+            " sugar, etc.) with that?",
         ],
     },
 ]
@@ -3247,10 +3215,11 @@ KB_MCP_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
                 "name": "knowledge_base_retrieve",
                 "arguments": {
                     "request": {
-                        "knowledgeAgentIntents": ["Provide general information about the Earth."],
+                        "knowledgeAgentIntents": [
+                            "Provide general information about the Earth.",
+                        ],
                     },
                 },
-                "tool_result": "Retrieved 11 documents.",
             },
         ],
     },
@@ -3268,8 +3237,8 @@ KB_MCP_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
     {
         "role": "assistant",
         "content": [
-            "Here's an interesting overview about Earth from space, focusing on nighttime images "
-            "and what they tell us about our planet and humanity.",
+            "Here's an interesting overview about Earth from space, focusing on nighttime images and what they tell us"
+            " about our planet and humanity.",
         ],
     },
 ]
@@ -3293,7 +3262,6 @@ MCP_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
                 "arguments": {
                     "query": "how Azure Functions work",
                 },
-                "tool_result": "Retrieved documentation about Azure Functions.",
             },
         ],
     },
@@ -3310,7 +3278,9 @@ MCP_GROUNDEDNESS_EXPECTED_FLOW_RESPONSE = [
     },
     {
         "role": "assistant",
-        "content": ["Azure Functions is a serverless compute service."],
+        "content": [
+            "Azure Functions is a serverless compute service.",
+        ],
     },
 ]
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_coherence_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_coherence_evaluator_behavior.py
@@ -218,8 +218,12 @@ class TestCoherenceMultiturnBehavior:
         result = evaluator(messages=messages)
         assert "coherence" in result
 
-    def test_messages_intermediate_response_rejected(self):
-        """Messages ending with only tool calls (no text) are rejected."""
+    def test_messages_intermediate_response_accepted(self):
+        """Messages ending with only tool calls (no final text) are accepted.
+
+        The "final message must contain text" guard was intentionally removed to align with
+        azure-ai-evaluation (SDK PR #47526); mid-execution conversations are no longer rejected.
+        """
         evaluator = _create_mocked_coherence_evaluator()
         messages = [
             {"role": "user", "content": [{"type": "text", "text": "Find me flights."}]},
@@ -235,8 +239,8 @@ class TestCoherenceMultiturnBehavior:
                 ],
             },
         ]
-        with pytest.raises(EvaluationException, match="must contain text content"):
-            evaluator(messages=messages)
+        result = evaluator(messages=messages)
+        assert isinstance(result, dict)
 
     def test_messages_uses_multi_turn_flow(self):
         """Verify that messages path calls _multi_turn_flow, not _flow."""

--- a/assets/evaluators/tests/test_evaluators_behavior/test_customer_satisfaction_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_customer_satisfaction_evaluator_behavior.py
@@ -145,7 +145,7 @@ class TestCustomerSatisfactionSessionBehavior:
         assert 1.0 <= result["customer_satisfaction"] <= 5.0
 
     def test_messages_intermediate_response(self):
-        """Messages ending with a function_call are rejected by validation (must contain text)."""
+        """Messages ending with a function_call are accepted (mid-execution guard removed to align with SDK)."""
         evaluator = _create_mocked_evaluator()
         intermediate_messages = [
             {"role": "user", "content": [{"type": "text", "text": "Cancel my order."}]},
@@ -161,8 +161,8 @@ class TestCustomerSatisfactionSessionBehavior:
                 ],
             },
         ]
-        with pytest.raises(EvaluationException, match="must contain text content"):
-            evaluator(messages=intermediate_messages)
+        result = evaluator(messages=intermediate_messages)
+        assert isinstance(result, dict)
 
     def test_messages_string_content(self):
         """Messages with string content (not list) are handled and user text is preserved."""
@@ -299,8 +299,8 @@ class TestCustomerSatisfactionSessionBehavior:
         with pytest.raises(EvaluationException):
             evaluator(messages=messages)
 
-    def test_messages_rejects_conversation_ending_with_tool(self):
-        """Messages ending with a tool message raise validation error."""
+    def test_messages_allows_conversation_ending_with_tool(self):
+        """Messages ending with a tool message are accepted (mid-execution guard removed to align with SDK)."""
         evaluator = _create_mocked_evaluator()
         messages = [
             {"role": "user", "content": [{"type": "text", "text": "Check status"}]},
@@ -316,8 +316,8 @@ class TestCustomerSatisfactionSessionBehavior:
                 "content": [{"type": "tool_result", "tool_result": {"status": "ok"}}],
             },
         ]
-        with pytest.raises(EvaluationException):
-            evaluator(messages=messages)
+        result = evaluator(messages=messages)
+        assert isinstance(result, dict)
 
     def test_messages_allows_consecutive_user_messages(self):
         """Consecutive user messages are accepted."""

--- a/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
@@ -361,7 +361,7 @@ class TestGroundednessMultiturnBehavior:
             evaluator(messages=messages)
 
     def test_messages_intermediate_response(self):
-        """Messages ending with only tool calls (no text) are rejected."""
+        """Messages ending with only tool calls (no final text) are accepted (mid-execution guard removed)."""
         evaluator = _create_mocked_groundedness_evaluator()
         intermediate_messages = [
             {"role": "user", "content": [{"type": "text", "text": "Search for info."}]},
@@ -377,8 +377,8 @@ class TestGroundednessMultiturnBehavior:
                 ],
             },
         ]
-        with pytest.raises(EvaluationException, match="must contain text content"):
-            evaluator(messages=intermediate_messages)
+        result = evaluator(messages=intermediate_messages)
+        assert isinstance(result, dict)
 
     def test_messages_pass_fail_threshold(self):
         """Score result respects threshold for pass/fail."""

--- a/assets/evaluators/tests/test_evaluators_behavior/test_task_adherence_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_task_adherence_evaluator_behavior.py
@@ -294,7 +294,7 @@ class TestTaskAdherenceMultiturnBehavior:
             evaluator(messages=messages)
 
     def test_messages_intermediate_response(self):
-        """Messages ending with only tool calls are rejected."""
+        """Messages ending with only tool calls are accepted (mid-execution guard removed to align with SDK)."""
         evaluator = _create_mocked_evaluator()
         messages = [
             {"role": "user", "content": [{"type": "text", "text": "Search for info."}]},
@@ -310,8 +310,8 @@ class TestTaskAdherenceMultiturnBehavior:
                 ],
             },
         ]
-        with pytest.raises(EvaluationException, match="must contain text content"):
-            evaluator(messages=messages)
+        result = evaluator(messages=messages)
+        assert isinstance(result, dict)
 
 # endregion
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_task_completion_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_task_completion_evaluator_behavior.py
@@ -260,7 +260,7 @@ class TestTaskCompletionMultiturnBehavior:
         assert result["task_completion"] in (0, 1)
 
     def test_messages_intermediate_response(self):
-        """Messages ending with only tool calls (no text) are rejected."""
+        """Messages ending with only tool calls (no final text) are accepted (mid-execution guard removed)."""
         evaluator = _create_mocked_evaluator()
         intermediate_messages = [
             {"role": "user", "content": [{"type": "text", "text": "Book a flight."}]},
@@ -276,8 +276,8 @@ class TestTaskCompletionMultiturnBehavior:
                 ],
             },
         ]
-        with pytest.raises(EvaluationException, match="must contain text content"):
-            evaluator(messages=intermediate_messages)
+        result = evaluator(messages=intermediate_messages)
+        assert isinstance(result, dict)
 
     def test_messages_string_content(self):
         """Messages with string content (not list) are handled and user text is preserved."""
@@ -419,8 +419,8 @@ class TestTaskCompletionMultiturnBehavior:
         with pytest.raises(EvaluationException, match="assistant"):
             evaluator(messages=messages)
 
-    def test_messages_rejects_conversation_ending_with_tool(self):
-        """Messages ending with a tool message raise validation error."""
+    def test_messages_allows_conversation_ending_with_tool(self):
+        """Messages ending with a tool message are accepted (mid-execution guard removed to align with SDK)."""
         evaluator = _create_mocked_evaluator()
         messages = [
             {"role": "user", "content": [{"type": "text", "text": "What's the weather?"}]},
@@ -441,8 +441,8 @@ class TestTaskCompletionMultiturnBehavior:
                 "content": [{"type": "tool_result", "tool_result": {"temp": "14C"}}],
             },
         ]
-        with pytest.raises(EvaluationException, match="must contain text content"):
-            evaluator(messages=messages)
+        result = evaluator(messages=messages)
+        assert isinstance(result, dict)
 
     def test_messages_allows_consecutive_user_messages(self):
         """Consecutive user messages followed by assistant are valid."""
@@ -669,7 +669,9 @@ class TestSerializeMessages:
         ]
         expected = (
             "User turn 1:\n"
-            "  Hello, I need help.  I am trying to book a flight.  From London to Paris, next Monday.\n"
+            "  Hello, I need help.\n"
+            "  I am trying to book a flight.\n"
+            "  From London to Paris, next Monday.\n"
             "\n"
             "Agent turn 1:\n"
             "  Sure! Let me look that up for you."
@@ -707,7 +709,8 @@ class TestSerializeMessages:
         ]
         expected = (
             "User turn 1:\n"
-            "  Step 1: set up the environment.  Step 2: install the dependencies.\n"
+            "  Step 1: set up the environment.\n"
+            "  Step 2: install the dependencies.\n"
             "\n"
             "Agent turn 1:\n"
             "  Environment set up successfully.\n"
@@ -762,14 +765,16 @@ class TestSerializeMessages:
         ]
         expected = (
             "User turn 1:\n"
-            "  What is the weather in Paris?  And also in London?\n"
+            "  What is the weather in Paris?\n"
+            "  And also in London?\n"
             "\n"
             "Agent turn 1:\n"
             "  Paris is sunny and 22 C.\n"
             "  London is cloudy and 15 C.\n"
             "\n"
             "User turn 2:\n"
-            "  Which city is warmer?  By how many degrees?\n"
+            "  Which city is warmer?\n"
+            "  By how many degrees?\n"
             "\n"
             "Agent turn 2:\n"
             '  [TOOL_CALL] compare_temps(city1="Paris", city2="London")\n'

--- a/assets/evaluators/tests/test_evaluators_behavior/test_tool_output_utilization_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_tool_output_utilization_evaluator_behavior.py
@@ -66,7 +66,7 @@ class TestToolOutputUtilizationEvaluatorBehavior(BaseToolsEvaluatorBehaviorTest,
 
     test_kb_mcp_expected_flow_inputs = {
         "query": data.KB_MCP_EXPECTED_FLOW_QUERY,
-        "response": data.KB_MCP_EXPECTED_FLOW_RESPONSE,
+        "response": data.KB_MCP_TOU_EXPECTED_FLOW_RESPONSE,
         "tool_definitions": data.KB_MCP_EXPECTED_FLOW_TOOL_DEFINITIONS_STR,
     }
 


### PR DESCRIPTION
## Summary
Removes the mid-execution `last message must contain text` guard from the affected evaluators and adopts `azure-ai-evaluation==1.18.0` (which dropped this guard upstream), with the corresponding test and golden-data updates.

Independent of #5199 (both target `main`). Because both PRs touch the same validator files, whichever merges second will need a small rebase.

## Details
- Removes the guard from **coherence**, **customer_satisfaction**, **groundedness**, **task_adherence**, and **task_completion** validators, so conversations ending in a tool call/result are accepted (the assistant-role presence check is retained).
- Bumps the evaluator test requirement to `azure-ai-evaluation==1.18.0`.
- Updates the affected behavior tests to assert acceptance instead of rejection.
- Refreshes golden flow-input data for the 1.18.0 serialization changes (consecutive user messages on separate lines; SDK tool-call payloads no longer quoted) and adds `KB_MCP_TOU_EXPECTED_FLOW_RESPONSE` so `tool_output_utilization` keeps its distinct serialization.

## Validation
- Full evaluator behavior suite: **1763 passed / 0 failed**.
- `flake8 --max-line-length=119`, copyright, and doc-style checks clean.
