### PR TITLE
Add HealthBench benchmark (inspect_ai) - 5000 healthcare conversations

### DIFF
--- a/assets/benchmarkspecs/builtin/inspect_ai/healthbench/asset.yaml
+++ b/assets/benchmarkspecs/builtin/inspect_ai/healthbench/asset.yaml
@@ -1,0 +1,4 @@
+type: benchmarkspec
+spec: spec.yaml
+categories:
+- BenchmarkSpec

--- a/assets/benchmarkspecs/builtin/inspect_ai/healthbench/spec.yaml
+++ b/assets/benchmarkspecs/builtin/inspect_ai/healthbench/spec.yaml
@@ -1,0 +1,30 @@
+type: "benchmarkspec"
+name: "builtin.inspect_ai.healthbench"
+version: 1
+display_name: "HealthBench (inspect_ai)"
+description: "HealthBench: A multi-turn benchmark evaluating LLM medical knowledge and clinical reasoning across 5000 physician-crafted healthcare conversations with rubric-based scoring. Evaluated using the inspect_ai framework."
+benchmarkType: "builtin"
+categories: ["quality", "healthcare", "reasoning"]
+
+evaluator:
+  testingCriteria:
+    type: "inspect_ai"
+    name: "HealthBench"
+    task_name: "inspect_evals/healthbench"
+
+dataset:
+  datasetName: "healthbench"
+  datasetType: "oss"
+  recordCount: "5000"
+  license: "MIT"
+  properties:
+    domain: "healthcare"
+    source_paper: "https://github.com/openai/simple-evals"
+    dataset_source: "https://openaipublic.blob.core.windows.net/simple-evals/healthbench/2025-05-07-06-14-12_oss_eval.jsonl"
+  source:
+    provider: "mlregistry"
+    sourceDatasetId: "azureml://registries/azureml/data/healthbench/versions/1"
+    sourceFormat: "jsonl"
+    properties:
+      file_name: "healthbench.jsonl"
+      type: "uri_folder"

--- a/assets/pipelines/data/global_dataset/jsonl/healthbench/asset.yaml
+++ b/assets/pipelines/data/global_dataset/jsonl/healthbench/asset.yaml
@@ -1,0 +1,7 @@
+name: healthbench
+version: 1
+type: data
+spec: spec.yaml
+extra_config: storage.yaml
+categories:
+  - pipeline

--- a/assets/pipelines/data/global_dataset/jsonl/healthbench/sample_data/_meta.yaml
+++ b/assets/pipelines/data/global_dataset/jsonl/healthbench/sample_data/_meta.yaml
@@ -1,0 +1,5 @@
+type: DataFrameDirectory
+extension: {}
+format: JSONL
+data: healthbench.jsonl
+schema: schema/_schema.json

--- a/assets/pipelines/data/global_dataset/jsonl/healthbench/sample_data/license.txt
+++ b/assets/pipelines/data/global_dataset/jsonl/healthbench/sample_data/license.txt
@@ -1,0 +1,5 @@
+HealthBench dataset from OpenAI simple-evals.
+
+Dataset sourced from https://openaipublic.blob.core.windows.net/simple-evals/healthbench/
+
+Licensed under MIT License. Copyright (c) 2025 OpenAI.

--- a/assets/pipelines/data/global_dataset/jsonl/healthbench/sample_data/schema/_schema.json
+++ b/assets/pipelines/data/global_dataset/jsonl/healthbench/sample_data/schema/_schema.json
@@ -1,0 +1,40 @@
+{
+  "columnAttributes": [
+    {
+      "name": "prompt_id",
+      "type": "String",
+      "isFeature": true,
+      "elementType": {
+        "typeName": "str",
+        "isNullable": false
+      }
+    },
+    {
+      "name": "prompt",
+      "type": "String",
+      "isFeature": true,
+      "elementType": {
+        "typeName": "list",
+        "isNullable": false
+      }
+    },
+    {
+      "name": "rubrics",
+      "type": "String",
+      "isFeature": true,
+      "elementType": {
+        "typeName": "list",
+        "isNullable": false
+      }
+    },
+    {
+      "name": "example_tags",
+      "type": "String",
+      "isFeature": true,
+      "elementType": {
+        "typeName": "list",
+        "isNullable": true
+      }
+    }
+  ]
+}

--- a/assets/pipelines/data/global_dataset/jsonl/healthbench/spec.yaml
+++ b/assets/pipelines/data/global_dataset/jsonl/healthbench/spec.yaml
@@ -1,0 +1,8 @@
+$schema: https://azuremlschemas.azureedge.net/latest/data.schema.json
+name: "{{asset.name}}"
+version: "{{asset.version}}"
+tags:
+  azureml.Designer: false
+description: "HealthBench - 5000 multi-turn healthcare conversations with physician-written evaluation rubrics"
+type: uri_folder
+path: sample_data/

--- a/assets/pipelines/data/global_dataset/jsonl/healthbench/storage.yaml
+++ b/assets/pipelines/data/global_dataset/jsonl/healthbench/storage.yaml
@@ -1,0 +1,5 @@
+path:
+  container_name: data
+  container_path: foundry_benchmark_dataset_assets/healthbench/v1
+  storage_name: foundrybenchmarkdatasets
+  type: azureblob


### PR DESCRIPTION
## Summary

Adds HealthBench as a new inspect_ai benchmark. HealthBench evaluates LLM medical knowledge and clinical reasoning across 5000 multi-turn physician-crafted healthcare conversations with rubric-based scoring.

## Changes

- **Benchmarkspec**: builtin.inspect_ai.healthbench (v1)
  - Task: inspect_evals/healthbench
  - Categories: quality, healthcare, reasoning
  - Uses judge-model scoring pattern (no Docker/sandbox needed)

- **Data asset**: healthbench v1
  - 5000 samples from OpenAI HealthBench (simple-evals)
  - MIT licensed
  - Uploaded to foundrybenchmarkdatasets blob storage

## Dataset Source

- URL: https://openaipublic.blob.core.windows.net/simple-evals/healthbench/2025-05-07-06-14-12_oss_eval.jsonl
- Origin: OpenAI simple-evals (MIT license)
- CELA review: submitted

## Testing

- Dataset uploaded and verified in blob storage (57 MB, 5000 records)
- Follows same pattern as aime2025, browse_comp, tau2_telecom benchmarks
- Will validate in INT after asset release