### PR TITLE
Update gemma-4 and ministral models in Foundry Local

### DIFF
--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cuda/v2
+  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cuda/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 6182900994
-    vRamFootprintBytes: 6182900994
-version: 2
+    fileSizeBytes: 6182881980
+    vRamFootprintBytes: 6182881980
+version: 3

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cpu_and_mobile/v2
+  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/cpu_and_mobile/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: cpu
     executionProvider: CPUExecutionProvider
-    fileSizeBytes: 6324928525
-    vRamFootprintBytes: 6324928525
-version: 2
+    fileSizeBytes: 6324909511
+    vRamFootprintBytes: 6324909511
+version: 3

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/webgpu/v2
+  container_path: foundrylocal/models/gemma-4-e2b-it/onnx/webgpu/v3
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/gemma-4-e2b-it-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: gemma-4-e2b-it
   publisher: Microsoft
-  directoryPath: v2
+  directoryPath: v3
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: WebGPUExecutionProvider
-    fileSizeBytes: 7377474676
-    vRamFootprintBytes: 7377474676
-version: 2
+    fileSizeBytes: 7377474168
+    vRamFootprintBytes: 7377474168
+version: 3

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512/onnx/cuda/v1
+  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512/onnx/cuda/v2
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-cuda-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: ministral-3-3b-instruct-2512
   publisher: Microsoft
-  directoryPath: v1
+  directoryPath: v2
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -45,6 +45,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 3857772715
-    vRamFootprintBytes: 3857772715
-version: 1
+    fileSizeBytes: 3857772599
+    vRamFootprintBytes: 3857772599
+version: 2

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/model.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512/onnx/cpu_and_mobile/v1
+  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512/onnx/cpu_and_mobile/v2
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/spec.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-cpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: ministral-3-3b-instruct-2512
   publisher: Microsoft
-  directoryPath: v1
+  directoryPath: v2
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -45,6 +45,6 @@ variantInfo:
     - RTN
     device: cpu
     executionProvider: CPUExecutionProvider
-    fileSizeBytes: 4919876920
-    vRamFootprintBytes: 4919876920
-version: 1
+    fileSizeBytes: 4919876804
+    vRamFootprintBytes: 4919876804
+version: 2

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/model.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512/onnx/webgpu/v1
+  container_path: foundrylocal/models/ministral-3-3b-Instruct-2512/onnx/webgpu/v2
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/spec.yaml
+++ b/assets/models/foundrylocal/ministral-3-3b-instruct-2512-generic-gpu/spec.yaml
@@ -9,7 +9,7 @@ tags:
 system_metadata:
   alias: ministral-3-3b-instruct-2512
   publisher: Microsoft
-  directoryPath: v1
+  directoryPath: v2
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -45,6 +45,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: WebGPUExecutionProvider
-    fileSizeBytes: 3857775303
-    vRamFootprintBytes: 3857775303
-version: 1
+    fileSizeBytes: 3857775187
+    vRamFootprintBytes: 3857775187
+version: 2


### PR DESCRIPTION
This PR contains a few fixes in gemma-4 and ministral Foundry Local models.

- Gemma-4 models in Foundry Local was broken due to redundancy of chat template at tokenizer_json.config and chat_template.jinja.  V3 models remove a chat template from tokenizer_json.config.
- Gemma-4 webgpu model has inconsistent max_length. Fixed it to align with max context length.
- ministral models call RGB conversion twice. V2 models remove it from processor_config.json.