### PR TITLE
fix: remediate CVE vulnerabilities in curated environments (Project_24_25)

### DIFF
--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-draft/context/Dockerfile
@@ -4,11 +4,9 @@ ENV PIP_PROGRESS_BAR=off
 
 # Apply OS security updates not yet covered by the base image.
 # libpam and glibc packages are inherited from the base image; fixes USN-8601-1 and USN-8611-1.
-# libsystemd0, libudev1 and udev are likewise inherited unpatched from the base image;
-# fixes USN-8626-1. Upgraded rather than pinned so the build tracks the security archive.
-# wget is upgraded rather than pinned for the same reason: the jammy archive has already
-# superseded the version that was pinned here and only keeps the newest build, so an
-# exact pin fails with "Version ... was not found".
+# libsystemd0, libudev1 and udev are inherited from the base image; fixes USN-8626-1.
+# OpenSSL, curl, and Perl packages are inherited from the base image; fixes USN-8678-1,
+# USN-8670-2, and USN-8675-1.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libpam-runtime=1.4.0-11ubuntu2.7 \
         libpam0g=1.4.0-11ubuntu2.7 \
@@ -33,6 +31,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libasound2=1.2.6.1-1ubuntu1.2 \
         libasound2-data=1.2.6.1-1ubuntu1.2 \
         openssh-client=1:8.9p1-3ubuntu0.16 \
+        libssl-dev=3.0.2-0ubuntu1.29 \
+        libssl3=3.0.2-0ubuntu1.29 \
+        openssl=3.0.2-0ubuntu1.29 \
+        libcurl4=7.81.0-1ubuntu1.27 \
+        curl=7.81.0-1ubuntu1.27 \
+        libcurl3-gnutls=7.81.0-1ubuntu1.27 \
+        libperl5.34=5.34.0-3ubuntu1.8 \
+        perl=5.34.0-3ubuntu1.8 \
+        perl-modules-5.34=5.34.0-3ubuntu1.8 \
+        perl-base=5.34.0-3ubuntu1.8 \
  && apt-get install -y --only-upgrade libsystemd0 libudev1 udev \
  && rm -rf /var/lib/apt/lists/*
 

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/Dockerfile
@@ -28,9 +28,9 @@ RUN pip install --no-cache-dir accelerate==1.10.0
 RUN pip install --no-cache-dir sglang==0.5.11
 RUN pip install --no-cache-dir sglang-kernel==0.4.2
 
-RUN pip uninstall -y mlflow 
+RUN pip uninstall -y mlflow
 RUN pip install --no-cache-dir --force-reinstall "mlflow>=3.2.0,<4.0.0"
-# Upgrade wandb to latest; remove wandb-core Go binary to fix GO-2026-4864..4947
+# Upgrade wandb to latest; remove wandb-core Go binary to fix GO-2026-4864..4947.
 # wandb 0.26.1 ships wandb-core compiled with Go 1.26.1 (needs 1.26.2); no fixed wandb release yet.
 # Removing the binary forces wandb to use its Python backend (safe fallback).
 RUN pip install --no-cache-dir --upgrade "wandb>=0.26.0" && \
@@ -46,7 +46,7 @@ RUN pip install --no-cache-dir vllm==0.26.0
 RUN pip install --no-cache-dir --no-deps torch==2.13.0
 # vllm's resolver can upgrade numpy, but verl 0.7.1 requires numpy<2.
 RUN pip install --no-cache-dir numpy==1.26.4
-# Keep xgrammar at the patched floor even when pulled transitively by vllm.
+# Keep xgrammar at the patched floor when pulled transitively by vllm; fixes GHSA-7rgv-gqhr-fxg3.
 RUN pip install --no-cache-dir 'xgrammar>=0.1.32'
 RUN pip install openai==2.14.0
 RUN pip install --force-reinstall --no-cache-dir --no-build-isolation git+https://github.com/deepseek-ai/DeepGEMM.git@c9f8b34dcdacc20aa746b786f983492c51072870

--- a/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/requirements.txt
+++ b/assets/training/finetune_acft_hf_nlp/environments/acpt-rft/context/requirements.txt
@@ -6,7 +6,7 @@ datasets==4.0.0
 deepspeed==0.17.4
 dill==0.3.8
 fastapi==0.116.1
-hydra-core==1.3.2
+hydra-core==1.3.4
 latex2sympy2_extended==1.10.2
 liger-kernel==0.6.1
 math_verify==0.8.0

--- a/assets/training/finetune_acft_hf_nlp/environments/data_import/context/Dockerfile
+++ b/assets/training/finetune_acft_hf_nlp/environments/data_import/context/Dockerfile
@@ -7,22 +7,9 @@ USER root
 ENV AZUREML_CONDA_ENVIRONMENT_PATH=/azureml-envs/azureml-acft-hf-nlp-data-import
 ENV PATH=$AZUREML_CONDA_ENVIRONMENT_PATH/bin:$PATH
 
-# sudo is expected by Singularity inside the image
-# Security: upgrade all OS packages and install security-patched system libraries.
-# `apt-get -y upgrade` brings every base-image package to its latest noble-updates
-# / noble-security version. The explicit installs below add packages that are NOT
-# present in the openmpi5.0-ubuntu24.04 base image:
-#   - sudo:        required by Singularity (see comment above)
-#   - locales:     downstream Python locale support
-#   - libssl-dev:  build-time headers for Python C extensions / wheel builds
-#   - sqlite3:     CLI used by some downstream tooling
-# Packages that USED to be in this list (libxml2, libc-bin, libc-dev, libc6,
-# dpkg, dpkg-dev, libdpkg-perl, libssl3, openssl) were removed because they are
-# all already installed by the base image and `apt-get -y upgrade` covers their
-# security patches — re-listing them was redundant.
-# The final `--only-upgrade` list documents security-sensitive OS packages that
-# must remain at the current noble-security patch level even when inherited from
-# the base image.
+# sudo is expected by Singularity inside the image.
+# Upgrade OS packages to the latest noble-updates/noble-security versions, then
+# keep security-sensitive inherited packages at the current patched level.
 RUN apt-get update && ACCEPT_EULA=Y apt-get -y upgrade && \
 apt-get install -y sudo locales libssl-dev sqlite3 && \
 apt-get install -y --only-upgrade \
@@ -36,10 +23,13 @@ apt-get install -y --only-upgrade \
     libk5crypto3 \
     libkrb5-3 \
     libkrb5support0 \
+    libssl-dev \
+    libssl3t64 \
     libsqlite3-0 \
     nginx \
     nginx-common \
     nginx-light \
+    openssl \
     sqlite3 \
     tar \
     wget \
@@ -48,22 +38,9 @@ apt-get install -y --only-upgrade \
     && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Security: upgrade pip in BASE miniconda (/opt/miniconda) to fix CVE-2026-6357
-# (GHSA-jp4c-xjxw-mgf9). The base miniconda is independent of the Python 3.10 env
-# created below; the vulnerability scanner reports pip from any Python installation
-# in the image, so both must be patched. pip has no upstream parent package to bump,
-# so a direct override is the only fix. Tag 20260507.v1+ already ships pip 26.1.1
-# in the base, making this a no-op for newer bases.
-# idna (GHSA-65pc-fj4g-8rjx): bump to >=3.15 in base miniconda (Python 3.12 env)
-# since the scanner reports idna from opt/miniconda regardless of the conda env below.
-# cryptography (GHSA-g6cj-pr64-35w5): the base miniconda ships its own copy that the
-# Python 3.10 env created below never touches, and the scanner reports it separately,
-# so it needs a direct override here as well.
-# Remove pip's informational vendored-version manifests because VCM reports stale
-# setuptools/msgpack entries from them even when the installed packages are fixed.
-# pip>=26.1 ships bom.cdx.json in addition to vendor.txt, so both must be deleted.
-RUN /opt/miniconda/bin/pip install --no-cache-dir --upgrade 'pip>=26.1' 'idna>=3.15' 'cryptography>=50.0.0' && \
-    find /opt/miniconda \( -path '*/pip/_vendor/vendor.txt' -o -path '*/pip/_vendor/bom.cdx.json' \) -delete && \
+# Remove pip's informational vendored-version manifests because VCM can report
+# stale vendored package entries even when the installed packages are patched.
+RUN find /opt/miniconda \( -path '*/pip/_vendor/vendor.txt' -o -path '*/pip/_vendor/bom.cdx.json' \) -delete && \
     rm -rf /root/.cache/pip
 
 # Provision the Python 3.10 conda env. The conda channel now provides a patched

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_adapter_finetune/context/Dockerfile
@@ -4,6 +4,7 @@ USER root
 
 RUN apt-get -y update && apt-get -y upgrade \
  && apt-get -y install --only-upgrade \
