### PR TITLE
fix: rename kwargs to instruction_kwargs in IFEval evaluator spec

### DIFF
--- a/assets/benchmarkspecs/builtin/ifeval/spec.yaml
+++ b/assets/benchmarkspecs/builtin/ifeval/spec.yaml
@@ -14,12 +14,12 @@ inference:
     max_completion_tokens: 4096
 
 evaluator:
-  id: "azureml://registries/azureml/evaluators/builtin.ifeval/versions/2"
+  id: "azureml://registries/azureml/evaluators/builtin.ifeval/versions/3"
   testingCriteria:
     type: "azure_ai_evaluator"
     name: "IFEval"
     evaluator_name: "builtin.ifeval"
-    evaluator_version: "2"
+    evaluator_version: "3"
     initialization_parameters: {}
     data_mapping:
       instruction_id_list: "{{item.instruction_id_list}}"

--- a/assets/evaluators/builtin/ifeval/spec.yaml
+++ b/assets/evaluators/builtin/ifeval/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.ifeval"
-version: 2
+version: 3
 displayName: "IFEval-Evaluator"
 description: "Evaluates model responses for the Instruction-Following Eval (IFEval) benchmark. Checks whether model outputs comply with verifiable instructions such as word count constraints, format requirements, keyword usage, and language specifications. Returns both strict (exact compliance) and loose (minor tolerance) accuracy scores."
 evaluatorType: "builtin"
@@ -22,10 +22,10 @@ dataMappingSchema:
     instruction_id_list:
       type: "string"
       description: "JSON array of instruction IDs to verify, e.g. '[\"punctuation:no_comma\", \"length_constraints:number_words\"]'"
-    kwargs:
+    instruction_kwargs:
       type: "string"
       description: "JSON array of parameter dicts for each instruction, e.g. '[{}, {\"relation\": \"at least\", \"num_words\": 300}]'"
-  required: ["response", "instruction_id_list", "kwargs"]
+  required: ["response", "instruction_id_list", "instruction_kwargs"]
 outputSchema:
   ifeval_strict:
     type: "boolean"


### PR DESCRIPTION
## Summary

Rename `kwargs` to `instruction_kwargs` in the IFEval evaluator spec's `dataMappingSchema` to match the Python evaluator's `__call__` parameter name. Bumps evaluator version 2 → 3.

## Problem

The IFEval evaluator works correctly as part of the **benchmark flow** (via benchmarkspec), because the benchmarkspec's `data_mapping` handles the field name translation (`instruction_kwargs: "{{item.kwargs}}"`).

However, when invoking the evaluator **directly via the evaluation API** (e.g., for standalone evaluation or FAOS agent optimization), users must provide an explicit `data_mapping`. The .NET service validates mapping keys against the spec's `dataMappingSchema`, requiring `kwargs` as a key. This key then gets passed as the parameter name to the Python evaluator — but the evaluator's `__call__` expects `instruction_kwargs`, causing: `"Either 'conversation' or individual inputs must be provided"`

## Fix

Align the spec's `dataMappingSchema` field name with the Python code:
- `kwargs` → `instruction_kwargs` in both `properties` and `required`
- Version bump 2 → 3 (breaking schema change)
- Update benchmarkspec to reference evaluator v3

## Validation

- Benchmark flow: works with both v2 and v3 (benchmarkspec handles mapping)
- Direct API invocation: validated in INT — v2 fails, omitting data_mapping works, v3 will fix explicit mapping case