### PR TITLE
Update mltable to 1.7.0 and fix setuptools vulnerability in responsibleai-tabular environment

### DIFF
--- a/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
@@ -47,6 +47,9 @@ RUN pip install 'pyarrow>=14.0.1'
 # To resolve vulnerability issue regarding cryptography
 RUN pip install 'cryptography>=46.0.5'
 
+# To resolve vulnerability issue regarding setuptools (GHSA-5rjg-fvgr-3xxf)
+RUN pip install 'setuptools>=78.1.1'
+
 # TODO: remove rai-core-flask pin with next raiwidgets release
 RUN pip install 'rai-core-flask==0.7.6'
 

--- a/assets/responsibleai/environments/responsibleai-tabular/context/conda_dependencies.yaml
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/conda_dependencies.yaml
@@ -15,6 +15,6 @@ dependencies:
     - pdfkit==1.0.0
     - plotly==5.6.0
     - kaleido==0.2.1
-    - mltable==1.6.3
+    - mltable==1.7.0
     - responsibleai-tabular-automl==0.15.1
     - https://publictestdatasets.blob.core.windows.net/packages/pypi/raiwidgets_big_data/raiwidgets_big_data-0.12.0-py3-none-any.whl

--- a/assets/responsibleai/environments/responsibleai-tabular/tests/responsibleai_sample_test.py
+++ b/assets/responsibleai/environments/responsibleai-tabular/tests/responsibleai_sample_test.py
@@ -90,10 +90,6 @@ def test_responsibleai():
     verify_if_command_job_completed(ml_client, returned_job)
 
 
-# NOTE: The current AzureML AutoML curated environment (ai-ml-automl) is broken —
-# azureml-train-automl-runtime requires bokeh<3.0.0, which conflicts with the
-# bokeh>=3.8.2 security pin in that environment's Dockerfile, causing
-# ResolutionImpossible pip errors when this test submits an AutoML job.
 def test_responsibleai_automl_regression():
     """Tests a sample automl job using responsibleai image as the environment."""
     this_dir = Path(__file__).parent
@@ -170,10 +166,6 @@ def test_responsibleai_automl_regression():
     verify_if_command_job_completed(ml_client, returned_job)
 
 
-# NOTE: The current AzureML AutoML curated environment (ai-ml-automl) is broken —
-# azureml-train-automl-runtime requires bokeh<3.0.0, which conflicts with the
-# bokeh>=3.8.2 security pin in that environment's Dockerfile, causing
-# ResolutionImpossible pip errors when this test submits an AutoML job.
 def test_responsibleai_automl_classification():
     """Tests a sample automl job using responsibleai image as the environment."""
     this_dir = Path(__file__).parent

--- a/assets/responsibleai/environments/responsibleai-tabular/tests/responsibleai_sample_test.py
+++ b/assets/responsibleai/environments/responsibleai-tabular/tests/responsibleai_sample_test.py
@@ -90,6 +90,10 @@ def test_responsibleai():
     verify_if_command_job_completed(ml_client, returned_job)
 
 
+# NOTE: The current AzureML AutoML curated environment (ai-ml-automl) is broken —
+# azureml-train-automl-runtime requires bokeh<3.0.0, which conflicts with the
+# bokeh>=3.8.2 security pin in that environment's Dockerfile, causing
+# ResolutionImpossible pip errors when this test submits an AutoML job.
 def test_responsibleai_automl_regression():
     """Tests a sample automl job using responsibleai image as the environment."""
     this_dir = Path(__file__).parent
@@ -166,6 +170,10 @@ def test_responsibleai_automl_regression():
     verify_if_command_job_completed(ml_client, returned_job)
 
 
+# NOTE: The current AzureML AutoML curated environment (ai-ml-automl) is broken —
+# azureml-train-automl-runtime requires bokeh<3.0.0, which conflicts with the
+# bokeh>=3.8.2 security pin in that environment's Dockerfile, causing
+# ResolutionImpossible pip errors when this test submits an AutoML job.
 def test_responsibleai_automl_classification():
     """Tests a sample automl job using responsibleai image as the environment."""
     this_dir = Path(__file__).parent


### PR DESCRIPTION
Updates the responsibleai-tabular environment:

- Updates mltable pinned version from 1.6.3 to the latest PyPI release 1.7.0 in conda dependencies, matching the corresponding update in Azure/RAI-vNext-Preview#235.
- Upgrades setuptools to >=78.1.1 to fix a HIGH severity vulnerability (GHSA-5rjg-fvgr-3xxf / CVE-2025-47273, QID 5004129), a path traversal vulnerability in PackageIndex.