### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/clone-repo/action.yaml
+++ b/.github/actions/clone-repo/action.yaml
@@ -13,13 +13,13 @@ runs:
   steps:
     - name: Clone branch
       if: "!fromJSON(inputs.forked-pr)"
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
     
     - name: Clone forked PR
       if: fromJSON(inputs.forked-pr)
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       with:
         ref: refs/pull/${{ github.event.number }}/merge
         fetch-depth: ${{ inputs.fetch-depth }}

--- a/.github/actions/create-azure-resources/action.yaml
+++ b/.github/actions/create-azure-resources/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Log in to Azure
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
       with:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/assets-docs.yaml
+++ b/.github/workflows/assets-docs.yaml
@@ -37,27 +37,27 @@ jobs:
     
     steps:
       - name: Clone branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 1
           path: ${{ env.main_dir }}
 
       - name: Clone release branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           ref: release
           fetch-depth: 1
           path: ${{ env.release_dir }}
 
       - name: Clone wiki
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           repository: Azure/azureml-assets.wiki
           fetch-depth: 0
           path: ${{ env.wiki_dir }}
 
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.12'
     

--- a/.github/workflows/assets-release.yaml
+++ b/.github/workflows/assets-release.yaml
@@ -45,20 +45,20 @@ jobs:
 
     steps:
       - name: Clone branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 1
           path: ${{ env.main_dir }}
       
       - name: Clone release branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           ref: release
           fetch-depth: 0
           path: ${{ env.release_dir }}
       
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.12'
     
@@ -71,14 +71,14 @@ jobs:
         working-directory: ${{ env.main_dir }}
 
       - name: Upload changed assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: steps.find-updated-assets.outputs.updated_count > 0
         with:
           name: ${{ env.changed_assets_artifact }}
           path: ${{ runner.temp }}/${{ env.changed_assets_artifact }}
       
       - name: Upload non-testable assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: steps.find-updated-assets.outputs.updated_count > 0
         with:
           name: ${{ env.releasable_assets_artifact }}
@@ -102,7 +102,7 @@ jobs:
           exit 1
 
       - name: Upload list of assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ env.asset_list_artifact }}
           path: ${{ runner.temp }}/${{ env.asset_list_artifact }}
@@ -179,7 +179,7 @@ jobs:
     steps:
       - name: Download releasable assets
         id: download-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ env.releasable_assets_artifact }}
           path: ${{ runner.temp }}/${{ env.releasable_assets_artifact }}
@@ -198,32 +198,32 @@ jobs:
       - name: Download releasable assets
         if: needs.check-release-assets.outputs.has_releasable_assets != ''
         id: download-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ env.releasable_assets_artifact }}
           path: ${{ runner.temp }}/${{ env.releasable_assets_artifact }}
       
       - name: Download list of assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ env.asset_list_artifact }}
           path: ${{ runner.temp }}/${{ env.asset_list_artifact }}
       
       - name: Clone branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 1
           path: ${{ env.main_dir }}
 
       - name: Clone release branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           ref: release
           fetch-depth: 0
           path: ${{ env.release_dir }}
 
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.12'
     

--- a/.github/workflows/assets-test.yaml
+++ b/.github/workflows/assets-test.yaml
@@ -67,7 +67,7 @@ jobs:
           fetch-depth: 2
 
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.12'
     
@@ -116,7 +116,7 @@ jobs:
           forked-pr: ${{ needs.check-execution-context.outputs.forked_pr }}
       
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.12'
     
@@ -158,7 +158,7 @@ jobs:
         run: python -u $scripts_test_dir/test_assets.py -i "${{ matrix.asset_config_path }}" -a $asset_config_filename -p $scripts_test_dir/requirements.txt -r $GITHUB_WORKSPACE/$pytest_reports-"${{ strategy.job-index }}"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: ${{ env.pytest_reports }}-${{ strategy.job-index }}
@@ -181,7 +181,7 @@ jobs:
     steps:
       - name: Download all test results
         id: download-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ${{ env.pytest_reports }}
           pattern: ${{ env.pytest_reports }}-*
@@ -190,7 +190,7 @@ jobs:
 
       - name: Publish test results
         if: steps.download-artifact.outputs.download-path != ''
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         with:
           check_name: Test Results for ${{ github.workflow }}
           # Quote 'off' so YAML does not coerce it to the boolean false; the action

--- a/.github/workflows/assets-validation.yaml
+++ b/.github/workflows/assets-validation.yaml
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Clone branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.12'
 
