### PR TITLE
Fix benchmark answer parsing for markdown bold formatting

### DIFF
--- a/assets/benchmarkspecs/builtin/bigbenchhard/spec.yaml
+++ b/assets/benchmarkspecs/builtin/bigbenchhard/spec.yaml
@@ -22,8 +22,8 @@ evaluator:
     evaluator_version: "2"
     initialization_parameters:
       patterns:
-        - "(?i)\\*{0,2}ANSWER\\*{0,2}\\s*:\\s*\\*{0,2}\\$?({{ground_truth}})\\*{0,2}(?:\\s|$|\\.|,)"
-        - "(?i)\\*{0,2}ANSWER\\*{0,2}\\s*:\\s*\\*{0,2}\\$?\\(?({{ground_truth}})\\)?\\*{0,2}(?:\\s|$|\\.|,)"
+        - "(?i)\\*{0,3}ANSWER\\*{0,3}\\s*:\\s*\\*{0,3}\\$?({{ground_truth}})\\*{0,3}(?:\\s|$|\\.|,)"
+        - "(?i)\\*{0,3}ANSWER\\*{0,3}\\s*:\\s*\\*{0,3}\\$?\\(?({{ground_truth}})\\)?\\*{0,3}(?:\\s|$|\\.|,)"
     data_mapping:
       ground_truth: "{{item.target}}"
       response: "{{sample.output_text}}"

--- a/assets/benchmarkspecs/builtin/bigbenchhard/spec.yaml
+++ b/assets/benchmarkspecs/builtin/bigbenchhard/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.bigbenchhard"
-version: 1
+version: 2
 display_name: "BIG-Bench Hard Benchmark"
 description: "BIG-Bench Hard (BBH) is a suite of 23 challenging tasks from the BIG-Bench benchmark where prior language models did not outperform average human performance. It evaluates diverse reasoning capabilities including algorithmic, causal, logical, spatial, and temporal reasoning, as well as language understanding and common-sense inference. This is a 1k sample, generated using IRT method."
 benchmarkType: "builtin"
@@ -22,8 +22,8 @@ evaluator:
     evaluator_version: "2"
     initialization_parameters:
       patterns:
-        - "(?i)ANSWER\\s*:\\s*\\$?({{ground_truth}})(?:\\s|$|\\.|,)"
-        - "(?i)ANSWER\\s*:\\s*\\$?\\(?({{ground_truth}})\\)?(?:\\s|$|\\.|,)"
+        - "(?i)\\*{0,2}ANSWER\\*{0,2}\\s*:\\s*\\*{0,2}\\$?({{ground_truth}})\\*{0,2}(?:\\s|$|\\.|,)"
+        - "(?i)\\*{0,2}ANSWER\\*{0,2}\\s*:\\s*\\*{0,2}\\$?\\(?({{ground_truth}})\\)?\\*{0,2}(?:\\s|$|\\.|,)"
     data_mapping:
       ground_truth: "{{item.target}}"
       response: "{{sample.output_text}}"

--- a/assets/benchmarkspecs/builtin/gpqa_diamond/spec.yaml
+++ b/assets/benchmarkspecs/builtin/gpqa_diamond/spec.yaml
@@ -22,7 +22,7 @@ evaluator:
     evaluator_version: "2"
     initialization_parameters:
       patterns:
-        - "(?i)\\*{0,3}ANSWER\\*{0,3}\\s*:\\s*\\*{0,3}({{ground_truth}})\\*{0,3}"
+        - "(?i)\\*{0,3}ANSWER\\*{0,3}\\s*:\\s*\\*{0,3}({{ground_truth}})\\*{0,3}(?:\\s|$|\\.|,)"
     data_mapping:
       ground_truth: "{{item.Correct_Answer}}"
       response: "{{sample.output_text}}"

--- a/assets/benchmarkspecs/builtin/gpqa_diamond/spec.yaml
+++ b/assets/benchmarkspecs/builtin/gpqa_diamond/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.gpqa_diamond"
-version: 5
+version: 6
 display_name: "GPQA Diamond Benchmark"
 description: "GPQA Diamond is a curated to be a higher-difficulty subset of the GPQA benchmark. (Graduate-Level Google-Proof Q&A) benchmark for evaluating model reasoning accuracy on multiple-choice science questions."
 benchmarkType: "builtin"
