### PR TITLE
Bump azure-ai-evaluation to 1.18.2 for built-in evaluators

### DIFF
--- a/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
+++ b/assets/evaluation_on_cloud/environments/evaluations-built-in/context/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-evaluation==1.11.1
+azure-ai-evaluation==1.18.2
 azureml-mlflow=={{latest-pypi-version}}
 azure-ai-ml=={{latest-pypi-version}}
 

--- a/assets/evaluators/tests/requirements.txt
+++ b/assets/evaluators/tests/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-evaluation==1.18.1
+azure-ai-evaluation==1.18.2
 azure-ai-projects==2.0.0b2
 azureml-mlflow
 azure-ai-ml


### PR DESCRIPTION
Bumps the pinned `azure-ai-evaluation` SDK to the released **1.18.2** so the built-in evaluator assets support admin-connected (bring-your-own / BYO) judge models.

1.18.2 is the first released version that ships the BYO prompty shim (`_byo_judge.AsyncByoProjectResponsesClient` + `_legacy/prompty/_prompty.py` `is_byo_model_config` branch), which routes the built-in prompty judges' `chat.completions` calls through the Foundry project Responses API so the platform resolves the connection's auth.

Changes:
- `evaluation_on_cloud/environments/evaluations-built-in`: `1.11.1` -> `1.18.2` (the curated environment that runs the built-in evaluators). The asset version is auto-computed, so only the context `requirements.txt` changes.
- `evaluators/tests`: `1.18.1` -> `1.18.2` (keep the evaluator asset test pin in lockstep).

Verified the 1.18.2 wheel contains the BYO shim; dependency constraints are compatible (`openai>=1.108.0`).