@@ -67,7 +67,7 @@ jobs:
           tenant_id: ${{ secrets.AZURE_TENANT_ID }}
           subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         if: env.client_id != '' && env.tenant_id != ''
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
         with:
           client-id: ${{ env.client_id }}
           tenant-id: ${{ env.tenant_id }}

--- a/.github/workflows/batch-score-ci.yaml
+++ b/.github/workflows/batch-score-ci.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           forked-pr: ${{ needs.check-execution-context.outputs.forked_pr }}
       - name: Use Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.10'
 
@@ -48,7 +48,7 @@ jobs:
       - name: Run unit tests
         run: python -m pytest --junitxml=${{ env.pytest_report_folder }}/${{ env.pytest_report_file }} ${{ env.testsRootPath }} --strict-markers -v -s -m "unit" -o log_level=DEBUG -n 8
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: ${{ env.pytest_report_folder }}
@@ -68,7 +68,7 @@ jobs:
       steps:
         - name: Download test results
           id: download-artifact
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
           with:
             name: ${{ env.pytest_report_folder }}
             path: ${{ env.pytest_report_folder }}
@@ -76,7 +76,7 @@ jobs:
 
         - name: Publish test results
           if: steps.download-artifact.outputs.download-path != ''
-          uses: EnricoMi/publish-unit-test-result-action@v2
+          uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
           with:
             check_name: Test Results for ${{ github.workflow }}
             junit_files: ${{ env.pytest_report_folder }}/**/*.xml

--- a/.github/workflows/batch-score-oss-ci.yaml
+++ b/.github/workflows/batch-score-oss-ci.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           forked-pr: ${{ needs.check-execution-context.outputs.forked_pr }}
       - name: Use Python 3.12 or below
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '<=3.12'
       - name: Log in to Azure and create resources
@@ -71,7 +71,7 @@ jobs:
           RESOURCE_GROUP: ${{ env.resource_group }}
           WORKSPACE_NAME: ${{ env.workspace }}
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: ${{ env.pytest_report_folder }}
@@ -91,7 +91,7 @@ jobs:
       steps:
         - name: Download test results
           id: download-artifact
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
           with:
             name: ${{ env.pytest_report_folder }}
             path: ${{ env.pytest_report_folder }}
@@ -99,7 +99,7 @@ jobs:
 
         - name: Publish test results
           if: steps.download-artifact.outputs.download-path != ''
-          uses: EnricoMi/publish-unit-test-result-action@v2
+          uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
           with:
             check_name: Test Results for ${{ github.workflow }}
             junit_files: ${{ env.pytest_report_folder }}/**/*.xml

--- a/.github/workflows/check-changed-files.yaml
+++ b/.github/workflows/check-changed-files.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Get changed files under directory
         id: changed-scripts
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
           files: ${{ inputs.folder_path }}
           files_separator: ','

--- a/.github/workflows/check-new-assets.yaml
+++ b/.github/workflows/check-new-assets.yaml
@@ -27,11 +27,11 @@ jobs:
 
     steps:
       - name: Clone branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
 
       - name: Check for new asset
         run: |

--- a/.github/workflows/close-stale-items.yml
+++ b/.github/workflows/close-stale-items.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2.8.0
 
       - name: Resolve stale issues
-        uses: actions/stale@v9.1.0
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-issue-stale: 30

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,11 +31,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -46,4 +46,4 @@ jobs:
         # queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1

--- a/.github/workflows/environments-ci.yaml
+++ b/.github/workflows/environments-ci.yaml
@@ -65,7 +65,7 @@ jobs:
           fetch-depth: 2
 
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.12'
     
@@ -89,7 +89,7 @@ jobs:
         run: python -u $scripts_environment_dir/validate_build_logs.py -l '${{ runner.temp }}'/$build_logs_artifact_name
 
       - name: Upload build logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: ${{ env.build_logs_artifact_name }}

--- a/.github/workflows/evaluation-on-cloud-tests.yaml
+++ b/.github/workflows/evaluation-on-cloud-tests.yaml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Clone branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '>=3.10'
 
@@ -50,7 +50,7 @@ jobs:
         run: conda run -p $conda_env_prefix python -m pytest $eval_on_cloud_tests_dir --tb=native --junitxml=$pytest_reports/test-result.xml -x -n 1 -ra --show-capture=no
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           check_name: Test Results for ${{ github.workflow }}

