### PR TITLE
Accept SDK input aliases (response/ground_truth) in Task Navigation Efficiency evaluator

### DIFF
--- a/assets/evaluators/builtin/task_navigation_efficiency/evaluator/_task_navigation_efficiency.py
+++ b/assets/evaluators/builtin/task_navigation_efficiency/evaluator/_task_navigation_efficiency.py
@@ -445,6 +445,9 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
 
     _validator: ValidatorInterface
 
+    _INPUT_ALIASES = {"actions": "response", "expected_actions": "ground_truth"}
+    """Canonical eval-input keys mapped to their accepted SDK-style aliases."""
+
     @override
     def __init__(
         self,
@@ -490,6 +493,17 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
 
         super().__init__(threshold=1.0)
 
+    def _normalize_input_aliases(self, eval_input: Dict[str, Any]) -> None:
+        """Map SDK-style input keys onto the canonical keys in place.
+
+        If a canonical key (``actions``/``expected_actions``) is absent but its alias
+        (``response``/``ground_truth``) is provided, copy the alias value to the canonical
+        key so the rest of the pipeline can rely on a single set of names.
+        """
+        for canonical, alias in self._INPUT_ALIASES.items():
+            if eval_input.get(canonical) is None and eval_input.get(alias) is not None:
+                eval_input[canonical] = eval_input[alias]
+
     @override
     async def _real_call(self, **kwargs):
         """Perform asynchronous call where real end-to-end evaluation logic is executed.
@@ -499,6 +513,7 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
         :return: The evaluation result.
         :rtype: Dict[str, Union[float, str, Dict[str, float]]]
         """
+        self._normalize_input_aliases(kwargs)
         self._validator.validate_eval_input(kwargs)
         return await self._the_super_real_call(**kwargs)
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_task_navigation_efficiency_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_task_navigation_efficiency_evaluator_behavior.py
@@ -271,6 +271,59 @@ class TestTaskNavigationEfficiencyEvaluatorBehavior(BaseCodeEvaluatorRunner):
         assert "recall_score" in result_data["properties"]
         assert "f1_score" in result_data["properties"]
 
+    # ==================== SDK INPUT-NAME ALIAS TESTS ====================
+
+    def test_sdk_aliases_equivalent_to_canonical_names(self):
+        """SDK names (response/ground_truth) produce identical results to actions/expected_actions."""
+        canonical = self._run_evaluation(
+            actions=self.VALID_ACTIONS,
+            expected_actions=self.VALID_EXPECTED_ACTIONS,
+            matching_mode=TaskNavigationEfficiencyMatchingMode.EXACT_MATCH,
+        )
+        sdk = self._run_evaluation(
+            response=self.VALID_ACTIONS,
+            ground_truth=self.VALID_EXPECTED_ACTIONS,
+            matching_mode=TaskNavigationEfficiencyMatchingMode.EXACT_MATCH,
+        )
+        canonical_data = self._extract_and_print_result(canonical, "Alias - Canonical Names")
+        sdk_data = self._extract_and_print_result(sdk, "Alias - SDK Names")
+        self.assert_pass(canonical_data)
+        self.assert_pass(sdk_data)
+        assert sdk_data["score"] == canonical_data["score"]
+        assert sdk_data["properties"] == canonical_data["properties"]
+
+    def test_response_alias_only(self):
+        """'response' alias maps to 'actions' when actions is absent."""
+        results = self._run_evaluation(
+            response=self.VALID_ACTIONS,
+            expected_actions=self.VALID_EXPECTED_ACTIONS,
+            matching_mode=TaskNavigationEfficiencyMatchingMode.EXACT_MATCH,
+        )
+        result_data = self._extract_and_print_result(results, "Alias - response only")
+        self.assert_pass(result_data)
+
+    def test_ground_truth_alias_only(self):
+        """'ground_truth' alias maps to 'expected_actions' when expected_actions is absent."""
+        results = self._run_evaluation(
+            actions=self.VALID_ACTIONS,
+            ground_truth=self.VALID_EXPECTED_ACTIONS,
+            matching_mode=TaskNavigationEfficiencyMatchingMode.EXACT_MATCH,
+        )
+        result_data = self._extract_and_print_result(results, "Alias - ground_truth only")
+        self.assert_pass(result_data)
+
+    def test_canonical_names_take_precedence_over_aliases(self):
+        """When both canonical and alias keys are present, the canonical key wins."""
+        results = self._run_evaluation(
+            actions=self.VALID_ACTIONS,
+            expected_actions=self.VALID_EXPECTED_ACTIONS,
+            response=self.STRING_ACTIONS,  # invalid value; ignored because 'actions' present
+            ground_truth=["ignored"],  # ignored because 'expected_actions' present
+            matching_mode=TaskNavigationEfficiencyMatchingMode.EXACT_MATCH,
+        )
+        result_data = self._extract_and_print_result(results, "Alias - Canonical Precedence")
+        self.assert_pass(result_data)
+
     # ==================== EXACT MATCH MODE TESTS ====================
 
     def test_exact_match_perfect_match(self):


### PR DESCRIPTION
## What

`TaskNavigationEfficiencyEvaluator` now accepts the SDK-standard input names **`response`** and **`ground_truth`** as aliases for its canonical **`actions`** and **`expected_actions`** inputs.

## How

- Adds `_INPUT_ALIASES = {actions: response, expected_actions: ground_truth}`.
- Adds `_normalize_input_aliases(eval_input)` which copies an alias value onto its canonical key **only when the canonical key is absent** — so when both are supplied, the canonical name wins.
- It runs at the start of `_real_call` (before validation and input conversion), so the validator, `_convert_kwargs_to_eval_input`, and `_do_eval` all see a single canonical set of names.

## Tests

Adds 4 behavior tests to `test_task_navigation_efficiency_evaluator_behavior.py`:
- `test_sdk_aliases_equivalent_to_canonical_names` — `response`/`ground_truth` produce identical score + properties to `actions`/`expected_actions`.
- `test_response_alias_only`, `test_ground_truth_alias_only` — each alias works on its own.
- `test_canonical_names_take_precedence_over_aliases` — canonical keys win when both are present.

Full task-nav behavior suite: **74 passed**; flake8 clean.