### PR TITLE
fix: verify AutoML model signatures before loading

### DIFF
--- a/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
+++ b/assets/training/forecasting_demand/automl-single-model-inference/components/inference/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.jso
 name: automl_forecasting_inference
 display_name: AutoML Forecasting Inference
 description: Inference component for AutoML Forecasting.
-version: 0.0.15
+version: 0.0.16
 type: command
 
 inputs:
@@ -11,7 +11,11 @@ inputs:
     description: "Test data folder with csv or parquet file."
   model_path:
     type: mlflow_model
-    description: "The trained AutoML Forecasting MLFLOW model."
+    description: >-
+      The trained AutoML Forecasting MLflow model. The model file must have a
+      matching detached RSA PKCS#1 v1.5 SHA-256 signature named
+      <model file>.sig. A trusted pipeline operator must supply the corresponding
+      public key through AUTOML_MODEL_SIGNING_PUBLIC_KEY_PEM.
   target_column_name:
     type: string
     description: "The name of the target column."

--- a/assets/training/forecasting_demand/automl-single-model-inference/src/inference.py
+++ b/assets/training/forecasting_demand/automl-single-model-inference/src/inference.py
@@ -5,7 +5,6 @@
 import argparse
 import json
 import os
-import pickle
 
 import azureml.automl.core.shared.constants as automl_constants
 import numpy as np
@@ -14,13 +13,13 @@ from azureml._common._error_definition import AzureMLError, error_decorator
 from azureml._common._error_definition.user_error import BadArgument
 from azureml.automl.core.shared.forecasting_exception import ForecastingDataException
 from azureml.core import Run
-
-try:
-    import torch  # noqa: F401
-
-    _torch_present = True
-except ImportError:
-    _torch_present = False
+from model_loader import (
+    PICKLE_FILE_POSTFIX,
+    PTH_FILE_POSTFIX,
+    PT_FILE_POSTFIX,
+    SIGNATURE_FILE_POSTFIX,
+    get_model,
+)
 
 
 class _ForecastModes:
@@ -36,8 +35,6 @@ _FORECAST_ORIGIN_COLUMN_NAME = "automl_forecast_origin"
 _PREDICTED_COLUMN_NAME = "automl_prediction"
 _ACTUAL_COLUMN_NAME = "automl_actual"
 _PI = "prediction_interval"
-_PTH_FILE_POSTFIX = ".pth"
-_PT_FILE_POSTFIX = ".pt"
 _CSV_POSTFIX = ".csv"
 _PARQ_POSTFIX = ".parquet"
 _CONDA_YAML_FILE_NAME = "conda.yaml"
@@ -65,10 +62,6 @@ _INVALID_ARG_QUANTILE_FORMAT = 'abc26505-87e4-4877-a855-7532473290a1'
 
 # ------------------------------------------
 # Util methods.
-def _map_location_cuda(storage, loc):
-    return storage.cuda()
-
-
 def _get_test_data(target_column_name, test_dataset):
     print("Loading test data.")
     test_df = None
@@ -100,7 +93,12 @@ def _get_test_data(target_column_name, test_dataset):
 def _get_model_fullpath(model_path):
     model_fl_name = ""
     for filename in os.listdir(model_path):
-        if filename == automl_constants.MODEL_FILENAME or filename == automl_constants.PT_MODEL_FILENAME:
+        model_full_path = os.path.join(model_path, filename)
+        signature_path = f"{model_full_path}{SIGNATURE_FILE_POSTFIX}"
+        if (
+            filename == automl_constants.MODEL_FILENAME
+            or filename == automl_constants.PT_MODEL_FILENAME
+        ) and os.path.isfile(signature_path):
             model_fl_name = filename
             break
 
@@ -108,39 +106,32 @@ def _get_model_fullpath(model_path):
     if model_fl_name:
         model_full_path = os.path.join(model_path, model_fl_name)
     else:
-        # Find the .pt or .pth pytorch model file in sub-folders:
+        supported_postfixes = (
+            PICKLE_FILE_POSTFIX,
+            PT_FILE_POSTFIX,
+            PTH_FILE_POSTFIX,
+        )
         for root, dirs, files in os.walk(model_path):
             for filename in files:
-                if filename.endswith(_PT_FILE_POSTFIX) or filename.endswith(_PTH_FILE_POSTFIX):
-                    model_full_path = os.path.join(root, filename)
+                candidate_path = os.path.join(root, filename)
+                signature_path = f"{candidate_path}{SIGNATURE_FILE_POSTFIX}"
+                if filename.lower().endswith(supported_postfixes) and os.path.isfile(signature_path):
+                    model_full_path = candidate_path
                     break
+            if model_full_path:
+                break
 
     if not model_full_path:
-        raise Exception(f"Unable to find any valid model in folder {model_path}!")
+        raise ValueError(
+            f"Unable to find a supported signed model in folder {model_path}. "
+            "Each model must have a matching detached .sig file."
+        )
 
     return model_full_path
 
 
 def _get_model(model_full_path):
-    fitted_model = None
-    print(f"Loading the model from path: {model_full_path}")
-    if model_full_path.endswith(_PT_FILE_POSTFIX) or model_full_path.endswith(_PTH_FILE_POSTFIX):
-        if not _torch_present:
-            raise Exception("Loading Forecasting TCN model requires torch to be installed in the environment.")
-
-        if torch.cuda.is_available():
-            map_location = _map_location_cuda
-        else:
-            map_location = "cpu"
-        with open(model_full_path, "rb") as fh:
-            fitted_model = torch.load(fh, map_location=map_location)
-    else:
-        # Load the sklearn pipeline.
-        with open(model_full_path, 'rb') as fp:
-            fitted_model = pickle.load(fp)
-
-    print("Model loading succeeded.")
-    return fitted_model
+    return get_model(model_full_path)
 
 
 # ------------------------------------------

