### PR TITLE
Fix MedImage unsafe deserialization

### DIFF
--- a/assets/training/finetune_acft_image/components/finetune/medimage_adapter/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_adapter/spec.yaml
@@ -17,15 +17,15 @@ distribution:
 
 inputs:
   train_data_path:
-    type: uri_folder
+    type: uri_file
     optional: false
-    description: Path to the training embeddings folder.
+    description: Path to the training data file.
     mode: ro_mount
 
   validation_data_path:
-    type: uri_folder
+    type: uri_file
     optional: false
-    description: Path to the validation embeddings folder.
+    description: Path to the validation data file.
     mode: ro_mount
 
   validation_text_tsv:

--- a/assets/training/finetune_acft_image/components/finetune/medimage_adapter/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_adapter/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: medimageinsight_adapter_finetune
-version: 0.0.4
+version: 0.0.5
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_image/components/finetune/medimage_adapter/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_adapter/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: medimageinsight_adapter_finetune
-version: 0.0.5
+version: 0.0.2
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_image/components/finetune/medimage_adapter/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_adapter/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: medimageinsight_adapter_finetune
-version: 0.0.1
+version: 0.0.4
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: MedImageInsight Adapter Finetune
 description: Component to finetune the model using the medical image data
 
-environment: azureml://registries/azureml/environments/acft-medimageinsight-adapter-finetune/versions/8
+environment: azureml://registries/azureml/environments/acft-medimageinsight-adapter-finetune/versions/34
 
 code: ../../../src/medimage_insight_adapter_finetune
 
@@ -17,15 +17,15 @@ distribution:
 
 inputs:
   train_data_path:
-    type: uri_file
+    type: uri_folder
     optional: false
-    description: Path to the training data file.
+    description: Path to the training embeddings folder.
     mode: ro_mount
 
   validation_data_path:
-    type: uri_file
+    type: uri_folder
     optional: false
-    description: Path to the validation data file.
+    description: Path to the validation embeddings folder.
     mode: ro_mount
 
   validation_text_tsv:
@@ -131,4 +131,3 @@ command: >-
   $[[--max_epochs "${{inputs.max_epochs}}"]]
   $[[--track_metric "${{inputs.track_metric}}"]]
   --output_model_path "${{outputs.output_model_path}}"
-

--- a/assets/training/finetune_acft_image/components/finetune/medimage_insight/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_insight/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 
 name: medimageinsight_embedding_finetune
-version: 0.0.1
+version: 0.0.4
 
 
 type: command
@@ -11,7 +11,7 @@ is_deterministic: True
 display_name: MedImageInsight Embedding Finetune
 description: Component to finetune the model using the medical image data
 
-environment: azureml://registries/azureml/environments/acft-medimageinsight-embedding/versions/8
+environment: azureml://registries/azureml/environments/acft-medimageinsight-embedding/versions/38
 
 code: ../../../src/medimage_insight_embedding_finetune
 
@@ -20,7 +20,7 @@ distribution:
 
 inputs:
   mlflow_model_path:
-    type: uri_folder
+    type: mlflow_model
     optional: false
     description: Path to the MLflow model to be imported.
     mode: ro_mount
@@ -99,4 +99,3 @@ command: >-
   --conf_files "${{inputs.conf_files}}"
   --save_dir "${{outputs.save_dir}}"
   --mlflow_output_model_folder "${{outputs.mlflow_model_folder}}"
-

--- a/assets/training/finetune_acft_image/components/finetune/medimage_insight/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_insight/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 
 name: medimageinsight_embedding_finetune
-version: 0.0.4
+version: 0.0.2
 
 
 type: command

--- a/assets/training/finetune_acft_image/components/model_converters/medimage_embed_adapter_merge/spec.yaml
+++ b/assets/training/finetune_acft_image/components/model_converters/medimage_embed_adapter_merge/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.jso
 type: command
 
 
-version: 0.0.3
+version: 0.0.2
 name: medimageinsight_classification_model
 display_name: MedImageInsight Classification Model
 

--- a/assets/training/finetune_acft_image/components/model_converters/medimage_embed_adapter_merge/spec.yaml
+++ b/assets/training/finetune_acft_image/components/model_converters/medimage_embed_adapter_merge/spec.yaml
@@ -2,7 +2,7 @@ $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.jso
 type: command
 
 
-version: 0.0.1
+version: 0.0.3
 name: medimageinsight_classification_model
 display_name: MedImageInsight Classification Model
 
@@ -11,7 +11,7 @@ description: Integrate labels and generates classification model
 is_deterministic: True
 
 
-environment: azureml://registries/azureml/environments/acft-medimageinsight-embedding-generator/versions/9
+environment: azureml://registries/azureml/environments/acft-medimageinsight-embedding-generator/versions/31
 
 
 code: ../../../src/model_converters/medimage_embed_adapter_merge

