### PR TITLE
Add setuptools dependency to conda environments for inference

### DIFF
--- a/assets/inference/environments/minimal-py311-inference/context/conda_dependencies.yaml
+++ b/assets/inference/environments/minimal-py311-inference/context/conda_dependencies.yaml
@@ -9,5 +9,6 @@ dependencies:
   - azureml-inference-server-http=={{latest-pypi-version}}
   - azure-storage-blob=={{latest-pypi-version}}
   - azure-identity=={{latest-pypi-version}}
+  - setuptools>=82.0.1
   - numpy
   - joblib=={{latest-pypi-version}}

--- a/assets/inference/environments/minimal-py312-cuda12.4-inference/context/conda_dependencies.yaml
+++ b/assets/inference/environments/minimal-py312-cuda12.4-inference/context/conda_dependencies.yaml
@@ -7,4 +7,5 @@ dependencies:
 - pip
 - pip:
   - azureml-inference-server-http=={{latest-pypi-version}}
+  - setuptools>=82.0.1
   - numpy=={{latest-pypi-version}}

--- a/assets/inference/environments/mlflow-py312-inference/context/conda_dependencies.yaml
+++ b/assets/inference/environments/mlflow-py312-inference/context/conda_dependencies.yaml
@@ -8,6 +8,7 @@ dependencies:
 - pip:
   - azureml-inference-server-http=={{latest-pypi-version}}
   - azureml-ai-monitoring=={{latest-pypi-version}}
+  - setuptools>=82.0.1
   - mlflow
   - scikit-learn
   - cloudpickle


### PR DESCRIPTION
- Added setuptools>=82.0.1 to the inference conda environments.
- Updated the following inference environments:
  - minimal-py311-inference
  - minimal-py312-cuda12.4-inference
  - mlflow-py312-inference

## Reason
Remediates the setuptools vulnerability identified in the inference environments.