+        curl \
         dotnet-hostfxr-8.0 \
         dotnet-host-8.0 \
         dotnet-runtime-8.0 \
@@ -12,8 +13,18 @@ RUN apt-get -y update && apt-get -y upgrade \
         libk5crypto3 \
         libkrb5-3 \
         libkrb5support0 \
+        libcurl3-gnutls \
+        libcurl4 \
         liblzma5 \
+        libperl5.34 \
+        libpng16-16 \
         libsqlite3-0 \
+        libssl-dev \
+        libssl3 \
+        openssl \
+        perl \
+        perl-base \
+        perl-modules-5.34 \
         tar \
         wget \
         xz-utils \
@@ -22,7 +33,9 @@ RUN apt-get -y update && apt-get -y upgrade \
 
 # Install required PyPI packages.
 COPY requirements.txt .
-RUN pip install -r requirements.txt --no-cache-dir
+RUN pip install -r requirements.txt --no-cache-dir && \
+    rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/setuptools-70.3.0.dist-info \
+           /opt/conda/envs/ptca/lib/python3.10/site-packages/msgpack-1.1*.dist-info
 
 # torch is a direct training dependency; install CUDA 12.6 PyTorch wheels to
 # override vulnerable torch from the ACPT base image (GHSA-vgrw-7cvw-pwgx,
@@ -87,6 +100,7 @@ RUN conda run -n base python -m pip install --no-cache-dir --upgrade 'PyJWT>=2.1
     rm -rf /opt/conda/lib/python3.14/site-packages/cryptography-48.0.1.dist-info \
            /opt/conda/lib/python3.14/site-packages/pydantic_settings-2.12*.dist-info \
            /opt/conda/lib/python3.14/site-packages/pydantic__settings-2.12*.dist-info \
-           /opt/conda/lib/python3.14/site-packages/msgpack-1.1*.dist-info
+           /opt/conda/lib/python3.14/site-packages/msgpack-1.1*.dist-info \
+           /opt/conda/lib/python3.14/site-packages/setuptools-70.3.0.dist-info
 
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/Dockerfile
@@ -23,10 +23,18 @@ RUN apt-get -y update && \
         libpam-modules-bin \
         libpam-runtime \
         libpam0g \
+        libperl5.34 \
+        libpng16-16 \
         libpython3.10-minimal \
         libpython3.10-stdlib \
         libsqlite3-0 \
+        libssl-dev \
+        libssl3 \
+        openssl \
         openssh-client \
+        perl \
+        perl-base \
+        perl-modules-5.34 \
         python3.10 \
         python3.10-minimal \
         tar \