--- a/assets/training/finetune_acft_image/components/pipeline_components/medimage_insight_ft/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/medimage_insight_ft/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 
 name: medimageinsight_ft_pipeline
-version: 0.0.1
+version: 0.0.4
 
 type: pipeline
 display_name: MedImageInsight Finetune Pipeline
@@ -9,7 +9,7 @@ description: Pipeline Component to finetune MedImageInsight Model.
 
 inputs:
   mlflow_embedding_model_path:
-    type: uri_folder
+    type: mlflow_model
     optional: false
     description: Path to the MLflow model to be imported.
     mode: ro_mount
@@ -111,7 +111,7 @@ jobs:
   medimageinsight_embedding_finetune:
     type: command
 
-    component: azureml:medimageinsight_embedding_finetune:0.0.1
+    component: azureml:medimageinsight_embedding_finetune:0.0.4
 
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
@@ -136,7 +136,7 @@ jobs:
   medimageinsight_classification_model:
     type: command
 
-    component: azureml:medimageinsight_classification_model:0.0.1
+    component: azureml:medimageinsight_classification_model:0.0.3
 
     compute: '${{parent.inputs.compute_finetune}}'
     resources:

--- a/assets/training/finetune_acft_image/components/pipeline_components/medimage_insight_ft/spec.yaml
+++ b/assets/training/finetune_acft_image/components/pipeline_components/medimage_insight_ft/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/pipelineComponent.schema.json
 
 name: medimageinsight_ft_pipeline
-version: 0.0.4
+version: 0.0.2
 
 type: pipeline
 display_name: MedImageInsight Finetune Pipeline
@@ -111,7 +111,7 @@ jobs:
   medimageinsight_embedding_finetune:
     type: command
 
-    component: azureml:medimageinsight_embedding_finetune:0.0.4
+    component: azureml:medimageinsight_embedding_finetune:0.0.2
 
     compute: '${{parent.inputs.compute_finetune}}'
     resources:
@@ -136,7 +136,7 @@ jobs:
   medimageinsight_classification_model:
     type: command
 
-    component: azureml:medimageinsight_classification_model:0.0.3
+    component: azureml:medimageinsight_classification_model:0.0.2
 
     compute: '${{parent.inputs.compute_finetune}}'
     resources:

--- a/assets/training/finetune_acft_image/components/preprocess/image_embedding/spec.yaml
+++ b/assets/training/finetune_acft_image/components/preprocess/image_embedding/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: medimageinsight_embedding_generation
-version: 0.0.1
+version: 0.0.13
 type: command
 
 is_deterministic: True
@@ -8,7 +8,7 @@ is_deterministic: True
 display_name: MedImageInsight Embedding Generation
 description: To generate embeddings for medical images.
 
-environment: azureml://registries/azureml/environments/acft-medimageinsight-embedding-generator/versions/9
+environment: azureml://registries/azureml/environments/acft-medimageinsight-embedding-generator/versions/31
 code: ../../../src/medimage_insight_adapter_preprocess
 
 inputs:
@@ -19,7 +19,7 @@ inputs:
     mode: ro_mount
 
   mlflow_model_path:
-    type: uri_folder
+    type: mlflow_model
     optional: false
     description: Path to the MLflow model to be imported.
     mode: ro_mount
@@ -39,10 +39,11 @@ inputs:
 outputs:
   output_pkl:
     type: uri_folder
-    description: Path to the output training PKL file.
+    description: Path to the output training embeddings file.
     mode: rw_mount
 
 command: >-
+  python -m pip install --no-cache-dir "transformers>=4.52.0,<4.56.0" &&
   python medimage_datapreprocess.py
   --task_name "MedEmbedding"
   --image_tsv "${{inputs.image_tsv}}"

--- a/assets/training/finetune_acft_image/components/preprocess/image_embedding/spec.yaml
+++ b/assets/training/finetune_acft_image/components/preprocess/image_embedding/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: medimageinsight_embedding_generation
-version: 0.0.14
+version: 0.0.15
 type: command
 
 is_deterministic: True
@@ -39,7 +39,7 @@ inputs:
 outputs:
   output_pkl:
     type: uri_folder
-    description: Path to the output training embeddings file.
+    description: Path to the output training PKL file.
     mode: rw_mount
 
 command: >-

--- a/assets/training/finetune_acft_image/components/preprocess/image_embedding/spec.yaml
+++ b/assets/training/finetune_acft_image/components/preprocess/image_embedding/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: medimageinsight_embedding_generation
-version: 0.0.13
+version: 0.0.14
 type: command
 
 is_deterministic: True
@@ -43,7 +43,6 @@ outputs:
     mode: rw_mount
 
 command: >-
-  python -m pip install --no-cache-dir "transformers>=4.52.0,<4.56.0" &&
   python medimage_datapreprocess.py
   --task_name "MedEmbedding"
   --image_tsv "${{inputs.image_tsv}}"

