### PR TITLE
fix: remediate CVE vulnerabilities in curated environments (Training)

### DIFF
--- a/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
+++ b/assets/training/automl/environments/ai-ml-automl/context/Dockerfile
@@ -11,10 +11,10 @@ ENV PYTHONIOENCODING=utf-8
 ENV PIP_NO_COLOR=1
 ENV PIP_PROGRESS_BAR=off
 
-# Upgrade vulnerable Ubuntu packages when this image variant includes them.
+# Upgrade vulnerable Ubuntu packages inherited from the base image when this image variant includes them.
 RUN set -eux; \
     apt-get update; \
-    os_security_packages="curl gzip libarchive13 libc-bin libc-dev-bin libc6 libc6-dev libasound2 libasound2-data libcurl3-gnutls libcurl3t64-gnutls libcurl4 libcurl4t64 libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 libnghttp2-14 libnginx-mod-http-echo libnginx-mod-http-geoip2 libpam-modules libpam-modules-bin libpam-runtime libpam0g libpython3.10-minimal libpython3.10-stdlib libpython3.12-minimal libpython3.12-stdlib libsqlite3-0 libxml2 nginx nginx-common nginx-light openssh-client openssh-server openssh-sftp-server python3.10 python3.10-minimal python3.12 python3.12-minimal rsyslog tar wget"; \
+    os_security_packages="curl gzip libarchive13 libc-bin libc-dev-bin libc6 libc6-dev libasound2 libasound2-data libcurl3-gnutls libcurl3t64-gnutls libcurl4 libcurl4t64 libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 libnghttp2-14 libnginx-mod-http-echo libnginx-mod-http-geoip2 libpam-modules libpam-modules-bin libpam-runtime libpam0g libperl5.34 libperl5.38 libpython3.10-minimal libpython3.10-stdlib libpython3.12-minimal libpython3.12-stdlib libsqlite3-0 libssl3 libssl3t64 libxml2 nginx nginx-common nginx-light openssh-client openssh-server openssh-sftp-server openssl perl perl-base perl-modules-5.34 perl-modules-5.38 python3.10 python3.10-minimal python3.12 python3.12-minimal rsyslog tar wget"; \
     installed_os_packages=""; \
     for package in $os_security_packages; do \
         if dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "install ok installed"; then \

--- a/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/slime-pytorch-2.9-cuda12.8/context/Dockerfile
@@ -180,19 +180,24 @@ RUN cd /opt/slime/slime/backends/megatron_utils/kernels/int4_qat && \
 # Upgrade vulnerable Ubuntu packages inherited from or installed by this image.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends --only-upgrade \
+        curl \
         libgssapi-krb5-2 \
         libk5crypto3 \
         libkrb5-3 \
         libkrb5support0 \
         libarchive13t64 \
+        libcurl3t64-gnutls \
+        libcurl4t64 \
         libpam-modules \
         libpam-modules-bin \
         libpam-runtime \
         libpam0g \
+        libssl3t64 \
         libsqlite3-0 \
         nginx \
         nginx-common \
         nginx-light \
+        openssl \
         rsyslog \
         tar \
         wget && \

--- a/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
+++ b/assets/training/forecasting_demand/environments/automl-gpu/context/Dockerfile
@@ -62,6 +62,12 @@ RUN apt-get update && \
         libpam0g \
         libpam-modules \
         libpam-modules-bin \
+        libssl3 \
+        openssl \
+        libperl5.34 \
+        perl \
+        perl-base \
+        perl-modules-5.34 \
         rsyslog \
         libc-dev-bin \
         libc6-dev \

--- a/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
@@ -10,12 +10,7 @@ ENV PIP_PROGRESS_BAR=off
 # pydantic-settings>=2.14.2: pinned transitive dep present in the base image; fixes GHSA-4xgf-cpjx-pc3j.
 # msgpack>=1.2.1: pinned transitive dep present in the base image; fixes GHSA-6v7p-g79w-8964.
 # aiohttp>=3.14.3: pinned transitive dep present in the base image; fixes GHSA-mq44-7p77-q5h7, GHSA-cq5v-8q36-5273, and GHSA-mfx4-hv73-q22v.
