### PR TITLE
Fix curated pip cache corruption

### DIFF
--- a/assets/inference/environments/minimal-py311-inference/context/Dockerfile
+++ b/assets/inference/environments/minimal-py311-inference/context/Dockerfile
@@ -21,10 +21,8 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
 # Fix Trivy/Qualys vuln from pip's internally vendored setuptools (GHSA-5rjg-fvgr-3xxf, CVE-2025-47273).
 # pip bundles a stale-versioned manifest of setuptools under pip/_vendor for its own internal use only;
 # the real installed setuptools package is unaffected.
-# conda clean -a -y above does not purge /opt/miniconda/pkgs for packages still owned by the base
-# conda install (e.g. pip), so remove it explicitly first - otherwise the find below also patches the
-# cached pip package's files, which breaks Conda's own integrity manifest for that cache entry and
-# causes CondaVerificationError/SafetyError the next time an environment build re-links it from cache.
+# Remove Conda's retained package cache before patching pip metadata; modifying cached files breaks
+# integrity verification when Conda later re-links them into an environment.
 RUN rm -rf /opt/miniconda/pkgs && \
     find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
         -exec sed -i '/^setuptools==/d' {} + && \

--- a/assets/inference/environments/minimal-py311-inference/context/Dockerfile
+++ b/assets/inference/environments/minimal-py311-inference/context/Dockerfile
@@ -21,8 +21,12 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
 # Fix Trivy/Qualys vuln from pip's internally vendored setuptools (GHSA-5rjg-fvgr-3xxf, CVE-2025-47273).
 # pip bundles a stale-versioned manifest of setuptools under pip/_vendor for its own internal use only;
 # the real installed setuptools package is unaffected.
-# Remove the stale manifest entry so scanners stop flagging it as a live vulnerable component.
-RUN find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
+# conda clean -a -y above does not purge /opt/miniconda/pkgs for packages still owned by the base
+# conda install (e.g. pip), so remove it explicitly first - otherwise the find below also patches the
+# cached pip package's files, which breaks Conda's own integrity manifest for that cache entry and
+# causes CondaVerificationError/SafetyError the next time an environment build re-links it from cache.
+RUN rm -rf /opt/miniconda/pkgs && \
+    find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
         -exec sed -i '/^setuptools==/d' {} + && \
     find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/bom.cdx.json' -delete
 

--- a/assets/inference/environments/minimal-py312-cuda12.4-inference/context/Dockerfile
+++ b/assets/inference/environments/minimal-py312-cuda12.4-inference/context/Dockerfile
@@ -21,10 +21,8 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
 # Fix Trivy/Qualys vuln from pip's internally vendored setuptools (GHSA-5rjg-fvgr-3xxf, CVE-2025-47273).
 # pip bundles a stale-versioned manifest of setuptools under pip/_vendor for its own internal use only;
 # the real installed setuptools package is unaffected.
-# conda clean -a -y above does not purge /opt/miniconda/pkgs for packages still owned by the base
-# conda install (e.g. pip), so remove it explicitly first - otherwise the find below also patches the
-# cached pip package's files, which breaks Conda's own integrity manifest for that cache entry and
-# causes CondaVerificationError/SafetyError the next time an environment build re-links it from cache.
+# Remove Conda's retained package cache before patching pip metadata; modifying cached files breaks
+# integrity verification when Conda later re-links them into an environment.
 RUN rm -rf /opt/miniconda/pkgs && \
     find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
         -exec sed -i '/^setuptools==/d' {} + && \

--- a/assets/inference/environments/minimal-py312-cuda12.4-inference/context/Dockerfile
+++ b/assets/inference/environments/minimal-py312-cuda12.4-inference/context/Dockerfile
@@ -21,8 +21,12 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
 # Fix Trivy/Qualys vuln from pip's internally vendored setuptools (GHSA-5rjg-fvgr-3xxf, CVE-2025-47273).
 # pip bundles a stale-versioned manifest of setuptools under pip/_vendor for its own internal use only;
 # the real installed setuptools package is unaffected.
-# Remove the stale manifest entry so scanners stop flagging it as a live vulnerable component.
-RUN find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
+# conda clean -a -y above does not purge /opt/miniconda/pkgs for packages still owned by the base
+# conda install (e.g. pip), so remove it explicitly first - otherwise the find below also patches the
+# cached pip package's files, which breaks Conda's own integrity manifest for that cache entry and
+# causes CondaVerificationError/SafetyError the next time an environment build re-links it from cache.
+RUN rm -rf /opt/miniconda/pkgs && \
+    find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
         -exec sed -i '/^setuptools==/d' {} + && \
     find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/bom.cdx.json' -delete
 

--- a/assets/inference/environments/mlflow-py312-inference/context/Dockerfile
+++ b/assets/inference/environments/mlflow-py312-inference/context/Dockerfile
@@ -26,8 +26,12 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
 # Fix Trivy/Qualys vuln from pip's internally vendored setuptools (GHSA-5rjg-fvgr-3xxf, CVE-2025-47273).
 # pip bundles a stale-versioned manifest of setuptools under pip/_vendor for its own internal use only;
 # the real installed setuptools package is unaffected.
-# Remove the stale manifest entry so scanners stop flagging it as a live vulnerable component.
-RUN find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
+# conda clean -a -y above does not purge /opt/miniconda/pkgs for packages still owned by the base
+# conda install (e.g. pip), so remove it explicitly first - otherwise the find below also patches the
+# cached pip package's files, which breaks Conda's own integrity manifest for that cache entry and
+# causes CondaVerificationError/SafetyError the next time an environment build re-links it from cache.
+RUN rm -rf /opt/miniconda/pkgs && \
+    find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
         -exec sed -i '/^setuptools==/d' {} + && \
     find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/bom.cdx.json' -delete
 

--- a/assets/inference/environments/mlflow-py312-inference/context/Dockerfile
+++ b/assets/inference/environments/mlflow-py312-inference/context/Dockerfile
@@ -26,10 +26,8 @@ RUN conda env create -p $AZUREML_CONDA_ENVIRONMENT_PATH -f conda_dependencies.ya
 # Fix Trivy/Qualys vuln from pip's internally vendored setuptools (GHSA-5rjg-fvgr-3xxf, CVE-2025-47273).
 # pip bundles a stale-versioned manifest of setuptools under pip/_vendor for its own internal use only;
 # the real installed setuptools package is unaffected.
-# conda clean -a -y above does not purge /opt/miniconda/pkgs for packages still owned by the base
-# conda install (e.g. pip), so remove it explicitly first - otherwise the find below also patches the
-# cached pip package's files, which breaks Conda's own integrity manifest for that cache entry and
-# causes CondaVerificationError/SafetyError the next time an environment build re-links it from cache.
+# Remove Conda's retained package cache before patching pip metadata; modifying cached files breaks
+# integrity verification when Conda later re-links them into an environment.
 RUN rm -rf /opt/miniconda/pkgs && \
     find /opt/miniconda $AZUREML_CONDA_ENVIRONMENT_PATH -path '*/pip/_vendor/vendor.txt' \
         -exec sed -i '/^setuptools==/d' {} + && \


### PR DESCRIPTION
Remove Conda's package cache before modifying pip's vendored scanner metadata, preventing later environment builds from failing Conda integrity verification.