### PR TITLE
Add gemma-4-e2b-it in Foundry Local

### DIFF
--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/description.md
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/description.md
@@ -1,0 +1,15 @@
+This model is an optimized version of Gemma 4 E2B IT for local inference on CUDA GPUs. This optimized model is published here in ONNX format to run on CUDA-capable GPU devices, with the precision best suited to this target.
+
+# ONNX Models
+Here are some of the optimized configurations we have added:
+1. ONNX model for CUDA GPU using RTN quantization.
+
+# Model Description
+- **Developed by:** Google DeepMind
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of Gemma 4 E2B IT for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Gemma 4 E2B IT](https://huggingface.co/google/gemma-4-e2b-it) for details.

--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cuda/v1
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
   directoryPath: v1
-  foundryLocal: "test"
+  foundryLocal: 'test'
   inputModalities:
   - text
   - image
@@ -33,8 +33,8 @@ system_metadata:
     - vision-language-chat
   platformCapabilities:
     enableMaap: false
-  reasoningStart: "<|channel>thought\n"
-  reasoningEnd: <channel|>
+  reasoningStart: '<|channel>thought\n'
+  reasoningEnd: '<|channel|>'
   minFLVersion: 1.2.1
 variantInfo:
   parents:
@@ -45,4 +45,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
+    fileSizeBytes: 6182901110
+    vRamFootprintBytes: 6182901110
 version: 1

--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
@@ -1,0 +1,48 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: gemma-4-e2b-it-cuda-gpu
+path: ./
+isArchived: true
+tags:
+  capabilities: reasoning,tool-calling
+  supportsReasoning: 'true'
+  contextLength: 131072
+system_metadata:
+  alias: gemma-4-e2b-it
+  publisher: Microsoft
+  directoryPath: v1
+  foundryLocal: ''
+  inputModalities:
+  - text
+  - image
+  - audio
+  license: apache-2.0
+  licenseDescription: This model is provided under the License Terms available at <https://www.apache.org/licenses/LICENSE-2.0.html>.
+  maxOutputTokens: 8192
+  outputModalities:
+  - text
+  promptTemplate: '{"system": "<|turn>system\n{Content}<turn|>\n", "user": "<|turn>user\n{Content}<turn|>\n", "assistant": "<|turn>model\n{Content}<turn|>\n", "prompt": "<|turn>user\n{Content}<turn|>\n<|turn>model\n"}'
+  supportsToolCalling: true
+  toolCallEnd: <tool_call|>
+  toolCallStart: <|tool_call>
+  toolRegisterEnd: <tool|>
+  toolRegisterStart: <|tool>
+  toolResponseEnd: <tool_response|>
+  toolResponseStart: <|tool_response>
+  tasks:
+    inferenceTasks:
+    - vision-language-chat
+  platformCapabilities:
+    enableMaap: false
+  reasoningStart: "<|channel>thought\n"
+  reasoningEnd: <channel|>
+  minFLVersion: 1.2.1
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/gemma-4-e2b-it/versions/1
+  variantMetadata:
+    modelType: ONNX
+    quantization:
+    - RTN
+    device: gpu
+    executionProvider: CUDAExecutionProvider
+version: 1

--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
   directoryPath: v1
-  foundryLocal: ''
+  foundryLocal: "test"
   inputModalities:
   - text
   - image

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/asset.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/description.md
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/description.md
@@ -1,0 +1,15 @@
+This model is an optimized version of Gemma 4 E2B IT for local inference on CPU and mobile devices. This optimized model is published here in ONNX format to run on CPU and mobile targets, with the precision best suited to this target.
+
+# ONNX Models
+Here are some of the optimized configurations we have added:
+1. ONNX model for CPU and mobile using RTN quantization.
+
+# Model Description
+- **Developed by:** Google DeepMind
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of Gemma 4 E2B IT for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Gemma 4 E2B IT](https://huggingface.co/google/gemma-4-e2b-it) for details.

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cpu_and_mobile/v1
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
   directoryPath: v1
-  foundryLocal: ''
+  foundryLocal: "test"
   inputModalities:
   - text
   - image

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
   directoryPath: v1
-  foundryLocal: "test"
+  foundryLocal: 'test'
   inputModalities:
   - text
   - image
@@ -33,8 +33,8 @@ system_metadata:
     - vision-language-chat
   platformCapabilities:
     enableMaap: false
-  reasoningStart: "<|channel>thought\n"
-  reasoningEnd: <channel|>
+  reasoningStart: '<|channel>thought\n'
+  reasoningEnd: '<|channel|>'
   minFLVersion: 1.2.1
 variantInfo:
   parents:
@@ -45,4 +45,6 @@ variantInfo:
     - RTN
     device: cpu
     executionProvider: CPUExecutionProvider
+    fileSizeBytes: 6324928641
+    vRamFootprintBytes: 6324928641
 version: 1

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
@@ -1,0 +1,48 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: gemma-4-e2b-it-generic-cpu
+path: ./
+isArchived: true
+tags:
+  capabilities: reasoning,tool-calling
+  supportsReasoning: 'true'
+  contextLength: 131072
+system_metadata:
+  alias: gemma-4-e2b-it
+  publisher: Microsoft
+  directoryPath: v1
+  foundryLocal: ''
+  inputModalities:
+  - text
+  - image
+  - audio
+  license: apache-2.0
+  licenseDescription: This model is provided under the License Terms available at <https://www.apache.org/licenses/LICENSE-2.0.html>.
+  maxOutputTokens: 8192
+  outputModalities:
+  - text
+  promptTemplate: '{"system": "<|turn>system\n{Content}<turn|>\n", "user": "<|turn>user\n{Content}<turn|>\n", "assistant": "<|turn>model\n{Content}<turn|>\n", "prompt": "<|turn>user\n{Content}<turn|>\n<|turn>model\n"}'
+  supportsToolCalling: true
+  toolCallEnd: <tool_call|>
+  toolCallStart: <|tool_call>
+  toolRegisterEnd: <tool|>
+  toolRegisterStart: <|tool>
+  toolResponseEnd: <tool_response|>
+  toolResponseStart: <|tool_response>
+  tasks:
+    inferenceTasks:
+    - vision-language-chat
+  platformCapabilities:
+    enableMaap: false
+  reasoningStart: "<|channel>thought\n"
+  reasoningEnd: <channel|>
+  minFLVersion: 1.2.1
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/gemma-4-e2b-it/versions/1
+  variantMetadata:
+    modelType: ONNX
+    quantization:
+    - RTN
+    device: cpu
+    executionProvider: CPUExecutionProvider
+version: 1

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/asset.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/description.md
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/description.md
@@ -1,0 +1,15 @@
+This model is an optimized version of Gemma 4 E2B IT for local inference on WebGPU-capable devices. This optimized model is published here in ONNX format to run with the WebGPU execution provider, with the precision best suited to this target.
+
+# ONNX Models
+Here are some of the optimized configurations we have added:
+1. ONNX model for WebGPU using RTN quantization.
+
+# Model Description
+- **Developed by:** Google DeepMind
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of Gemma 4 E2B IT for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Gemma 4 E2B IT](https://huggingface.co/google/gemma-4-e2b-it) for details.

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/webgpu/v1
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
   directoryPath: v1
-  foundryLocal: "test"
+  foundryLocal: 'test'
   inputModalities:
   - text
   - image
@@ -33,8 +33,8 @@ system_metadata:
     - vision-language-chat
   platformCapabilities:
     enableMaap: false
-  reasoningStart: "<|channel>thought\n"
-  reasoningEnd: <channel|>
+  reasoningStart: '<|channel>thought\n'
+  reasoningEnd: '<|channel|>'
   minFLVersion: 1.2.1
 variantInfo:
   parents:
@@ -45,4 +45,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: WebGPUExecutionProvider
+    fileSizeBytes: 7377541854
+    vRamFootprintBytes: 7377541854
 version: 1

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
   directoryPath: v1
-  foundryLocal: ''
+  foundryLocal: "test"
   inputModalities:
   - text
   - image

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
@@ -1,0 +1,48 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: gemma-4-e2b-it-generic-gpu
+path: ./
+isArchived: true
+tags:
+  capabilities: reasoning,tool-calling
+  supportsReasoning: 'true'
+  contextLength: 131072
+system_metadata:
+  alias: gemma-4-e2b-it
+  publisher: Microsoft
+  directoryPath: v1
+  foundryLocal: ''
+  inputModalities:
+  - text
+  - image
+  - audio
+  license: apache-2.0
+  licenseDescription: This model is provided under the License Terms available at <https://www.apache.org/licenses/LICENSE-2.0.html>.
+  maxOutputTokens: 8192
+  outputModalities:
+  - text
+  promptTemplate: '{"system": "<|turn>system\n{Content}<turn|>\n", "user": "<|turn>user\n{Content}<turn|>\n", "assistant": "<|turn>model\n{Content}<turn|>\n", "prompt": "<|turn>user\n{Content}<turn|>\n<|turn>model\n"}'
+  supportsToolCalling: true
+  toolCallEnd: <tool_call|>
+  toolCallStart: <|tool_call>
+  toolRegisterEnd: <tool|>
+  toolRegisterStart: <|tool>
+  toolResponseEnd: <tool_response|>
+  toolResponseStart: <|tool_response>
+  tasks:
+    inferenceTasks:
+    - vision-language-chat
+  platformCapabilities:
+    enableMaap: false
+  reasoningStart: "<|channel>thought\n"
+  reasoningEnd: <channel|>
+  minFLVersion: 1.2.1
+variantInfo:
+  parents:
+  - assetId: azureml://registries/azureml/models/gemma-4-e2b-it/versions/1
+  variantMetadata:
+    modelType: ONNX
+    quantization:
+    - RTN
+    device: gpu
+    executionProvider: WebGPUExecutionProvider
+version: 1

--- a/assets/models/foundrylocal/gemma-4-e2b-it/asset.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it/asset.yaml
@@ -1,0 +1,4 @@
+extra_config: model.yaml
+spec: spec.yaml
+type: model
+categories: ["Local"]

--- a/assets/models/foundrylocal/gemma-4-e2b-it/description.md
+++ b/assets/models/foundrylocal/gemma-4-e2b-it/description.md
@@ -1,0 +1,16 @@
+This model is an optimized version of Gemma 4 E2B IT for local inference. Optimized models are published here in ONNX format to run on CPU and GPU across devices, including server platforms, Windows, Linux and Mac desktops, and mobile CPUs, with the precision best suited to each target.
+
+# ONNX Models
+Here are some of the optimized configurations we have added:
+1. ONNX model for CPU and mobile using RTN quantization.
+2. ONNX model for GPU using RTN quantization.
+
+# Model Description
+- **Developed by:** Google DeepMind
+- **Model type:** ONNX
+- **License:** apache-2.0
+- **Model Description:** This is a conversion of Gemma 4 E2B IT for local inference.
+- **Disclaimer:** Model is only an optimization of the base model, any risk associated with the model is the responsibility of the user of the model. Please verify and test for your scenarios. There may be a slight difference in output from the base model with the optimizations applied. Note that optimizations applied are distinct from fine tuning and thus do not alter the intended uses or capabilities of the model.
+
+# Base Model Information
+See Hugging Face model [Gemma 4 E2B IT](https://huggingface.co/google/gemma-4-e2b-it) for details.

--- a/assets/models/foundrylocal/gemma-4-e2b-it/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it/model.yaml
@@ -1,0 +1,8 @@
+path:
+  container_name: models
+  container_path: foundrylocal/models/gemma-4-e2b-it
+  storage_name: foundrylocalassetdata
+  type: azureblob
+publish:
+  description: description.md
+  type: custom_model

--- a/assets/models/foundrylocal/gemma-4-e2b-it/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it/spec.yaml
@@ -1,0 +1,7 @@
+$schema: https://azuremlschemas.azureedge.net/latest/model.schema.json
+name: gemma-4-e2b-it
+path: ./
+isArchived: true
+system_metadata:
+  foundryLocal: ''
+version: 1


### PR DESCRIPTION
This PR is to adds gemma-4-e2b-it in Foundry Local. Models are fully tested locally and will be archived once published, so not visible form any Azure services.

- gemma-4-e2b-it
- gemma-4-e2b-it-generic-cpu
- gemma-4-e2b-it-cuda-gpu
- gemma-4-e2b-it-generic-gpu