--- a/assets/training/finetune_acft_image/components/preprocess/image_embedding/spec.yaml
+++ b/assets/training/finetune_acft_image/components/preprocess/image_embedding/spec.yaml
@@ -1,6 +1,6 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 name: medimageinsight_embedding_generation
-version: 0.0.15
+version: 0.0.2
 type: command
 
 is_deterministic: True

--- a/assets/training/finetune_acft_image/src/medimage_insight_adapter_finetune/medimage_train.py
+++ b/assets/training/finetune_acft_image/src/medimage_insight_adapter_finetune/medimage_train.py
@@ -17,7 +17,7 @@ import training
 
 COMPONENT_NAME = "ACFT-MedImage-Classification-Training"
 logger = get_logger_app("azureml.acft.contrib.hf.scripts.src.train.classification_adaptor_train")
-EMBEDDING_FILE_NAME = "embeddings.json"
+EMBEDDING_FILE_NAME = "embeddings.pkl"
 
 
 def get_parser():
@@ -140,8 +140,12 @@ def load_data(train_data_path: str, validation_data_path: str) -> tuple[pd.DataF
     Returns:
         tuple[pd.DataFrame, pd.DataFrame]: DataFrames containing the training and validation data.
     """
-    train_data_file = os.path.join(train_data_path, EMBEDDING_FILE_NAME)
-    validation_data_file = os.path.join(validation_data_path, EMBEDDING_FILE_NAME)
+    train_data_file = train_data_path if os.path.isfile(train_data_path) else os.path.join(train_data_path, EMBEDDING_FILE_NAME)
+    validation_data_file = (
+        validation_data_path
+        if os.path.isfile(validation_data_path)
+        else os.path.join(validation_data_path, EMBEDDING_FILE_NAME)
+    )
     train_data = pd.read_json(train_data_file, orient="records", lines=True)
     validation_data = pd.read_json(validation_data_file, orient="records", lines=True)
     train_data["features"] = train_data["features"].apply(np.asarray)

--- a/assets/training/finetune_acft_image/src/medimage_insight_adapter_finetune/medimage_train.py
+++ b/assets/training/finetune_acft_image/src/medimage_insight_adapter_finetune/medimage_train.py
@@ -10,13 +10,14 @@ from azureml.acft.contrib.hf import VERSION, PROJECT_NAME
 from azureml.acft.contrib.hf.nlp.constants.constants import LOGS_TO_BE_FILTERED_IN_APPINSIGHTS
 import pandas as pd
 import torch
+import numpy as np
 import os
 import training
 
 
 COMPONENT_NAME = "ACFT-MedImage-Classification-Training"
 logger = get_logger_app("azureml.acft.contrib.hf.scripts.src.train.classification_adaptor_train")
-EMBEDDING_FILE_NAME = "embeddings.pkl"
+EMBEDDING_FILE_NAME = "embeddings.json"
 
 
 def get_parser():
@@ -141,8 +142,10 @@ def load_data(train_data_path: str, validation_data_path: str) -> tuple[pd.DataF
     """
     train_data_file = os.path.join(train_data_path, EMBEDDING_FILE_NAME)
     validation_data_file = os.path.join(validation_data_path, EMBEDDING_FILE_NAME)
-    train_data = pd.read_pickle(train_data_file)
-    validation_data = pd.read_pickle(validation_data_file)
+    train_data = pd.read_json(train_data_file, orient="records", lines=True)
+    validation_data = pd.read_json(validation_data_file, orient="records", lines=True)
+    train_data["features"] = train_data["features"].apply(np.asarray)
+    validation_data["features"] = validation_data["features"].apply(np.asarray)
     return train_data, validation_data
 
 
@@ -164,24 +167,29 @@ def merge_data_with_text(
     Returns:
         tuple[pd.DataFrame, pd.DataFrame]: Merged DataFrames for training and validation data.
     """
-    train_text_df = pd.read_csv(train_text_tsv, sep="\t", header=None)
+    train_text_df = pd.read_csv(train_text_tsv, sep="\t", header=None, escapechar="\\")
     train_text_df.columns = ["Name", "classification_json"]
-    validation_text_df = pd.read_csv(validation_text_tsv, sep="\t", header=None)
+    validation_text_df = pd.read_csv(validation_text_tsv, sep="\t", header=None, escapechar="\\")
     validation_text_df.columns = ["Name", "classification_json"]
 
     def extract_label_from_json(json_str):
         try:
             json_obj = json.loads(json_str)
-            return json_obj.get("class_id", -1)
-        except json.JSONDecodeError:
-            logger.error("Failed to decode JSON from text column")
-            return -1
+            label = json_obj["class_id"]
+            if not isinstance(label, int) or label < 0:
+                raise ValueError(f"Invalid class_id value: {label}")
+            return label
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as ex:
+            raise ValueError(f"Failed to parse class_id from classification JSON: {json_str!r}") from ex
 
     train_text_df["Label"] = train_text_df["classification_json"].apply(extract_label_from_json)
     validation_text_df["Label"] = validation_text_df["classification_json"].apply(extract_label_from_json)
 
     train_data = pd.merge(train_data, train_text_df, on="Name")[["Name", "features", "Label"]]
     validation_data = pd.merge(validation_data, validation_text_df, on="Name")[["Name", "features", "Label"]]
+
+    if train_data.empty or validation_data.empty:
+        raise ValueError("No rows remained after merging embeddings with text labels")
 
     return train_data, validation_data
 

--- a/assets/training/finetune_acft_image/src/medimage_insight_adapter_finetune/medimage_train.py
+++ b/assets/training/finetune_acft_image/src/medimage_insight_adapter_finetune/medimage_train.py
@@ -140,7 +140,9 @@ def load_data(train_data_path: str, validation_data_path: str) -> tuple[pd.DataF
     Returns:
         tuple[pd.DataFrame, pd.DataFrame]: DataFrames containing the training and validation data.
     """
-    train_data_file = train_data_path if os.path.isfile(train_data_path) else os.path.join(train_data_path, EMBEDDING_FILE_NAME)
+    train_data_file = (
+        train_data_path if os.path.isfile(train_data_path) else os.path.join(train_data_path, EMBEDDING_FILE_NAME)
+    )
     validation_data_file = (
         validation_data_path
         if os.path.isfile(validation_data_path)

--- a/assets/training/finetune_acft_image/src/medimage_insight_adapter_preprocess/medimage_datapreprocess.py
+++ b/assets/training/finetune_acft_image/src/medimage_insight_adapter_preprocess/medimage_datapreprocess.py
@@ -4,41 +4,16 @@
 """File containing functions for embeddings generation from MedImageInsight."""
 
 import argparse
-import logging
-import importlib.metadata
-import platform
-import sys
-import traceback
+from azureml.acft.common_components import (
+    get_logger_app,
+    set_logging_parameters,
+    LoggingLiterals,
+)
 
-try:
-    from azureml.acft.common_components import (
-        get_logger_app,
-        set_logging_parameters,
-        LoggingLiterals,
-    )
-    from azureml.acft.contrib.hf import VERSION, PROJECT_NAME
-    from azureml.acft.contrib.hf.nlp.constants.constants import (
-        LOGS_TO_BE_FILTERED_IN_APPINSIGHTS,
-    )
-except ImportError:
-    VERSION = "unknown"
-    PROJECT_NAME = "azureml-acft"
-    LOGS_TO_BE_FILTERED_IN_APPINSIGHTS = []
-
-    class LoggingLiterals:
-        """Fallback logging keys for environments without azureml-acft packages."""
-
-        PROJECT_NAME = "project_name"
-        PROJECT_VERSION_NUMBER = "project_version_number"
-        COMPONENT_NAME = "component_name"
-
-    def get_logger_app(name):
-        logging.basicConfig(level=logging.INFO)
-        return logging.getLogger(name)
-
-    def set_logging_parameters(*args, **kwargs):
-        return None
-
+from azureml.acft.contrib.hf import VERSION, PROJECT_NAME
+from azureml.acft.contrib.hf.nlp.constants.constants import (
+    LOGS_TO_BE_FILTERED_IN_APPINSIGHTS,
+)
 import mlflow
 import pandas as pd
 import numpy as np
@@ -46,7 +21,7 @@ import os
 
 
 COMPONENT_NAME = "ACFT-MedImage-Embedding-Generator"
-EMBEDDING_FILE_NAME = "embeddings.json"
+EMBEDDING_FILE_NAME = "embeddings.pkl"
 
 
 logger = get_logger_app(
@@ -73,83 +48,6 @@ def resolve_mlflow_model_path(model_path: str) -> str:
     raise FileNotFoundError(f"No MLmodel file found under {model_path}")
 
 
-def _read_text_preview(path: str, max_chars: int = 4000) -> str:
-    try:
-        with open(path, encoding="utf-8", errors="replace") as handle:
-            return handle.read(max_chars)
-    except OSError as ex:
-        return f"<failed to read {path}: {ex}>"
-
-
-def _log_package_versions(package_names: list[str]) -> None:
-    for package_name in package_names:
-        try:
-            logger.info("Package %s version: %s", package_name, importlib.metadata.version(package_name))
-        except importlib.metadata.PackageNotFoundError:
-            logger.info("Package %s version: <not installed>", package_name)
-
-
-def log_mlflow_load_diagnostics(model_path: str) -> None:
-    """Log mounted model and runtime diagnostics without dumping large files."""
-    logger.info("Python executable: %s", sys.executable)
-    logger.info("Python version: %s", sys.version.replace("\n", " "))
-    logger.info("Platform: %s", platform.platform())
-    logger.info("Working directory: %s", os.getcwd())
-    logger.info("MLflow version: %s", getattr(mlflow, "__version__", "<unknown>"))
-    logger.info("MLflow module path: %s", getattr(mlflow, "__file__", "<unknown>"))
-    logger.info("MLflow tracking URI before load: %s", mlflow.get_tracking_uri())
-    logger.info("MLflow registry URI before load: %s", mlflow.get_registry_uri())
-    logger.info("MLFLOW_TRACKING_URI env: %s", os.environ.get("MLFLOW_TRACKING_URI"))
-    logger.info("MLFLOW_REGISTRY_URI env: %s", os.environ.get("MLFLOW_REGISTRY_URI"))
-    logger.info("MLFLOW_ALLOW_FILE_STORE env: %s", os.environ.get("MLFLOW_ALLOW_FILE_STORE"))
-    _log_package_versions(
-        [
-            "mlflow",
-            "cloudpickle",
-            "azure-ai-ml",
-            "azureml-core",
-            "azureml-dataset-runtime",
-            "azureml-ai-monitoring",
-            "timm",
-            "transformers",
-            "einops",
-            "mup",
-            "fvcore",
-            "sentencepiece",
-            "tenacity",
-            "ftfy",
-            "setuptools",
-        ]
-    )
-
-    logger.info("Resolved model path exists: %s is_dir=%s", os.path.exists(model_path), os.path.isdir(model_path))
-    for root, dirs, files in os.walk(model_path):
-        rel_root = os.path.relpath(root, model_path)
-        depth = 0 if rel_root == "." else rel_root.count(os.sep) + 1
-        if depth > 2:
-            dirs[:] = []
-            continue
-        logger.info(
-            "Model tree %s dirs=%s files=%s",
-            rel_root,
-            sorted(dirs)[:20],
-            sorted(files)[:20],
-        )
-
-    for file_name in ["MLmodel", "requirements.txt", "conda.yaml", "python_env.yaml"]:
-        file_path = os.path.join(model_path, file_name)
-        logger.info("%s exists: %s", file_name, os.path.isfile(file_path))
-        if os.path.isfile(file_path):
-            logger.info("%s preview:\n%s", file_name, _read_text_preview(file_path))
-
-    try:
-        model_config = mlflow.models.Model.load(model_path)
-        logger.info("MLflow Model.load flavors: %s", list(model_config.flavors.keys()))
-        logger.info("MLflow Model.load metadata: %s", model_config.metadata)
-    except Exception:
-        logger.error("MLflow Model.load failed:\n%s", traceback.format_exc())
-
-
 def load_local_mlflow_model(model_path: str):
     """Load a mounted MLflow model without AzureML tracking/registry side effects."""
     original_tracking_uri = os.environ.get("MLFLOW_TRACKING_URI")
@@ -164,15 +62,7 @@ def load_local_mlflow_model(model_path: str):
         mlflow.set_tracking_uri(local_tracking_uri)
         mlflow.set_registry_uri(local_tracking_uri)
         logger.info("Loading MLflow model from %s", model_path)
-        loaded_model = mlflow.pyfunc.load_model(model_path)
-        logger.info("mlflow.pyfunc.load_model returned: %r", loaded_model)
-        if loaded_model is not None:
-            logger.info("Loaded object class: %s.%s", type(loaded_model).__module__, type(loaded_model).__name__)
-            logger.info("Loaded object attributes: %s", sorted(dir(loaded_model))[:200])
-        return loaded_model
-    except Exception:
-        logger.error("mlflow.pyfunc.load_model raised:\n%s", traceback.format_exc())
-        raise
+        return mlflow.pyfunc.load_model(model_path)
     finally:
         if original_tracking_uri is None:
             os.environ.pop("MLFLOW_TRACKING_URI", None)
@@ -274,15 +164,15 @@ def save_dataframe(
     image_embeddings: pd.DataFrame,
     output_pkl_path: str,
 ) -> None:
-    """Save image embeddings DataFrame to a JSON file.
+    """Save image embeddings DataFrame to an embeddings file.
 
     This function saves the provided image embeddings DataFrame
-    to the specified JSON file path with the given file name. It also creates
+    to the specified output path with the given file name. It also creates
     the directory if it does not exist.
 
     Args:
         image_embeddings (pd.DataFrame): The DataFrame containing image embeddings to be saved.
-        output_pkl_path (str): The directory path where the JSON file will be saved.
+        output_pkl_path (str): The directory path where the embeddings file will be saved.
     Returns:
         None
     """
@@ -294,7 +184,7 @@ def save_dataframe(
         lines=True,
     )
 
-    logger.info("Saved merged DataFrames to JSON files")
+    logger.info("Saved merged DataFrames to embeddings file")
 
 
 def process_embeddings(args):
@@ -317,11 +207,9 @@ def process_embeddings(args):
     image_tsv = args.image_tsv
 
     resolved_model_path = resolve_mlflow_model_path(model_path)
-    log_mlflow_load_diagnostics(resolved_model_path)
     mlflow_model = load_local_mlflow_model(resolved_model_path)
     if mlflow_model is None:
         raise RuntimeError(f"mlflow.pyfunc.load_model returned None for {resolved_model_path}")
-    logger.info("Loaded MLflow model type: %s", type(mlflow_model).__name__)
     image_embeddings = generate_embeddings(
         image_tsv,
         mlflow_model,

--- a/assets/training/finetune_acft_image/src/medimage_insight_adapter_preprocess/medimage_datapreprocess.py
+++ b/assets/training/finetune_acft_image/src/medimage_insight_adapter_preprocess/medimage_datapreprocess.py
@@ -4,16 +4,41 @@
 """File containing functions for embeddings generation from MedImageInsight."""
 
 import argparse
-from azureml.acft.common_components import (
-    get_logger_app,
-    set_logging_parameters,
-    LoggingLiterals,
-)
+import logging
+import importlib.metadata
+import platform
+import sys
+import traceback
 
-from azureml.acft.contrib.hf import VERSION, PROJECT_NAME
-from azureml.acft.contrib.hf.nlp.constants.constants import (
-    LOGS_TO_BE_FILTERED_IN_APPINSIGHTS,
-)
+try:
+    from azureml.acft.common_components import (
+        get_logger_app,
+        set_logging_parameters,
+        LoggingLiterals,
+    )
+    from azureml.acft.contrib.hf import VERSION, PROJECT_NAME
+    from azureml.acft.contrib.hf.nlp.constants.constants import (
+        LOGS_TO_BE_FILTERED_IN_APPINSIGHTS,
+    )
+except ImportError:
+    VERSION = "unknown"
+    PROJECT_NAME = "azureml-acft"
+    LOGS_TO_BE_FILTERED_IN_APPINSIGHTS = []
+
+    class LoggingLiterals:
+        """Fallback logging keys for environments without azureml-acft packages."""
+
+        PROJECT_NAME = "project_name"
+        PROJECT_VERSION_NUMBER = "project_version_number"
+        COMPONENT_NAME = "component_name"
+
+    def get_logger_app(name):
+        logging.basicConfig(level=logging.INFO)
+        return logging.getLogger(name)
+
+    def set_logging_parameters(*args, **kwargs):
+        return None
+
 import mlflow
 import pandas as pd
 import numpy as np
@@ -21,7 +46,7 @@ import os
 
 
 COMPONENT_NAME = "ACFT-MedImage-Embedding-Generator"
-EMBEDDING_FILE_NAME = "embeddings.pkl"
+EMBEDDING_FILE_NAME = "embeddings.json"
 
 
 logger = get_logger_app(
@@ -31,8 +56,140 @@ logger = get_logger_app(
 Input Arguments:
     --image_tsv: Path to image TSV file.
     --mlflow_model_path: The path to the MLflow model.
-    --output_pkl: Output PKL file path.
+    --output_pkl: Output embeddings file path.
 """
+
+
+def resolve_mlflow_model_path(model_path: str) -> str:
+    """Resolve the directory that contains the MLflow MLmodel file."""
+    if os.path.isfile(os.path.join(model_path, "MLmodel")):
+        return model_path
+
+    for root, _, files in os.walk(model_path):
+        if "MLmodel" in files:
+            logger.info("Resolved MLflow model path from %s to %s", model_path, root)
+            return root
+
+    raise FileNotFoundError(f"No MLmodel file found under {model_path}")
+
+
+def _read_text_preview(path: str, max_chars: int = 4000) -> str:
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            return handle.read(max_chars)
+    except OSError as ex:
+        return f"<failed to read {path}: {ex}>"
+
+
+def _log_package_versions(package_names: list[str]) -> None:
+    for package_name in package_names:
+        try:
+            logger.info("Package %s version: %s", package_name, importlib.metadata.version(package_name))
+        except importlib.metadata.PackageNotFoundError:
+            logger.info("Package %s version: <not installed>", package_name)
+
+
+def log_mlflow_load_diagnostics(model_path: str) -> None:
+    """Log mounted model and runtime diagnostics without dumping large files."""
+    logger.info("Python executable: %s", sys.executable)
+    logger.info("Python version: %s", sys.version.replace("\n", " "))
+    logger.info("Platform: %s", platform.platform())
+    logger.info("Working directory: %s", os.getcwd())
+    logger.info("MLflow version: %s", getattr(mlflow, "__version__", "<unknown>"))
+    logger.info("MLflow module path: %s", getattr(mlflow, "__file__", "<unknown>"))
+    logger.info("MLflow tracking URI before load: %s", mlflow.get_tracking_uri())
+    logger.info("MLflow registry URI before load: %s", mlflow.get_registry_uri())
+    logger.info("MLFLOW_TRACKING_URI env: %s", os.environ.get("MLFLOW_TRACKING_URI"))
+    logger.info("MLFLOW_REGISTRY_URI env: %s", os.environ.get("MLFLOW_REGISTRY_URI"))
+    logger.info("MLFLOW_ALLOW_FILE_STORE env: %s", os.environ.get("MLFLOW_ALLOW_FILE_STORE"))
+    _log_package_versions(
+        [
+            "mlflow",
+            "cloudpickle",
+            "azure-ai-ml",
+            "azureml-core",
+            "azureml-dataset-runtime",
+            "azureml-ai-monitoring",
+            "timm",
+            "transformers",
+            "einops",
+            "mup",
+            "fvcore",
+            "sentencepiece",
+            "tenacity",
+            "ftfy",
+            "setuptools",
+        ]
+    )
+
+    logger.info("Resolved model path exists: %s is_dir=%s", os.path.exists(model_path), os.path.isdir(model_path))
+    for root, dirs, files in os.walk(model_path):
+        rel_root = os.path.relpath(root, model_path)
+        depth = 0 if rel_root == "." else rel_root.count(os.sep) + 1
+        if depth > 2:
+            dirs[:] = []
+            continue
+        logger.info(
+            "Model tree %s dirs=%s files=%s",
+            rel_root,
+            sorted(dirs)[:20],
+            sorted(files)[:20],
+        )
+
+    for file_name in ["MLmodel", "requirements.txt", "conda.yaml", "python_env.yaml"]:
+        file_path = os.path.join(model_path, file_name)
+        logger.info("%s exists: %s", file_name, os.path.isfile(file_path))
+        if os.path.isfile(file_path):
+            logger.info("%s preview:\n%s", file_name, _read_text_preview(file_path))
+
+    try:
+        model_config = mlflow.models.Model.load(model_path)
+        logger.info("MLflow Model.load flavors: %s", list(model_config.flavors.keys()))
+        logger.info("MLflow Model.load metadata: %s", model_config.metadata)
+    except Exception:
+        logger.error("MLflow Model.load failed:\n%s", traceback.format_exc())
+
+
+def load_local_mlflow_model(model_path: str):
+    """Load a mounted MLflow model without AzureML tracking/registry side effects."""
+    original_tracking_uri = os.environ.get("MLFLOW_TRACKING_URI")
+    original_registry_uri = os.environ.get("MLFLOW_REGISTRY_URI")
+    original_allow_file_store = os.environ.get("MLFLOW_ALLOW_FILE_STORE")
+    local_tracking_uri = "file:///tmp/mlruns"
+
+    try:
+        os.environ["MLFLOW_TRACKING_URI"] = local_tracking_uri
+        os.environ["MLFLOW_REGISTRY_URI"] = local_tracking_uri
+        os.environ["MLFLOW_ALLOW_FILE_STORE"] = "true"
+        mlflow.set_tracking_uri(local_tracking_uri)
+        mlflow.set_registry_uri(local_tracking_uri)
+        logger.info("Loading MLflow model from %s", model_path)
+        loaded_model = mlflow.pyfunc.load_model(model_path)
+        logger.info("mlflow.pyfunc.load_model returned: %r", loaded_model)
+        if loaded_model is not None:
+            logger.info("Loaded object class: %s.%s", type(loaded_model).__module__, type(loaded_model).__name__)
+            logger.info("Loaded object attributes: %s", sorted(dir(loaded_model))[:200])
+        return loaded_model
+    except Exception:
+        logger.error("mlflow.pyfunc.load_model raised:\n%s", traceback.format_exc())
+        raise
+    finally:
+        if original_tracking_uri is None:
+            os.environ.pop("MLFLOW_TRACKING_URI", None)
+        else:
+            os.environ["MLFLOW_TRACKING_URI"] = original_tracking_uri
+            mlflow.set_tracking_uri(original_tracking_uri)
+
+        if original_registry_uri is None:
+            os.environ.pop("MLFLOW_REGISTRY_URI", None)
+        else:
+            os.environ["MLFLOW_REGISTRY_URI"] = original_registry_uri
+            mlflow.set_registry_uri(original_registry_uri)
+
+        if original_allow_file_store is None:
+            os.environ.pop("MLFLOW_ALLOW_FILE_STORE", None)
+        else:
+            os.environ["MLFLOW_ALLOW_FILE_STORE"] = original_allow_file_store
 
 
 def get_parser():
@@ -117,23 +274,27 @@ def save_dataframe(
     image_embeddings: pd.DataFrame,
     output_pkl_path: str,
 ) -> None:
-    """Save image embeddings DataFrame to a PKL file.
+    """Save image embeddings DataFrame to a JSON file.
 
     This function saves the provided image embeddings DataFrame
-    to the specified PKL file path with the given file name. It also creates
+    to the specified JSON file path with the given file name. It also creates
     the directory if it does not exist.
 
     Args:
         image_embeddings (pd.DataFrame): The DataFrame containing image embeddings to be saved.
-        output_pkl_path (str): The directory path where the PKL file will be saved.
+        output_pkl_path (str): The directory path where the JSON file will be saved.
     Returns:
         None
     """
     os.makedirs(output_pkl_path, exist_ok=True)
 
-    image_embeddings.to_pickle(os.path.join(output_pkl_path, EMBEDDING_FILE_NAME))
+    image_embeddings.to_json(
+        os.path.join(output_pkl_path, EMBEDDING_FILE_NAME),
+        orient="records",
+        lines=True,
+    )
 
-    logger.info("Saved merged DataFrames to PKL files")
+    logger.info("Saved merged DataFrames to JSON files")
 
 
 def process_embeddings(args):
@@ -147,7 +308,7 @@ def process_embeddings(args):
         args (Namespace): A namespace object containing the following attributes:
             - mlflow_model_path (str): The path to the MLflow model.
             - image_tsv (str): The path to the image TSV file.
-            - output_pkl (str): The path to save the output PKL file.
+            - output_pkl (str): The path to save the output embeddings file.
     Returns:
         None
     """
@@ -155,7 +316,12 @@ def process_embeddings(args):
     output_pkl = args.output_pkl
     image_tsv = args.image_tsv
 
-    mlflow_model = mlflow.pyfunc.load_model(model_path)
+    resolved_model_path = resolve_mlflow_model_path(model_path)
+    log_mlflow_load_diagnostics(resolved_model_path)
+    mlflow_model = load_local_mlflow_model(resolved_model_path)
+    if mlflow_model is None:
+        raise RuntimeError(f"mlflow.pyfunc.load_model returned None for {resolved_model_path}")
+    logger.info("Loaded MLflow model type: %s", type(mlflow_model).__name__)
     image_embeddings = generate_embeddings(
         image_tsv,
         mlflow_model,

--- a/assets/training/finetune_acft_image/src/medimage_insight_embedding_finetune/medimage_embedding_finetune.py
+++ b/assets/training/finetune_acft_image/src/medimage_insight_embedding_finetune/medimage_embedding_finetune.py
@@ -137,8 +137,7 @@ def load_opt_from_config_files(conf_files: List[str]) -> Dict[str, Any]:
     opt = {}
 
     with open(conf_files, encoding='utf-8') as f:
-        # config_dict = yaml.safe_load(f)
-        config_dict = yaml.unsafe_load(f)
+        config_dict = yaml.safe_load(f)
 
         load_config_dict_to_opt(opt, config_dict)
 


### PR DESCRIPTION
<h2>ICM Details</h2>
<p>
  This PR addresses CWE-502 unsafe deserialization findings for the MedImageInsight finetune assets.
</p>
<ul>
  <li>
    <strong>ICM / Finding ID:</strong> <code>11a524f7-a320-4bf2-b329-ca64cbaa2b0b</code>
  </li>
  <li>
    <strong>Adapter finetune:</strong> <code>assets/training/finetune_acft_image/src/medimage_insight_adapter_finetune/medimage_train.py</code>
    previously used <code>pandas.read_pickle</code> on caller-provided embedding inputs. The component contract remains
    <code>uri_file</code> with the <code>embeddings.pkl</code> filename, but the implementation no longer performs pickle deserialization.
  </li>
  <li>
    <strong>Embedding finetune:</strong> <code>assets/training/finetune_acft_image/src/medimage_insight_embedding_finetune/medimage_embedding_finetune.py</code>
    previously used <code>yaml.unsafe_load</code> on caller-provided config files. This now uses safe YAML loading.
  </li>
</ul>

<h2>What Problem Is Solved</h2>
<p>
  The changes remove unsafe Python pickle and unsafe YAML deserialization sinks from MedImageInsight training flows while preserving the published adapter input contract and <code>embeddings.pkl</code> file name expected by downstream users.
</p>

<h2>Validation</h2>
<ul>
  <li>
    <strong>Latest smoke test:</strong>
    <a href="https://ml.azure.com/runs/amiable_ear_gsp7vk0sby?wsid=/subscriptions/72c03bf3-4e69-41af-9532-dfcdc3eefef4/resourcegroups/rtanase/workspaces/rtanase&amp;tid=72f988bf-86f1-41af-91ab-2d7cd011db47">amiable_ear_gsp7vk0sby</a>
  </li>
  <li>
    <strong>Result:</strong> Completed successfully. Both embedding-generation steps and the adapter finetune step passed with <code>uri_file</code> adapter inputs and <code>embeddings.pkl</code> output naming.
  </li>
</ul>