--- a/.github/workflows/model-monitoring-ci.yml
+++ b/.github/workflows/model-monitoring-ci.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           forked-pr: ${{ needs.check-execution-context.outputs.forked_pr }}
       - name: Use Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.9'
       - name: Install dependencies
@@ -64,7 +64,7 @@ jobs:
           RESOURCE_GROUP: ${{ env.resource_group }}
           WORKSPACE_NAME: ${{ env.workspace }}
       - name: Upload component Version artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: ${{ env.pytest_component_version_folder }}
@@ -86,12 +86,12 @@ jobs:
           forked-pr: ${{ needs.check-execution-context.outputs.forked_pr }}
       - name: Download component version
         id: download-version
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ env.pytest_component_version_folder }}
           path: ./
       - name: Use Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.9'
       - name: Log in to Azure and create resources
@@ -132,7 +132,7 @@ jobs:
           RESOURCE_GROUP: ${{ env.resource_group }}
           WORKSPACE_NAME: ${{ env.workspace }}
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: ${{ env.pytest_report_folder }}-${{ matrix.group }}
@@ -155,7 +155,7 @@ jobs:
       steps:
         - name: Download test results
           id: download-artifact
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
           with:
             name: ${{ env.pytest_report_folder }}-${{ matrix.group }}
             path: ${{ env.pytest_report_folder }}-${{ matrix.group }}
@@ -163,7 +163,7 @@ jobs:
 
         - name: Publish test results
           if: steps.download-artifact.outputs.download-path != ''
-          uses: EnricoMi/publish-unit-test-result-action@v2
+          uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
           with:
             check_name: Test Results for ${{ github.workflow }} - Group ${{ matrix.group }}
             junit_files: ${{ env.pytest_report_folder }}-${{ matrix.group }}/**/*.xml

--- a/.github/workflows/model-monitoring-gsq-ci.yml
+++ b/.github/workflows/model-monitoring-gsq-ci.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           forked-pr: ${{ needs.check-execution-context.outputs.forked_pr }}
       - name: Use Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.9'
 
@@ -87,7 +87,7 @@ jobs:
           RESOURCE_GROUP: ${{ env.resource_group }}
           WORKSPACE_NAME: ${{ env.workspace }}
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: ${{ env.pytest_report_folder }}
@@ -107,7 +107,7 @@ jobs:
       steps:
         - name: Download test results
           id: download-artifact
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
           with:
             name: ${{ env.pytest_report_folder }}
             path: ${{ env.pytest_report_folder }}
@@ -115,7 +115,7 @@ jobs:
 
         - name: Publish test results
           if: steps.download-artifact.outputs.download-path != ''
-          uses: EnricoMi/publish-unit-test-result-action@v2
+          uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
           with:
             check_name: Test Results for ${{ github.workflow }}
             junit_files: ${{ env.pytest_report_folder }}/**/*.xml

--- a/.github/workflows/scripts-syntax.yaml
+++ b/.github/workflows/scripts-syntax.yaml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Clone branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 2
 
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '>=3.10'
       

--- a/.github/workflows/scripts-test.yaml
+++ b/.github/workflows/scripts-test.yaml
@@ -62,7 +62,7 @@ jobs:
           forked-pr: ${{ needs.check-execution-context.outputs.forked_pr }}
 
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '>=3.10'
     
@@ -81,7 +81,7 @@ jobs:
         run: pytest --junitxml=$pytest_reports/test-result.xml --ignore=$resources_dir --resource-group $resource_group --registry $container_registry $test_dir
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           check_name: Test Results for ${{ github.workflow }}

--- a/.github/workflows/training-model-eval-unittests.yaml
+++ b/.github/workflows/training-model-eval-unittests.yaml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Clone branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '>=3.10'
 
@@ -54,7 +54,7 @@ jobs:
         run: conda run -p $conda_env_prefix python -m pytest $model_eval_unittests_dir --tb=native --junitxml=$pytest_reports/test-result.xml -x -n 1 -ra --show-capture=no
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           check_name: Test Results for ${{ github.workflow }}

--- a/.github/workflows/training-model-mgmt-unittests.yaml
+++ b/.github/workflows/training-model-mgmt-unittests.yaml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Clone branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Use Python 3.10 or newer
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '>=3.10'
 
@@ -54,7 +54,7 @@ jobs:
         run: conda run -p $conda_env_prefix python -m pytest $model_mgmt_unittests_dir --tb=native --junitxml=$pytest_reports/test-result.xml -x -n 1 -ra --show-capture=no
 
       - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
           check_name: Test Results for ${{ github.workflow }}


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes in action execution are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