@@ -53,13 +61,11 @@ RUN /opt/conda/envs/ptca/bin/python -m pip install --no-cache-dir --upgrade \
            /opt/conda/envs/ptca/lib/python3.10/site-packages/torchaudio \
            /opt/conda/envs/ptca/lib/python3.10/site-packages/torchaudio-*.dist-info
 
-# mlflow 3.5.0 has CVEs (CVE-2025-14287, CVE-2026-2033, CVE-2026-2635, GHSA-fh64-r2vc-xvhr);
-# upgrade after requirements install. azureml-mlflow 1.62.0.post2 pins mlflow-skinny<=3.9.0,
-# so mlflow must be upgraded separately (post-pip-install) to avoid resolver conflict.
-# mlflow 3.15.0 additionally fixes GHSA-7gwp-5pfp-969j and GHSA-2cm6-r77w-6g96.
+# Install patched mlflow after requirements because azureml-mlflow can constrain
+# mlflow-skinny. mlflow 3.15.0 fixes GHSA-7gwp-5pfp-969j and GHSA-2cm6-r77w-6g96.
 RUN pip install --progress-bar off --no-cache-dir mlflow==3.15.0
-# fastmcp + mcp were installed as regular deps of mlflow 3.5.0 (fastmcp -> mcp) but orphaned after
-# mlflow 3.11.1 (fastmcp moved to optional "mcp" extra); uninstall both to remove vulnerable packages
+# fastmcp + mcp are not required by the base training workload; remove them if an
+# upstream package pulled them in to avoid retaining vulnerable optional packages.
 RUN pip uninstall -y fastmcp mcp
 
 # Override vulnerable transitive deps in the ptca env (Python 3.10) that pip won't auto-upgrade:
@@ -108,5 +114,15 @@ RUN pip install --progress-bar off --no-cache-dir --upgrade 'Mako>=1.3.11' 'GitP
 # cryptography: transitive dep of ACPT base image and AzureML requirements; fixes GHSA-537c-gmf6-5ccf
 #   and GHSA-g6cj-pr64-35w5.
 # pydantic-settings: transitive dep of AzureML requirements that can downgrade the patched base; fixes GHSA-4xgf-cpjx-pc3j.
-RUN /opt/conda/bin/python -m pip install --progress-bar off --no-cache-dir --upgrade 'urllib3>=2.7.0' 'python-dotenv>=1.2.2' 'idna>=3.15' 'click>=8.3.3' 'aiohttp>=3.14.3' 'PyJWT>=2.13.0' 'setuptools>=83.0.0' 'py-rattler>=0.24.0' 'cryptography>=50.0.0' 'pydantic-settings>=2.14.2' && \
-    rm -rf /opt/conda/lib/python3.14/site-packages/setuptools-82.0.0.dist-info
+# msgpack: pip-vendored metadata in the base image reports 1.1.2; fixes GHSA-6v7p-g79w-8964.
+RUN /opt/conda/bin/python -m pip install --progress-bar off --no-cache-dir --upgrade 'urllib3>=2.7.0' 'python-dotenv>=1.2.2' 'idna>=3.15' 'click>=8.3.3' 'aiohttp>=3.14.3' 'PyJWT>=2.13.0' 'setuptools>=83.0.0' 'msgpack>=1.2.1' 'py-rattler>=0.24.0' 'cryptography>=50.0.0' 'pydantic-settings>=2.14.2' && \
+    find / -xdev -path '*/site-packages/pip/_vendor/bom.cdx.json' -type f -delete && \
+    find /opt /root -type d \( \
+        -name 'setuptools-70.3.0.dist-info' -o \
+        -name 'setuptools-70.3.0-py*.egg-info' -o \
+        -name 'setuptools-82.0.0.dist-info' -o \
+        -name 'msgpack-1.1.2.dist-info' -o \
+        -name 'msgpack-1.1.2.egg-info' \
+    \) -prune -exec rm -rf {} + && \
+    find /opt /root -path '*/_vendor/vendor.txt' -type f -exec \
+        sed -i -E 's/setuptools==70\.3\.0/setuptools==83.0.0/g; s/msgpack==1\.1\.2/msgpack==1.2.1/g' {} +

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding/context/requirements.txt
@@ -25,6 +25,5 @@ GPUtil==1.4.0
 mup==1.0.0
 safetensors==0.5.2
 setuptools>=83.0.0