@@ -22,7 +22,7 @@ evaluator:
     evaluator_version: "2"
     initialization_parameters:
       patterns:
-        - "(?i)ANSWER\\s*:\\s*({{ground_truth}})"
+        - "(?i)\\*{0,3}ANSWER\\*{0,3}\\s*:\\s*\\*{0,3}({{ground_truth}})\\*{0,3}"
     data_mapping:
       ground_truth: "{{item.Correct_Answer}}"
       response: "{{sample.output_text}}"

--- a/assets/benchmarkspecs/builtin/musr/spec.yaml
+++ b/assets/benchmarkspecs/builtin/musr/spec.yaml
@@ -22,7 +22,7 @@ evaluator:
     evaluator_version: "2"
     initialization_parameters:
       patterns:
-        - "(?i)\\*{0,2}ANSWER\\*{0,2}\\s*:\\s*\\*{0,2}({{ground_truth}})\\*{0,2}"
+        - "(?i)\\*{0,3}ANSWER\\*{0,3}\\s*:\\s*\\*{0,3}({{ground_truth}})\\*{0,3}"
     data_mapping:
       ground_truth: "{{item.answer_choice}}"
       response: "{{sample.output_text}}"

--- a/assets/benchmarkspecs/builtin/musr/spec.yaml
+++ b/assets/benchmarkspecs/builtin/musr/spec.yaml
@@ -22,7 +22,7 @@ evaluator:
     evaluator_version: "2"
     initialization_parameters:
       patterns:
-        - "(?i)\\*{0,3}ANSWER\\*{0,3}\\s*:\\s*\\*{0,3}({{ground_truth}})\\*{0,3}"
+        - "(?i)\\*{0,3}ANSWER\\*{0,3}\\s*:\\s*\\*{0,3}({{ground_truth}})\\*{0,3}(?:\\s|$|\\.|,)"
     data_mapping:
       ground_truth: "{{item.answer_choice}}"
       response: "{{sample.output_text}}"

--- a/assets/benchmarkspecs/builtin/musr/spec.yaml
+++ b/assets/benchmarkspecs/builtin/musr/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.musr"
-version: 3
+version: 4
 display_name: "MuSR Benchmark"
 description: "MuSR (Multistep Soft Reasoning) is a benchmark designed to evaluate chain-of-thought reasoning in language models. It contains murder mystery narratives requiring models to identify the most likely murderer by carefully analyzing motives, opportunities, and clues from the story."
 benchmarkType: "builtin"
@@ -22,7 +22,7 @@ evaluator:
     evaluator_version: "2"
     initialization_parameters:
       patterns:
-        - "(?i)ANSWER\\s*:\\s*({{ground_truth}})"
+        - "(?i)\\*{0,2}ANSWER\\*{0,2}\\s*:\\s*\\*{0,2}({{ground_truth}})\\*{0,2}"
     data_mapping:
       ground_truth: "{{item.answer_choice}}"
       response: "{{sample.output_text}}"

--- a/assets/evaluators/tests/test_evaluators_behavior/test_regex_match_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_regex_match_evaluator_behavior.py
@@ -225,3 +225,39 @@ class TestRegexMatchEvaluatorBehavior(BaseCodeEvaluatorRunner):
         evaluator = RegexMatchEvaluator(patterns=r"answer: {{ground_truth}}")
         resolved = evaluator._resolve_pattern(r"answer: {{ground_truth}}", {})
         assert resolved == r"answer: {{ground_truth}}"
