### PR TITLE
Fix Qualys vuln from pip's internally vendored setuptools

### DIFF
--- a/assets/inference/environments/minimal-py311-inference/context/Dockerfile
+++ b/assets/inference/environments/minimal-py311-inference/context/Dockerfile
@@ -16,7 +16,16 @@ COPY conda_dependencies.yaml .
 RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
     rm conda_dependencies.yaml && \
     conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
-    conda clean -a -y   
+    conda clean -a -y
+
+# Fix Trivy/Qualys vuln from pip's internally vendored setuptools (GHSA-5rjg-fvgr-3xxf, CVE-2025-47273).
+# pip bundles a stale-versioned manifest of setuptools under pip/_vendor for its own internal use only;
+# the real installed setuptools package is unaffected.
+# Remove the stale manifest entry so scanners stop flagging it as a live vulnerable component.
+RUN find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
+        -exec sed -i '/^setuptools==/d' {} + && \
+    find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/bom.cdx.json' -delete
+
 USER dockeruser
 
 CMD [ "runsvdir", "/var/runit" ]

--- a/assets/inference/environments/minimal-py311-inference/context/conda_dependencies.yaml
+++ b/assets/inference/environments/minimal-py311-inference/context/conda_dependencies.yaml
@@ -9,6 +9,5 @@ dependencies:
   - azureml-inference-server-http=={{latest-pypi-version}}
   - azure-storage-blob=={{latest-pypi-version}}
   - azure-identity=={{latest-pypi-version}}
-  - setuptools>=82.0.1
   - numpy
   - joblib=={{latest-pypi-version}}

--- a/assets/inference/environments/minimal-py312-cuda12.4-inference/context/Dockerfile
+++ b/assets/inference/environments/minimal-py312-cuda12.4-inference/context/Dockerfile
@@ -16,7 +16,16 @@ COPY conda_dependencies.yaml .
 RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
     rm conda_dependencies.yaml && \
     conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
-    conda clean -a -y   
+    conda clean -a -y
+
+# Fix Trivy/Qualys vuln from pip's internally vendored setuptools (GHSA-5rjg-fvgr-3xxf, CVE-2025-47273).
+# pip bundles a stale-versioned manifest of setuptools under pip/_vendor for its own internal use only;
+# the real installed setuptools package is unaffected.
+# Remove the stale manifest entry so scanners stop flagging it as a live vulnerable component.
+RUN find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
+        -exec sed -i '/^setuptools==/d' {} + && \
+    find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/bom.cdx.json' -delete
+
 USER dockeruser
 
 CMD [ "runsvdir", "/var/runit" ]

--- a/assets/inference/environments/minimal-py312-cuda12.4-inference/context/conda_dependencies.yaml
+++ b/assets/inference/environments/minimal-py312-cuda12.4-inference/context/conda_dependencies.yaml
@@ -7,5 +7,4 @@ dependencies:
 - pip
 - pip:
   - azureml-inference-server-http=={{latest-pypi-version}}
-  - setuptools>=82.0.1
   - numpy=={{latest-pypi-version}}

--- a/assets/inference/environments/mlflow-py312-inference/context/Dockerfile
+++ b/assets/inference/environments/mlflow-py312-inference/context/Dockerfile
@@ -21,7 +21,16 @@ COPY conda_dependencies.yaml .
 RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.yaml -q && \
     rm conda_dependencies.yaml && \
     conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip cache purge && \
-    conda clean -a -y   
+    conda clean -a -y
+
+# Fix Trivy/Qualys vuln from pip's internally vendored setuptools (GHSA-5rjg-fvgr-3xxf, CVE-2025-47273).
+# pip bundles a stale-versioned manifest of setuptools under pip/_vendor for its own internal use only;
+# the real installed setuptools package is unaffected.
+# Remove the stale manifest entry so scanners stop flagging it as a live vulnerable component.
+RUN find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
+        -exec sed -i '/^setuptools==/d' {} + && \
+    find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/bom.cdx.json' -delete
+
 USER dockeruser
 
 CMD [ "runsvdir", "/var/runit" ]

--- a/assets/inference/environments/mlflow-py312-inference/context/conda_dependencies.yaml
+++ b/assets/inference/environments/mlflow-py312-inference/context/conda_dependencies.yaml
@@ -8,7 +8,6 @@ dependencies:
 - pip:
   - azureml-inference-server-http=={{latest-pypi-version}}
   - azureml-ai-monitoring=={{latest-pypi-version}}
-  - setuptools>=82.0.1
   - mlflow
   - scikit-learn
   - cloudpickle


### PR DESCRIPTION
Delete stale setuptools entry from pip/_vendor/vendor.txt and remove pip/_vendor/bom.cdx.json in the inference conda environments (minimal-py311-inference, minimal-py312-cuda12.4-inference, mlflow-py312-inference), covering both the base image's own /opt/miniconda and the newly created AzureML conda env. This manifest only records pip's bundled metadata (unused at runtime) and was causing false-positive QID 5004129 (GHSA-5rjg-fvgr-3xxf) findings even after the real setuptools package was upgraded via conda_dependencies.yaml (#5277).