### PR TITLE
Make tool_definitions optional for tool_input_accuracy and tool_output_utilization evaluators

### DIFF
--- a/assets/evaluators/builtin/tool_input_accuracy/evaluator/_tool_input_accuracy.py
+++ b/assets/evaluators/builtin/tool_input_accuracy/evaluator/_tool_input_accuracy.py
@@ -533,7 +533,7 @@ class ToolInputAccuracyEvaluator(PromptyEvaluatorBase[Union[str, float]]):
 
         # Initialize input validator
         self._validator = ToolDefinitionsValidator(
-            error_target=ExtendedErrorTarget.TOOL_INPUT_ACCURACY_EVALUATOR, optional_tool_definitions=False,
+            error_target=ExtendedErrorTarget.TOOL_INPUT_ACCURACY_EVALUATOR, optional_tool_definitions=True,
             check_for_unsupported_tools=False,
         )
 

--- a/assets/evaluators/builtin/tool_input_accuracy/spec.yaml
+++ b/assets/evaluators/builtin/tool_input_accuracy/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.tool_input_accuracy"
-version: 15
+version: 16
 displayName: "Tool-Input-Accuracy-Evaluator"
 description: "A binary evaluator (0 or 1) that checks whether all parameters in an agent’s tool call are correct, validating grounding, type, format, completeness, and contextual appropriateness using LLM-based analysis. Use it to verify agent tool usage, API integration tests, or to ensure tool call parameters are fully correct in AI workflows."
 evaluatorType: "builtin"

--- a/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
+++ b/assets/evaluators/builtin/tool_output_utilization/evaluator/_tool_output_utilization.py
@@ -315,7 +315,7 @@ class ToolOutputUtilizationEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         # Initialize input validator
         self._validator = ToolDefinitionsValidator(
             error_target=ErrorTarget.TOOL_OUTPUT_UTILIZATION_EVALUATOR,
-            optional_tool_definitions=False,
+            optional_tool_definitions=True,
             check_for_unsupported_tools=True,
         )
         # azure_ai_search, azure_fabric and sharepoint_grounding are supported by this