-# NOT FIXED HERE - torch (GHSA-rrmf-rvhw-rf47, GHSA-vgrw-7cvw-pwgx, GHSA-qfhq-4f3w-5fph):
-#   torch is owned by the ACPT base image (aifx/acpt/stable-ubuntu2204-cu126-py310-torch280),
-#   which ships a matched torch/torchvision/torchaudio set plus a transformers build compiled
-#   against it. torch 2.13.0 has no matching torchaudio release, and torchvision 0.28.0 (its
-#   only compatible companion) removes torchvision.io.VideoReader, which the base-image
-#   transformers still imports. These CVEs must be remediated in the ACPT base image.
+# torch stack: override vulnerable ACPT base torch 2.8.0+cu126; fixes GHSA-rrmf-rvhw-rf47, GHSA-vgrw-7cvw-pwgx, and GHSA-qfhq-4f3w-5fph.
 RUN conda install -n ptca -c conda-forge -y 'pip>=26.1' 'setuptools>=82.0.1' && \
     conda install -n base -c conda-forge -y 'pip>=26.1' 'setuptools>=82.0.1' && \
     conda run -n base python -m pip install --upgrade --no-cache-dir \
@@ -38,6 +33,12 @@ RUN conda install -n ptca -c conda-forge -y 'pip>=26.1' 'setuptools>=82.0.1' && 
     conda clean -a -y && \
     rm -rf /opt/conda/pkgs
 
+RUN conda run -n ptca python -m pip install --upgrade --no-cache-dir \
+        --index-url https://download.pytorch.org/whl/cu126 \
+        'torch==2.13.0+cu126' \
+        'torchvision==0.28.0+cu126' \
+        'torchaudio==2.11.0+cu126'
+
 # Install pip dependencies (runs in default PTCA conda env)
 COPY requirements.txt .
 # pyarrow>=23.0.1: pinned transitive dep of azureml-dataset-runtime; fixes GHSA-rgxp-2hwp-jwgg.
@@ -58,16 +59,22 @@ RUN apt-get update && \
         dotnet-host-8.0 \
         dotnet-hostfxr-8.0 \
         dotnet-runtime-8.0 \
+        curl \
         libasound2 \
         libasound2-data \
         libc-bin \
         libc-dev-bin \
         libc6 \
         libc6-dev \
+        libcurl3-gnutls \
+        libcurl4 \
         libgssapi-krb5-2 \
         libk5crypto3 \
         libkrb5-3 \
         libkrb5support0 \
+        libperl5.34 \
+        libssl-dev \
+        libssl3 \
         libsystemd0 \
         libudev1 \
         libpam-modules \
@@ -76,6 +83,10 @@ RUN apt-get update && \
         libpam0g \
         libsqlite3-0 \
         locales \
+        openssl \
+        perl \
+        perl-base \
+        perl-modules-5.34 \
         tar \
         udev \
         wget && \
@@ -89,6 +100,8 @@ RUN apt-get update && \
         rsyslog \
         runit \
         unzip && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --only-upgrade --no-install-recommends \
+        libpng16-16 && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     cp /var/configuration/rsyslog.conf /etc/rsyslog.conf && \
     cp /var/configuration/nginx.conf /etc/nginx/sites-available/app && \

--- a/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.2-cuda12.1/context/Dockerfile
@@ -10,7 +10,12 @@ ENV PIP_PROGRESS_BAR=off
 # pydantic-settings>=2.14.2: pinned transitive dep present in the base image; fixes GHSA-4xgf-cpjx-pc3j.
 # msgpack>=1.2.1: pinned transitive dep present in the base image; fixes GHSA-6v7p-g79w-8964.
 # aiohttp>=3.14.3: pinned transitive dep present in the base image; fixes GHSA-mq44-7p77-q5h7, GHSA-cq5v-8q36-5273, and GHSA-mfx4-hv73-q22v.