+
+    # ==================== BENCHMARK MARKDOWN BOLD PATTERN TESTS ====================
+    # These tests validate the regex patterns used by bigbenchhard, musr, and gpqa_diamond
+    # to handle markdown bold/italic formatting in model responses.
+
+    # The benchmark pattern for BBH/GPQA-style answers
+    BENCHMARK_PATTERN = r"(?i)\*{0,3}ANSWER\*{0,3}\s*:\s*\*{0,3}({{ground_truth}})\*{0,3}"
+
+    @pytest.mark.parametrize("response,ground_truth", [
+        ("ANSWER: B", "B"),                          # plain
+        ("**ANSWER**: **B**", "B"),                   # bold keyword and answer
+        ("**ANSWER: B**", "B"),                       # bold entire line
+        ("***ANSWER***: ***B***", "B"),               # bold+italic
+        ("*ANSWER*: *B*", "B"),                       # italic only
+        ("ANSWER: True", "True"),                     # boolean answer (MuSR)
+        ("**ANSWER**: **True**", "True"),             # bold boolean
+        ("ANSWER:B", "B"),                            # no space after colon
+    ])
+    def test_benchmark_markdown_bold_patterns_match(self, response, ground_truth):
+        """Test that benchmark patterns handle markdown bold/italic formatting."""
+        evaluator = RegexMatchEvaluator(patterns=self.BENCHMARK_PATTERN)
+        results = evaluator(response=response, ground_truth=ground_truth)
+        result_data = self._extract_and_print_result(results, "benchmark_bold")
+        self.assert_pass(result_data)
+
+    @pytest.mark.parametrize("response,ground_truth", [
+        ("ANSWER: A", "B"),                           # wrong answer
+        ("The answer is B", "B"),                     # missing ANSWER: prefix
+        ("**ANSWER**: **A**", "B"),                   # bold but wrong
+    ])
+    def test_benchmark_markdown_bold_patterns_no_match(self, response, ground_truth):
+        """Test that benchmark patterns correctly reject wrong answers."""
+        evaluator = RegexMatchEvaluator(patterns=self.BENCHMARK_PATTERN)
+        results = evaluator(response=response, ground_truth=ground_truth)
+        result_data = self._extract_and_print_result(results, "benchmark_bold_no_match")
+        self.assert_fail(result_data)

--- a/assets/evaluators/tests/test_evaluators_behavior/test_regex_match_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_regex_match_evaluator_behavior.py
@@ -231,7 +231,10 @@ class TestRegexMatchEvaluatorBehavior(BaseCodeEvaluatorRunner):
     # to handle markdown bold/italic formatting in model responses.
 
     # The benchmark pattern for BBH/GPQA-style answers
-    BENCHMARK_PATTERN = r"(?i)\*{0,3}ANSWER\*{0,3}\s*:\s*\*{0,3}({{ground_truth}})\*{0,3}"
+    BENCHMARK_PATTERN = r"(?i)\*{0,3}ANSWER\*{0,3}\s*:\s*\*{0,3}({{ground_truth}})\*{0,3}(?:\s|$|\.|,)"
+
+    # BBH pattern with dollar sign and parentheses support
+    BBH_PATTERN = r"(?i)\*{0,3}ANSWER\*{0,3}\s*:\s*\*{0,3}\$?\(?({{ground_truth}})\)?\*{0,3}(?:\s|$|\.|,)"
 
     @pytest.mark.parametrize("response,ground_truth", [
         ("ANSWER: B", "B"),                          # plain
@@ -242,6 +245,8 @@ class TestRegexMatchEvaluatorBehavior(BaseCodeEvaluatorRunner):
         ("ANSWER: True", "True"),                     # boolean answer (MuSR)
         ("**ANSWER**: **True**", "True"),             # bold boolean
         ("ANSWER:B", "B"),                            # no space after colon
+        ("ANSWER: B.", "B"),                          # trailing period
+        ("ANSWER: B, as explained", "B"),             # trailing comma
     ])
     def test_benchmark_markdown_bold_patterns_match(self, response, ground_truth):
         """Test that benchmark patterns handle markdown bold/italic formatting."""
@@ -254,10 +259,37 @@ class TestRegexMatchEvaluatorBehavior(BaseCodeEvaluatorRunner):
         ("ANSWER: A", "B"),                           # wrong answer
         ("The answer is B", "B"),                     # missing ANSWER: prefix
         ("**ANSWER**: **A**", "B"),                   # bold but wrong