--- a/assets/training/forecasting_demand/automl-single-model-inference/src/model_loader.py
+++ b/assets/training/forecasting_demand/automl-single-model-inference/src/model_loader.py
@@ -1,0 +1,134 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Load AutoML forecasting models only after verifying their provenance."""
+
+import hashlib
+import os
+import pickle
+import tempfile
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa, utils
+
+try:
+    import torch
+
+    _torch_present = True
+except ImportError:
+    _torch_present = False
+
+
+MODEL_SIGNING_PUBLIC_KEY_ENV_VAR = "AUTOML_MODEL_SIGNING_PUBLIC_KEY_PEM"
+PTH_FILE_POSTFIX = ".pth"
+PT_FILE_POSTFIX = ".pt"
+PICKLE_FILE_POSTFIX = ".pkl"
+SIGNATURE_FILE_POSTFIX = ".sig"
+_SUPPORTED_MODEL_POSTFIXES = (PICKLE_FILE_POSTFIX, PT_FILE_POSTFIX, PTH_FILE_POSTFIX)
+_HASH_CHUNK_SIZE = 1024 * 1024
+
+
+def _load_signing_public_key():
+    public_key_pem = os.environ.get(MODEL_SIGNING_PUBLIC_KEY_ENV_VAR)
+    if not public_key_pem:
+        raise ValueError(
+            f"{MODEL_SIGNING_PUBLIC_KEY_ENV_VAR} must contain the trusted RSA public key "
+            "used to verify model artifacts."
+        )
+
+    try:
+        public_key = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
+    except (TypeError, ValueError) as ex:
+        raise ValueError(
+            f"{MODEL_SIGNING_PUBLIC_KEY_ENV_VAR} does not contain a valid PEM public key."
+        ) from ex
+
+    if not isinstance(public_key, rsa.RSAPublicKey):
+        raise ValueError("The model-signing public key must be an RSA public key.")
+
+    return public_key
+
+
+def _stage_and_verify_model(model_full_path):
+    signature_path = f"{model_full_path}{SIGNATURE_FILE_POSTFIX}"
+    if not os.path.isfile(signature_path):
+        raise ValueError(f"Model signature file not found: {signature_path}")
+
+    public_key = _load_signing_public_key()
+    hasher = hashlib.sha256()
+    staged_path = None
+    verified = False
+
+    try:
+        model_postfix = os.path.splitext(model_full_path)[1].lower()
+        with open(model_full_path, "rb") as model_file, tempfile.NamedTemporaryFile(
+            mode="wb", suffix=model_postfix, delete=False
+        ) as staged_file:
+            staged_path = staged_file.name
+            while chunk := model_file.read(_HASH_CHUNK_SIZE):
+                hasher.update(chunk)
+                staged_file.write(chunk)
+
+        expected_signature_size = (public_key.key_size + 7) // 8
+        with open(signature_path, "rb") as signature_file:
+            signature = signature_file.read(expected_signature_size + 1)
+        if len(signature) != expected_signature_size:
+            raise ValueError(
+                f"Model signature must be exactly {expected_signature_size} bytes."
+            )
+
+        public_key.verify(
+            signature,
+            hasher.digest(),
+            padding.PKCS1v15(),
+            utils.Prehashed(hashes.SHA256()),
+        )
+        verified = True
+        return staged_path
+    except InvalidSignature as ex:
+        raise ValueError(f"Model signature verification failed for {model_full_path}.") from ex
+    finally:
+        if staged_path and not verified:
+            os.unlink(staged_path)
+
+
+def _map_location_cuda(storage, loc):
+    return storage.cuda()
+
+
+def get_model(model_full_path):
+    """Verify and load a supported AutoML forecasting model."""
+    model_postfix = os.path.splitext(model_full_path)[1].lower()
+    if model_postfix not in _SUPPORTED_MODEL_POSTFIXES:
+        raise ValueError(
+            f"Unsupported model format '{model_postfix}'. "
+            f"Supported formats: {', '.join(_SUPPORTED_MODEL_POSTFIXES)}."
+        )
+
+    print(f"Verifying the model signature for path: {model_full_path}")
+    staged_model_path = _stage_and_verify_model(model_full_path)
+    try:
+        print(f"Loading the verified model from path: {model_full_path}")
+        # Legacy AutoML artifacts require full-object loading; the detached signature is the trust boundary.
+        if model_postfix in (PT_FILE_POSTFIX, PTH_FILE_POSTFIX):
+            if not _torch_present:
+                raise RuntimeError(
+                    "Loading Forecasting TCN model requires torch to be installed in the environment."
+                )
+
+            map_location = _map_location_cuda if torch.cuda.is_available() else "cpu"
+            with open(staged_model_path, "rb") as model_file:
+                fitted_model = torch.load(
+                    model_file,
+                    map_location=map_location,
+                    weights_only=False,
+                )
+        else:
+            with open(staged_model_path, "rb") as model_file:
+                fitted_model = pickle.load(model_file)
+    finally:
+        os.unlink(staged_model_path)
+
+    print("Model loading succeeded.")
+    return fitted_model

--- a/assets/training/forecasting_demand/automl-single-model-inference/tests/test_model_loader.py
+++ b/assets/training/forecasting_demand/automl-single-model-inference/tests/test_model_loader.py
@@ -1,0 +1,117 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for signed AutoML forecasting model loading."""
+
+import hashlib
+import pickle
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa, utils
+
+
+SRC_PATH = Path(__file__).parents[1] / "src"
+sys.path.insert(0, str(SRC_PATH))
+
+import model_loader  # noqa: E402
+
+
+EXPLOIT_EXECUTED = False
+
+
+def _mark_executed():
+    global EXPLOIT_EXECUTED
+    EXPLOIT_EXECUTED = True
+
+
+class _MaliciousPayload:
+    def __reduce__(self):
+        return _mark_executed, ()
+
+
+@pytest.fixture
+def signing_key(monkeypatch):
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    monkeypatch.setenv(
+        model_loader.MODEL_SIGNING_PUBLIC_KEY_ENV_VAR,
+        public_key_pem.decode("utf-8"),
+    )
+    return private_key
+
+
+def _sign_model(model_path, private_key):
+    digest = hashlib.sha256(model_path.read_bytes()).digest()
+    signature = private_key.sign(
+        digest,
+        padding.PKCS1v15(),
+        utils.Prehashed(hashes.SHA256()),
+    )
+    Path(f"{model_path}{model_loader.SIGNATURE_FILE_POSTFIX}").write_bytes(signature)
+
+
+def test_get_model_loads_valid_signed_pickle(tmp_path, signing_key):
+    model_path = tmp_path / "model.pkl"
+    expected_model = {"model": "trusted"}
+    model_path.write_bytes(pickle.dumps(expected_model))
+    _sign_model(model_path, signing_key)
+
+    assert model_loader.get_model(str(model_path)) == expected_model
+
+
+def test_get_model_rejects_unsigned_pickle_without_deserializing(tmp_path):
+    global EXPLOIT_EXECUTED
+    EXPLOIT_EXECUTED = False
+    model_path = tmp_path / "model.pkl"
+    model_path.write_bytes(pickle.dumps(_MaliciousPayload()))
+
+    with pytest.raises(ValueError, match="signature file not found"):
+        model_loader.get_model(str(model_path))
+
+    assert not EXPLOIT_EXECUTED
+
+
+def test_get_model_rejects_invalid_signature_without_deserializing(
+    tmp_path, signing_key
+):
+    global EXPLOIT_EXECUTED
+    EXPLOIT_EXECUTED = False
+    model_path = tmp_path / "model.pkl"
+    model_path.write_bytes(pickle.dumps({"model": "trusted"}))
+    _sign_model(model_path, signing_key)
+    model_path.write_bytes(pickle.dumps(_MaliciousPayload()))
+
+    with pytest.raises(ValueError, match="signature verification failed"):
+        model_loader.get_model(str(model_path))
+
+    assert not EXPLOIT_EXECUTED
+
+
+def test_get_model_requires_trusted_public_key(tmp_path, monkeypatch):
+    model_path = tmp_path / "model.pkl"
+    model_path.write_bytes(pickle.dumps({"model": "unsigned"}))
+    Path(f"{model_path}{model_loader.SIGNATURE_FILE_POSTFIX}").write_bytes(b"signature")
+    monkeypatch.delenv(model_loader.MODEL_SIGNING_PUBLIC_KEY_ENV_VAR, raising=False)
+
+    with pytest.raises(
+        ValueError, match=model_loader.MODEL_SIGNING_PUBLIC_KEY_ENV_VAR
+    ):
+        model_loader.get_model(str(model_path))
+
+
+def test_get_model_rejects_oversized_signature(tmp_path, signing_key):
+    model_path = tmp_path / "model.pkl"
+    model_path.write_bytes(pickle.dumps({"model": "trusted"}))
+    signature_path = Path(
+        f"{model_path}{model_loader.SIGNATURE_FILE_POSTFIX}"
+    )
+    signature_path.write_bytes(b"x" * 257)
+
+    with pytest.raises(ValueError, match="exactly 256 bytes"):
+        model_loader.get_model(str(model_path))

