### PR TITLE
Patch docker-tools vulnerabilities: Go 1.26.8, Trivy 0.74.0, ORAS 1.3.4

### DIFF
--- a/assets/system/context/Dockerfile
+++ b/assets/system/context/Dockerfile
@@ -1,8 +1,8 @@
 # Shared Go toolchain version used across builder stages; compiled from source so the
 # trivy and oras binaries link a patched Go stdlib. Bump to the latest patched Go.
-ARG GO_VERSION=1.26.5
-ARG TRIVY_VERSION=0.72.0
-ARG ORAS_VERSION=1.3.2
+ARG GO_VERSION=1.26.8
+ARG TRIVY_VERSION=0.74.0
+ARG ORAS_VERSION=1.3.4
 
 # Mode toggles: "build" (compile from source with patched Go + deps) or
 # "install" (download the upstream release binary). Both default to "build"
@@ -31,7 +31,6 @@ ENV PATH=/usr/local/go/bin:$PATH
 RUN git clone --depth 1 --branch v${ORAS_VERSION} https://github.com/oras-project/oras.git /tmp/oras \
  && cd /tmp/oras \
  && go get golang.org/x/crypto@latest \
- && go get oras.land/oras-go/v2@v2.6.1 \
  && go mod tidy \
  && GOBIN=/out go install ./cmd/oras \
  && test -x /out/oras \
@@ -76,24 +75,20 @@ RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go
  && rm /tmp/go.tar.gz
 ENV PATH=/usr/local/go/bin:$PATH
 # Build env replicates trivy's magefile (CGO disabled, jsonv2 experiment, version ldflag).
-# go get pins below patch modules that trivy v0.72.0 (the latest release) still lags and the
-# scanner flags in the built binary: x/net, x/text, grpc (GHSA-hrxh-6v49-42gf), moby/buildkit.
-# Drop a pin once the tagged release carries a fixed version.
+# No module pins are needed here: trivy v0.74.0's go.mod already carries fixed versions of
+# every dep previously pinned (x/crypto 0.55.0, x/mod 0.40.0, x/net 0.58.0, x/text 0.41.0,
+# grpc 1.82.1, moby/buildkit 0.32.2, oras-go/v2 2.6.2). Add a `go get pkg@version` below
+# only for a module a future tagged release still lags, and drop it once the release
+# catches up.
 RUN git clone --depth 1 --branch v${TRIVY_VERSION} https://github.com/aquasecurity/trivy.git /tmp/trivy \
  && cd /tmp/trivy \
- && go get oras.land/oras-go/v2@v2.6.1 \
- && go get golang.org/x/net@v0.56.0 \
- && go get golang.org/x/text@v0.39.0 \
- && go get google.golang.org/grpc@v1.82.1 \
- && go get github.com/moby/buildkit@v0.31.2 \
- && go mod tidy \
  && CGO_ENABLED=0 GOEXPERIMENT=jsonv2 go build \
       -ldflags="-s -w -X=github.com/aquasecurity/trivy/pkg/version/app.ver=${TRIVY_VERSION}" \
       -o /out/trivy ./cmd/trivy \
  && test -x /out/trivy \
  && /out/trivy --version \
  && echo "--- linked Go module versions (verifying CVE-fix pins) ---" \
- && go version -m /out/trivy | grep -E '(stdlib|oras-go|rekor|golang\.org/x/(crypto|net|text)|in-toto-golang|go-git/v5|go-billy/v5|containerd|grpc|buildkit)' \
+ && go version -m /out/trivy | grep -E '(stdlib|oras-go|rekor|golang\.org/x/(crypto|mod|net|text)|in-toto-golang|go-git/v5|go-billy/v5|containerd|grpc|buildkit)' \
  && rm -rf /tmp/trivy
 
 # =========================================

--- a/assets/system/environment.yaml
+++ b/assets/system/environment.yaml
@@ -12,5 +12,5 @@ image:
   tags:
     System: ""
     Docker: ""
-    Oras: "1.3.2"
-    Trivy: "0.72.0"
+    Oras: "1.3.4"
+    Trivy: "0.74.0"


### PR DESCRIPTION
## What

Vulnerability patch pass on the `docker-tools` environment. Fixes the 10 Qualys findings currently reported against the image, all of which are in the `trivy` and `oras` binaries this context builds.

| Finding | Package | Installed → Required | Fix |
|---|---|---|---|
| 5016882/83/84/85/88/89 (HIGH), 5016886/87 (MEDIUM) | `stdlib` | v1.26.5 → 1.26.6 | `GO_VERSION` 1.26.5 → **1.26.8** |
| 5016885, 5016888 (HIGH) | `golang.org/x/mod` | v0.37.0 → 0.40.0 | `TRIVY_VERSION` 0.72.0 → **0.74.0** (its `go.mod` ships 0.40.0) |
| 5017683 (HIGH) | `golang.org/x/crypto` | v0.53.0 → 0.55.0 | `TRIVY_VERSION` 0.74.0 (ships 0.55.0) |
| 5017713 (MEDIUM) | `oras.land/oras` | v1.3.2 → 1.3.3 | `ORAS_VERSION` 1.3.2 → **1.3.4** |

`environment.yaml` image tags bumped to match the built binaries.

## Cleanup

The per-module `go get` pins in the trivy builder stage are removed — trivy v0.74.0's own `go.mod` now meets or exceeds every one of them (`x/net` 0.58.0, `x/text` 0.41.0, `grpc` 1.82.1, `moby/buildkit` 0.32.2, `oras-go/v2` 2.6.2) — along with the `go mod tidy` they required, so the trivy build is now straight from the release tag.

Two mitigations are deliberately kept:

- **`go get golang.org/x/crypto@latest` in the oras stage.** oras v1.3.4 still pulls `x/crypto` v0.52.0 indirectly, below the 0.55.0 the advisory requires; the pin resolves it to 0.56.0.
- **The `pip/_vendor/bom.cdx.json` delete**, unchanged.

## Why not Go 1.27

The trivy stage builds with `GOEXPERIMENT=jsonv2`; an experiment graduation or removal in 1.27 would fail the build. 1.26.8 is the latest 1.26.x patch and clears the 1.26.6 advisory floor.

## Validation

Rendered the template against the current base (`mcr.microsoft.com/azureml/openmpi5.0-ubuntu24.04:20260901.v1`), then built and scanned it on ACR before and after the change:

- **before** — 10 findings, all context-introduced (install paths `usr/local/bin/trivy`, `usr/local/bin/oras`); none inherited from the base
- **after** — **0 findings**; baseline diff 8 fixed / 0 new / 0 remaining

Both builder stages compile cleanly, and the build's own `go version -m` verification step (extended to cover `golang.org/x/mod`) passes.
