### PR TITLE
Groundedness: enable Bing/Fabric/Search/SharePoint/OpenAPI tool calls

### DIFF
--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -51,8 +51,13 @@ from azure.ai.evaluation._evaluators._common._validators import (
 # ---------------------------------------------------------------------------
 
 try:  # azure-ai-evaluation >= 1.18.1
-    from azure.ai.evaluation._common.utils import _is_intermediate_response, _preprocess_messages
-except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._common.utils import (
+        _is_intermediate_response,
+        _preprocess_messages,
+    )
+except (
+    ImportError
+):  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
     from azure.ai.evaluation._evaluators._common._base_prompty_eval import (
         _is_intermediate_response,
         _preprocess_messages,
@@ -65,7 +70,9 @@ try:  # azure-ai-evaluation >= 1.18.1
         _drop_mcp_approval_messages,
         _normalize_function_call_types,
     )
-except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+except (
+    ImportError
+):  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
     from azure.ai.evaluation._evaluators._common._base_prompty_eval import (  # noqa: F401
         _drop_mcp_approval_messages,
         _normalize_function_call_types,
@@ -73,7 +80,9 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
 
 try:  # azure-ai-evaluation >= 1.18.1
     from azure.ai.evaluation._evaluators._common._validators import MessageRole
-except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+except (
+    ImportError
+):  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
     # azure-ai-evaluation 1.18.1 MessageRole; the 1.17.x SDK enum omits DEVELOPER,
     # which serialize_messages below relies on.
     class MessageRole(str, Enum):
@@ -85,6 +94,7 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
         TOOL = "tool"
         DEVELOPER = "developer"
 
+
 try:  # azure-ai-evaluation >= 1.18.1
     from azure.ai.evaluation._common.constants import EvaluationLevel
     from azure.ai.evaluation._common.utils import (
@@ -94,8 +104,12 @@ try:  # azure-ai-evaluation >= 1.18.1
         _split_messages_at_latest_user,
         serialize_messages,
     )
-    from azure.ai.evaluation._evaluators._common._validators import MessagesOrQueryResponseInputValidator
-except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._evaluators._common._validators import (
+        MessagesOrQueryResponseInputValidator,
+    )
+except (
+    ImportError
+):  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
     # Bodies below are copied from azure-ai-evaluation 1.18.1 (the earliest release
     # that ships these symbols). The only change is that serialize_messages uses the
     # module-level MessageRole above so the DEVELOPER role stays available on 1.17.x
@@ -110,7 +124,9 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
         CONVERSATION = "conversation"
         TURN = "turn"
 
-    def _merge_query_response_messages(query: List[dict], response: List[dict]) -> List[dict]:
+    def _merge_query_response_messages(
+        query: List[dict], response: List[dict]
+    ) -> List[dict]:
         """Merge query and response message lists into a single conversation.
 
         :param query: The query messages.
@@ -122,7 +138,9 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
         """
         return [*query, *response]
 
-    def _split_messages_at_latest_user(messages: List[dict]) -> Tuple[List[dict], List[dict]]:
+    def _split_messages_at_latest_user(
+        messages: List[dict],
+    ) -> Tuple[List[dict], List[dict]]:
         """Split messages into query/response slices at the latest user turn.
 
         :param messages: The conversation messages.
@@ -135,10 +153,14 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
             default=-1,
         )
         if latest_user_index == -1:
-            raise ValueError("messages must contain at least one message with role 'user'.")
-        return messages[: latest_user_index + 1], messages[latest_user_index + 1:]
+            raise ValueError(
+                "messages must contain at least one message with role 'user'."
+            )
+        return messages[: latest_user_index + 1], messages[latest_user_index + 1 :]
 
-    def _wrap_string_messages(query: str, response: str) -> Tuple[List[dict], List[dict]]:
+    def _wrap_string_messages(
+        query: str, response: str
+    ) -> Tuple[List[dict], List[dict]]:
         """Wrap string query/response into separate message lists.
 
         :param query: The query string.
@@ -176,13 +198,19 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
                 return EvaluationLevel(evaluation_level)
             except ValueError as exc:
                 raise EvaluationException(
-                    message=(f"Invalid evaluation_level '{evaluation_level}'. " f"Must be one of: {valid}."),
+                    message=(
+                        f"Invalid evaluation_level '{evaluation_level}'. "
+                        f"Must be one of: {valid}."
+                    ),
                     blame=ErrorBlame.USER_ERROR,
                     category=ErrorCategory.INVALID_VALUE,
                     target=error_target,
                 ) from exc
         raise EvaluationException(
-            message=(f"Invalid evaluation_level '{evaluation_level}'. " f"Must be one of: {valid}."),
+            message=(
+                f"Invalid evaluation_level '{evaluation_level}'. "
+                f"Must be one of: {valid}."
+            ),
             blame=ErrorBlame.USER_ERROR,
             category=ErrorCategory.INVALID_VALUE,
             target=error_target,
@@ -239,7 +267,10 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
             # _get_agent_response expects content as list of dicts, not a plain string
             normalized = msg
             if role == MessageRole.ASSISTANT and isinstance(msg.get("content"), str):
-                normalized = {**msg, "content": [{"type": "text", "text": msg["content"]}]}
+                normalized = {
+                    **msg,
+                    "content": [{"type": "text", "text": msg["content"]}],
+                }
 
             if role in (MessageRole.SYSTEM, MessageRole.DEVELOPER):
                 content = msg.get("content", "")
@@ -250,7 +281,9 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
 
             elif role == MessageRole.USER and "content" in msg:
                 if cur_agent_response:
-                    formatted = _get_agent_response(cur_agent_response, include_tool_messages=True)
+                    formatted = _get_agent_response(
+                        cur_agent_response, include_tool_messages=True
+                    )
                     all_agent_responses.append([formatted])
                     cur_agent_response = []
                 content = msg["content"]
@@ -271,12 +304,18 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
         if cur_user_query:
             all_user_queries.append(cur_user_query)
         if cur_agent_response:
-            formatted = _get_agent_response(cur_agent_response, include_tool_messages=True)
+            formatted = _get_agent_response(
+                cur_agent_response, include_tool_messages=True
+            )
             all_agent_responses.append([formatted])
 
         conversation_history: Dict = {
             "user_queries": all_user_queries,
-            "agent_responses": all_agent_responses[: len(all_user_queries) - 1] if len(all_user_queries) > 0 else [],
+            "agent_responses": (
+                all_agent_responses[: len(all_user_queries) - 1]
+                if len(all_user_queries) > 0
+                else []
+            ),
         }
         if system_message:
             conversation_history["system_message"] = system_message
@@ -318,7 +357,12 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
             enforce_tool_definitions: bool = False,
         ):
             """Initialize MessagesOrQueryResponseInputValidator."""
-            super().__init__(error_target, requires_query, optional_tool_definitions, check_for_unsupported_tools)
+            super().__init__(
+                error_target,
+                requires_query,
+                optional_tool_definitions,
+                check_for_unsupported_tools,
+            )
             self.enforce_tool_definitions = enforce_tool_definitions
 
         @override
@@ -397,7 +441,9 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
 
                 if self.enforce_tool_definitions:
                     tool_definitions = eval_input.get("tool_definitions")
-                    tool_definitions_validation_exception = self._validate_tool_definitions(tool_definitions)
+                    tool_definitions_validation_exception = (
+                        self._validate_tool_definitions(tool_definitions)
+                    )
                     if tool_definitions_validation_exception:
                         raise tool_definitions_validation_exception
                 return True
@@ -406,11 +452,13 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
                 return super().validate_eval_input(eval_input)
             return ConversationValidator.validate_eval_input(self, eval_input)
 
+
 try:
     from azure.ai.evaluation._evaluators._common._validators import (
         GroundednessConversationValidator,
     )
 except ImportError:  # pragma: no cover
+
     class GroundednessConversationValidator(ConversationValidator):
         """Fallback used when the installed SDK lacks GroundednessConversationValidator.
 
@@ -436,7 +484,9 @@ _GROUNDEDNESS_ALLOWED_RESTRICTED_TOOLS = {
 }
 
 
-class GroundednessConversationValidatorPolicyOverride(GroundednessConversationValidator):
+class GroundednessConversationValidatorPolicyOverride(
+    GroundednessConversationValidator
+):
     """Groundedness-specific tool support policy override.
 
     Keep the validator's unsupported-tool enforcement behavior enabled, but
@@ -523,7 +573,9 @@ def simplify_messages(messages, drop_system=True, drop_tool_calls=False, logger=
                     continue
 
                 # Drop tool calls (if should)
-                if drop_tool_calls and any(c.get("type") == "tool_call" for c in content if isinstance(c, dict)):
+                if drop_tool_calls and any(
+                    c.get("type") == "tool_call" for c in content if isinstance(c, dict)
+                ):
                     continue
 
             # If we reach here, it means we want to keep the message
@@ -533,7 +585,9 @@ def simplify_messages(messages, drop_system=True, drop_tool_calls=False, logger=
 
     except Exception as ex:
         if logger:
-            logger.debug(f"Error simplifying messages: {str(ex)}. Returning original messages.")
+            logger.debug(
+                f"Error simplifying messages: {str(ex)}. Returning original messages."
+            )
         return messages
 
 
@@ -616,7 +670,15 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
     """Evaluator identifier, experimental and to be used only with evaluation in cloud."""
 
     @override
-    def __init__(self, model_config, *, threshold=3, credential=None, evaluation_level=None, **kwargs):
+    def __init__(
+        self,
+        model_config,
+        *,
+        threshold=3,
+        credential=None,
+        evaluation_level=None,
+        **kwargs,
+    ):
         """Initialize a GroundednessEvaluator instance.
 
         :param model_config: Configuration for the Azure OpenAI model.
@@ -632,7 +694,9 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :type evaluation_level: Optional[Union[EvaluationLevel, str]]
         """
         current_dir = os.path.dirname(__file__)
-        prompty_path = os.path.join(current_dir, self._PROMPTY_FILE_NO_QUERY)  # Default to no query
+        prompty_path = os.path.join(
+            current_dir, self._PROMPTY_FILE_NO_QUERY
+        )  # Default to no query
 
         self._higher_is_better = True
 
@@ -645,12 +709,13 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         self._validator = GroundednessConversationValidatorPolicyOverride(
             error_target=ErrorTarget.GROUNDEDNESS_EVALUATOR,
             requires_query=False,
-            check_for_unsupported_tools=True
+            check_for_unsupported_tools=True,
         )
 
         self._validator_with_query = GroundednessConversationValidatorPolicyOverride(
-            error_target=ErrorTarget.GROUNDEDNESS_EVALUATOR, requires_query=True,
-            check_for_unsupported_tools=True
+            error_target=ErrorTarget.GROUNDEDNESS_EVALUATOR,
+            requires_query=True,
+            check_for_unsupported_tools=True,
         )
 
         self._validator_messages = MessagesOrQueryResponseInputValidator(
@@ -673,7 +738,9 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         self._credential = credential
 
         # Load the multi-turn prompty flow for conversation-level evaluation
-        multi_turn_prompty_path = os.path.join(current_dir, self._MULTI_TURN_PROMPTY_FILE)
+        multi_turn_prompty_path = os.path.join(
+            current_dir, self._MULTI_TURN_PROMPTY_FILE
+        )
         prompty_model_config = construct_prompty_model_config(
             validate_model_config(model_config),
             self._DEFAULT_OPEN_API_VERSION,
@@ -868,7 +935,12 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         if status is not None:
             parsed_result[f"{self._result_key}_status"] = status
         # Add top-level token metadata fields for backward compatibility.
-        parsed_result.update({f"{self._result_key}_{key}": value for key, value in token_metadata.items()})
+        parsed_result.update(
+            {
+                f"{self._result_key}_{key}": value
+                for key, value in token_metadata.items()
+            }
+        )
         return parsed_result
 
     def _return_not_applicable_result(
@@ -895,10 +967,17 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
             f"{self._result_key}_properties": None,
         }
         # Add top-level token metadata fields for backward compatibility.
-        result.update({f"{self._result_key}_{key}": value for key, value in token_metadata.items()})
+        result.update(
+            {
+                f"{self._result_key}_{key}": value
+                for key, value in token_metadata.items()
+            }
+        )
         return result
 
-    async def _the_super_do_eval(self, eval_input: Dict) -> Dict[str, Union[float, str]]:
+    async def _the_super_do_eval(
+        self, eval_input: Dict
+    ) -> Dict[str, Union[float, str]]:
         """Do a relevance evaluation.
 
         :param eval_input: The input to the evaluator.
@@ -926,7 +1005,9 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         if isinstance(eval_input.get("query"), list):
             eval_input["query"] = _preprocess_messages(eval_input["query"])
         # Call the prompty flow to get the evaluation result.
-        prompty_output_dict = await self._flow(timeout=self._LLM_CALL_TIMEOUT, **eval_input)
+        prompty_output_dict = await self._flow(
+            timeout=self._LLM_CALL_TIMEOUT, **eval_input
+        )
         score = math.nan
         reason = ""
         llm_properties = {}
@@ -944,12 +1025,17 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                 llm_status = parsed_output.get("status", "completed")
                 if llm_status == "skipped":
                     skip_reason = parsed_output.get("reason", "")
-                    return self._return_not_applicable_result(skip_reason, self._threshold)
+                    return self._return_not_applicable_result(
+                        skip_reason, self._threshold
+                    )
                 score = parsed_output.get("score", math.nan)
                 reason = parsed_output.get("reason", "")
                 llm_properties = parsed_output.get("properties", {}) or {}
             else:
-                if isinstance(llm_output, str) and self._result_key in PROMPT_BASED_REASON_EVALUATORS:
+                if (
+                    isinstance(llm_output, str)
+                    and self._result_key in PROMPT_BASED_REASON_EVALUATORS
+                ):
                     score, reason = parse_quality_evaluator_reason_score(llm_output)
                 elif isinstance(llm_output, str):
                     match = re.search(r"\d", llm_output)
@@ -970,7 +1056,12 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                 f"{self._result_key}_properties": llm_properties,
             }
             # Add top-level token metadata fields for backward compatibility.
-            result.update({f"{self._result_key}_{key}": value for key, value in token_metadata.items()})
+            result.update(
+                {
+                    f"{self._result_key}_{key}": value
+                    for key, value in token_metadata.items()
+                }
+            )
             return result
         raise EvaluationException(
             message="Evaluator returned invalid output.",
@@ -1040,8 +1131,12 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
 
         contains_context = self.has_context(eval_input)
 
-        simplified_query = simplify_messages(eval_input["query"], drop_tool_calls=contains_context)
-        simplified_response = simplify_messages(eval_input["response"], drop_tool_calls=False)
+        simplified_query = simplify_messages(
+            eval_input["query"], drop_tool_calls=contains_context
+        )
+        simplified_response = simplify_messages(
+            eval_input["response"], drop_tool_calls=False
+        )
 
         # Build simplified input
         simplified_eval_input = {
@@ -1063,7 +1158,9 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
             )
         return result
 
-    async def _do_eval_conversation_level(self, eval_input: Dict) -> Dict[str, Union[float, str]]:
+    async def _do_eval_conversation_level(
+        self, eval_input: Dict
+    ) -> Dict[str, Union[float, str]]:
         """Evaluate groundedness for a full conversation-level evaluation.
 
         :param eval_input: The input containing ``messages`` and optionally ``tool_definitions``.
@@ -1079,9 +1176,13 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         prompty_kwargs: Dict[str, Any] = {"messages": conversation_text}
         tool_definitions = eval_input.get("tool_definitions")
         if tool_definitions:
-            prompty_kwargs["tool_definitions"] = reformat_tool_definitions(tool_definitions, logger)
+            prompty_kwargs["tool_definitions"] = reformat_tool_definitions(
+                tool_definitions, logger
+            )
 
-        prompty_output_dict = await self._multi_turn_flow(timeout=self._LLM_CALL_TIMEOUT, **prompty_kwargs)
+        prompty_output_dict = await self._multi_turn_flow(
+            timeout=self._LLM_CALL_TIMEOUT, **prompty_kwargs
+        )
         return self._parse_prompty_output(prompty_output_dict)
 
     def _parse_prompty_output(self, prompty_output_dict: Dict) -> Dict[str, Any]:
@@ -1103,7 +1204,9 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         if isinstance(llm_output, dict):
             status = str(llm_output.get("status", "completed")).strip().lower()
             reason = llm_output.get("reason", llm_output.get("explanation", ""))
-            properties = llm_output.get("properties", llm_output.get("properties", {})) or {}
+            properties = (
+                llm_output.get("properties", llm_output.get("properties", {})) or {}
+            )
             if not isinstance(properties, dict):
                 properties = {}
 
@@ -1114,7 +1217,11 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                 score_value = llm_output.get("score", self.threshold)
                 if isinstance(score_value, str):
                     normalized_score = score_value.strip()
-                    score = float(normalized_score) if normalized_score.replace(".", "", 1).isdigit() else None
+                    score = (
+                        float(normalized_score)
+                        if normalized_score.replace(".", "", 1).isdigit()
+                        else None
+                    )
                 elif isinstance(score_value, (int, float)):
                     score = float(score_value)
                 else:
@@ -1153,16 +1260,25 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :rtype: Union[DoEvalResult[T_EvalValue], AggregateResult[T_EvalValue]]
         """
         # Reshape inputs based on evaluation level before validation
-        if self._evaluation_level == EvaluationLevel.CONVERSATION and not kwargs.get("messages"):
+        if self._evaluation_level == EvaluationLevel.CONVERSATION and not kwargs.get(
+            "messages"
+        ):
             query = kwargs.get("query")
             response = kwargs.get("response")
-            if isinstance(query, str) and isinstance(response, str) and query and response:
+            if (
+                isinstance(query, str)
+                and isinstance(response, str)
+                and query
+                and response
+            ):
                 query, response = _wrap_string_messages(query, response)
             if isinstance(query, list) and isinstance(response, list):
                 kwargs["messages"] = _merge_query_response_messages(query, response)
         elif self._evaluation_level == EvaluationLevel.TURN and kwargs.get("messages"):
             if any(m.get("role") == MessageRole.USER for m in kwargs["messages"]):
-                query_messages, response_messages = _split_messages_at_latest_user(kwargs["messages"])
+                query_messages, response_messages = _split_messages_at_latest_user(
+                    kwargs["messages"]
+                )
                 kwargs["query"] = query_messages
                 kwargs["response"] = response_messages
                 kwargs.pop("messages", None)
@@ -1216,7 +1332,9 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                             result_key = f"{base_key}_result"
                             threshold_key = f"{base_key}_threshold"
                             threshold_value = (
-                                self._threshold.get(base_key) if isinstance(self._threshold, dict) else self._threshold
+                                self._threshold.get(base_key)
+                                if isinstance(self._threshold, dict)
+                                else self._threshold
                             )
                             if not isinstance(threshold_value, (int, float)):
                                 raise EvaluationException(
@@ -1233,14 +1351,22 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                             if not contains_result_key:
                                 if self._higher_is_better:
                                     if float(score_value) >= threshold_value:
-                                        result[result_key] = EVALUATION_PASS_FAIL_MAPPING[True]
+                                        result[result_key] = (
+                                            EVALUATION_PASS_FAIL_MAPPING[True]
+                                        )
                                     else:
-                                        result[result_key] = EVALUATION_PASS_FAIL_MAPPING[False]
+                                        result[result_key] = (
+                                            EVALUATION_PASS_FAIL_MAPPING[False]
+                                        )
                                 else:
                                     if float(score_value) <= threshold_value:
-                                        result[result_key] = EVALUATION_PASS_FAIL_MAPPING[True]
+                                        result[result_key] = (
+                                            EVALUATION_PASS_FAIL_MAPPING[True]
+                                        )
                                     else:
-                                        result[result_key] = EVALUATION_PASS_FAIL_MAPPING[False]
+                                        result[result_key] = (
+                                            EVALUATION_PASS_FAIL_MAPPING[False]
+                                        )
             except Exception as e:
                 logger.warning(f"Error calculating binary result: {e}")
             per_turn_results.append(result)
@@ -1288,11 +1414,17 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
 
         # If response is a string, we can skip the context extraction and just return the eval input
         if response and isinstance(response, str):
-            return super()._convert_kwargs_to_eval_input(query=query, response=response, context=response)
+            return super()._convert_kwargs_to_eval_input(
+                query=query, response=response, context=response
+            )
 
         context = self._get_context_from_agent_response(response, tool_definitions)
 
-        if not self._validate_context(context) and self._is_single_entry(response) and self._is_single_entry(query):
+        if (
+            not self._validate_context(context)
+            and self._is_single_entry(response)
+            and self._is_single_entry(query)
+        ):
             msg = (
                 f"{type(self).__name__}: No valid context provided or could be extracted from the query or response. "
                 "Please either provide valid context or pass the full items list for 'response' and 'query' "
@@ -1305,14 +1437,26 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                 target=ErrorTarget.GROUNDEDNESS_EVALUATOR,
             )
 
-        filtered_response = self._filter_file_search_results(response) if self._validate_context(context) else response
-        return super()._convert_kwargs_to_eval_input(response=filtered_response, context=context, query=query)
+        filtered_response = (
+            self._filter_file_search_results(response)
+            if self._validate_context(context)
+            else response
+        )
+        return super()._convert_kwargs_to_eval_input(
+            response=filtered_response, context=context, query=query
+        )
 
-    def _filter_file_search_results(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _filter_file_search_results(
+        self, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
         """Filter out file_search tool results from the messages."""
         file_search_ids = self._get_file_search_tool_call_ids(messages)
         return [
-            msg for msg in messages if not (msg.get("role") == "tool" and msg.get("tool_call_id") in file_search_ids)
+            msg
+            for msg in messages
+            if not (
+                msg.get("role") == "tool" and msg.get("tool_call_id") in file_search_ids
+            )
         ]
 
     def _get_context_from_agent_response(self, response, tool_definitions):
@@ -1322,14 +1466,20 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         try:
             logger.debug("Extracting context from response")
             tool_calls = self._parse_tools_from_response(response=response)
-            logger.debug("Tool calls parsed successfully: count=%d", len(tool_calls) if tool_calls else 0)
+            logger.debug(
+                "Tool calls parsed successfully: count=%d",
+                len(tool_calls) if tool_calls else 0,
+            )
 
             if not tool_calls:
                 return NO_CONTEXT
 
             context_lines = []
             for tool_call in tool_calls:
-                if not isinstance(tool_call, dict) or tool_call.get("type") != "tool_call":
+                if (
+                    not isinstance(tool_call, dict)
+                    or tool_call.get("type") != "tool_call"
+                ):
                     continue
 
                 tool_name = tool_call.get("name")
@@ -1358,4 +1508,8 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
     def _get_file_search_tool_call_ids(self, query_or_response):
         """Return a list of tool_call_ids for file search tool calls."""
         tool_calls = self._parse_tools_from_response(query_or_response)
-        return [tc.get("tool_call_id") for tc in tool_calls if tc.get("name") == "file_search"]
+        return [
+            tc.get("tool_call_id")
+            for tc in tool_calls
+            if tc.get("name") == "file_search"
+        ]

--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -426,6 +426,31 @@ except ImportError:  # pragma: no cover
         ]
 
 
+_GROUNDEDNESS_ALLOWED_RESTRICTED_TOOLS = {
+    "azure_ai_search",
+    "azure_fabric",
+    "bing_custom_search",
+    "bing_grounding",
+    "openapi_call",
+    "sharepoint_grounding",
+}
+
+
+class GroundednessConversationValidatorPolicyOverride(GroundednessConversationValidator):
+    """Groundedness-specific tool support policy override.
+
+    Keep the validator's unsupported-tool enforcement behavior enabled, but
+    allow a curated subset of tool calls that now have stable grounding
+    semantics for this evaluator.
+    """
+
+    UNSUPPORTED_TOOLS: List[str] = [
+        tool
+        for tool in GroundednessConversationValidator.UNSUPPORTED_TOOLS
+        if tool not in _GROUNDEDNESS_ALLOWED_RESTRICTED_TOOLS
+    ]
+
+
 try:
     from azure.ai.evaluation._user_agent import UserAgentSingleton
 except ImportError:  # pragma: no cover
@@ -617,13 +642,13 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         )
 
         # Initialize input validators
-        self._validator = GroundednessConversationValidator(
+        self._validator = GroundednessConversationValidatorPolicyOverride(
             error_target=ErrorTarget.GROUNDEDNESS_EVALUATOR,
             requires_query=False,
             check_for_unsupported_tools=True
         )
 
-        self._validator_with_query = GroundednessConversationValidator(
+        self._validator_with_query = GroundednessConversationValidatorPolicyOverride(
             error_target=ErrorTarget.GROUNDEDNESS_EVALUATOR, requires_query=True,
             check_for_unsupported_tools=True
         )

--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -156,7 +156,7 @@ except (
             raise ValueError(
                 "messages must contain at least one message with role 'user'."
             )
-        return messages[: latest_user_index + 1], messages[latest_user_index + 1 :]
+        return messages[: latest_user_index + 1], messages[latest_user_index + 1:]
 
     def _wrap_string_messages(
         query: str, response: str

--- a/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
@@ -98,6 +98,84 @@ class TestGroundednessEvaluatorBehavior(
 
     MINIMAL_RESPONSE = BaseEvaluatorBehaviorTest.weather_tool_result_and_assistant_response
 
+    def test_bing_grounding(self):
+        """Bing grounding tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Bing Grounding",
+            evaluation_inputs={
+                "query": data.BING_GROUNDING_QUERY,
+                "response": data.BING_GROUNDING_RESPONSE,
+                "tool_definitions": data.BING_GROUNDING_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_bing_grounding_expected_flow_inputs,
+        )
+
+    def test_bing_custom_search(self):
+        """Bing custom search tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Bing Custom Search",
+            evaluation_inputs={
+                "query": data.BING_CUSTOM_SEARCH_QUERY,
+                "response": data.BING_CUSTOM_SEARCH_RESPONSE,
+                "tool_definitions": data.BING_CUSTOM_SEARCH_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_bing_custom_search_expected_flow_inputs,
+        )
+
+    def test_azure_ai_search(self):
+        """Azure AI Search tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Azure AI Search",
+            evaluation_inputs={
+                "query": data.AZURE_AI_SEARCH_QUERY,
+                "response": data.AZURE_AI_SEARCH_RESPONSE,
+                "tool_definitions": data.AZURE_AI_SEARCH_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_azure_ai_search_expected_flow_inputs,
+        )
+
+    def test_sharepoint_grounding(self):
+        """SharePoint grounding tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="SharePoint Grounding",
+            evaluation_inputs={
+                "query": data.SHAREPOINT_QUERY,
+                "response": data.SHAREPOINT_RESPONSE,
+                "tool_definitions": data.SHAREPOINT_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_sharepoint_grounding_expected_flow_inputs,
+        )
+
+    def test_fabric_data_agent(self):
+        """Fabric data agent tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Fabric Data Agent",
+            evaluation_inputs={
+                "query": data.FABRIC_QUERY,
+                "response": data.FABRIC_RESPONSE,
+                "tool_definitions": data.FABRIC_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_fabric_data_agent_expected_flow_inputs,
+        )
+
+    def test_openapi(self):
+        """OpenAPI tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="OpenAPI",
+            evaluation_inputs={
+                "query": data.OPENAPI_QUERY,
+                "response": data.OPENAPI_RESPONSE,
+                "tool_definitions": data.OPENAPI_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_openapi_expected_flow_inputs,
+        )
+
 
 # region Conversation-level (messages) behavioral tests
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
@@ -46,7 +46,10 @@ from ..common.evaluator_mock_config import (
 
 @pytest.mark.unittest
 class TestGroundednessEvaluatorBehavior(
-    BaseEvaluatorBehaviorTest, BaseToolEvaluationTest, _TurnLevelUtilE2ETests, _MessagesUtilE2ETests
+    BaseEvaluatorBehaviorTest,
+    BaseToolEvaluationTest,
+    _TurnLevelUtilE2ETests,
+    _MessagesUtilE2ETests,
 ):
     """
     Behavioral tests for Groundedness Evaluator.
@@ -96,7 +99,9 @@ class TestGroundednessEvaluatorBehavior(
 
     check_for_unsupported_tools = True
 
-    MINIMAL_RESPONSE = BaseEvaluatorBehaviorTest.weather_tool_result_and_assistant_response
+    MINIMAL_RESPONSE = (
+        BaseEvaluatorBehaviorTest.weather_tool_result_and_assistant_response
+    )
 
     def test_bing_grounding(self):
         """Bing grounding tool is supported for groundedness evaluation."""
@@ -138,7 +143,7 @@ class TestGroundednessEvaluatorBehavior(
         )
 
     def test_sharepoint_grounding(self):
-        """SharePoint grounding tool is supported for groundedness evaluation."""
+        """Validate that sharepoint grounding is supported for groundedness evaluation."""
         self._run_tool_type_test(
             test_label="SharePoint Grounding",
             evaluation_inputs={
@@ -164,7 +169,7 @@ class TestGroundednessEvaluatorBehavior(
         )
 
     def test_openapi(self):
-        """OpenAPI tool is supported for groundedness evaluation."""
+        """Validate that openapi tool calls are supported for groundedness evaluation."""
         self._run_tool_type_test(
             test_label="OpenAPI",
             evaluation_inputs={
@@ -192,14 +197,18 @@ _MULTI_TURN_PROPERTIES = {
 def _create_mocked_groundedness_evaluator():
     """Create a GroundednessEvaluator with both _flow and _multi_turn_flow mocked."""
     model_config = AzureOpenAIModelConfiguration(
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT", "https://Sanitized.api.cognitive.microsoft.com"),
+        azure_endpoint=os.getenv(
+            "AZURE_OPENAI_ENDPOINT", "https://Sanitized.api.cognitive.microsoft.com"
+        ),
         azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT", "aoai-deployment"),
     )
     evaluator = GroundednessEvaluator(model_config=model_config)
     mock_side_effect = get_flow_side_effect_for_evaluator("groundedness")
     evaluator._flow = MagicMock(side_effect=mock_side_effect)
     evaluator._multi_turn_flow = MagicMock(
-        side_effect=create_multi_turn_mock_side_effect(reason=_MULTI_TURN_REASON, properties=_MULTI_TURN_PROPERTIES)
+        side_effect=create_multi_turn_mock_side_effect(
+            reason=_MULTI_TURN_REASON, properties=_MULTI_TURN_PROPERTIES
+        )
     )
     return evaluator
 
@@ -207,7 +216,12 @@ def _create_mocked_groundedness_evaluator():
 VALID_GROUNDEDNESS_MESSAGES: List[Dict[str, Any]] = [
     {
         "role": "user",
-        "content": [{"type": "text", "text": "What are the office hours for the downtown branch?"}],
+        "content": [
+            {
+                "type": "text",
+                "text": "What are the office hours for the downtown branch?",
+            }
+        ],
     },
     {
         "role": "assistant",
@@ -242,7 +256,9 @@ VALID_GROUNDEDNESS_MESSAGES: List[Dict[str, Any]] = [
     },
     {
         "role": "user",
-        "content": [{"type": "text", "text": "Can I visit on Saturday afternoon at 1 PM?"}],
+        "content": [
+            {"type": "text", "text": "Can I visit on Saturday afternoon at 1 PM?"}
+        ],
     },
     {
         "role": "assistant",
@@ -280,10 +296,15 @@ class TestGroundednessMultiturnBehavior:
             {
                 "name": "search_info",
                 "description": "Search for information.",
-                "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
             }
         ]
-        result = evaluator(messages=VALID_GROUNDEDNESS_MESSAGES, tool_definitions=tool_defs)
+        result = evaluator(
+            messages=VALID_GROUNDEDNESS_MESSAGES, tool_definitions=tool_defs
+        )
 
         assert "groundedness" in result
         assert 1 <= result["groundedness"] <= 5
@@ -307,7 +328,10 @@ class TestGroundednessMultiturnBehavior:
 
         assert result["groundedness"] is None
         assert result["groundedness_result"] == "not_applicable"
-        assert result["groundedness_reason"] == "No agent responses to evaluate for groundedness."
+        assert (
+            result["groundedness_reason"]
+            == "No agent responses to evaluate for groundedness."
+        )
         assert result["groundedness_status"] == "skipped"
 
     def test_messages_invalid_output_returns_error_result(self):
@@ -371,7 +395,10 @@ class TestGroundednessMultiturnBehavior:
     def test_query_response_uses_single_turn_flow(self):
         """Verify that the query/response/context path still calls _flow, not _multi_turn_flow."""
         evaluator = _create_mocked_groundedness_evaluator()
-        evaluator(response="The sky is blue.", context="The sky appears blue due to Rayleigh scattering.")
+        evaluator(
+            response="The sky is blue.",
+            context="The sky appears blue due to Rayleigh scattering.",
+        )
 
         evaluator._flow.assert_called_once()
         evaluator._multi_turn_flow.assert_not_called()
@@ -388,7 +415,9 @@ class TestGroundednessMultiturnBehavior:
             {
                 "role": "tool",
                 "tool_call_id": "req_1",
-                "content": [{"type": "mcp_approval_response", "id": "req_1", "approved": True}],
+                "content": [
+                    {"type": "mcp_approval_response", "id": "req_1", "approved": True}
+                ],
             },
             {"role": "assistant", "content": [{"type": "text", "text": "Done!"}]},
         ]
@@ -423,7 +452,10 @@ class TestGroundednessMultiturnBehavior:
         evaluator = _create_mocked_groundedness_evaluator()
         messages = [
             {"role": "user", "content": [{"type": "text", "text": "Hello"}]},
-            {"role": "narrator", "content": [{"type": "text", "text": "The agent responded."}]},
+            {
+                "role": "narrator",
+                "content": [{"type": "text", "text": "The agent responded."}],
+            },
             {"role": "assistant", "content": [{"type": "text", "text": "Hi!"}]},
         ]
         with pytest.raises(EvaluationException, match="Invalid role"):
@@ -485,10 +517,13 @@ class TestGroundednessMultiturnBehavior:
 
 # region evaluation_level tests
 
+
 def _create_mocked_groundedness_evaluator_with_level(evaluation_level=None):
     """Create a GroundednessEvaluator with evaluation_level and mocked flows."""
     model_config = AzureOpenAIModelConfiguration(
-        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT", "https://Sanitized.api.cognitive.microsoft.com"),
+        azure_endpoint=os.getenv(
+            "AZURE_OPENAI_ENDPOINT", "https://Sanitized.api.cognitive.microsoft.com"
+        ),
         azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT", "aoai-deployment"),
     )
     evaluator = GroundednessEvaluator(
@@ -498,7 +533,9 @@ def _create_mocked_groundedness_evaluator_with_level(evaluation_level=None):
     mock_side_effect = get_flow_side_effect_for_evaluator("groundedness")
     evaluator._flow = MagicMock(side_effect=mock_side_effect)
     evaluator._multi_turn_flow = MagicMock(
-        side_effect=create_multi_turn_mock_side_effect(reason=_MULTI_TURN_REASON, properties=_MULTI_TURN_PROPERTIES)
+        side_effect=create_multi_turn_mock_side_effect(
+            reason=_MULTI_TURN_REASON, properties=_MULTI_TURN_PROPERTIES
+        )
     )
     return evaluator
 
@@ -509,15 +546,22 @@ class TestGroundednessEvaluationLevel:
 
     def test_auto_detect_uses_multi_turn_for_messages(self):
         """Default (None) mode auto-detects multi-turn when messages provided."""
-        evaluator = _create_mocked_groundedness_evaluator_with_level(evaluation_level=None)
+        evaluator = _create_mocked_groundedness_evaluator_with_level(
+            evaluation_level=None
+        )
         evaluator(messages=VALID_GROUNDEDNESS_MESSAGES)
         evaluator._multi_turn_flow.assert_called_once()
         evaluator._flow.assert_not_called()
 
     def test_auto_detect_uses_single_turn_for_response_context(self):
         """Default (None) mode auto-detects single-turn when response/context provided."""
-        evaluator = _create_mocked_groundedness_evaluator_with_level(evaluation_level=None)
-        evaluator(response="The sky is blue.", context="The sky is blue due to Rayleigh scattering.")
+        evaluator = _create_mocked_groundedness_evaluator_with_level(
+            evaluation_level=None
+        )
+        evaluator(
+            response="The sky is blue.",
+            context="The sky is blue due to Rayleigh scattering.",
+        )
         evaluator._flow.assert_called_once()
         evaluator._multi_turn_flow.assert_not_called()
 
@@ -539,7 +583,7 @@ class TestGroundednessEvaluationLevel:
         result = evaluator(
             query="What color is the sky?",
             response="The sky is blue.",
-            context="The sky is blue."
+            context="The sky is blue.",
         )
         # Note: _flow may be reassigned by _ensure_query_prompty_loaded when query is present,
         # so we only assert that multi_turn_flow was used for conversation-level evaluation.
@@ -552,29 +596,42 @@ class TestGroundednessEvaluationLevel:
 
     def test_string_level_conversation(self):
         """String 'conversation' is accepted as evaluation_level."""
-        evaluator = _create_mocked_groundedness_evaluator_with_level(evaluation_level="conversation")
+        evaluator = _create_mocked_groundedness_evaluator_with_level(
+            evaluation_level="conversation"
+        )
         result = evaluator(messages=VALID_GROUNDEDNESS_MESSAGES)
         evaluator._multi_turn_flow.assert_called_once()
         assert "groundedness" in result
 
     def test_string_level_turn(self):
         """String 'turn' is accepted as evaluation_level."""
-        evaluator = _create_mocked_groundedness_evaluator_with_level(evaluation_level="turn")
-        evaluator(response="The sky is blue.", context="The sky is blue due to scattering.")
+        evaluator = _create_mocked_groundedness_evaluator_with_level(
+            evaluation_level="turn"
+        )
+        evaluator(
+            response="The sky is blue.", context="The sky is blue due to scattering."
+        )
         evaluator._flow.assert_called_once()
         evaluator._multi_turn_flow.assert_not_called()
 
     def test_empty_string_level_defaults_to_auto_detect_messages(self):
         """Empty string evaluation_level is treated as None (auto-detect) and uses multi-turn for messages."""
-        evaluator = _create_mocked_groundedness_evaluator_with_level(evaluation_level="")
+        evaluator = _create_mocked_groundedness_evaluator_with_level(
+            evaluation_level=""
+        )
         evaluator(messages=VALID_GROUNDEDNESS_MESSAGES)
         evaluator._multi_turn_flow.assert_called_once()
         evaluator._flow.assert_not_called()
 
     def test_empty_string_level_defaults_to_auto_detect_response_context(self):
         """Empty string evaluation_level is treated as None (auto-detect) and uses single-turn for response/context."""
-        evaluator = _create_mocked_groundedness_evaluator_with_level(evaluation_level="")
-        evaluator(response="The sky is blue.", context="The sky is blue due to Rayleigh scattering.")
+        evaluator = _create_mocked_groundedness_evaluator_with_level(
+            evaluation_level=""
+        )
+        evaluator(
+            response="The sky is blue.",
+            context="The sky is blue due to Rayleigh scattering.",
+        )
         evaluator._flow.assert_called_once()
         evaluator._multi_turn_flow.assert_not_called()
 
@@ -628,7 +685,10 @@ class TestGroundednessSerializeMessages:
     def test_with_tool_calls(self):
         """Tool calls and results are included in serialization."""
         messages = [
-            {"role": "user", "content": [{"type": "text", "text": "What's the weather?"}]},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "What's the weather?"}],
+            },
             {
                 "role": "assistant",
                 "content": [
@@ -672,7 +732,10 @@ class TestGroundednessSerializeMessages:
     def test_system_content_block_list_flattened_to_string(self):
         """System message with content-block list is flattened, not passed as raw list."""
         messages = [
-            {"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant."}]},
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "You are a helpful assistant."}],
+            },
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi!"},
         ]
@@ -703,10 +766,13 @@ class TestGroundednessSerializeMessages:
     def test_multi_text_block_user_message(self):
         """User message with multiple text blocks produces flat turn content."""
         messages = [
-            {"role": "user", "content": [
-                {"type": "text", "text": "Part A."},
-                {"type": "text", "text": "Part B."},
-            ]},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Part A."},
+                    {"type": "text", "text": "Part B."},
+                ],
+            },
             {"role": "assistant", "content": "Got it."},
         ]
         result = serialize_messages(messages)
@@ -716,10 +782,13 @@ class TestGroundednessSerializeMessages:
     def test_system_content_block_multi_text(self):
         """System message with multiple text blocks joins them with newline."""
         messages = [
-            {"role": "system", "content": [
-                {"type": "text", "text": "Rule 1."},
-                {"type": "text", "text": "Rule 2."},
-            ]},
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "Rule 1."},
+                    {"type": "text", "text": "Rule 2."},
+                ],
+            },
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": "Hi!"},
         ]
@@ -736,7 +805,9 @@ class TestGroundednessSerializeMessages:
         # serialize_messages resolves _get_agent_response from the module where it is
         # defined: the SDK's _common.utils on 1.18.1, or this evaluator module on 1.17.x.
         serialize_module = sys.modules[serialize_messages.__module__]
-        with patch.object(serialize_module, "_get_agent_response", return_value="line one\nline two"):
+        with patch.object(
+            serialize_module, "_get_agent_response", return_value="line one\nline two"
+        ):
             result = serialize_messages(messages)
         assert "Agent turn 1:" in result
         assert "line one" in result
@@ -747,6 +818,7 @@ class TestGroundednessSerializeMessages:
 
 
 # region None score handling tests
+
 
 @pytest.mark.unittest
 class TestGroundednessNoneScoreHandling:
@@ -798,12 +870,19 @@ class TestGroundednessInternalBranches:
 
     def test_simplify_messages_drops_tool_call_only_assistant(self):
         """Assistant message with only a tool_call is dropped when drop_tool_calls=True."""
-        messages = [{"role": "assistant", "content": [{"type": "tool_call", "name": "f", "arguments": {}}]}]
+        messages = [
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_call", "name": "f", "arguments": {}}],
+            }
+        ]
         assert simplify_messages(messages, drop_tool_calls=True) == []
 
     def test_serialize_messages_single_turn_appends_agent_text(self):
         """Single user/assistant turn serializes with an 'Agent turn' string block."""
-        result = serialize_messages([{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}])
+        result = serialize_messages(
+            [{"role": "user", "content": "q"}, {"role": "assistant", "content": "a"}]
+        )
         assert "Agent turn 1:" in result
 
     def test_validate_context_list_with_content(self):
@@ -819,13 +898,17 @@ class TestGroundednessInternalBranches:
     def test_parse_prompty_output_non_dict_properties_reset(self):
         """Non-dict 'properties' in llm_output is reset to an empty dict."""
         ev = create_mocked_evaluator(GroundednessEvaluator, "groundedness")
-        result = ev._parse_prompty_output({"llm_output": {"status": "completed", "properties": "x", "score": 5}})
+        result = ev._parse_prompty_output(
+            {"llm_output": {"status": "completed", "properties": "x", "score": 5}}
+        )
         assert result[ev._result_key] == 5.0
 
     def test_parse_prompty_output_non_numeric_score_becomes_none(self):
         """A score value that is neither string nor number becomes None."""
         ev = create_mocked_evaluator(GroundednessEvaluator, "groundedness")
-        result = ev._parse_prompty_output({"llm_output": {"status": "completed", "score": ["l"]}})
+        result = ev._parse_prompty_output(
+            {"llm_output": {"status": "completed", "score": ["l"]}}
+        )
         assert result[ev._result_key] is None
 
     def test_is_single_entry_string(self):
@@ -836,12 +919,16 @@ class TestGroundednessInternalBranches:
     def test_filter_file_search_results_removes_matching_tool_messages(self):
         """File-search tool result messages are filtered out by tool_call_id."""
         ev = create_mocked_evaluator(GroundednessEvaluator, "groundedness")
-        ev._parse_tools_from_response = MagicMock(return_value=[{"name": "file_search", "tool_call_id": "tc1"}])
+        ev._parse_tools_from_response = MagicMock(
+            return_value=[{"name": "file_search", "tool_call_id": "tc1"}]
+        )
         messages = [
             {"role": "tool", "tool_call_id": "tc1"},
             {"role": "assistant", "content": "x"},
         ]
-        assert ev._filter_file_search_results(messages) == [{"role": "assistant", "content": "x"}]
+        assert ev._filter_file_search_results(messages) == [
+            {"role": "assistant", "content": "x"}
+        ]
 
     def test_get_context_from_agent_response_extracts_file_search_text(self):
         """Context text is extracted from file_search tool results."""
@@ -851,7 +938,9 @@ class TestGroundednessInternalBranches:
                 {
                     "type": "tool_call",
                     "name": "file_search",
-                    "tool_result": [{"file_name": "f.txt", "content": [{"text": "hello"}]}],
+                    "tool_result": [
+                        {"file_name": "f.txt", "content": [{"text": "hello"}]}
+                    ],
                 }
             ]
         )
@@ -862,13 +951,17 @@ class TestGroundednessInternalBranches:
         """Parsed entries that are not tool_calls are skipped, yielding no context."""
         ev = create_mocked_evaluator(GroundednessEvaluator, "groundedness")
         ev._parse_tools_from_response = MagicMock(return_value=[{"type": "other"}])
-        assert ev._get_context_from_agent_response([{"role": "assistant"}], None) == "<>"
+        assert (
+            ev._get_context_from_agent_response([{"role": "assistant"}], None) == "<>"
+        )
 
     def test_get_context_from_agent_response_handles_parse_exception(self):
         """An exception while parsing tool calls falls back to the no-context marker."""
         ev = create_mocked_evaluator(GroundednessEvaluator, "groundedness")
         ev._parse_tools_from_response = MagicMock(side_effect=ValueError("boom"))
-        assert ev._get_context_from_agent_response([{"role": "assistant"}], None) == "<>"
+        assert (
+            ev._get_context_from_agent_response([{"role": "assistant"}], None) == "<>"
+        )
 
     def test_do_eval_intermediate_response_returns_not_applicable(self):
         """An intermediate (function_call) response yields a not-applicable result."""
@@ -876,7 +969,12 @@ class TestGroundednessInternalBranches:
         eval_input = {
             "query": "q",
             "response": [
-                {"role": "assistant", "content": [{"type": "function_call", "name": "f", "arguments": "{}"}]}
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "function_call", "name": "f", "arguments": "{}"}
+                    ],
+                }
             ],
             "context": "c",
         }
