### PR TITLE
acft-rft-training: correct the remediation path in the bucket-overflow error

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/verl_rft_compat_patches
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/verl_rft_compat_patches
@@ -303,6 +303,29 @@ _VERL_LOGITS_NEW = '''                    logits_rmpad = output.logits.squeeze(0
 
 
 # --------------------------------------------------------------------------------------
+# The bucket-overflow assertion names a Hydra path that does not exist. The field lives on
+# CheckpointEngineConfig (verl/workers/config/rollout.py), nested under the rollout config,
+# so following the printed hint fails with
+#   RolloutConfig.__init__() got an unexpected keyword argument
+#   'update_weights_bucket_megabytes'
+# Print the override that actually works. Also add the missing space between the two
+# sentences, which run together in the original.
+# --------------------------------------------------------------------------------------
+_VERL_BUCKET_HINT_OLD = '''                assert offset + weight.nbytes <= self.bucket_size, (
+                    f"Weight {name}({weight.shape}, {weight.dtype}) is too large to fit in the bucket."
+                    f"Please increase rollout.update_weights_bucket_megabytes({self.bucket_size_mb} MB)."
+                )'''
+_VERL_BUCKET_HINT_NEW = '''                # ACFT-RFT-COMPAT: name the Hydra path that actually exists.
+                # update_weights_bucket_megabytes is on CheckpointEngineConfig, nested under
+                # the rollout config, so the original hint is rejected by RolloutConfig.
+                assert offset + weight.nbytes <= self.bucket_size, (
+                    f"Weight {name}({weight.shape}, {weight.dtype}) is too large to fit in the bucket. "
+                    f"Please increase actor_rollout_ref.rollout.checkpoint_engine."
+                    f"update_weights_bucket_megabytes (currently {self.bucket_size_mb} MB)."
+                )'''
+
+
+# --------------------------------------------------------------------------------------
 # The bundled RFT driver starts the Ray head with the dashboard disabled. Enable it on
 # port 8265 (ray[default] from PyPI ships the dashboard frontend, so no separate frontend
 # install is required). The recipe-supplied driver copy is enabled separately at submit time.
@@ -395,6 +418,15 @@ def main():
     # verl actor forward <-> flash-attn 4 / activation offload
     _replace("verl.utils.attention_utils", _VERL_BERT_OLD, _VERL_BERT_NEW)
     _replace("verl.workers.actor.dp_actor", _VERL_LOGITS_OLD, _VERL_LOGITS_NEW)
+
+    # verl weight transfer: correct the remediation path in the bucket-overflow message.
+    # Optional anchor: this is a message-only fix, so a wording change upstream should not
+    # fail the image build.
+    _replace_if_present(
+        "verl.workers.rollout.vllm_rollout.bucketed_weight_transfer",
+        _VERL_BUCKET_HINT_OLD,
+        _VERL_BUCKET_HINT_NEW,
+    )
 
     # Ray dashboard: reporter robustness + enable it on :8265
     _replace("ray.dashboard.modules.reporter.reporter_agent", _RAY_REPORTER_OLD, _RAY_REPORTER_NEW)


### PR DESCRIPTION
## Problem

When a single weight exceeds the transfer bucket, verl raises:

```
Weight model.embed_tokens.weight(151936, 5120) fp32 = 3.11GB is too large for the 2048 MB bucket.
Please increase rollout.update_weights_bucket_megabytes
```

**That Hydra path does not exist.** Following it fails with:

```
RolloutConfig.__init__() got an unexpected keyword argument 'update_weights_bucket_megabytes'
```

`update_weights_bucket_megabytes` is a field on `CheckpointEngineConfig` (`verl/workers/config/rollout.py:132`), nested one level deeper under the rollout config — confirmed by `_generated_ppo_trainer.yaml:298-301` and by the consumer at `vllm_rollout.py:166` (`self.config.checkpoint_engine.update_weights_bucket_megabytes`).

So a user hitting an OOM-shaped failure is handed a remediation that produces a second, more confusing failure.

## Fix

Patch the message to name the override that works:

```
actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes
```

Also adds the missing space between the two sentences, which run together in the original (`...in the bucket.Please increase...`).

## Why `_replace_if_present` rather than `_replace`

This is a message-only fix. Registering it with `_replace` would fail the entire image build if upstream rewords the assertion. `_replace_if_present` degrades to a no-op instead. The correctness-critical patches in this file keep using `_replace`.

## Validation

Applied against the real `verl==0.7.1` file from PyPI:

- anchor found, exactly 1 occurrence
- patched file byte-compiles
- `ACFT-RFT-COMPAT` marker present in the replacement, so the patcher's idempotency check works on re-run
- patcher script itself byte-compiles

Resulting message:

```
Weight {name}({shape}, {dtype}) is too large to fit in the bucket. Please increase
actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes (currently 2048 MB).
```

Companion PR exposing the knob in the sample driver: microsoft-foundry/custom-code-training#22.

Fixes [AB#5519820](https://msdata.visualstudio.com/3adb301f-9ede-41f2-933b-fcd1a486ff7f/_workitems/edit/5519820)
