### PR TITLE
Prune lm_head of qwen3.5 Foundry Local models

### DIFF
--- a/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-0.8b/onnx/cuda/v2
+  container_path: foundrylocal/models/qwen3.5-0.8b/onnx/cuda/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-0.8b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 1415803624
-    vRamFootprintBytes: 1415803624
-version: 2
+    fileSizeBytes: 1555287614
+    vRamFootprintBytes: 1555287614
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-0.8b/onnx/cpu_and_mobile/v2
+  container_path: foundrylocal/models/qwen3.5-0.8b/onnx/cpu_and_mobile/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-0.8b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: cpu
     executionProvider: CPUExecutionProvider
-    fileSizeBytes: 948583190
-    vRamFootprintBytes: 948583190
-version: 2
+    fileSizeBytes: 1088056779
+    vRamFootprintBytes: 1088056779
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-0.8b/onnx/webgpu/v2
+  container_path: foundrylocal/models/qwen3.5-0.8b/onnx/webgpu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-0.8b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: WebGPUExecutionProvider
-    fileSizeBytes: 1406878115
-    vRamFootprintBytes: 1406878115
-version: 2
+    fileSizeBytes: 1555674493
+    vRamFootprintBytes: 1555674493
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-2b/onnx/cuda/v2
+  container_path: foundrylocal/models/qwen3.5-2b/onnx/cuda/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-2b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 3357039819
-    vRamFootprintBytes: 3357039819
-version: 2
+    fileSizeBytes: 3071018029
+    vRamFootprintBytes: 3071018029
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-2b/onnx/cpu_and_mobile/v2
+  container_path: foundrylocal/models/qwen3.5-2b/onnx/cpu_and_mobile/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-2b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: cpu
     executionProvider: CPUExecutionProvider
-    fileSizeBytes: 2251117020
-    vRamFootprintBytes: 2251117020
-version: 2
+    fileSizeBytes: 1877016577
+    vRamFootprintBytes: 1877016577
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-2b/onnx/webgpu/v2
+  container_path: foundrylocal/models/qwen3.5-2b/onnx/webgpu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-2b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: WebGPUExecutionProvider
-    fileSizeBytes: 3357024145
-    vRamFootprintBytes: 3357024145
-version: 2
+    fileSizeBytes: 3189350241
+    vRamFootprintBytes: 3189350241
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-4b/onnx/cuda/v2
+  container_path: foundrylocal/models/qwen3.5-4b/onnx/cuda/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-4b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 5752594443
-    vRamFootprintBytes: 5752594443
-version: 2
+    fileSizeBytes: 4384876649
+    vRamFootprintBytes: 4384876649
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-4b/onnx/cpu_and_mobile/v2
+  container_path: foundrylocal/models/qwen3.5-4b/onnx/cpu_and_mobile/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-4b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: cpu
     executionProvider: CPUExecutionProvider
-    fileSizeBytes: 4599784965
-    vRamFootprintBytes: 4599784965
-version: 2
+    fileSizeBytes: 3235313264
+    vRamFootprintBytes: 3235313264
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-4b/onnx/webgpu/v2
+  container_path: foundrylocal/models/qwen3.5-4b/onnx/webgpu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-4b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: WebGPUExecutionProvider
-    fileSizeBytes: 5752580195
-    vRamFootprintBytes: 5752580195
-version: 2
+    fileSizeBytes: 4388512336
+    vRamFootprintBytes: 4388512336
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-9b/onnx/cuda/v2
+  container_path: foundrylocal/models/qwen3.5-9b/onnx/cuda/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-9b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 10122047952
-    vRamFootprintBytes: 10122047952
-version: 2
+    fileSizeBytes: 7491584028
+    vRamFootprintBytes: 7491584028
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-9b/onnx/cpu_and_mobile/v2
+  container_path: foundrylocal/models/qwen3.5-9b/onnx/cpu_and_mobile/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-9b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: cpu
     executionProvider: CPUExecutionProvider
-    fileSizeBytes: 8470177603
-    vRamFootprintBytes: 8470177603
-version: 2
+    fileSizeBytes: 5840016799
+    vRamFootprintBytes: 5840016799
+version: 3

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-9b/onnx/webgpu/v2
+  container_path: foundrylocal/models/qwen3.5-9b/onnx/webgpu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: qwen3.5-9b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   inputModalities:
   - text
@@ -44,6 +44,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: WebGPUExecutionProvider
-    fileSizeBytes: 10122031718
-    vRamFootprintBytes: 10122031718
-version: 2
+    fileSizeBytes: 7492005352
+    vRamFootprintBytes: 7492005352
+version: 3


### PR DESCRIPTION
This PR is to update qwen3.5 Foundry Local models, which are pruned lm_head to reduce the peak memory in prefill. The affected models are

- qwen3.5 0.8b cpu/cuda/webgpu
- qwen3.5 2b cpu/cuda/webgpu
- qwen3.5 4b cpu/cuda/webgpu
- qwen3.5 9b cpu/cuda/webgpu