### PR TITLE
Add judge model dropdown to browse_comp and tau2_telecom benchmark specs

### DIFF
--- a/assets/benchmarkspecs/builtin/inspect_ai/browse_comp/spec.yaml
+++ b/assets/benchmarkspecs/builtin/inspect_ai/browse_comp/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.inspect_ai.browse_comp"
-version: 1
+version: 2
 display_name: "BrowseComp Benchmark (inspect_ai)"
 description: "BrowseComp is a benchmark for evaluating browsing agents on realistic web research tasks. Problems are encrypted at rest and decrypted at runtime. Evaluated using the inspect_ai framework."
 benchmarkType: "builtin"
@@ -11,6 +11,7 @@ evaluator:
     type: "inspect_ai"
     name: "BrowseComp"
     task_name: "inspect_evals/browse_comp"
+    model: "{{aoai_deployment_and_model}}"
 
 dataset:
   datasetName: "browse_comp"

--- a/assets/benchmarkspecs/builtin/inspect_ai/tau2_telecom/spec.yaml
+++ b/assets/benchmarkspecs/builtin/inspect_ai/tau2_telecom/spec.yaml
@@ -1,6 +1,6 @@
 type: "benchmarkspec"
 name: "builtin.inspect_ai.tau2_telecom"
-version: 1
+version: 2
 display_name: "τ²-Bench Telecom Benchmark (inspect_ai)"
 description: "τ²-bench Telecom is a dual-control agent benchmark that evaluates AI agents on realistic telecom customer service tasks. Both the AI agent and a simulated user interact to resolve issues. Evaluated using the inspect_ai framework."
 benchmarkType: "builtin"
@@ -11,6 +11,7 @@ evaluator:
     type: "inspect_ai"
     name: "tau2 Telecom"
     task_name: "inspect_evals/tau2_telecom"
+    model: "{{aoai_deployment_and_model}}"
 
 dataset:
   datasetName: "tau2_telecom"


### PR DESCRIPTION
## Problem

When running **browse_comp** or **tau2_telecom** benchmarks with an **agent target**, the evaluation fails immediately with:

> `No model specified (and no model environment variable defined)`

### Root Cause

In `inspect_ai_utils.py`, `build_scorer_task_kwargs()` has three code paths:

| Path | Condition | Result |
|------|-----------|--------|
| 1 | Explicit `benchmark_grader_model` from UI | ✅ Uses that model |
| 2 | Model target, no grader_model | ✅ Defaults judge to evaluated model |
| 3 | **Agent target**, no grader_model | ❌ Returns empty → `No model specified` |

These specs lacked `model: "{{aoai_deployment_and_model}}"` in their `testingCriteria`, so the UI never showed the judge model dropdown, and `benchmark_grader_model` was never populated for agent targets.

### Telemetry Evidence

- Failures observed in production when running these benchmarks against agent targets
- Failed in ~7 seconds — hit "No model specified" immediately on inspect_ai startup

## Fix

Add `model: "{{aoai_deployment_and_model}}"` to `testingCriteria` for both specs, matching the existing **healthbench** and **frontierscience** pattern. This enables the judge model dropdown in the UI.

### Changes

| File | Change |
|------|--------|
| `browse_comp/spec.yaml` | Added `model` field, version 1 → 2 |
| `tau2_telecom/spec.yaml` | Added `model` field, version 1 → 2 |

### Why other inspect_ai specs don't need this

| Spec | Needs judge model? | Reason |
|------|-------------------|--------|
| healthbench | ✅ Already has it | Medical rubric scoring requires LLM judge |
| frontierscience | ✅ Already has it | Science evaluation requires LLM judge |
| **browse_comp** | ✅ **This PR** | Verifying browsing results requires LLM judge |
| **tau2_telecom** | ✅ **This PR** | Simulated user + scoring requires LLM judge |
| aime2025 | ❌ Not needed | Math — uses exact string match scoring |
| chembench | ❌ Not needed | Chemistry — uses exact string match scoring |

## Testing

- Pattern matches healthbench (which works correctly in production)
- Model targets are unaffected (path 2 still defaults correctly; dropdown is optional)
- Version bump ensures new registrations pick up the change