### PR TITLE
Fix acft-rft-training: install torch from the cu126 index

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
@@ -43,7 +43,10 @@ COPY utils /opt/conda/envs/ptca/lib/python3.10/site-packages/verl/utils/vllm/uti
 # vllm is a direct top-level runtime dependency in this image; pin the patched release.
 RUN pip install --no-cache-dir vllm==0.24.0
 # vllm 0.24.0 pins torch==2.11.0; override after vllm to fix GHSA-rrmf-rvhw-rf47 / VCM 5014621.
-RUN pip install --no-cache-dir --no-deps torch==2.13.0
+# Install from the cu126 index. The base image is cu126 and the recommended A100 v4 SKU ships a
+# driver capped at CUDA 12.8, but the default PyPI torch wheel is built against CUDA 13.0, so the
+# image fails at runtime with "CUDA driver too old (found version 12080)" / cuda_is_available=false.
+RUN pip install --no-cache-dir --no-deps torch==2.13.0 --index-url https://download.pytorch.org/whl/cu126
 # vllm's resolver can upgrade numpy, but verl 0.7.1 requires numpy<2.
 RUN pip install --no-cache-dir numpy==1.26.4
 # Keep xgrammar at the patched floor even when pulled transitively by vllm.


### PR DESCRIPTION
## Problem

`acft-rft-training` installs torch from the **default PyPI index**, which serves wheels built against **CUDA 13.0**, onto a **cu126** base image (`stable-ubuntu2204-cu126-py310-torch280`).

On the SKU the samples document (`Standard_NC96ads_A100_v4`, driver 570.195.03, CUDA 12.8 max) the image fails at runtime:

```
CUDA driver too old (found version 12080)
cuda_is_available=false
```

The user workload never starts.

## Root cause

Tags `:15`-`:17` pinned `--index-url https://download.pytorch.org/whl/cu126` and worked. The flag was dropped in #5084 when torch moved `2.9.0` -> `2.11.0`. Every tag since has shipped a CUDA 13.0 build on a cu126 base:

| Tag | Built | torch | Index |
|---|---|---|---|
| 15-17 | 2026-05-18 .. 05-25 | 2.9.0 | **cu126** |
| 18-21 | 2026-06-11 .. 07-16 | 2.11.0 | default PyPI |
| 22-24 | 2026-07-27 .. 08-13 | 2.13.0 | default PyPI |

(Read from the published image configs on MCR.)

## Why this matters beyond the CUDA error

The verl GRPO compatibility patches from #5156 ship in `:20` and later — but those are exactly the tags that cannot start on the documented SKU. Users are pushed back to `:15`, which **predates** those patches, so they hit the already-fixed failures again:

- `RuntimeError: Output 0 of SqueezeBackward1 is a view and is being modified inplace` (fixed by `_VERL_LOGITS_NEW`)
- `TypeError: set object is not subscriptable` (fixed by `_VERL_FSDP2_NEW`)
- `TypeError: Parameter.__new__() got an unexpected keyword argument _is_hf_initialized` (fixed by the `accelerate==1.14.0` bump)

No published tag currently has both a working CUDA build and the verl patches.

## Fix

Restore `--index-url https://download.pytorch.org/whl/cu126` on the torch install.

The pinned version is unchanged, so the `GHSA-rrmf-rvhw-rf47` / VCM 5014621 override still holds. `torch-2.13.0+cu126-cp310-cp310-manylinux_2_28_x86_64.whl` is published on that index.

## Follow-up (not in this PR)

`torchvision==0.26.0` in `requirements.txt` is still resolved from default PyPI. It is installed before the torch override, so it should be validated against the cu126 runtime in the build.

## Validation requested

Please confirm the built image reports `torch.cuda.is_available() == True` on `Standard_NC96ads_A100_v4` before publishing the next tag.

Refs: ADO bug 5519811.
