### PR TITLE
Enable Web Search support in Groundedness evaluator

### DIFF
--- a/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
+++ b/assets/evaluators/builtin/groundedness/evaluator/_groundedness.py
@@ -433,6 +433,7 @@ _GROUNDEDNESS_ALLOWED_RESTRICTED_TOOLS = {
     "bing_grounding",
     "openapi_call",
     "sharepoint_grounding",
+    "web_search",
 }
 
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py
@@ -176,6 +176,19 @@ class TestGroundednessEvaluatorBehavior(
             expected_flow_inputs=self.test_openapi_expected_flow_inputs,
         )
 
+    def test_web_search(self):
+        """Web search tool is supported for groundedness evaluation."""
+        self._run_tool_type_test(
+            test_label="Web Search",
+            evaluation_inputs={
+                "query": data.WEB_SEARCH_QUERY,
+                "response": data.WEB_SEARCH_RESPONSE,
+                "tool_definitions": data.WEB_SEARCH_TOOL_DEFINITIONS,
+            },
+            assert_type=self.AssertType.PASS,
+            expected_flow_inputs=self.test_web_search_expected_flow_inputs,
+        )
+
 
 # region Conversation-level (messages) behavioral tests
 


### PR DESCRIPTION
## Summary
- Add web_search to groundedness restricted-tool allowlist
- Add groundedness behavior test that expects Web Search to pass

## Validation
- Ran targeted tests:
  - python -m pytest assets/evaluators/tests/test_evaluators_behavior/test_groundedness_evaluator_behavior.py -k "web_search or openapi or bing_grounding or azure_ai_search" -q
- Result: 4 passed

## Formatting
- Ran Black in check mode on changed files.
- Black reports formatting differences, but this PR intentionally keeps whitespace churn minimal.
