### PR TITLE
[Security] Bump starlette>=1.3.1 in evaluations-built-in (2 HIGH CVEs, ICM 831170435)

### DIFF
--- a/assets/evaluation_on_cloud/environments/evaluations-built-in/context/Dockerfile
+++ b/assets/evaluation_on_cloud/environments/evaluations-built-in/context/Dockerfile
@@ -3,6 +3,12 @@ FROM mcr.microsoft.com/azureml/openmpi5.0-ubuntu24.04:{{latest-image-tag}}
 COPY requirements.txt /app/requirements.txt
 RUN pip install -r /app/requirements.txt
 
+# Security: starlette is pulled in transitively (via fastapi). Bump to >=1.3.1 to fix
+# GHSA-82w8-qh3p-5jfq and GHSA-wqp7-x3pw-xc5r (both HIGH; fixed in 1.3.1). Applied as a
+# separate post-install upgrade rather than a requirements.txt pin because forcing the
+# floor inside the combined resolution triggers pip "resolution-too-deep". (ICM 831170435)
+RUN pip install --no-cache-dir --upgrade 'starlette>=1.3.1'
+
 # Copy your Python file into the image
 COPY evaluate_on_data.py /app/evaluate_on_data.py
 COPY model_target.py /app/model_target.py

--- a/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
+++ b/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
@@ -10,3 +10,4 @@ azure-monitor-opentelemetry==1.8.0
 promptflow-azure=={{latest-pypi-version}}
 azure-identity=={{latest-pypi-version}}
 aiohttp>=3.14.0
+starlette>=1.3.1

--- a/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
+++ b/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
@@ -10,4 +10,3 @@ azure-monitor-opentelemetry==1.8.0
 promptflow-azure=={{latest-pypi-version}}
 azure-identity=={{latest-pypi-version}}
 aiohttp>=3.14.0
-starlette>=1.3.1


### PR DESCRIPTION
## Summary

Bumps `starlette` to `>=1.3.1` in the **`evaluations-built-in`** curated environment
(`assets/evaluation_on_cloud/environments/evaluations-built-in`) to remediate **2 HIGH-severity**
`starlette` advisories flagged by AzureML vulnerability management. Both are fixed in **starlette 1.3.1**.

`starlette` is pulled in transitively (via `fastapi`). The floor is applied as a **separate post-install
`pip install --upgrade` step in the `Dockerfile`** rather than a `requirements.txt` pin: forcing
`starlette>=1.3.1` inside the combined `requirements.txt` resolution makes pip backtrack across the
`fastapi`/`promptflow-azure`/`azure-*` graph and fail the build with
[`resolution-too-deep`](https://pip.pypa.io/en/stable/topics/dependency-resolution/#handling-resolution-too-deep-errors).
The separate step keeps the `requirements.txt` resolution identical to the previously-passing build and
bumps `starlette` in a trivial one-package resolution.

> Note: an earlier revision of this PR pinned `starlette>=1.3.1` directly in `requirements.txt`, which is
> what produced the `resolution-too-deep` build failure. That change has been reverted; `requirements.txt`
> is now unchanged vs `main`.

## Affected image

- **Image:** `azuremlmcr.azurecr.io/public/azureml/curated/evaluations-built-in`
- **Flagged tag:** `41`
- **Owner:** EvaluationService (ServiceTreeId `776fcc4a-80c5-455a-8490-449352e5b55b`)

## Vulnerabilities fixed

| VulnId  | Advisory | Package | Severity | Fixed in |
|---------|----------|---------|----------|----------|
| 5013833 | [GHSA-82w8-qh3p-5jfq](https://github.com/advisories/GHSA-82w8-qh3p-5jfq) | starlette | HIGH | 1.3.1 |
| 5013846 | [GHSA-wqp7-x3pw-xc5r](https://github.com/advisories/GHSA-wqp7-x3pw-xc5r) | starlette | HIGH | 1.3.1 |

- **GHSA-82w8-qh3p-5jfq**: `request.form()` does not enforce parsing limits on some form types → potential DoS. Affected `>=0.4.1, <1.3.1`.
- **GHSA-wqp7-x3pw-xc5r**: fixed in the same 1.3.1 release.

## Change (`context/Dockerfile`)

```dockerfile
 COPY requirements.txt /app/requirements.txt
 RUN pip install -r /app/requirements.txt

+# Security: starlette is pulled in transitively (via fastapi). Bump to >=1.3.1 to fix
+# GHSA-82w8-qh3p-5jfq and GHSA-wqp7-x3pw-xc5r (both HIGH; fixed in 1.3.1). Applied as a
+# separate post-install upgrade rather than a requirements.txt pin because forcing the
+# floor inside the combined resolution triggers pip "resolution-too-deep". (ICM 831170435)
+RUN pip install --no-cache-dir --upgrade 'starlette>=1.3.1'
+
 # Copy your Python file into the image
```

`asset.yaml` uses `version: auto`, so the environment version/tag bump and image rebuild are handled by
the build pipeline on merge.

## ICM / SLA

- **ICM:** 831170435 (Sev 3, non-customer-impacting)
- **Due date:** 2026-07-16 (14-day remediation bucket)