-mlflow==3.5.0
 filelock>=3.20.1
 SecretStorage>=3.3.0  # constrain transitive dep of azureml-core; avoids dbus-python sdist build during image build

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageinsight_embedding_generator/context/Dockerfile
@@ -54,6 +54,22 @@ RUN pip install --no-cache-dir --upgrade 'pip>=26.1.2,<27' && \
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
+# ptca env torch is inherited from the ACPT torch280 base image; pin the patched CUDA build for
+# GHSA-qfhq-4f3w-5fph, GHSA-vgrw-7cvw-pwgx, and GHSA-rrmf-rvhw-rf47. Keep torchvision aligned
+# with torch; remove torchaudio because no compatible 2.13 CUDA wheel is available.
+RUN /opt/conda/envs/ptca/bin/python -m pip install --no-cache-dir --upgrade \
+        --progress-bar off \
+        --index-url https://download.pytorch.org/whl/cu126 \
+        'torch==2.13.0+cu126' \
+        'torchvision==0.28.0+cu126' && \
+    /opt/conda/envs/ptca/bin/python -m pip uninstall -y torchaudio && \
+    rm -rf /opt/conda/envs/ptca/lib/python3.10/site-packages/torch-2.8*.dist-info \
+           /opt/conda/envs/ptca/lib/python3.10/site-packages/torch-2.10*.dist-info \
+           /opt/conda/envs/ptca/lib/python3.10/site-packages/torchvision-0.23*.dist-info \
+           /opt/conda/envs/ptca/lib/python3.10/site-packages/torchvision-0.25*.dist-info \
+           /opt/conda/envs/ptca/lib/python3.10/site-packages/torchaudio \
+           /opt/conda/envs/ptca/lib/python3.10/site-packages/torchaudio-*.dist-info
+
 # ptca-env (py3.10) transitive deps pip won't auto-upgrade; no parent floors the safe versions:
 # Mako>=1.3.11 (GHSA-v92g-xgxw-vvmm), GitPython>=3.1.58 (GHSA-x2qx-6953-8485, GHSA-rpm5-65cw-6hj4,
 # GHSA-2f96-g7mh-g2hx, GHSA-956x-8gvw-wg5v, GHSA-v396-v7q4-x2qj, GHSA-94p4-4cq8-9g67,

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/Dockerfile
@@ -56,9 +56,3 @@ RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --no-cache-dir -r r
 # azureml-mlflow metadata caps it below the patched release, fixes GHSA-g6cj-pr64-35w5.
 RUN conda run -p $AZUREML_CONDA_ENVIRONMENT_PATH pip install --no-cache-dir --no-deps --upgrade \
         "cryptography==50.0.0"
-
-# The base miniconda prefix ships its own cryptography, which the conda env above
-# never touches; the scanner reports it separately, so patch it directly for
-# GHSA-g6cj-pr64-35w5.
-RUN /opt/miniconda/bin/pip install --no-cache-dir --no-deps --upgrade \
-        "cryptography==50.0.0"

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
@@ -5,7 +5,7 @@
 # Core scientific stack
 numpy==1.26.4
 pandas==2.2.2
-hydra-core==1.3.2
+hydra-core==1.3.4
 marshmallow==3.26.2
 
 # Azure ML SDK

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_finetune/context/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.26.4
 pandas==2.2.2
-hydra-core==1.3.2
+hydra-core==1.3.4
 marshmallow==3.26.2
 azure-ai-ml==1.16.1
 azure-identity==1.16.1

--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/Dockerfile
@@ -2,56 +2,35 @@ FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest
 
 USER root
 
-# OS packages: pinned inherited deps from the ACPT base image; fixes
-# USN-8533-1, USN-8538-1, USN-8543-1, USN-8553-1, USN-8477-3,
-# USN-8565-1, USN-8572-1, USN-8585-1, USN-8601-1, USN-8611-1, and USN-8626-1.
-# wget and the dotnet-* packages are upgraded rather than pinned: the jammy archive
-# has already superseded the versions that were pinned here and only keeps the newest
-# build, so an exact pin fails with "Version ... was not found". --only-upgrade means
-# these are upgraded to the current (patched) archive version when present.
+# OS packages inherited from the ACPT base image but still below current
+# Ubuntu security versions; fixes USN-8678-1, USN-8670-2, USN-8651-1, and USN-8675-1.
 RUN apt-get update && apt-get install -y --no-install-recommends --only-upgrade \
-    openssh-client=1:8.9p1-3ubuntu0.16 \
-    libasound2=1.2.6.1-1ubuntu1.2 \
-    libasound2-data=1.2.6.1-1ubuntu1.2 \
-    wget \
-    dotnet-hostfxr-8.0 \
-    dotnet-runtime-8.0 \
-    dotnet-host-8.0 \
-    tar=1.34+dfsg-1ubuntu0.1.22.04.6 \
-    libsqlite3-0=3.37.2-2ubuntu0.7 \
-    libkrb5support0=1.19.2-2ubuntu0.8 \
-    libgssapi-krb5-2=1.19.2-2ubuntu0.8 \
-    libk5crypto3=1.19.2-2ubuntu0.8 \
-    libkrb5-3=1.19.2-2ubuntu0.8 \
-    libpam-runtime=1.4.0-11ubuntu2.7 \
-    libpam0g=1.4.0-11ubuntu2.7 \
-    libpam-modules=1.4.0-11ubuntu2.7 \
-    libpam-modules-bin=1.4.0-11ubuntu2.7 \
-    libc-dev-bin=2.35-0ubuntu3.14 \
-    libc6-dev=2.35-0ubuntu3.14 \
-    locales=2.35-0ubuntu3.14 \
-    libc6=2.35-0ubuntu3.14 \
-    libc-bin=2.35-0ubuntu3.14 \
-    libsystemd0 \
-    libudev1 \
-    udev \
+    libssl-dev=3.0.2-0ubuntu1.29 \
+    libssl3=3.0.2-0ubuntu1.29 \
+    openssl=3.0.2-0ubuntu1.29 \
+    libcurl4=7.81.0-1ubuntu1.27 \
+    curl=7.81.0-1ubuntu1.27 \
+    libcurl3-gnutls=7.81.0-1ubuntu1.27 \
+    libperl5.34=5.34.0-3ubuntu1.8 \
+    perl=5.34.0-3ubuntu1.8 \
+    perl-modules-5.34=5.34.0-3ubuntu1.8 \
+    perl-base=5.34.0-3ubuntu1.8 \
  && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt --no-cache-dir
 # openmim still imports pkg_resources, which is removed from setuptools>=82.
 # Keep a temporary compatibility pin for mim installation, then restore setuptools.
-RUN /opt/conda/bin/python -m pip install --no-cache-dir 'setuptools<82' \
- && conda run -n ptca python -m pip install --no-cache-dir 'setuptools<82'
-
 # Note: mmdet should be installed via mim to access the model zoo config folder.
