### PR TITLE
Add judge model requirement to HealthBench benchmark spec

### DIFF
--- a/assets/benchmarkspecs/builtin/inspect_ai/healthbench/spec.yaml
+++ b/assets/benchmarkspecs/builtin/inspect_ai/healthbench/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.inspect_ai.healthbench"
-version: 1
+version: 2
 display_name: "HealthBench (inspect_ai)"
 description: "HealthBench: A multi-turn benchmark evaluating LLM medical knowledge and clinical reasoning across 5000 physician-crafted healthcare conversations with rubric-based scoring. Evaluated using the inspect_ai framework."
 benchmarkType: "builtin"
@@ -11,6 +11,7 @@ evaluator:
     type: "inspect_ai"
     name: "HealthBench"
     task_name: "inspect_evals/healthbench"
+    model: "{{aoai_deployment_and_model}}"
 
 dataset:
   datasetName: "healthbench"
@@ -23,7 +24,7 @@ dataset:
     dataset_source: "https://openaipublic.blob.core.windows.net/simple-evals/healthbench/2025-05-07-06-14-12_oss_eval.jsonl"
   source:
     provider: "mlregistry"
-    sourceDatasetId: "azureml://registries/azureml/data/healthbench/versions/1"
+    sourceDatasetId: "azureml://registries/azureml/data/healthbench/versions/2"
     sourceFormat: "jsonl"
     properties:
       file_name: "healthbench.jsonl"

--- a/assets/pipelines/data/global_dataset/jsonl/healthbench/asset.yaml
+++ b/assets/pipelines/data/global_dataset/jsonl/healthbench/asset.yaml
@@ -1,5 +1,5 @@
 name: healthbench
-version: 1
+version: 2
 type: data
 spec: spec.yaml
 extra_config: storage.yaml


### PR DESCRIPTION
## Summary

HealthBench uses a judge model for rubric-based scoring of medical conversations. This PR:
1. Adds the `model` field to the inspect_ai grader so the service validates that users provide `grader_model` in `data_source_config`
2. Bumps dataset version 1 -> 2 to avoid 'already exists' errors in the release pipeline (v1 was released to azureml-dev and azureml-staging but not the azureml prod registry)

This is the first InspectAI benchmark to declare a model grader requirement.

## Changes

- `healthbench/spec.yaml`: Added `model: '{{aoai_deployment_and_model}}'` to inspect_ai testing criteria (consistent with FrontierScience's label_model pattern), spec version 1 -> 2, dataset ref versions/1 -> versions/2
- `healthbench dataset asset.yaml`: version 1 -> 2

## How it works

When `model` is set on an inspect_ai grader, `GraderTypeHelper.IsModelGrader()` returns true, which:
1. Requires the user to specify `grader_model` in `data_source_config` (e.g. `connection/gpt-4o`)
2. The service replaces the placeholder with the user's model connection via `SetGraderModel()`
3. The judge model is passed to the inspect_ai task for rubric evaluation

## Validated

- INT validation confirmed HealthBench runs successfully with judge model (3/3 passed, 0 errors)
- Scores: 0.05, 0.26, 0.18 (partial credit from rubric-based judge)