### PR TITLE
Fix MLflow local validation command injection

### DIFF
--- a/assets/common/components/mlflow_model_local_validation/spec.yaml
+++ b/assets/common/components/mlflow_model_local_validation/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 
 name: mlflow_model_local_validation
-version: 0.0.18
+version: 0.0.19
 type: command
 
 is_deterministic: True

--- a/assets/common/src/run_mlflow_model_local_validation.py
+++ b/assets/common/src/run_mlflow_model_local_validation.py
@@ -8,10 +8,11 @@ import os
 import shutil
 from azure.ai.ml.exceptions import ErrorTarget, ErrorCategory, MlException
 from pathlib import Path
+from typing import List, Optional
 
 from utils.config import AppName
 from utils.logging_utils import custom_dimensions, get_logger
-from utils.common_utils import run_command
+from utils.common_utils import run_command, run_command_args
 from utils.exceptions import (
     swallow_all_exceptions,
     ModelImportErrorStrings,
@@ -26,7 +27,6 @@ LOCAL_VALIDATION_OUT_FILE = "output.log"
 CONDA_FILE_NAME = "conda.yaml"
 CREATE_CONDA_CMD = "conda env create -p {} -f {} -q"
 CONDA_LIST = "conda list -p {}"
-CONDA_EXEC_CMD = "conda run -p {} {}"
 SCRIPT_PATH = "scripts/validate_model.py"
 
 
@@ -35,8 +35,35 @@ def _get_parser():
     parser.add_argument("--model-path", type=Path, required=True, help="Model input path")
     parser.add_argument("--test-data-path", type=Path, required=False, help="Test dataset path")
     parser.add_argument("--column-rename-map", type=str, required=False, help="")
+    parser.add_argument("--task-name", type=str, required=False, help="Hugging Face task type")
     parser.add_argument("--output-model-path", type=Path, required=True, help="Output model path")
     return parser
+
+
+def _get_validation_command(
+    model_dir: Path,
+    test_data_path: Optional[Path],
+    col_rename_map_str: Optional[str],
+    task_name: Optional[str],
+) -> List[str]:
+    """Build local validation command arguments without shell-interpreted input."""
+    cmd = [
+        "conda",
+        "run",
+        "-p",
+        ENV_PREFIX,
+        "python",
+        SCRIPT_PATH,
+        "--model-path",
+        str(model_dir),
+    ]
+    if test_data_path:
+        cmd.extend(["--test-data-path", str(test_data_path)])
+    if col_rename_map_str:
+        cmd.extend(["--column-rename-map", col_rename_map_str])
+    if task_name:
+        cmd.extend(["--task-name", task_name])
+    return cmd
 
 
 @swallow_all_exceptions(logger)
@@ -48,6 +75,7 @@ def run():
     model_dir: Path = args.model_path
     test_data_path: Path = args.test_data_path
     col_rename_map_str: str = args.column_rename_map
+    task_name: str = args.task_name
     output_model_path: Path = args.output_model_path
 
     logger.info(f"col_rename_map_str {col_rename_map_str}")
@@ -87,24 +115,15 @@ def run():
         )
     logger.info(f"pip list: \n{stdout}")
 
-    cmd = f"python {SCRIPT_PATH} --model-path {model_dir}"
-    if test_data_path:
-        cmd += f" --test-data-path {test_data_path}"
-    if col_rename_map_str:
-        cmd += f" --column-rename-map '{col_rename_map_str}'"
-    cmd += f" > {LOCAL_VALIDATION_OUT_FILE} 2>&1"
+    run_script_cmd = _get_validation_command(model_dir, test_data_path, col_rename_map_str, task_name)
+    exit_code, stdout = run_command_args(run_script_cmd)
+    with open(LOCAL_VALIDATION_OUT_FILE, "w") as f:
+        f.write(stdout or "")
 
-    run_script_cmd = CONDA_EXEC_CMD.format(ENV_PREFIX, cmd)
-    logger.info(f"cmd string: {run_script_cmd}")
-
-    exit_code, stdout = run_command(run_script_cmd)
-    if os.path.exists(LOCAL_VALIDATION_OUT_FILE):
-        # read script logs and feed to logger handler here
-        with open(LOCAL_VALIDATION_OUT_FILE) as f:
-            for line in f:
-                logger.info(f"[SCRIPT_LOG] {line}")
-    else:
-        logger.warning("local validation script execution log was not captured")
+    # read script logs and feed to logger handler here
+    with open(LOCAL_VALIDATION_OUT_FILE) as f:
+        for line in f:
+            logger.info(f"[SCRIPT_LOG] {line}")
 
     if exit_code != 0:
         logger.warning(f"Local validation failed. Error {stdout}")