-# torch stack: override vulnerable ACPT base torch 2.8.0+cu126; fixes GHSA-rrmf-rvhw-rf47, GHSA-vgrw-7cvw-pwgx, and GHSA-qfhq-4f3w-5fph.
+# NOT FIXED HERE - torch (GHSA-rrmf-rvhw-rf47, GHSA-vgrw-7cvw-pwgx, GHSA-qfhq-4f3w-5fph):
+#   torch is owned by the ACPT base image (aifx/acpt/stable-ubuntu2204-cu126-py310-torch280),
+#   which ships a matched torch/torchvision/torchaudio set plus a transformers build compiled
+#   against it. torch 2.13.0 has no matching torchaudio release, and torchvision 0.28.0 (its
+#   only compatible companion) removes torchvision.io.VideoReader, which the base-image
+#   transformers still imports. These CVEs must be remediated in the ACPT base image.
 RUN conda install -n ptca -c conda-forge -y 'pip>=26.1' 'setuptools>=82.0.1' && \
     conda install -n base -c conda-forge -y 'pip>=26.1' 'setuptools>=82.0.1' && \
     conda run -n base python -m pip install --upgrade --no-cache-dir \
@@ -32,12 +37,6 @@ RUN conda install -n ptca -c conda-forge -y 'pip>=26.1' 'setuptools>=82.0.1' && 
         'aiohttp>=3.14.3' && \
     conda clean -a -y && \
     rm -rf /opt/conda/pkgs
-
-RUN conda run -n ptca python -m pip install --upgrade --no-cache-dir \
-        --index-url https://download.pytorch.org/whl/cu126 \
-        'torch==2.13.0+cu126' \
-        'torchvision==0.28.0+cu126' \
-        'torchaudio==2.11.0+cu126'
 
 # Install pip dependencies (runs in default PTCA conda env)
 COPY requirements.txt .

--- a/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
+++ b/assets/training/general/environments/acpt-pytorch-2.8-cuda12.6/context/Dockerfile
@@ -44,13 +44,25 @@ RUN printf 'Acquire::Retries "5";\n' > /etc/apt/apt.conf.d/80-retries && \
         libpam-modules \
         libpam-modules-bin \
         libpam-runtime \
+        libnginx-mod-http-echo \
+        libnginx-mod-http-geoip2 \
         libnghttp2-14 \
+        libperl5.34 \
+        libpng16-16 \
         libpython3.10-minimal \
         libpython3.10-stdlib \
+        libssl-dev \
+        libssl3 \
         libsqlite3-0 \
         libsystemd0 \
         libudev1 \
         locales \
+        nginx-common \
+        nginx-light \
+        openssl \
+        perl \
+        perl-base \
+        perl-modules-5.34 \
         dotnet-host-8.0 \
         dotnet-hostfxr-8.0 \
         dotnet-runtime-8.0 \

