### PR TITLE
Update all gemma-4 variants and nemotron cuda models in Foundry Local

### DIFF
--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cuda/v1
+  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cuda/v2
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
-  directoryPath: v1
+  directoryPath: v2
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 6182901110
-    vRamFootprintBytes: 6182901110
-version: 1
+    fileSizeBytes: 6182900994
+    vRamFootprintBytes: 6182900994
+version: 2

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cpu_and_mobile/v1
+  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cpu_and_mobile/v2
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
-  directoryPath: v1
+  directoryPath: v2
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: cpu
     executionProvider: CPUExecutionProvider
-    fileSizeBytes: 6324928641
-    vRamFootprintBytes: 6324928641
-version: 1
+    fileSizeBytes: 6324928525
+    vRamFootprintBytes: 6324928525
+version: 2

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/webgpu/v1
+  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/webgpu/v2
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
-  directoryPath: v1
+  directoryPath: v2
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: WebGPUExecutionProvider
-    fileSizeBytes: 7377541854
-    vRamFootprintBytes: 7377541854
-version: 1
+    fileSizeBytes: 7377474676
+    vRamFootprintBytes: 7377474676
+version: 2

--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/nemotron-3.5-asr-streaming-0.6b/onnx/cuda/v2
+  container_path: foundrylocal/models/nemotron-3.5-asr-streaming-0.6b/onnx/cuda/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-3.5-asr-streaming-0.6b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: nemotron-3.5-asr-streaming-0.6b
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -37,6 +37,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 793344782
-    vRamFootprintBytes: 793344782
-version: 2
+    fileSizeBytes: 793344835
+    vRamFootprintBytes: 793344835
+version: 3

--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/nemotron-speech-streaming-en-0.6b/onnx/cuda/v1
+  container_path: foundrylocal/models/nemotron-speech-streaming-en-0.6b/onnx/cuda/v2
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-en-0.6b-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: nemotron-speech-streaming-en-0.6b
   publisher: Microsoft
-  directoryPath: v1
+  directoryPath: v2
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -37,6 +37,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 730746955
-    vRamFootprintBytes: 730746955
-version: 1
+    fileSizeBytes: 730747008
+    vRamFootprintBytes: 730747008
+version: 2

--- a/assets/models/foundrylocal/nemotron-speech-streaming-es-0.6b-ft-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-es-0.6b-ft-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/nemotron-speech-streaming-es-0.6b-ft/onnx/cuda/v1
+  container_path: foundrylocal/models/nemotron-speech-streaming-es-0.6b-ft/onnx/cuda/v2
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/nemotron-speech-streaming-es-0.6b-ft-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/nemotron-speech-streaming-es-0.6b-ft-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: nemotron-speech-streaming-es-0.6b
   publisher: Microsoft
-  directoryPath: v1
+  directoryPath: v2
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -37,6 +37,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 764952910
-    vRamFootprintBytes: 764952910
-version: 1
+    fileSizeBytes: 764953110
+    vRamFootprintBytes: 764953110
+version: 2


### PR DESCRIPTION
This PR is to update Gemma-4 variants to fix jinja parse error and Nemotron CUDA models to run VAD model at CPU.