### PR TITLE
Fix false-positive setuptools vulnerability scan finding in responsibleai-tabular

### DIFF
--- a/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
@@ -47,9 +47,6 @@ RUN pip install 'pyarrow>=14.0.1'
 # To resolve vulnerability issue regarding cryptography
 RUN pip install 'cryptography>=46.0.5'
 
-# To resolve vulnerability issue regarding setuptools (GHSA-5rjg-fvgr-3xxf)
-RUN pip install 'setuptools>=78.1.1'
-
 # TODO: remove rai-core-flask pin with next raiwidgets release
 RUN pip install 'rai-core-flask==0.7.6'
 
@@ -68,7 +65,8 @@ RUN pip install --no-deps 'skops>=0.13.0'
 # Drop pip's vendored-dependency SBOM. Modern pip ships pip/_vendor/bom.cdx.json (a CycloneDX
 # file) that scanners ingest, surfacing pip's internal vendored setuptools (70.3.0,
 # CVE-2025-47273) as an image finding even though it's a pip internal, not an installed
-# package (our actual setuptools is upgraded above). Safe to remove; pip doesn't use it at runtime.
+# package (our actual setuptools is 83.0.0, provided by conda-forge). Safe to remove;
+# pip doesn't use it at runtime.
 RUN find "$CONDA_PREFIX" -path '*/pip/_vendor/bom.cdx.json' -delete
 
 # clean conda and pip caches

--- a/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
+++ b/assets/responsibleai/environments/responsibleai-tabular/context/Dockerfile
@@ -65,6 +65,12 @@ RUN pip install 'mcp>=1.23.0'
 # --no-deps to prevent skops from upgrading numpy (skops>=0.13.0 requires numpy>=1.25 but we pin numpy<1.24)
 RUN pip install --no-deps 'skops>=0.13.0'
 
+# Drop pip's vendored-dependency SBOM. Modern pip ships pip/_vendor/bom.cdx.json (a CycloneDX
+# file) that scanners ingest, surfacing pip's internal vendored setuptools (70.3.0,
+# CVE-2025-47273) as an image finding even though it's a pip internal, not an installed
+# package (our actual setuptools is upgraded above). Safe to remove; pip doesn't use it at runtime.
+RUN find "$CONDA_PREFIX" -path '*/pip/_vendor/bom.cdx.json' -delete
+
 # clean conda and pip caches
 RUN conda run -p $CONDA_PREFIX pip cache purge && \
     conda clean -a -y


### PR DESCRIPTION
## Summary
Fixes a HIGH severity vulnerability scan finding (QID 5004129, CVE-2025-47273 / GHSA-5rjg-fvgr-3xxf) on the 
responsibleai-tabular curated environment: "setuptools 70.3.0 installed, 78.1.1 required".

## Root cause
Modern pip (26.2+) ships pip/_vendor/bom.cdx.json, a CycloneDX SBOM listing pip's own **internal vendored** setuptools version (70.3.0). Vulnerability scanners ingest this file and misreport it as an installed package finding — even though the environment's actual setuptools package is already 83.0.0 (provided by conda-forge). This file is purely informational metadata; pip does not use it at runtime, so it's safe to delete.

The same fix pattern is already used in `assets/system/context/Dockerfile`.

## Changes
1. Added RUN find "$CONDA_PREFIX" -path '*/pip/_vendor/bom.cdx.json' -delete after all pip installs in the responsibleai-tabular Dockerfile, which addresses the actual root cause of the scanner finding.
2. Removed the earlier RUN pip install 'setuptools>=78.1.1' line added in #5268. Build logs showed this was a no-op (conda-forge already provides setuptools 83.0.0 before that line runs), and it did not actually resolve the scanner finding since the finding was caused by pip's vendored SBOM, not the installed package. A 5-model review (Claude Opus, GPT-5.5, Gemini 3.1 Pro, Grok 4.5, GPT-5.3-Codex) confirmed 4/5 recommended removing this redundant/no-op line in favor of the SBOM fix.