### PR TITLE
Enable qwen2.5-coder-3b models to validate metadata changes

### DIFF
--- a/assets/models/foundrylocal/qwen2.5-coder-3b-instruct-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-3b-instruct-cuda-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   alias: qwen2.5-coder-3b
   publisher: Microsoft
   directoryPath: v2
-  foundryLocal: hide
+  foundryLocal: test
   inputModalities:
   - text
   license: apache-2.0

--- a/assets/models/foundrylocal/qwen2.5-coder-3b-instruct-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-3b-instruct-generic-cpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   alias: qwen2.5-coder-3b
   publisher: Microsoft
   directoryPath: v2
-  foundryLocal: hide
+  foundryLocal: test
   inputModalities:
   - text
   license: apache-2.0

--- a/assets/models/foundrylocal/qwen2.5-coder-3b-instruct-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-3b-instruct-generic-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   alias: qwen2.5-coder-3b
   publisher: Microsoft
   directoryPath: v2
-  foundryLocal: hide
+  foundryLocal: test
   inputModalities:
   - text
   license: apache-2.0

--- a/assets/models/foundrylocal/qwen2.5-coder-3b-instruct/spec.yaml
+++ b/assets/models/foundrylocal/qwen2.5-coder-3b-instruct/spec.yaml
@@ -3,5 +3,5 @@ name: qwen2.5-coder-3b-instruct
 path: ./
 isArchived: true
 system_metadata:
-  foundryLocal: hide
+  foundryLocal: ''
 version: 1


### PR DESCRIPTION
PR(https://github.com/Azure/azureml-assets/pull/5150) migrated Foundry local tags into system metadata, which needs to be validated with Foundry Local. Since it's risky to change production models, this PR enables hidden models for test purpose.