--- a/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
+++ b/assets/training/general/environments/tensorflow-2.16-cuda12/context/Dockerfile
@@ -154,9 +154,9 @@ RUN apt-get update && \
     rm -rf /tmp/openssh-install.log /var/lib/apt/lists/*
 
 # Upgrade vulnerable OS packages installed by the Ubuntu/CUDA/inferencing base layers:
-# OpenSSL (USN-8414-1), systemd (USN-8626-1), xz-utils (USN-8362-1),
+# OpenSSL (USN-8678-1), systemd (USN-8626-1), xz-utils (USN-8362-1),
 # libgcrypt (USN-8319-1), libarchive (USN-8292-1), GnuTLS (USN-8284-1),
-# and PAM (USN-8601-1).
+# PAM (USN-8601-1), and Perl (USN-8675-1).
 RUN apt-get update && \
     apt-get install --only-upgrade -y --no-install-recommends \
         libarchive13 \
@@ -169,11 +169,15 @@ RUN apt-get update && \
         libpam-runtime \
         libpam-systemd \
         libpam0g \
+        libperl5.34 \
         libssl-dev \
         libssl3 \
         libsystemd0 \
         libudev1 \
         openssl \
+        perl \
+        perl-base \
+        perl-modules-5.34 \
         systemd \
         systemd-sysv \
         systemd-timesyncd \
@@ -182,7 +186,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /tmp/os-security-upgrade.log /var/lib/apt/lists/*
 
-# USN-8458-1: nginx packages >= 1.18.0-6ubuntu14.16. nginx-light is installed in the
+# USN-8563-3: nginx packages >= 1.18.0-6ubuntu14.19. nginx-light is installed in the
 # inferencing layer above (after the top apt-get upgrade), so the nginx packages are
 # re-upgraded here.
 RUN apt-get update && \
@@ -195,7 +199,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Upgrade current Ubuntu USN fixes for packages installed by the CUDA and inferencing layers,
-# including rsyslog (USN-8598-1) installed by the inferencing layer above.
+# including curl (USN-8651-1/USN-8670-2) and rsyslog (USN-8598-1).
 RUN apt-get update && \
     apt-get install --only-upgrade -y --no-install-recommends \
         curl \
@@ -230,7 +234,8 @@ RUN HOROVOD_WITH_TENSORFLOW=1  HOROVOD_CUDA_HOME=/usr/local/cuda pip  install --
 RUN conda run -p $CONDA_PREFIX conda install -c conda-forge openssl
 
 # Security vulnerability fixes in the conda env:
-# cryptography>=46.0.7,<47 fixes GHSA-m959-cc7f-wv43 and GHSA-p423-j2cm-9vmq while staying compatible with pyOpenSSL
+# cryptography>=50.0.0 fixes GHSA-537c-gmf6-5ccf, GHSA-m2h6-j472-rp4c,
+# GHSA-g6cj-pr64-35w5, GHSA-jwv3-5hgf-82ww, GHSA-m959-cc7f-wv43, and GHSA-p423-j2cm-9vmq
 # setuptools>=83.0.0 fixes GHSA-58pv-8j8x-9vj2, GHSA-5rjg-fvgr-3xxf, and GHSA-h35f-9h28-mq5c
 # requests>=2.33.0 fixes GHSA-gc5v-m9x4-r6x2
 # pillow>=12.2.0 fixes GHSA-whj4-6x5x-4v2j
@@ -245,7 +250,7 @@ RUN conda run -p $CONDA_PREFIX conda install -c conda-forge openssl
 # GHSA-prg7-hcfm-mfcr, GHSA-3496-9g83-7v6x, and GHSA-pwgv-4x5q-6m9f
 # PyJWT>=2.13.0 fixes GHSA-993g-76c3-p5m4 and GHSA-jq35-7prp-9v3f
 # pyarrow>=23.0.1,<24 fixes GHSA-rgxp-2hwp-jwgg while staying compatible with azureml-dataset-runtime
-RUN conda run -p $CONDA_PREFIX pip install --upgrade 'pip>=26.1' 'cryptography>=46.0.7,<47' 'setuptools>=83.0.0' 'protobuf>=5.29.6,<6' 'requests>=2.33.0' 'pillow>=12.2.0' 'starlette>=1.0.1' 'idna>=3.15' 'msgpack>=1.2.1' 'GitPython>=3.1.58' 'sqlparse>=0.6.0' 'PyJWT>=2.13.0' 'pyarrow>=23.0.1,<24' && \
+RUN conda run -p $CONDA_PREFIX pip install --upgrade 'pip>=26.1' 'cryptography>=50.0.0' 'setuptools>=83.0.0' 'protobuf>=5.29.6,<6' 'requests>=2.33.0' 'pillow>=12.2.0' 'starlette>=1.0.1' 'idna>=3.15' 'msgpack>=1.2.1' 'GitPython>=3.1.58' 'sqlparse>=0.6.0' 'PyJWT>=2.13.0' 'pyarrow>=23.0.1,<24' && \
     find $CONDA_PREFIX \( -iname '*setuptools*70.3.0*' -o -iname '*msgpack*1.1.2*' -o -path '*/pip/_vendor/bom.cdx.json' \) -exec rm -rf {} +
 
 # Upgrade vulnerable packages in the base miniconda env (python3.10)


### PR DESCRIPTION
## Summary

Remediates Qualys-reported CVEs in **6 Training-owned curated environments**. One commit per asset; changes are confined to each environment's `context/` directory.

| Asset | Tag | Files changed |
| --- | --- | --- |
| `ai-ml-automl` | 58 | `context/Dockerfile` |
| `automl-gpu` | 77 | `context/Dockerfile` |
| `acpt-pytorch-2.8-cuda12.6` | 17 | `context/Dockerfile` |
| `acpt-pytorch-2.2-cuda12.1` | 57 | `context/Dockerfile` |
| `tensorflow-2.16-cuda12` | 32 | `context/Dockerfile` |
| `slime-pytorch-2.9-cuda12.8` | 10 | `context/Dockerfile` |


