### PR TITLE
Groundedness: enable Bing/Fabric/Search/SharePoint/OpenAPI tool calls

### DIFF
--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -426,6 +426,31 @@ except ImportError:  # pragma: no cover
         ]
 
 
+_GROUNDEDNESS_ALLOWED_RESTRICTED_TOOLS = {
+    "azure_ai_search",
+    "azure_fabric",
+    "bing_custom_search",
+    "bing_grounding",
+    "openapi_call",
+    "sharepoint_grounding",
+}
+
+
+class GroundednessConversationValidatorPolicyOverride(GroundednessConversationValidator):
+    """Groundedness-specific tool support policy override.
+
+    Keep the validator's unsupported-tool enforcement behavior enabled, but
+    allow a curated subset of tool calls that now have stable grounding
+    semantics for this evaluator.
+    """
+
+    UNSUPPORTED_TOOLS: List[str] = [
+        tool
+        for tool in GroundednessConversationValidator.UNSUPPORTED_TOOLS
+        if tool not in _GROUNDEDNESS_ALLOWED_RESTRICTED_TOOLS
+    ]
+
+
 try:
     from azure.ai.evaluation._user_agent import UserAgentSingleton
 except ImportError:  # pragma: no cover
@@ -617,13 +642,13 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         )
 
         # Initialize input validators
-        self._validator = GroundednessConversationValidator(
+        self._validator = GroundednessConversationValidatorPolicyOverride(
             error_target=ErrorTarget.GROUNDEDNESS_EVALUATOR,
             requires_query=False,
             check_for_unsupported_tools=True
         )
 
-        self._validator_with_query = GroundednessConversationValidator(
+        self._validator_with_query = GroundednessConversationValidatorPolicyOverride(
             error_target=ErrorTarget.GROUNDEDNESS_EVALUATOR, requires_query=True,
             check_for_unsupported_tools=True
         )

--- a/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
@@ -98,6 +98,84 @@ class TestGroundednessEvaluatorBehavior(
 
     MINIMAL_RESPONSE = BaseEvaluatorBehaviorTest.weather_tool_result_and_assistant_response
 
+    def test_bing_grounding(self):
+        """Bing grounding tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Bing Grounding",
+            evaluation_inputs={
+                "query": data.BING_GROUNDING_QUERY,
+                "response": data.BING_GROUNDING_RESPONSE,
+                "tool_definitions": data.BING_GROUNDING_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_bing_grounding_expected_flow_inputs,
+        )
+
+    def test_bing_custom_search(self):
+        """Bing custom search tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Bing Custom Search",
+            evaluation_inputs={
+                "query": data.BING_CUSTOM_SEARCH_QUERY,
+                "response": data.BING_CUSTOM_SEARCH_RESPONSE,
+                "tool_definitions": data.BING_CUSTOM_SEARCH_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_bing_custom_search_expected_flow_inputs,
+        )
+
+    def test_azure_ai_search(self):
+        """Azure AI Search tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Azure AI Search",
+            evaluation_inputs={
+                "query": data.AZURE_AI_SEARCH_QUERY,
+                "response": data.AZURE_AI_SEARCH_RESPONSE,
+                "tool_definitions": data.AZURE_AI_SEARCH_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_azure_ai_search_expected_flow_inputs,
+        )
+
+    def test_sharepoint_grounding(self):
+        """SharePoint grounding tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="SharePoint Grounding",
+            evaluation_inputs={
+                "query": data.SHAREPOINT_QUERY,
+                "response": data.SHAREPOINT_RESPONSE,
+                "tool_definitions": data.SHAREPOINT_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_sharepoint_grounding_expected_flow_inputs,
+        )
+
+    def test_fabric_data_agent(self):
+        """Fabric data agent tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Fabric Data Agent",
+            evaluation_inputs={
+                "query": data.FABRIC_QUERY,
+                "response": data.FABRIC_RESPONSE,
+                "tool_definitions": data.FABRIC_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_fabric_data_agent_expected_flow_inputs,
+        )
+
+    def test_openapi(self):
+        """OpenAPI tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="OpenAPI",
+            evaluation_inputs={
+                "query": data.OPENAPI_QUERY,
+                "response": data.OPENAPI_RESPONSE,
+                "tool_definitions": data.OPENAPI_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_openapi_expected_flow_inputs,
+        )
+
 
 # region Conversation-level (messages) behavioral tests
 


### PR DESCRIPTION
## Summary
- enable groundedness evaluator for these tool call types:
  - `bing_grounding`
  - `bing_custom_search`
  - `azure_ai_search`
  - `sharepoint_grounding`
  - `azure_fabric`
  - `openapi_call`
- keep unsupported-tool validation enabled, but apply a groundedness-specific validator policy override to allow the list above
- keep `code_interpreter_call`, `browser_automation`, `computer_call`, and `web_search` gated as unsupported

## Implementation
- added `GroundednessConversationValidatorPolicyOverride` in groundedness evaluator to derive unsupported tools from the base validator minus the newly allowed set
- switched groundedness validator initialization to use the policy override
- added groundedness behavior tests asserting PASS for the newly supported tool types

## Validation
- `python -m pytest assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py -k "test_bing_grounding or test_bing_custom_search or test_azure_ai_search or test_sharepoint_grounding or test_fabric_data_agent or test_openapi or test_code_interpreter" -q`
- result: 7 passed