@@ -349,6 +349,14 @@ class ToolOutputUtilizationEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :rtype: Union[DoEvalResult[T_EvalValue], AggregateResult[T_EvalValue]]
         """
         self._validator.validate_eval_input(kwargs)
+        # tool_definitions are optional for this evaluator (optional_tool_definitions=True).
+        # Tool output utilization is assessed from the query/response messages and does not
+        # require tool schemas, so when tool_definitions are missing (None or absent) we
+        # normalize them to an empty list. This lets evaluation proceed exactly like the
+        # explicit empty-list case, instead of the base evaluator rejecting the inputs with
+        # "Either 'conversation' or individual inputs must be provided."
+        if not kwargs.get("tool_definitions"):
+            kwargs["tool_definitions"] = []
         return await self._the_super_real_call(**kwargs)
 
     async def _the_super_real_call(self, **kwargs):

--- a/assets/evaluators/builtin/tool_output_utilization/spec.yaml
+++ b/assets/evaluators/builtin/tool_output_utilization/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.tool_output_utilization"
-version: 9
+version: 10
 displayName: "Tool-Output-Utilization-Evaluator"
 description: "Checks if an agent correctly interprets and contextually uses the outputs returned by invoked tools (e.g., APIs, DB queries, search results) without fabrication or omission. Use it to validate that agents accurately reuse and represent tool outputs in their responses across tool-dependent systems."
 evaluatorType: "builtin"

--- a/assets/evaluators/tests/test_evaluators_behavior/test_tool_input_accuracy_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_tool_input_accuracy_evaluator_behavior.py
@@ -82,7 +82,9 @@ class TestToolInputAccuracyEvaluatorBehavior(BaseToolsEvaluatorBehaviorTest, Bas
     check_for_unsupported_tools = False
 
     # Test Configs
-    requires_tool_definitions = True
+    # tool_definitions are optional: when absent, the evaluator returns
+    # not_applicable instead of a MISSING_FIELD error (optional_tool_definitions=True).
+    requires_tool_definitions = False
 
     MINIMAL_RESPONSE = BaseToolsEvaluatorBehaviorTest.tool_calls_with_arguments
 
@@ -93,6 +95,28 @@ class TestToolInputAccuracyEvaluatorBehavior(BaseToolsEvaluatorBehaviorTest, Bas
     def test_intermediate_response_returns_not_applicable(self):
         """A response ending in an unresolved function_call is treated as not-applicable."""
         self.run_intermediate_response_not_applicable_test()
+
+    def test_tool_definitions_not_present(self):
+        """Missing tool_definitions is optional: returns not_applicable, not a MISSING_FIELD error."""
+        results = self._run_evaluation(
+            query=self.VALID_QUERY,
+            response=self.VALID_RESPONSE,
+            tool_calls=self.VALID_TOOL_CALLS,
+            tool_definitions=None,
+        )
+        result_data = self._extract_and_print_result(results, "Tool Definitions Not Present")
+        self.assert_not_applicable(result_data)
+
+    def test_tool_definitions_empty_list(self):
+        """Empty tool_definitions is optional: returns not_applicable, not a MISSING_FIELD error."""
+        results = self._run_evaluation(
+            query=self.VALID_QUERY,
+            response=self.VALID_RESPONSE,
+            tool_calls=self.VALID_TOOL_CALLS,
+            tool_definitions=self.EMPTY_LIST,
+        )
+        result_data = self._extract_and_print_result(results, "Tool Definitions Empty List")
+        self.assert_not_applicable(result_data)
 
     def test_zero_parameters_extraction_accuracy_is_100_percent(self):
         """Zero total parameters returns 100% accuracy without dividing by zero."""

--- a/assets/evaluators/tests/test_evaluators_behavior/test_tool_output_utilization_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_tool_output_utilization_evaluator_behavior.py
@@ -120,7 +120,11 @@ class TestToolOutputUtilizationEvaluatorBehavior(BaseToolsEvaluatorBehaviorTest,
     check_for_unsupported_tools = True
 
     MINIMAL_RESPONSE = BaseEvaluatorBehaviorTest.VALID_RESPONSE
-    requires_tool_definitions = True
+    # tool_definitions are optional (optional_tool_definitions=True): tool output
+    # utilization is assessed from the query/response messages, so when they are
+    # absent evaluation proceeds normally (normalized to an empty list) instead of
+    # raising a MISSING_FIELD error.
+    requires_tool_definitions = False
 
     def test_skipped_llm_status_returns_not_applicable(self):
         """Flow output with status='skipped' yields a not-applicable result, not a crash."""
@@ -129,6 +133,11 @@ class TestToolOutputUtilizationEvaluatorBehavior(BaseToolsEvaluatorBehaviorTest,
     def test_intermediate_response_returns_not_applicable(self):
         """A response ending in an unresolved function_call is treated as not-applicable."""
         self.run_intermediate_response_not_applicable_test()
+
+    # tool_definitions not-present / empty-list are covered by the base class:
+    # with requires_tool_definitions = False, tool output utilization is assessed
+    # from the query/response messages and evaluation proceeds normally (PASS)
+    # instead of raising a MISSING_FIELD error.
 
     # --- Phase 2 overrides: these three tools used to be unsupported but TOU now
     # accepts them, so we override the base-class tests (which still branch to


### PR DESCRIPTION
## Summary

Makes `tool_definitions` **optional** for the `tool_input_accuracy` and `tool_output_utilization` evaluators so that evaluations no longer hard-fail with a `MISSING_FIELD` error when tool definitions are absent.

Today these agent/quality evaluators require explicit tool definitions with strict validation that easily diverges from the actual tool schemas over time, creating unnecessary friction and false failures. This change removes that strict gate and lets each evaluator degrade gracefully.

Part of the **Improve evaluation experiences** effort (Epic 5359243). Companion to the RAISvc change that infers `tool_definitions` from message `tool_calls` when missing.

## Changes

- Set `optional_tool_definitions=True` on the `ToolDefinitionsValidator` for both evaluators, removing the `MISSING_FIELD` failure for missing/empty tool definitions.
- **`tool_input_accuracy`** needs tool schemas to judge argument correctness, so when definitions are absent it now returns a graceful `not_applicable` (skipped) result instead of erroring.
- **`tool_output_utilization`** is assessed from the query/response messages and does **not** require tool schemas. Missing/`None` tool definitions are normalized to an empty list in `_real_call` so evaluation proceeds exactly like the explicit empty-list case, instead of the base evaluator raising `Either 'conversation' or individual inputs must be provided`.
- Bumped spec versions: `tool_input_accuracy` 15 → 16, `tool_output_utilization` 9 → 10.
- Updated behavior tests to assert the new graceful behavior (`not_applicable` for TIA, normal evaluation for TOU).

## Testing

Ran both evaluator behavior suites locally (`azure-ai-evaluation==1.18.2`):

```
tests/test_evaluators_behavior/test_tool_input_accuracy_evaluator_behavior.py
tests/test_evaluators_behavior/test_tool_output_utilization_evaluator_behavior.py
=> 287 passed, 2 skipped
```

## Acceptance Criteria

- [x] Evaluations run successfully without explicit tool definitions
- [x] Strict validation failures for missing tool definitions are removed
- [ ] Tool definitions inferred from agent configuration when not provided *(handled in RAISvc / SDK follow-ups)*
- [ ] Tool definitions fall back to trace data when agent config is unavailable *(handled in the RAISvc trace-inference change)*
