### PR TITLE
fix(task_navigation_efficiency): backward-compat alias normalization for azure-ai-evaluation 1.17.x

### DIFF
--- a/assets/evaluators/builtin/task_navigation_efficiency/evaluator/_task_navigation_efficiency.py
+++ b/assets/evaluators/builtin/task_navigation_efficiency/evaluator/_task_navigation_efficiency.py
@@ -215,6 +215,17 @@ class TaskNavigationEfficiencyEvaluator(EvaluatorBase):
         :rtype: Dict[str, Union[float, str, Dict[str, float]]]
         """
         self._normalize_input_aliases(kwargs)
+        # Backward compatibility with azure-ai-evaluation 1.17.x: that release's
+        # TaskNavigationEfficiencyValidator validates the canonical SDK keys
+        # ('response'/'ground_truth') but does not itself map the azureml-assets-style
+        # aliases ('actions'/'expected_actions') onto them. Newer SDKs (>= 1.18.0) expose
+        # ``_normalize_input_aliases`` on the validator and normalize internally, so we only
+        # backfill the canonical SDK keys here when that method is absent. Remove this shim
+        # once azure-ai-evaluation 1.17.x is no longer supported.
+        if not hasattr(self._validator, "_normalize_input_aliases"):
+            for assets_key, sdk_key in self._INPUT_ALIASES.items():
+                if kwargs.get(sdk_key) is None and kwargs.get(assets_key) is not None:
+                    kwargs[sdk_key] = kwargs[assets_key]
         self._validator.validate_eval_input(kwargs)
         return await self._the_super_real_call(**kwargs)
 

--- a/assets/evaluators/builtin/task_navigation_efficiency/spec.yaml
+++ b/assets/evaluators/builtin/task_navigation_efficiency/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.task_navigation_efficiency"
-version: 11
+version: 12
 displayName: "Task-Navigation-Efficiency-Evaluator"
 description: "Determines whether an agent’s sequence of steps (e.g., tool calls and parameters) matches an optimal or expected path of actions for completing a task. Use it to evaluate how effectively an agent follows expected sequence of actions and executes multi-step workflows."
 evaluatorType: "builtin"


### PR DESCRIPTION
## What
Make the `task_navigation_efficiency` builtin evaluator backward-compatible with **azure-ai-evaluation 1.17.x**.

## Why
The SDK `TaskNavigationEfficiencyValidator` only maps the azureml-assets-style aliases (`actions`/`expected_actions`) onto the canonical SDK keys (`response`/`ground_truth`) starting in **1.18.0**, via `_normalize_input_aliases` ([validator source](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/evaluation/azure-ai-evaluation/azure/ai/evaluation/_evaluators/_common/_validators/_task_navigation_efficiency_validator.py)). On **1.17.x** that method does not exist and `validate_eval_input` reads only `response`/`ground_truth`, so assets-style inputs are rejected with `'response' parameter is required`.

## What changed
In `_real_call`, after the existing alias normalization, backfill the canonical SDK keys from the assets keys **only when the validator does not expose `_normalize_input_aliases`**. This is a no-op on >= 1.18.0 (the SDK validator normalizes internally) and is removable once 1.17.x support is dropped. Spec version bumped 11 -> 12.

## Verification
- Deterministic evaluator (no LLM). Ran the evaluator with assets-style (`actions`/`expected_actions`) and SDK-style (`response`/`ground_truth`) inputs on 1.17.0 and 1.18.1 — both produce a valid score on both SDKs.
- `task_navigation_efficiency` behavior suite: **1.18.1 = 74 passed** (clean, no regression). **1.17.0 = 38 failed -> 3 failed** with this fix.
- The 3 remaining 1.17.0 failures are pre-existing SDK-internal drift unrelated to alias normalization (error category `MISSING_FIELD` vs `INVALID_VALUE` for empty/None ground_truth, and a unit test that calls the SDK validator directly to parse JSON strings). CI runs against the pinned 1.18.x SDK where the suite is green.
