### PR TITLE
Update cryptography version to 50.0.0 to fix vulnerabilities

### DIFF
--- a/assets/designer/environments/component/context/conda_dependencies.yaml
+++ b/assets/designer/environments/component/context/conda_dependencies.yaml
@@ -7,7 +7,7 @@ dependencies:
 - setuptools<82
 - pip:
   - urllib3>=2.6.0
-  - cryptography>=46.0.7
+  - cryptography>=50.0.0
   - azure-ml-component=={{latest-pypi-version}}
   - azureml-defaults=={{latest-pypi-version}}
   - pyarrow>=14.0.1


### PR DESCRIPTION
### Notes

- Refer these GH advisories:
  - https://github.com/advisories/GHSA-g6cj-pr64-35w5
  - https://github.com/advisories/GHSA-537c-gmf6-5ccf
  - https://github.com/advisories/GHSA-jwv3-5hgf-82ww