@@ -893,7 +991,14 @@ class TestGroundednessInternalBranches:
 
         ev._the_super_do_eval = _nan
         with pytest.raises(EvaluationException):
-            asyncio.run(ev._do_eval({"response": [{"role": "assistant", "content": "a"}], "context": "c"}))
+            asyncio.run(
+                ev._do_eval(
+                    {
+                        "response": [{"role": "assistant", "content": "a"}],
+                        "context": "c",
+                    }
+                )
+            )
 
     def test_do_eval_with_query_invalid_output_raises(self):
         """A NaN score from the base evaluator (query present) raises EvaluationException."""


### PR DESCRIPTION
## Summary
- enable groundedness evaluator for these tool call types:
  - `bing_grounding`
  - `bing_custom_search`
  - `azure_ai_search`
  - `sharepoint_grounding`
  - `azure_fabric`
  - `openapi_call`
- keep unsupported-tool validation enabled, but apply a groundedness-specific validator policy override to allow the list above
- keep `code_interpreter_call`, `browser_automation`, `computer_call`, and `web_search` gated as unsupported

## Implementation
- added `GroundednessConversationValidatorPolicyOverride` in groundedness evaluator to derive unsupported tools from the base validator minus the newly allowed set
- switched groundedness validator initialization to use the policy override
- added groundedness behavior tests asserting PASS for the newly supported tool types

## Validation
- `python -m pytest assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py -k "test_bing_grounding or test_bing_custom_search or test_azure_ai_search or test_sharepoint_grounding or test_fabric_data_agent or test_openapi or test_code_interpreter" -q`
- result: 7 passed
