### PR TITLE
Fix bokeh/azureml-train-automl-runtime dependency conflict in ai-ml-automl environment

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
@@ -91,7 +91,7 @@ RUN printf '%s\n' \
                 'pydantic-settings>=2.14.2' \
                 'pyasn1>=0.6.4' \
                 'setuptools>=83.0.0' && \
-    pip install --no-cache-dir --progress-bar off --upgrade -c /tmp/security-constraints.txt \
+    pip install --no-cache-dir --progress-bar off --upgrade --use-deprecated=legacy-resolver -c /tmp/security-constraints.txt \
                 'distributed>=2026.1.0' \
                 'bokeh>=3.8.2' \
                 'cryptography>=48.0.1' \


### PR DESCRIPTION
The ai-ml-automl Dockerfile pins `bokeh>=3.8.2` to fix CVE-2026-23528 and GHSA-793v-589g-574v. However, azureml-train-automl-runtime (including the latest 1.62.0 release on PyPI) declares `bokeh<3.0.0` as a hard dependency, causing pip's dependency resolver to hard-fail with a ResolutionImpossible error during environment/job builds (seen as a test failure in the responsibleai-tabular environment's AutoML test steps, which spin up this curated environment).

Since the first pip install step in this Dockerfile already uses `--use-deprecated=legacy-resolver` to work around similar strict-resolver conflicts, this PR applies the same flag to the second pip install step (the one installing the bokeh/distributed security pins), so pip proceeds with a warning instead of hard-failing.