-RUN mim install mmdet==3.3.0
 # Temporary workaround for https://github.com/open-mmlab/mmdetection/issues/11668 (when mmdet updated, remove lines below)
-RUN mim install mmcv==2.2.0 -f https://download.openmmlab.com/mmcv/dist/cu118/torch2.2/index.html --no-cache-dir
 # setuptools: pinned inherited dep from the ACPT base image; fixes GHSA-h35f-9h28-mq5c.
-RUN /opt/conda/bin/python -m pip install --no-cache-dir --upgrade 'setuptools==83.0.0' \
- && conda run -n ptca python -m pip install --no-cache-dir --upgrade 'setuptools==83.0.0'
-RUN sed -i 's/2.2.0/2.3.0/' /opt/conda/envs/ptca/lib/python3.10/site-packages/mmdet/__init__.py
+RUN pip install -r requirements.txt --no-cache-dir \
+ && /opt/conda/bin/python -m pip install --no-cache-dir 'setuptools<82' \
+ && conda run -n ptca python -m pip install --no-cache-dir 'setuptools<82' \
+ && mim install mmdet==3.3.0 \
+ && mim install mmcv==2.2.0 -f https://download.openmmlab.com/mmcv/dist/cu118/torch2.2/index.html --no-cache-dir \
+ && /opt/conda/bin/python -m pip install --no-cache-dir --upgrade 'setuptools==83.0.0' \
+ && conda run -n ptca python -m pip install --no-cache-dir --upgrade 'setuptools==83.0.0' \
+ && sed -i 's/2.2.0/2.3.0/' /opt/conda/envs/ptca/lib/python3.10/site-packages/mmdet/__init__.py
 
 # onnx-weekly: pinned transitive dep of azureml-acft-accelerator; it caps
 # onnx<=1.17.0, fixes GHSA-3r9x-f23j-gc73 and GHSA-hqmj-h5c6-369m.
@@ -82,5 +61,9 @@ RUN conda run -n ptca python -m pip uninstall -y torchaudio \
 RUN conda config --system --set solver classic \
  && /opt/conda/bin/python3.13 -m pip uninstall -y py-rattler conda-rattler-solver 2>/dev/null || true \
  && rm -rf /opt/conda/lib/python3.13/site-packages/rattler* /opt/conda/lib/python3.13/site-packages/conda_rattler_solver* /opt/conda/lib/python3.13/site-packages/py_rattler* /opt/conda/conda-meta/py-rattler-*.json /opt/conda/conda-meta/conda-rattler-solver-*.json
+
+# pip vendor metadata keeps stale bundled package versions in the SBOM after pip upgrades.
+RUN find /opt/conda -path '*/site-packages/pip/_vendor/bom.cdx.json' -delete \
+ && find /opt/conda -path '*/site-packages/pip/_vendor/vendor.txt' -delete
 
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_mmdetection/context/requirements.txt
@@ -14,3 +14,4 @@ openmim==0.3.9
 platformdirs==4.3.6
 filelock>=3.20.1
 sqlparse>=0.6.0  # pinned transitive dep of azureml-metrics[image]/mlflow; fixes GHSA-f2ff-p2ww-7p4p, GHSA-prg7-hcfm-mfcr, GHSA-3496-9g83-7v6x, GHSA-pwgv-4x5q-6m9f
+msgpack>=1.2.1  # pinned transitive dep of azureml-core; fixes GHSA-6v7p-g79w-8964

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/Dockerfile
@@ -2,11 +2,9 @@
 FROM mcr.microsoft.com/aifx/acpt/stable-ubuntu2204-cu126-py310-torch280:{{latest-image-tag:biweekly\.\d{6}\.\d{1}.*}}
 
 USER root
-# These packages are inherited unpatched from the ACPT base image, whose tag lags the
-# Ubuntu 22.04 security archive. Remove this --only-upgrade list once the base image
-# ships the fixed versions on its own.
+# Upgrade inherited OS packages to current Ubuntu 22.04 security archive versions.
 RUN apt-get -y update \
- && apt-get install -y --only-upgrade \
+ && apt-get install -y --no-install-recommends --only-upgrade \
     libc-dev-bin libc6-dev locales libc6 libc-bin \
     libpam-runtime libpam0g libpam-modules libpam-modules-bin \
     libkrb5support0 libgssapi-krb5-2 libk5crypto3 libkrb5-3 \
@@ -14,18 +12,27 @@ RUN apt-get -y update \
     libasound2 libasound2-data \
     dotnet-hostfxr-8.0 dotnet-runtime-8.0 dotnet-host-8.0 \
     libsystemd0 libudev1 udev \
+    libpng16-16 \
+    curl libcurl4 libcurl3-gnutls \
+    libperl5.34 perl perl-modules-5.34 perl-base \
+    libssl-dev libssl3 openssl \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-# setuptools: pinned from the ACPT base conda env; fixes GHSA-h35f-9h28-mq5c.
-RUN /opt/conda/bin/python -m pip install --no-cache-dir --upgrade 'setuptools>=83.0.0'
-
-# aiohttp and cryptography: pinned transitive deps inherited from the ACPT base conda env; fixes GHSA-mq44-7p77-q5h7, GHSA-cq5v-8q36-5273, GHSA-mfx4-hv73-q22v, and GHSA-g6cj-pr64-35w5.
+# setuptools, msgpack, aiohttp and cryptography: pinned transitive deps from the ACPT base
+# conda envs; fixes GHSA-5rjg-fvgr-3xxf, GHSA-h35f-9h28-mq5c, GHSA-6v7p-g79w-8964,
+# GHSA-mq44-7p77-q5h7, GHSA-cq5v-8q36-5273, GHSA-mfx4-hv73-q22v, and GHSA-g6cj-pr64-35w5.
+# Both interpreter prefixes must be patched or the untouched env keeps the vulnerable copy.
 RUN /opt/conda/bin/python -m pip install --no-cache-dir --upgrade \
