### PR TITLE
Enable Web Search support in Groundedness evaluator

### DIFF
--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -426,6 +426,31 @@ except ImportError:  # pragma: no cover
         ]
 
 
+_GROUNDEDNESS_ALLOWED_RESTRICTED_TOOLS = {
+    "azure_ai_search",
+    "azure_fabric",
+    "bing_custom_search",
+    "bing_grounding",
+    "openapi_call",
+    "sharepoint_grounding",
+}
+
+
+class GroundednessConversationValidatorPolicyOverride(GroundednessConversationValidator):
+    """Groundedness-specific tool support policy override.
+
+    Keep the validator's unsupported-tool enforcement behavior enabled, but
+    allow a curated subset of tool calls that now have stable grounding
+    semantics for this evaluator.
+    """
+
+    UNSUPPORTED_TOOLS: List[str] = [
+        tool
+        for tool in GroundednessConversationValidator.UNSUPPORTED_TOOLS
+        if tool not in _GROUNDEDNESS_ALLOWED_RESTRICTED_TOOLS
+    ]
+
+
 try:
     from azure.ai.evaluation._user_agent import UserAgentSingleton
 except ImportError:  # pragma: no cover
@@ -617,13 +642,13 @@ class GroundednessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         )
 
         # Initialize input validators
-        self._validator = GroundednessConversationValidator(
+        self._validator = GroundednessConversationValidatorPolicyOverride(
             error_target=ErrorTarget.GROUNDEDNESS_EVALUATOR,
             requires_query=False,
             check_for_unsupported_tools=True
         )
 
-        self._validator_with_query = GroundednessConversationValidator(
+        self._validator_with_query = GroundednessConversationValidatorPolicyOverride(
             error_target=ErrorTarget.GROUNDEDNESS_EVALUATOR, requires_query=True,
             check_for_unsupported_tools=True
         )

--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -433,6 +433,7 @@ _GROUNDEDNESS_ALLOWED_RESTRICTED_TOOLS = {
     "bing_grounding",
     "openapi_call",
     "sharepoint_grounding",
+    "web_search",
 }
 
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
@@ -176,6 +176,19 @@ class TestGroundednessEvaluatorBehavior(
             expected_flow_inputs=self.test_openapi_expected_flow_inputs,
         )
 
+    def test_web_search(self):
+        """Web search tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Web Search",
+            evaluation_inputs={
+                "query": data.WEB_SEARCH_QUERY,
+                "response": data.WEB_SEARCH_RESPONSE,
+                "tool_definitions": data.WEB_SEARCH_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_web_search_expected_flow_inputs,
+        )
+
 
 # region Conversation-level (messages) behavioral tests
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
@@ -98,6 +98,84 @@ class TestGroundednessEvaluatorBehavior(
 
     MINIMAL_RESPONSE = BaseEvaluatorBehaviorTest.weather_tool_result_and_assistant_response
 
+    def test_bing_grounding(self):
+        """Bing grounding tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Bing Grounding",
+            evaluation_inputs={
+                "query": data.BING_GROUNDING_QUERY,
+                "response": data.BING_GROUNDING_RESPONSE,
+                "tool_definitions": data.BING_GROUNDING_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_bing_grounding_expected_flow_inputs,
+        )
+
+    def test_bing_custom_search(self):
+        """Bing custom search tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Bing Custom Search",
+            evaluation_inputs={
+                "query": data.BING_CUSTOM_SEARCH_QUERY,
+                "response": data.BING_CUSTOM_SEARCH_RESPONSE,
+                "tool_definitions": data.BING_CUSTOM_SEARCH_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_bing_custom_search_expected_flow_inputs,
+        )
+
+    def test_azure_ai_search(self):
+        """Azure AI Search tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Azure AI Search",
+            evaluation_inputs={
+                "query": data.AZURE_AI_SEARCH_QUERY,
+                "response": data.AZURE_AI_SEARCH_RESPONSE,
+                "tool_definitions": data.AZURE_AI_SEARCH_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_azure_ai_search_expected_flow_inputs,
+        )
+
+    def test_sharepoint_grounding(self):
+        """SharePoint grounding tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="SharePoint Grounding",
+            evaluation_inputs={
+                "query": data.SHAREPOINT_QUERY,
+                "response": data.SHAREPOINT_RESPONSE,
+                "tool_definitions": data.SHAREPOINT_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_sharepoint_grounding_expected_flow_inputs,
+        )
+
+    def test_fabric_data_agent(self):
+        """Fabric data agent tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Fabric Data Agent",
+            evaluation_inputs={
+                "query": data.FABRIC_QUERY,
+                "response": data.FABRIC_RESPONSE,
+                "tool_definitions": data.FABRIC_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_fabric_data_agent_expected_flow_inputs,
+        )
+
+    def test_openapi(self):
+        """OpenAPI tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="OpenAPI",
+            evaluation_inputs={
+                "query": data.OPENAPI_QUERY,
+                "response": data.OPENAPI_RESPONSE,
+                "tool_definitions": data.OPENAPI_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_openapi_expected_flow_inputs,
+        )
+
 
 # region Conversation-level (messages) behavioral tests
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
@@ -138,7 +138,7 @@ class TestGroundednessEvaluatorBehavior(
         )
 
     def test_sharepoint_grounding(self):
-        """SharePoint grounding tool is supported for groundedness evaluation."""
+        """Validate that sharepoint grounding is supported for groundedness evaluation."""
         self._run_tool_type_test(
             test_label="SharePoint Grounding",
             evaluation_inputs={
@@ -164,7 +164,7 @@ class TestGroundednessEvaluatorBehavior(
         )
 
     def test_openapi(self):
-        """OpenAPI tool is supported for groundedness evaluation."""
+        """Validate that openapi tool calls are supported for groundedness evaluation."""
         self._run_tool_type_test(
             test_label="OpenAPI",
             evaluation_inputs={


### PR DESCRIPTION
## Summary
- Add web_search to groundedness restricted-tool allowlist
- Add groundedness behavior test that expects Web Search to pass

## Validation
- Ran targeted tests:
  - python -m pytest assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py -k "web_search or openapi or bing_grounding or azure_ai_search" -q
- Result: 4 passed

## Scope
- No changes outside groundedness evaluator policy and groundedness behavior tests.
