### PR TITLE
Bump browse_comp and tau2_telecom data + benchmarkspec versions to v2

### DIFF
--- a/assets/benchmarkspecs/builtin/inspect_ai/browse_comp/spec.yaml
+++ b/assets/benchmarkspecs/builtin/inspect_ai/browse_comp/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.inspect_ai.browse_comp"
-version: 1
+version: 2
 display_name: "BrowseComp Benchmark (inspect_ai)"
 description: "BrowseComp is a benchmark for evaluating browsing agents on realistic web research tasks. Problems are encrypted at rest and decrypted at runtime. Evaluated using the inspect_ai framework."
 benchmarkType: "builtin"
@@ -23,7 +23,7 @@ dataset:
     dataset_source: "https://github.com/openai/simple-evals"
   source:
     provider: "mlregistry"
-    sourceDatasetId: "azureml://registries/azureml/data/browse_comp/versions/1"
+    sourceDatasetId: "azureml://registries/azureml/data/browse_comp/versions/2"
     sourceFormat: "csv"
     properties:
       file_name: "browse_comp.csv"

--- a/assets/benchmarkspecs/builtin/inspect_ai/tau2_telecom/spec.yaml
+++ b/assets/benchmarkspecs/builtin/inspect_ai/tau2_telecom/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.inspect_ai.tau2_telecom"
-version: 1
+version: 2
 display_name: "τ²-Bench Telecom Benchmark (inspect_ai)"
 description: "τ²-bench Telecom is a dual-control agent benchmark that evaluates AI agents on realistic telecom customer service tasks. Both the AI agent and a simulated user interact to resolve issues. Evaluated using the inspect_ai framework."
 benchmarkType: "builtin"
@@ -23,7 +23,7 @@ dataset:
     dataset_source: "https://github.com/sierra-research/tau2-bench"
   source:
     provider: "mlregistry"
-    sourceDatasetId: "azureml://registries/azureml/data/tau2_telecom/versions/1"
+    sourceDatasetId: "azureml://registries/azureml/data/tau2_telecom/versions/2"
     sourceFormat: "jsonl"
     properties:
       file_name: "tau2_telecom.jsonl"

--- a/assets/pipelines/data/global_dataset/generic_csv/browse_comp/asset.yaml
+++ b/assets/pipelines/data/global_dataset/generic_csv/browse_comp/asset.yaml
@@ -1,5 +1,5 @@
 name: browse_comp
-version: 1
+version: 2
 type: data
 spec: spec.yaml
 extra_config: storage.yaml

--- a/assets/pipelines/data/global_dataset/jsonl/tau2_telecom/asset.yaml
+++ b/assets/pipelines/data/global_dataset/jsonl/tau2_telecom/asset.yaml
@@ -1,5 +1,5 @@
 name: tau2_telecom
-version: 1
+version: 2
 type: data
 spec: spec.yaml
 extra_config: storage.yaml


### PR DESCRIPTION
Data assets: version 1 -> 2 (re-release with fresh SAS tokens)
Benchmarkspecs: version 1 -> 2, updated sourceDatasetId to reference data v2