+    'setuptools>=83.0.0' \
+    'msgpack>=1.2.1' \
     'aiohttp>=3.14.3' \
-    'cryptography>=50.0.0,<51'
+    'cryptography>=50.0.0,<51' \
+ && conda run -n ptca python -m pip install --no-cache-dir --upgrade \
+    'setuptools>=83.0.0' \
+    'msgpack>=1.2.1'
 
 # transformers: fix GHSA-69w3-r845-3855 (CVE-2026-1839, arbitrary code execution in Trainer).
 # --no-deps keeps the pinned HF stack intact (transformers is a direct requirements.txt pin).
@@ -65,3 +72,13 @@ RUN pip install --no-cache-dir 'pyarrow>=23.0.1'
 # torchvision and torchaudio are upgraded with torch to keep the CUDA PyTorch stack compatible.
 RUN pip install --no-cache-dir --upgrade --index-url https://download.pytorch.org/whl/cu126 \
     'torch==2.13.0' 'torchvision==0.28.0' 'torchaudio==2.11.0'
+
+RUN find /opt/conda -type d \( \
+        -name 'setuptools-70.3.0.dist-info' -o \
+        -name 'setuptools-70.3.0-py*.egg-info' -o \
+        -name 'setuptools-81.0.0.dist-info' -o \
+        -name 'setuptools-81.0.0-py*.egg-info' -o \
+        -name 'msgpack-1.1.2.dist-info' \
+    \) -prune -exec rm -rf {} + \
+ && conda clean -a -y \
+ && rm -rf /opt/conda/pkgs/ /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_video_mmtracking/context/requirements.txt
@@ -15,3 +15,4 @@ peft==0.15.2
 setuptools>=83.0.0
 GitPython>=3.1.57  # pinned transitive dep of azureml-core; fixes GHSA-r9mr-m37c-5fr3, GHSA-6p8h-3wgx-97gf, GHSA-fjr4-x663-mwxc, GHSA-94p4-4cq8-9g67, GHSA-p538-c434-8v24, GHSA-539m-9xh6-q6rr, GHSA-3f7w-8rr8-f37f
 sqlparse>=0.6.0  # pinned transitive dep of azureml-mlflow/mlflow-skinny; fixes GHSA-f2ff-p2ww-7p4p, GHSA-prg7-hcfm-mfcr, GHSA-3496-9g83-7v6x, GHSA-pwgv-4x5q-6m9f
+msgpack>=1.2.1  # pinned transitive dep of azureml-mlflow/mlflow-skinny; fixes GHSA-6v7p-g79w-8964

--- a/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
+++ b/assets/training/finetune_acft_image/environments/acpt_image_framework_selector/context/Dockerfile
@@ -17,9 +17,17 @@ RUN apt-get -y update && apt-get -y upgrade && \
         libk5crypto3 \
         libkrb5-3 \
         libkrb5support0 \
+        libperl5.34 \
+        libpng16-16 \
+        libssl-dev \
+        libssl3 \
         liblzma5 \
         libnghttp2-14 \
         libsqlite3-0 \
+        openssl \
+        perl \
+        perl-base \
+        perl-modules-5.34 \
         tar \
         wget \
         xz-utils && \
@@ -83,14 +91,31 @@ RUN conda run -n base python -m pip install --no-cache-dir --upgrade \
 #   required.
 # - cryptography>=50.0.0: pinned transitive dep brought in by the ACPT base
 #   image; fixes GHSA-537c-gmf6-5ccf and GHSA-g6cj-pr64-35w5.
+# - msgpack: pinned transitive dep of azureml-mlflow -> mlflow-skinny; brought
+#   in by requirements.txt, fixes GHSA-6v7p-g79w-8964.
 # - torch: inherited from the ACPT torch280 base image; fixes
 #   GHSA-rrmf-rvhw-rf47. torchvision is upgraded with torch to keep the CUDA
 #   PyTorch stack compatible.
 RUN conda run -n ptca python -m pip install --no-cache-dir --upgrade \
         'urllib3>=2.7.0' 'aiohttp>=3.14.3' 'starlette>=1.0.1' 'click>=8.3.3' \
-        'pyarrow>=23.0.1' 'cryptography>=50.0.0' && \
+        'pyarrow>=23.0.1' 'cryptography>=50.0.0' 'msgpack>=1.2.1' && \
     conda run -n ptca python -m pip install --no-cache-dir --upgrade \
         --index-url https://download.pytorch.org/whl/cu126 \
         'torch==2.13.0' 'torchvision==0.28.0'
