### PR TITLE
Split AutoML DNN pip install layers

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl-dnn/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl-dnn/context/Dockerfile
@@ -54,7 +54,8 @@ RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --no-cache-dir \
     'psutil>5.0.0,<6.0.0' \
     'pip>=26.1'
 
-# Install pip dependencies
+# Install pip dependencies. Keep these split across multiple RUN statements so
+# no individual Docker layer exceeds the registry validation limit.
 # GitPython>=3.1.57 overrides the transitive copy pulled in by mlflow-skinny ->
 # databricks-sdk -> gitpython (also pulled by azureml-* telemetry helpers);
 # parent packages still allow the older, vulnerable versions.
@@ -65,21 +66,25 @@ RUN pip install \
                 azureml-telemetry=={{latest-pypi-version}} \
                 azureml-interpret=={{latest-pypi-version}} \
                 azureml-responsibleai=={{latest-pypi-version}} \
+                azureml-defaults=={{latest-pypi-version}} \
+                'inference-schema' \
+                'mlflow-skinny>=2.16.0' \
+                'GitPython>=3.1.57' \
+                'pillow>=12.1.1'
+
+RUN pip install \
                 azureml-automl-core=={{latest-pypi-version}} \
                 azureml-automl-runtime=={{latest-pypi-version}} \
                 azureml-train-automl-client=={{latest-pypi-version}} \
                 azureml-train-automl-runtime=={{latest-pypi-version}} \
-                azureml-defaults=={{latest-pypi-version}} \
-                'inference-schema' \
-                'mlflow-skinny>=2.16.0' \
+                'mltable>=1.0.0'
+
+RUN pip install \
                 'cmdstanpy==1.0.4' \
                 'prophet==1.1.4' \
                 'xgboost==1.5.2' \
-                'mltable>=1.0.0' \
                 'pytorch-transformers==1.0.0' \
-                'GitPython>=3.1.57' \
                 'spacy==3.7.4' \
-                'pillow>=12.1.1' \
                 'https://aka.ms/automl-resources/packages/en_core_web_sm-3.7.1.tar.gz'
 
 # azureml-dataset-runtime is resolved in its own pip invocation, as the other


### PR DESCRIPTION
## Summary
- Split the `ai-ml-automl-dnn` main pip dependency install into three smaller `RUN pip install` layers.
- This avoids producing one oversized Docker layer while keeping the package set unchanged.

## Validation methodology
1. Reproduced the current oversized layer by building the pinned latest `origin/main` Dockerfile in ACR `vulnscan1779267129n1`:
   - Run ID: `wb98`
   - Image: `vulnscan1779267129n1.azurecr.io/azureml/curated/ai-ml-automl-dnn:layer-report-20260821-59968a20f`
   - Digest: `sha256:6bf22ff53e77f083f221a55dd738f586f52835cdc29fa6d651dde6bd781df749`
   - Result: max layer was `8.4478 GiB`, exceeding the 8 GiB validation limit.
2. Attempted local Docker build from a copied/pinned context. Local build is blocked before the changed layer by the AzureML base image failing TLS to `files.pythonhosted.org` with `SSLV3_ALERT_HANDSHAKE_FAILURE`; host Python can reach the same URL, so this is local Docker/base-image network behavior rather than the Dockerfile split.
3. Validated this PR's split using the same pinned context in ACR:
   - Run ID: `wb9a`
   - Image: `vulnscan1779267129n1.azurecr.io/azureml/curated/ai-ml-automl-dnn:split-layer-20260821-59968a20f`
   - Digest: `sha256:c0dde6cf29005034fcad875429b1cfeefb3e676f62d0c20fe29b26454194e49e`
   - Result: 23 layers, max layer `2.6642 GiB`, under the 8 GiB limit.

