### PR TITLE
Add Mamba-2 kernels (causal-conv1d + mamba-ssm) to slime image for Nemotron-H

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
@@ -14,6 +14,8 @@ ARG SGLANG_VERSION=0.5.11
 ARG MEGATRON_COMMIT=1dcf0dafa884ad52ffb243625717a3471643e087
 ARG MBRIDGE_COMMIT=89eb10887887bc74853f89a4de258c0702932a1c
 ARG LOG4J_VERSION=2.25.4
+ARG CAUSAL_CONV1D_REF=v1.5.0.post8
+ARG MAMBA_SSM_REF=v2.3.2.post1
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_NO_CACHE_DIR=1
@@ -61,6 +63,24 @@ RUN NVCC_APPEND_FLAGS="--threads 1" \
         --no-build-isolation \
         --config-settings "--build-option=--cpp_ext --cuda_ext --parallel 1" \
         git+https://github.com/NVIDIA/apex.git@10417aceddd7d5d05d7cbf7b0fc2daad1105f8b4
+
+# Mamba-2 CUDA kernels (causal-conv1d + mamba-ssm) back Megatron's MambaMixer, which
+# hybrid Mamba-2/MoE models such as Nemotron-H (model_type nemotron_h) require at
+# model-build time; without them MambaMixer aborts with "MambaSSM is not installed".
+# Build from the pinned git tags - the PyPI sdists ship without csrc/*.cpp, so the
+# ninja build fails with "missing and no known rule to make it". mamba-ssm 2.3.2.post1
+# imports the modern transformers.generation.GenerateDecoderOnlyOutput symbol and
+# guards its optional TileLang (Mamba-3 MIMO) import, so it loads cleanly on this
+# image's transformers and needs no source patch; --no-deps keeps the curated torch /
+# sglang / tilelang stack pinned. TORCH_CUDA_ARCH_LIST covers A100 (8.0) + H100 (9.0).
+RUN set -eux; \
+    export CAUSAL_CONV1D_FORCE_BUILD=TRUE MAMBA_FORCE_BUILD=TRUE TORCH_CUDA_ARCH_LIST="8.0;9.0"; \
+    python -m pip install --disable-pip-version-check --no-cache-dir \
+        --no-build-isolation --no-deps \
+        "git+https://github.com/Dao-AILab/causal-conv1d.git@${CAUSAL_CONV1D_REF}"; \
+    python -m pip install --disable-pip-version-check --no-cache-dir \
+        --no-build-isolation --no-deps \
+        "git+https://github.com/state-spaces/mamba.git@${MAMBA_SSM_REF}"
 
 RUN git clone https://github.com/NVIDIA/Megatron-LM.git --recursive /opt/Megatron-LM && \
     cd /opt/Megatron-LM && \

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/smoke_test.py
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/smoke_test.py
@@ -6,7 +6,9 @@
 import importlib.util
 import pathlib
 import zipfile
+import causal_conv1d
 import cryptography
+import mamba_ssm
 from packaging.version import Version
 import PIL
 import ray
@@ -14,6 +16,15 @@ import sglang
 import slime
 import torch
 import transformer_engine.pytorch as te
+from causal_conv1d import causal_conv1d_fn, causal_conv1d_update  # noqa: F401
+from mamba_ssm.ops.triton.layernorm_gated import RMSNorm as _MambaRMSNorm  # noqa: F401
+from mamba_ssm.ops.triton.selective_state_update import (  # noqa: F401
+    selective_state_update,
+)
+from mamba_ssm.ops.triton.ssd_combined import (  # noqa: F401
+    mamba_chunk_scan_combined,
+    mamba_split_conv1d_scan_combined,
+)
 
 
 LOG4J_ARTIFACTS = ("log4j-api", "log4j-core", "log4j-slf4j-impl")
@@ -74,6 +85,9 @@ assert Version(sglang.__version__) >= Version("0.5.11")
 assert sglang
 assert slime
 assert te
+# Mamba-2 kernels required by Megatron's MambaMixer for hybrid models (Nemotron-H).
+assert Version(mamba_ssm.__version__) >= Version("2.3.2")
+assert causal_conv1d
 
 # AML/Singularity jobs run as uid 9000 (aiscuser); /root is mode 700 so
 # slime must be editable-installed from a non-/root location. Pin the

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/spec.yaml
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/spec.yaml
@@ -26,3 +26,4 @@ tags:
   SGLang: "0.5.11"
   FlashAttention: "4"
   Megatron: "dev"
+  Mamba: "2"


### PR DESCRIPTION
## Why

The `slime-pytorch-2.9-cuda12.8` curated image does not ship the Mamba CUDA kernels, so Megatron's `MambaMixer` aborts with `ImportError: MambaSSM is not installed` at model-build time. This blocks training hybrid Mamba-2 / MoE models such as **Nemotron-H** (`model_type: nemotron_h`), even though the image already contains:
- the native `nemotron_h` bridge in the bundled `megatron.bridge` (`megatron/bridge/models/nemotronh/nemotron_h_bridge.py`), and
- `nemotron_h` rollout support in `sglang 0.5.11`.

Kernels were the only missing piece for end-to-end Nemotron-H post-training.

## What

- **Dockerfile**: build `causal-conv1d v1.5.0.post8` and `mamba-ssm v2.3.2.post1` from their pinned git tags after the apex step.
  - Built from git tags because the PyPI sdists omit `csrc/*.cpp` and fail the ninja build (`missing and no known rule to make it`).
  - `mamba-ssm 2.3.2.post1` imports the modern `transformers.generation.GenerateDecoderOnlyOutput` symbol and guards its optional TileLang (Mamba-3 MIMO) import, so it loads cleanly on this image's `transformers` with **no source patch**.
  - `--no-deps` keeps the curated torch / sglang / tilelang stack pinned (the image installs a cu128-nightly tilelang for flash-linear-attention; the Mamba-2 path Nemotron-H uses does not need tilelang).
  - `TORCH_CUDA_ARCH_LIST="8.0;9.0"` covers A100 + H100. Kernel refs are overridable `ARG`s.
- **smoke_test.py**: assert the `causal_conv1d` + `mamba_ssm.ops.triton` kernels Megatron's `MambaMixer` uses import, and `mamba_ssm >= 2.3.2`.
- **spec.yaml**: advertise `Mamba: "2"`.

## Validation

The `causal-conv1d 1.5.0.post8` + `mamba-ssm 2.3.2.post1` pair was validated end-to-end against `:7` on a cluster: both kernels import, and Megatron wires the mamba params (`mamba_num_heads=64`, `mamba_num_groups=8`, `mamba_state_dim=128`, `spec=mamba_stack_spec`). Image auto-versions via `asset.yaml` (`version: auto`).