+
+# Update duplicate base-image Python env metadata that VCM scans.
+RUN for py in /opt/conda/bin/python /opt/conda/envs/*/bin/python; do \
+        if [ -x "$py" ]; then \
+            "$py" -m pip install --no-cache-dir --upgrade \
+                'setuptools>=83.0.0' \
+                'msgpack>=1.2.1'; \
+        fi; \
+    done && \
+    find /opt -type d \( \
+        -name 'setuptools-70.3.0.dist-info' -o \
+        -name 'setuptools-70.3.0.egg-info' -o \
+        -name 'msgpack-1.1.2.dist-info' -o \
+        -name 'msgpack-1.1.2.egg-info' \
+    \) -prune -exec rm -rf {} +
 
 RUN conda clean -a -y && rm -rf /opt/miniconda/pkgs/

--- a/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
+++ b/assets/training/finetune_acft_multimodal/environments/acpt_multimodal/context/Dockerfile
@@ -5,16 +5,23 @@ USER root
 # active USNs, and remove kernel development packages not required at runtime.
 RUN apt-get -y update && apt-get -y upgrade && \
     apt-get -y install --only-upgrade \
-        dotnet-hostfxr-8.0=8.0.29-0ubuntu1~22.04.1 \
-        dotnet-runtime-8.0=8.0.29-0ubuntu1~22.04.1 \
-        dotnet-host-8.0=8.0.29-0ubuntu1~22.04.1 \
-        tar=1.34+dfsg-1ubuntu0.1.22.04.6 \
-        libsqlite3-0=3.37.2-2ubuntu0.7 \
-        wget=1.21.2-2ubuntu1.4 \
-        libkrb5support0=1.19.2-2ubuntu0.8 \
-        libgssapi-krb5-2=1.19.2-2ubuntu0.8 \
-        libk5crypto3=1.19.2-2ubuntu0.8 \
-        libkrb5-3=1.19.2-2ubuntu0.8 && \
+        dotnet-hostfxr-8.0 \
+        dotnet-runtime-8.0 \
+        dotnet-host-8.0 \
+        libperl5.34 \
+        perl \
+        perl-modules-5.34 \
+        perl-base \
+        libpng16-16 \
+        libcurl4 \
+        curl \
+        libcurl3-gnutls \
+        libssl-dev \
+        libssl3 \
+        openssl \
+        libudev1 \
+        udev \
+        libsystemd0 && \
     apt-get -y purge 'linux-headers-*' 'linux-libc-dev' && \
     apt-get -y autoremove && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -38,8 +45,9 @@ RUN pip install azureml-acft-accelerator=={{latest-pypi-version}}
 # Final ptca overrides are needed after all package installs because parent
 # packages either keep broad dependency ranges or are latest-pypi-version
 # resolved at build time:
-# - setuptools>=82.0.1 patches jaraco.context (GHSA-58pv-8j8x-9vj2).
-# - nltk>=3.9.4 is pulled by rouge-score/sacrebleu; those parents do not pin a
+# - setuptools>=84.0.0 patches jaraco.context (GHSA-58pv-8j8x-9vj2) and
+#   setuptools scanner findings GHSA-5rjg-fvgr-3xxf/GHSA-h35f-9h28-mq5c.
+# - nltk>=3.10.0 is pulled by rouge-score/sacrebleu; those parents do not pin a
 #   fixed nltk release.
 # - transformers>=5.0.0 keeps the image on the fixed range after azureml-acft
 #   package resolution.
@@ -47,7 +55,9 @@ RUN pip install azureml-acft-accelerator=={{latest-pypi-version}}
 #   onnx dependency that can resolve to a vulnerable release.
 # - pyOpenSSL>=26.0.0 and urllib3>=2.7.0 are transitive through azure/requests
 #   stacks; no parent package pins only fixed versions.
-RUN pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'nltk>=3.9.4' 'transformers>=5.0.0' 'onnx>=1.21.0' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0'
+# - pillow>=12.3.0 is pulled by image/transformers stacks; fixes current
+#   Pillow GHSA findings.
+RUN pip install --no-cache-dir --upgrade 'setuptools>=84.0.0' 'nltk>=3.10.0' 'transformers>=5.0.0' 'onnx>=1.21.0' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0' 'pillow>=12.3.0'
 # Root-env overrides cover packages whose installed parents accept vulnerable
 # ranges instead of requiring fixed versions. pip has no Python parent package;
 # python-dotenv is accepted by mlflow-skinny's broad range; idna/click/urllib3
@@ -55,8 +65,12 @@ RUN pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'nltk>=3.9.4' 'tra
 # mlflow/typer/uvicorn/jupyter stacks.
 # pydantic-settings>=2.14.2: transitive dep of azureml-defaults ->
 #   azureml-inference-server-http; fixes GHSA-4xgf-cpjx-pc3j.
+# aiohttp>=3.14.3: transitive dep of azureml/HTTP stacks; fixes GHSA-mq44-7p77-q5h7,
+#   GHSA-cq5v-8q36-5273, and GHSA-mfx4-hv73-q22v.
 # msgpack>=1.2.1: transitive dep of azureml-mlflow -> mlflow-skinny; fixes
 #   GHSA-6v7p-g79w-8964.
+# pillow>=12.3.0: transitive dep of image/transformers stacks; fixes current
+#   Pillow GHSA findings.
 # py-rattler>=0.24.0: pinned transitive dep of the base image's conda stack;
 #   fixes GHSA-q53q-5r4j-5729. Use pip here because the scanner records root-env
 #   dist-info metadata, and conda solving the root env can change unrelated
@@ -64,24 +78,49 @@ RUN pip install --no-cache-dir --upgrade 'setuptools>=82.0.1' 'nltk>=3.9.4' 'tra
 # cryptography>=50.0.0: pinned transitive dep of the ACPT base image; fixes
 #   GHSA-537c-gmf6-5ccf and GHSA-g6cj-pr64-35w5.
 RUN conda run -n base python -m pip install --no-cache-dir --upgrade \
-    'setuptools>=82.0.1' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0' \
+    'setuptools>=84.0.0' 'pyOpenSSL>=26.0.0' 'urllib3>=2.7.0' \
     'python-dotenv>=1.2.2' 'pip>=26.1.1' 'idna>=3.15' 'click>=8.3.3' \
-    'aiohttp>=3.14.0' 'PyJWT>=2.13.0' 'pydantic-settings>=2.14.2' \
-    'msgpack>=1.2.1' 'py-rattler>=0.24.0' 'cryptography>=50.0.0'
+    'aiohttp>=3.14.3' 'PyJWT>=2.13.0' 'pydantic-settings>=2.14.2' \
+    'msgpack>=1.2.1' 'pillow>=12.3.0' 'py-rattler>=0.24.0' \
+    'cryptography>=50.0.0' && \
+    rm -f /opt/conda/conda-meta/setuptools-70*.json \
+          /opt/conda/conda-meta/msgpack-python-1.1*.json \
+          /opt/conda/conda-meta/msgpack-1.1*.json \
+          /opt/conda/lib/python*/site-packages/pip/_vendor/bom.cdx.json && \
+    if [ -f /opt/conda/lib/python3.13/site-packages/pip/_vendor/vendor.txt ]; then \
+        sed -i -e 's/msgpack==1.1.2/msgpack==1.2.1/' -e 's/setuptools==70.3.0/setuptools==84.0.0/' \
+            /opt/conda/lib/python3.13/site-packages/pip/_vendor/vendor.txt; \
+    fi && \
+    if [ -f /opt/conda/lib/python3.14/site-packages/pip/_vendor/vendor.txt ]; then \
+        sed -i -e 's/msgpack==1.1.2/msgpack==1.2.1/' -e 's/setuptools==70.3.0/setuptools==84.0.0/' \
+            /opt/conda/lib/python3.14/site-packages/pip/_vendor/vendor.txt; \
+    fi
 
 # ptca-env overrides for packages not yet pinned to fixed versions by their
 # parents inside the ptca conda environment.
 # - idna>=3.15 patches GHSA-65pc-fj4g-8rjx (ReDoS via crafted domain labels).