--- a/assets/training/forecasting_demand/automl-single-model-inference/tests/test_model_loader.py
+++ b/assets/training/forecasting_demand/automl-single-model-inference/tests/test_model_loader.py
@@ -34,6 +34,7 @@ class _MaliciousPayload:
 
 @pytest.fixture
 def signing_key(monkeypatch):
+    """Create an RSA signing key and configure its public key as trusted."""
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     public_key_pem = private_key.public_key().public_bytes(
         encoding=serialization.Encoding.PEM,
@@ -57,6 +58,7 @@ def _sign_model(model_path, private_key):
 
 
 def test_get_model_loads_valid_signed_pickle(tmp_path, signing_key):
+    """Load a pickle only when its detached signature is valid."""
     model_path = tmp_path / "model.pkl"
     expected_model = {"model": "trusted"}
     model_path.write_bytes(pickle.dumps(expected_model))
@@ -66,6 +68,7 @@ def test_get_model_loads_valid_signed_pickle(tmp_path, signing_key):
 
 
 def test_get_model_rejects_unsigned_pickle_without_deserializing(tmp_path):
+    """Reject an unsigned pickle without executing its payload."""
     global EXPLOIT_EXECUTED
     EXPLOIT_EXECUTED = False
     model_path = tmp_path / "model.pkl"
@@ -80,6 +83,7 @@ def test_get_model_rejects_unsigned_pickle_without_deserializing(tmp_path):
 def test_get_model_rejects_invalid_signature_without_deserializing(
     tmp_path, signing_key
 ):
+    """Reject a model changed after signing without executing its payload."""
     global EXPLOIT_EXECUTED
     EXPLOIT_EXECUTED = False
     model_path = tmp_path / "model.pkl"
@@ -94,6 +98,7 @@ def test_get_model_rejects_invalid_signature_without_deserializing(
 
 
 def test_get_model_requires_trusted_public_key(tmp_path, monkeypatch):
+    """Reject a signed model when no trusted public key is configured."""
     model_path = tmp_path / "model.pkl"
     model_path.write_bytes(pickle.dumps({"model": "unsigned"}))
     Path(f"{model_path}{model_loader.SIGNATURE_FILE_POSTFIX}").write_bytes(b"signature")
@@ -106,6 +111,7 @@ def test_get_model_requires_trusted_public_key(tmp_path, monkeypatch):
 
 
 def test_get_model_rejects_oversized_signature(tmp_path, signing_key):
+    """Reject a signature whose size does not match the trusted RSA key."""
     model_path = tmp_path / "model.pkl"
     model_path.write_bytes(pickle.dumps({"model": "trusted"}))
     signature_path = Path(


### PR DESCRIPTION
## Summary
- require detached RSA PKCS#1 v1.5 SHA-256 signatures before loading AutoML forecasting model artifacts
- deserialize only staged bytes that were successfully verified, preventing model replacement between verification and loading
- reject unsigned, tampered, unsupported, and malformed-signature artifacts before `pickle.load` or `torch.load`
- bump `automl_forecasting_inference` to `0.0.16` and document the trusted public-key requirement

## Security context
Remediates CWE-502 reported under IcM 842340960 while preserving compatibility with existing AutoML pickle and full-object PyTorch artifacts. Secure `skops` migration is currently blocked because `skops>=0.12` requires NumPy >=1.25 while `azureml-train-automl-runtime==1.62.0` requires NumPy <=1.23.5.

The trusted pipeline operator must set `AUTOML_MODEL_SIGNING_PUBLIC_KEY_PEM`; each model must include a sibling `<model>.sig` detached signature.

## Why the vulnerability is resolved
The model input no longer flows directly into an unsafe deserialization sink:

1. The model is copied to a temporary staging file while its SHA-256 digest is calculated.
2. The digest is verified against a detached RSA PKCS#1 v1.5 signature using the operator-controlled public key.
3. Only the exact staged bytes that passed signature verification are supplied to `pickle.load()` or `torch.load()`.
4. Missing, malformed, forged, or tampered signatures fail before deserialization.

Staging and loading the same verified copy also prevents a time-of-check/time-of-use replacement between verification and deserialization.

Regression coverage verifies that a malicious pickle `__reduce__` payload is not executed when:
- the signature is missing
- the model is modified after signing
- the signature has an invalid size or value
- the trusted public key is unavailable

A production verification can sign an existing model without changing its bytes:

```bash
openssl dgst -sha256 -sign private.pem -out model.pkl.sig model.pkl
```

Inference should succeed with the signed model. Modifying any model byte afterward must produce `Model signature verification failed` before the model-loading log and before any payload executes.

This guarantee depends on protecting the private signing key and ensuring the model supplier cannot override `AUTOML_MODEL_SIGNING_PUBLIC_KEY_PEM`. The trusted key must be configured by the pipeline or platform operator, not supplied by the same principal that supplies the model.

## Backward compatibility
The model serialization and inference contracts are preserved:
- existing `.pkl`, `.pt`, and `.pth` formats remain supported
- existing model bytes do not need retraining, conversion, or reserialization
- the existing `pickle.load()` and full-object `torch.load()` behavior is retained after provenance verification
- component inputs, outputs, and forecasting behavior are unchanged

This is intentionally not zero-touch compatible with unsigned artifacts. Existing models must receive a sibling detached signature and the trusted public key must be configured. Component version `0.0.15` remains available for existing pipelines, while `0.0.16` introduces signature enforcement, allowing a controlled migration.

## Validation
- `python -m pytest assets\training\forecasting_demand\automl-single-model-inference\tests\test_model_loader.py -q`
- `python scripts\validation\doc_style.py -i .`
- `python -m py_compile assets\training\forecasting_demand\automl-single-model-inference\src\model_loader.py assets\training\forecasting_demand\automl-single-model-inference\src\inference.py`

Remediates CWE-502 from IcM 842340960.