+        ("ANSWER: Bx", "B"),                          # substring without boundary
     ])
     def test_benchmark_markdown_bold_patterns_no_match(self, response, ground_truth):
         """Test that benchmark patterns correctly reject wrong answers."""
         evaluator = RegexMatchEvaluator(patterns=self.BENCHMARK_PATTERN)
         results = evaluator(response=response, ground_truth=ground_truth)
         result_data = self._extract_and_print_result(results, "benchmark_bold_no_match")
+        self.assert_fail(result_data)
+
+    # ==================== BBH DOLLAR/PARENTHESIS PATTERN TESTS ====================
+
+    @pytest.mark.parametrize("response,ground_truth", [
+        ("ANSWER: $100", "100"),                      # dollar prefix
+        ("ANSWER: (B)", "B"),                         # parenthesized answer
+        ("**ANSWER**: **(B)**", "B"),                 # bold with parens
+        ("ANSWER: $50.", "50"),                       # dollar with trailing period
+    ])
+    def test_bbh_pattern_with_dollar_and_parens_match(self, response, ground_truth):
+        """Test BBH patterns handle dollar signs and parentheses."""
+        evaluator = RegexMatchEvaluator(patterns=self.BBH_PATTERN)
+        results = evaluator(response=response, ground_truth=ground_truth)
+        result_data = self._extract_and_print_result(results, "bbh_pattern")
+        self.assert_pass(result_data)
+
+    @pytest.mark.parametrize("response,ground_truth", [
+        ("ANSWER: $200", "100"),                      # wrong dollar value
+        ("ANSWER: (A)", "B"),                         # wrong paren answer
+    ])
+    def test_bbh_pattern_with_dollar_and_parens_no_match(self, response, ground_truth):
+        """Test BBH patterns reject incorrect answers."""
+        evaluator = RegexMatchEvaluator(patterns=self.BBH_PATTERN)
+        results = evaluator(response=response, ground_truth=ground_truth)
+        result_data = self._extract_and_print_result(results, "bbh_pattern_no_match")
         self.assert_fail(result_data)


### PR DESCRIPTION
## Problem

Newer GPT models (5.5, 5.6-sol, 5.6-luna) commonly output answers with markdown bold formatting like `**ANSWER: C**` or `**ANSWER:** Dale`. The existing regex patterns in BigBenchHard, MuSR, and GPQA Diamond specs did not handle this, causing correct answers to be incorrectly marked as failures.

Reported by internal customer - ~70 utterances in MuSR consistently use bold formatting with newer models.

## Fix

Updated regex patterns to optionally match `\*{0,3}` (italic/bold/bold+italic markers) around the ANSWER keyword and answer value. Also added trailing boundary `(?:\s|$|\.|,)` to gpqa_diamond and musr for consistency with bigbenchhard.

- **BigBenchHard** (v1 -> v2): Handle `**Answer**: **X**` patterns
- **MuSR** (v3 -> v4): Handle `**ANSWER**: **value**` patterns
- **GPQA Diamond** (v5 -> v6): Handle `**ANSWER**: **value**` patterns + add trailing boundary

## Testing

- 18 parametrized unit tests added covering:
  - Plain: `ANSWER: B`
  - Bold: `**ANSWER**: **B**`
  - Whole-line bold: `**ANSWER: B**`
  - Bold+italic: `***ANSWER***: ***B***`
  - Italic: `*ANSWER*: *B*`
  - BBH dollar/parens: `ANSWER: $100`, `ANSWER: (B)`
  - Boundary: trailing period, comma, substring rejection
- Patterns still match original unformatted `ANSWER: X` output (backward compatible)
- Version bumps ensure older pinned versions are unaffected

## 3-Model AI Review (3 iterations)

Reviewed by Claude Sonnet 4.6, GPT 5.4-mini, and Gemini 3.5 Flash across 3 iterations. All models approve. Remaining theoretical findings (asymmetric asterisks, underscore markdown) are not seen in production and accepted as-is.