--- a/assets/common/src/utils/common_utils.py
+++ b/assets/common/src/utils/common_utils.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import shlex
 import sys
 from azure.ai.ml import MLClient
 from azure.ai.ml.identity import AzureMLOnBehalfOfCredential
@@ -12,7 +13,7 @@ from azure.identity import ManagedIdentityCredential
 from azure.ai.ml.exceptions import ErrorTarget, ErrorCategory, MlException, ValidationException
 from pathlib import Path
 from subprocess import PIPE, run, STDOUT
-from typing import Tuple
+from typing import Sequence, Tuple
 
 from utils.logging_utils import get_logger
 from utils.exceptions import ModelImportErrorStrings
@@ -28,6 +29,21 @@ def run_command(cmd: str, cwd: Path = "./") -> Tuple[int, str]:
         cmd,
         cwd=cwd,
         shell=True,
+        stdout=PIPE,
+        stderr=STDOUT,
+        encoding=sys.stdout.encoding,
+        errors="ignore",
+    )
+    return result.returncode, result.stdout
+
+
+def run_command_args(cmd: Sequence[str], cwd: Path = "./") -> Tuple[int, str]:
+    """Run the command arguments without shell interpretation and return the result."""
+    logger.info(" ".join(shlex.quote(str(arg)) for arg in cmd))
+    result = run(
+        [str(arg) for arg in cmd],
+        cwd=cwd,
+        shell=False,
         stdout=PIPE,
         stderr=STDOUT,
         encoding=sys.stdout.encoding,

--- a/assets/training/model_management/components/import_model/spec.yaml
+++ b/assets/training/model_management/components/import_model/spec.yaml
@@ -4,7 +4,7 @@ type: pipeline
 name: import_model
 display_name: Import model
 description: Import a model into a workspace or a registry
-version: 0.0.42
+version: 0.0.43
 
 # Pipeline inputs
 inputs:
@@ -300,10 +300,12 @@ jobs:
         type: mlflow_model
 
   mlflow_model_local_validation:
-    component: azureml:mlflow_model_local_validation:0.0.17
+    component: azureml:mlflow_model_local_validation:0.0.19
     compute: ${{parent.inputs.compute}}
     resources:
       instance_type: '${{parent.inputs.instance_type}}'
+    identity:
+      type: user_identity
     inputs:
       model_path: ${{parent.jobs.convert_model_to_mlflow.outputs.mlflow_model_folder}}
       test_data_path: ${{parent.inputs.local_validation_test_data}}

--- a/test/test_mlflow_model_local_validation.py
+++ b/test/test_mlflow_model_local_validation.py
@@ -1,0 +1,122 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for MLflow model local validation command execution."""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+COMMON_SRC_DIR = Path(__file__).parents[1] / "assets" / "common" / "src"
+
+
+def _install_import_stubs(monkeypatch):
+    monkeypatch.syspath_prepend(str(COMMON_SRC_DIR))
+
+    azure = types.ModuleType("azure")
+    azure_ai = types.ModuleType("azure.ai")
+    azure_ai_ml = types.ModuleType("azure.ai.ml")
+    azure_ai_ml.MLClient = object
+
+    azure_exceptions = types.ModuleType("azure.ai.ml.exceptions")
+    azure_exceptions.ErrorTarget = types.SimpleNamespace()
+    azure_exceptions.ErrorCategory = types.SimpleNamespace()
+    azure_exceptions.MlException = Exception
+    azure_exceptions.ValidationException = Exception
+
+    azure_ml_identity = types.ModuleType("azure.ai.ml.identity")
+    azure_ml_identity.AzureMLOnBehalfOfCredential = object
+
+    azure_identity = types.ModuleType("azure.identity")
+    azure_identity.ManagedIdentityCredential = object
+
+    monkeypatch.setitem(sys.modules, "azure", azure)
+    monkeypatch.setitem(sys.modules, "azure.ai", azure_ai)
+    monkeypatch.setitem(sys.modules, "azure.ai.ml", azure_ai_ml)
+    monkeypatch.setitem(sys.modules, "azure.ai.ml.exceptions", azure_exceptions)
+    monkeypatch.setitem(sys.modules, "azure.ai.ml.identity", azure_ml_identity)
+    monkeypatch.setitem(sys.modules, "azure.identity", azure_identity)
+
+    azureml = types.ModuleType("azureml")
+    azureml_common = types.ModuleType("azureml._common")
+    azureml_error_definition = types.ModuleType("azureml._common._error_definition")
+    azureml_error_definition.AzureMLError = object
+    azureml_exceptions = types.ModuleType("azureml._common.exceptions")
+    azureml_exceptions.AzureMLException = Exception
+    azureml_core = types.ModuleType("azureml.core")
+    azureml_core_run = types.ModuleType("azureml.core.run")
+    azureml_core_run.Run = object
+
+    monkeypatch.setitem(sys.modules, "azureml", azureml)
+    monkeypatch.setitem(sys.modules, "azureml._common", azureml_common)
+    monkeypatch.setitem(sys.modules, "azureml._common._error_definition", azureml_error_definition)
+    monkeypatch.setitem(sys.modules, "azureml._common.exceptions", azureml_exceptions)
+    monkeypatch.setitem(sys.modules, "azureml.core", azureml_core)
+    monkeypatch.setitem(sys.modules, "azureml.core.run", azureml_core_run)
+
+    config = types.ModuleType("utils.config")
+    config.AppName = types.SimpleNamespace(MLFLOW_MODEL_LOCAL_VALIDATION="mlflow_model_local_validation")
+
+    logging_utils = types.ModuleType("utils.logging_utils")
+    logging_utils.custom_dimensions = types.SimpleNamespace(app_name=None)
+    logging_utils.get_logger = lambda _: Mock()
+
+    run_utils = types.ModuleType("utils.run_utils")
+    run_utils.JobRunDetails = object
+
+    exceptions = types.ModuleType("utils.exceptions")
+    exceptions.ModelImportErrorStrings = types.SimpleNamespace()
+    exceptions.UserIdentityMissingError = object
+    exceptions.InvalidModelIDError = object
+    exceptions.CondaEnvCreationError = object
+    exceptions.CondaFileMissingError = object
+    exceptions.MlflowModelValidationError = object
+    exceptions.swallow_all_exceptions = lambda _: lambda func: func
+
+    monkeypatch.setitem(sys.modules, "utils.config", config)
+    monkeypatch.setitem(sys.modules, "utils.logging_utils", logging_utils)
+    monkeypatch.setitem(sys.modules, "utils.run_utils", run_utils)
+    monkeypatch.setitem(sys.modules, "utils.exceptions", exceptions)
+
+
+def _reload_module(module_name: str):
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_validation_command_preserves_column_rename_map_as_single_argument(monkeypatch):
+    """Verify shell metacharacters in column_rename_map are not interpreted by a shell."""
+    _install_import_stubs(monkeypatch)
+    validation = _reload_module("run_mlflow_model_local_validation")
+
+    payload = "old:new'; touch /tmp/injected; echo 'still:data"
+    cmd = validation._get_validation_command(
+        model_dir=Path("/tmp/model"),
+        test_data_path=Path("/tmp/data.csv"),
+        col_rename_map_str=payload,
+        task_name="summarization",
+    )
+
+    assert cmd[:6] == ["conda", "run", "-p", validation.ENV_PREFIX, "python", validation.SCRIPT_PATH]
+    assert cmd[cmd.index("--column-rename-map") + 1] == payload
+    assert validation.LOCAL_VALIDATION_OUT_FILE not in cmd
+    assert "2>&1" not in cmd
+
+
+def test_run_command_args_executes_without_shell(monkeypatch):
+    """Verify argument-list commands are executed with shell disabled."""
+    _install_import_stubs(monkeypatch)
+    common_utils = _reload_module("utils.common_utils")
+
+    completed_process = types.SimpleNamespace(returncode=0, stdout="ok")
+    with patch.object(common_utils, "run", return_value=completed_process) as run_mock:
+        exit_code, stdout = common_utils.run_command_args(["echo", "hello; touch /tmp/injected"])
+
+    args, kwargs = run_mock.call_args
+    assert args[0] == ["echo", "hello; touch /tmp/injected"]
+    assert kwargs["shell"] is False
+    assert exit_code == 0
+    assert stdout == "ok"


### PR DESCRIPTION
## Summary
- run MLflow local validation with argv-based subprocess execution and `shell=False` for user-influenced arguments
- remove shell redirection from validation execution while preserving output logging
- pin `mlflow_model_local_validation` to `user_identity` and update component/pipeline versions
- add regression tests for command-injection payload handling

## Validation
- `python -m pytest Q:\gitrepos\azureml-assets\test\test_mlflow_model_local_validation.py -q`
- parsed edited component YAML specs with PyYAML