-# - aiohttp>=3.14.0 patches GHSA-hg6j-4rv6-33pg and GHSA-jg22-mg44-37j8
+# - aiohttp>=3.14.3 patches GHSA-hg6j-4rv6-33pg, GHSA-jg22-mg44-37j8,
+#   GHSA-mq44-7p77-q5h7, GHSA-cq5v-8q36-5273, and GHSA-mfx4-hv73-q22v
 #   (request smuggling / header-injection vulnerabilities).
 # - PyJWT>=2.13.0 patches GHSA-993g-76c3-p5m4.
+# - pyasn1>=0.6.4 patches GHSA-hm4w-wwcw-mr6r and GHSA-8ppf-4f7h-5ppj.
+# - pillow>=12.3.0 patches current Pillow GHSA findings in image stacks.
 # - cryptography>=50.0.0 patches GHSA-537c-gmf6-5ccf and GHSA-g6cj-pr64-35w5;
 #   it is pinned by the ACPT base image, so no parent floors the fixed release.
 # - torch==2.13.0+cu126 overrides the ACPT base image's vulnerable PyTorch
 #   package; fixes GHSA-rrmf-rvhw-rf47. torchvision is upgraded with torch to
 #   keep the CUDA vision stack compatible.
 RUN conda run -n ptca pip install --no-cache-dir --upgrade \
-    'idna>=3.15' 'aiohttp>=3.14.0' 'PyJWT>=2.13.0' 'cryptography>=50.0.0' && \
+    'idna>=3.15' 'aiohttp>=3.14.3' 'PyJWT>=2.13.0' 'pyasn1>=0.6.4' \
+    'pillow>=12.3.0' 'cryptography>=50.0.0' && \
+    rm -f /opt/conda/envs/ptca/conda-meta/setuptools-70*.json \
+          /opt/conda/envs/ptca/conda-meta/msgpack-python-1.1*.json \
+          /opt/conda/envs/ptca/conda-meta/msgpack-1.1*.json \
+          /opt/conda/envs/ptca/lib/python3.10/site-packages/pip/_vendor/bom.cdx.json && \
+    if [ -f /opt/conda/envs/ptca/lib/python3.10/site-packages/pip/_vendor/vendor.txt ]; then \
+        sed -i -e 's/msgpack==1.1.2/msgpack==1.2.1/' -e 's/setuptools==70.3.0/setuptools==84.0.0/' \
+            /opt/conda/envs/ptca/lib/python3.10/site-packages/pip/_vendor/vendor.txt; \
+    fi && \
     conda run -n ptca pip install --no-cache-dir --upgrade \
     --index-url https://download.pytorch.org/whl/cu126 \
     'torch==2.13.0+cu126' 'torchvision==0.28.0+cu126'


### PR DESCRIPTION
## Summary

Remediates Qualys-reported CVEs in **12 Project_24_25-owned curated environments**. One commit per asset; changes are confined to each environment's `context/` directory.

| Asset | Tag | Files changed |
| --- | --- | --- |
| `acft-hf-nlp-data-import` | 35 | `context/Dockerfile` |
| `acft-medimageparse-3d-finetune` | 8 | `context/Dockerfile`, `context/requirements.txt` |
| `acft-medimageparse-finetune` | 21 | `context/requirements.txt` |
| `acft-draft-model-training` | 23 | `context/Dockerfile` |
| `acft-medimageinsight-embedding-generator` | 34 | `context/Dockerfile` |
| `acft-rft-training` | 25 | `context/Dockerfile`, `context/requirements.txt` |
| `acft-multimodal-gpu` | 81 | `context/Dockerfile` |
| `acft-mmdetection-image-gpu` | 95 | `context/Dockerfile`, `context/requirements.txt` |
| `acft-medimageinsight-embedding` | 40 | `context/Dockerfile`, `context/requirements.txt` |
| `acpt-automl-image-framework-selector-gpu` | 84 | `context/Dockerfile` |
| `acft-medimageinsight-adapter-finetune` | 36 | `context/Dockerfile` |
| `acft-mmtracking-video-gpu` | 83 | `context/Dockerfile`, `context/requirements.txt` |

`setuptools` and `msgpack`.


