### PR TITLE
Add JSON response support to 11 evaluators

### DIFF
--- a/assets/evaluators/builtin/bbeh/evaluator/_bbeh.py
+++ b/assets/evaluators/builtin/bbeh/evaluator/_bbeh.py
@@ -11,6 +11,7 @@ and compares them against ground truth with tolerance for common variations.
 Reference: https://github.com/google-deepmind/bbeh
 """
 
+import json
 import logging
 from typing import Dict
 from typing_extensions import overload, override
@@ -18,7 +19,66 @@ from typing_extensions import overload, override
 from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 
+try:  # azure-ai-evaluation >= 1.18.1
+    from azure.ai.evaluation._common.utils import _preprocess_messages
+except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._evaluators._common._base_prompty_eval import _preprocess_messages
+
 logger = logging.getLogger(__name__)
+
+
+def _extract_final_text_response(messages):
+    """Extract only the plain text of assistant messages, dropping tool calls/results.
+
+    Iterates the preprocessed messages and collects the ``text`` content of every
+    ``assistant`` role message, ignoring any ``tool_call``/``tool_result`` content blocks
+    and any non-assistant messages (e.g. ``tool`` role messages). This ensures only the
+    final plain-text agent response is used for evaluation, never intermediate tool call
+    or tool result content.
+
+    :param messages: The preprocessed list of chat-message dicts.
+    :type messages: list
+    :return: The joined plain text of all assistant messages, or an empty string if none.
+    :rtype: str
+    """
+    text_lines = []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            for content in msg.get("content", []) or []:
+                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                    text_lines.append(content["text"])
+    return "\n".join(text_lines)
+
+
+def _parse_response_for_evaluation(response):
+    """Flatten ``response`` into a plain string, parsing a JSON-encoded list of messages if needed.
+
+    If ``response`` is a string, attempt to ``json.loads`` it. When it (or an already-parsed
+    ``response``) is a list of chat-message dicts, only the plain text of assistant messages
+    is extracted (tool calls, tool results, and other message types are dropped). Any other
+    input (a plain string that is not JSON, or a string/list that fails to parse or yields no
+    assistant text) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: A plain string ready for deterministic scoring.
+    :rtype: str
+    """
+    parsed = response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+    if isinstance(parsed, list):
+        try:
+            messages = _preprocess_messages(parsed)
+            text = _extract_final_text_response(messages)
+            if text:
+                return text
+        except Exception:
+            logger.debug("Could not extract plain text from response messages; falling back to original response")
+    return response
 
 
 def strip_latex(response: str) -> str:
@@ -243,7 +303,7 @@ class BBEHEvaluator(EvaluatorBase):
         :return: The evaluation result with score and match information.
         :rtype: Dict
         """
-        response = eval_input.get("response", "")
+        response = _parse_response_for_evaluation(eval_input.get("response", ""))
         ground_truth = eval_input.get("ground_truth", "")
 
         if not response:

--- a/assets/evaluators/builtin/bbeh/evaluator/_bbeh.py
+++ b/assets/evaluators/builtin/bbeh/evaluator/_bbeh.py
@@ -45,7 +45,7 @@ def _extract_final_text_response(messages):
     for msg in messages:
         if isinstance(msg, dict) and msg.get("role") == "assistant":
             for content in msg.get("content", []) or []:
-                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                if isinstance(content, dict) and "text" in content:
                     text_lines.append(content["text"])
     return "\n".join(text_lines)
 

--- a/assets/evaluators/builtin/bbeh/spec.yaml
+++ b/assets/evaluators/builtin/bbeh/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.bbeh"
-version: 1
+version: 2
 displayName: "BBEH-Evaluator"
 description: "Evaluates model responses for the BIG-Bench Extra Hard (BBEH) benchmark using fuzzy matching logic. Extracts answers from model output (handling 'The answer is:' prefixes and LaTeX formatting) and compares against ground truth with tolerance for common variations like (a) vs a, numeric equality, quote differences, and bracket formatting."
 evaluatorType: "builtin"
@@ -17,8 +17,12 @@ dataMappingSchema:
   type: "object"
   properties:
     response:
-      type: "string"
-      description: "The raw model output text to evaluate."
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
+      description: "The raw model output text to evaluate. Accepts a plain string or a JSON-encoded list of chat messages."
     ground_truth:
       type: "string"
       description: "The expected answer to match against."

--- a/assets/evaluators/builtin/bleu_score/evaluator/_bleu.py
+++ b/assets/evaluators/builtin/bleu_score/evaluator/_bleu.py
@@ -39,7 +39,7 @@ def _extract_final_text_response(messages):
     for msg in messages:
         if isinstance(msg, dict) and msg.get("role") == "assistant":
             for content in msg.get("content", []) or []:
-                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                if isinstance(content, dict) and "text" in content:
                     text_lines.append(content["text"])
     return "\n".join(text_lines)
 

--- a/assets/evaluators/builtin/bleu_score/evaluator/_bleu.py
+++ b/assets/evaluators/builtin/bleu_score/evaluator/_bleu.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import json
 import logging
 from typing import Dict
 from nltk.translate.bleu_score import SmoothingFunction, sentence_bleu
@@ -12,7 +13,66 @@ from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
+try:  # azure-ai-evaluation >= 1.18.1
+    from azure.ai.evaluation._common.utils import _preprocess_messages
+except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._evaluators._common._base_prompty_eval import _preprocess_messages
+
 logger = logging.getLogger(__name__)
+
+
+def _extract_final_text_response(messages):
+    """Extract only the plain text of assistant messages, dropping tool calls/results.
+
+    Iterates the preprocessed messages and collects the ``text`` content of every
+    ``assistant`` role message, ignoring any ``tool_call``/``tool_result`` content blocks
+    and any non-assistant messages (e.g. ``tool`` role messages). This ensures only the
+    final plain-text agent response is used for evaluation, never intermediate tool call
+    or tool result content.
+
+    :param messages: The preprocessed list of chat-message dicts.
+    :type messages: list
+    :return: The joined plain text of all assistant messages, or an empty string if none.
+    :rtype: str
+    """
+    text_lines = []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            for content in msg.get("content", []) or []:
+                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                    text_lines.append(content["text"])
+    return "\n".join(text_lines)
+
+
+def _parse_response_for_evaluation(response):
+    """Flatten ``response`` into a plain string, parsing a JSON-encoded list of messages if needed.
+
+    If ``response`` is a string, attempt to ``json.loads`` it. When it (or an already-parsed
+    ``response``) is a list of chat-message dicts, only the plain text of assistant messages
+    is extracted (tool calls, tool results, and other message types are dropped). Any other
+    input (a plain string that is not JSON, or a string/list that fails to parse or yields no
+    assistant text) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: A plain string ready for deterministic scoring.
+    :rtype: str
+    """
+    parsed = response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+    if isinstance(parsed, list):
+        try:
+            messages = _preprocess_messages(parsed)
+            text = _extract_final_text_response(messages)
+            if text:
+                return text
+        except Exception:
+            logger.debug("Could not extract plain text from response messages; falling back to original response")
+    return response
 
 
 class BleuScoreEvaluator(EvaluatorBase):
@@ -81,7 +141,7 @@ class BleuScoreEvaluator(EvaluatorBase):
         :rtype: Dict
         """
         ground_truth = eval_input["ground_truth"]
-        response = eval_input["response"]
+        response = _parse_response_for_evaluation(eval_input["response"])
         reference_tokens = nltk_tokenize(ground_truth)
         hypothesis_tokens = nltk_tokenize(response)
 

--- a/assets/evaluators/builtin/bleu_score/spec.yaml
+++ b/assets/evaluators/builtin/bleu_score/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.bleu_score"
-version: 2
+version: 3
 displayName: "Bleu-Score-Evaluator"
 description: "Measures how similar the model’s output is to a reference text. Useful for assessing alignment between generated and expected responses. It’s best used for natural language processing (NLP) tasks, including text summarization and text generation use cases."
 evaluatorType: "builtin"
@@ -23,7 +23,11 @@ dataMappingSchema:
     ground_truth:
       type: "string"
     response:
-      type: "string"
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
   required: ["ground_truth", "response"]
 outputSchema:
   bleu:

--- a/assets/evaluators/builtin/f1_score/evaluator/_f1_score.py
+++ b/assets/evaluators/builtin/f1_score/evaluator/_f1_score.py
@@ -37,7 +37,7 @@ def _extract_final_text_response(messages):
     for msg in messages:
         if isinstance(msg, dict) and msg.get("role") == "assistant":
             for content in msg.get("content", []) or []:
-                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                if isinstance(content, dict) and "text" in content:
                     text_lines.append(content["text"])
     return "\n".join(text_lines)
 

--- a/assets/evaluators/builtin/f1_score/evaluator/_f1_score.py
+++ b/assets/evaluators/builtin/f1_score/evaluator/_f1_score.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import json
 import logging
 from collections import Counter
 from typing import List, Dict
@@ -10,7 +11,66 @@ from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
+try:  # azure-ai-evaluation >= 1.18.1
+    from azure.ai.evaluation._common.utils import _preprocess_messages
+except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._evaluators._common._base_prompty_eval import _preprocess_messages
+
 logger = logging.getLogger(__name__)
+
+
+def _extract_final_text_response(messages):
+    """Extract only the plain text of assistant messages, dropping tool calls/results.
+
+    Iterates the preprocessed messages and collects the ``text`` content of every
+    ``assistant`` role message, ignoring any ``tool_call``/``tool_result`` content blocks
+    and any non-assistant messages (e.g. ``tool`` role messages). This ensures only the
+    final plain-text agent response is used for evaluation, never intermediate tool call
+    or tool result content.
+
+    :param messages: The preprocessed list of chat-message dicts.
+    :type messages: list
+    :return: The joined plain text of all assistant messages, or an empty string if none.
+    :rtype: str
+    """
+    text_lines = []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            for content in msg.get("content", []) or []:
+                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                    text_lines.append(content["text"])
+    return "\n".join(text_lines)
+
+
+def _parse_response_for_evaluation(response):
+    """Flatten ``response`` into a plain string, parsing a JSON-encoded list of messages if needed.
+
+    If ``response`` is a string, attempt to ``json.loads`` it. When it (or an already-parsed
+    ``response``) is a list of chat-message dicts, only the plain text of assistant messages
+    is extracted (tool calls, tool results, and other message types are dropped). Any other
+    input (a plain string that is not JSON, or a string/list that fails to parse or yields no
+    assistant text) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: A plain string ready for deterministic scoring.
+    :rtype: str
+    """
+    parsed = response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+    if isinstance(parsed, list):
+        try:
+            messages = _preprocess_messages(parsed)
+            text = _extract_final_text_response(messages)
+            if text:
+                return text
+        except Exception:
+            logger.debug("Could not extract plain text from response messages; falling back to original response")
+    return response
 
 
 class F1ScoreEvaluator(EvaluatorBase):
@@ -143,7 +203,7 @@ class F1ScoreEvaluator(EvaluatorBase):
         :rtype: Dict
         """
         ground_truth = eval_input["ground_truth"]
-        response = eval_input["response"]
+        response = _parse_response_for_evaluation(eval_input["response"])
         # Run f1 score computation.
         f1_result = self._compute_f1_score(response=response, ground_truth=ground_truth)
         binary_result = False

--- a/assets/evaluators/builtin/f1_score/spec.yaml
+++ b/assets/evaluators/builtin/f1_score/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.f1_score"
-version: 2
+version: 3
 displayName: "F1Score-Evaluator"
 description: "Balances correctness and completeness when comparing predictions to true results. Higher scores indicate better overall accuracy. It’s best used for natural language processing (NLP) tasks. Use the F1 score evaluator when you want a single comprehensive metric that combines both recall and precision in your model's responses."
 evaluatorType: "builtin"
@@ -23,7 +23,11 @@ dataMappingSchema:
     ground_truth:
       type: "string"
     response:
-      type: "string"
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
   required: ["ground_truth", "response"]
 outputSchema:
   f1_score:

--- a/assets/evaluators/builtin/fluency/evaluator/_fluency.py
+++ b/assets/evaluators/builtin/fluency/evaluator/_fluency.py
@@ -101,7 +101,7 @@ def _extract_final_text_response(response):
     for msg in response:
         if isinstance(msg, dict) and msg.get("role") == "assistant":
             for content in msg.get("content", []) or []:
-                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                if isinstance(content, dict) and "text" in content:
                     text_lines.append(content["text"])
     return "\n".join(text_lines)
 

--- a/assets/evaluators/builtin/fluency/evaluator/_fluency.py
+++ b/assets/evaluators/builtin/fluency/evaluator/_fluency.py
@@ -27,7 +27,6 @@ from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._common.constants import PROMPT_BASED_REASON_EVALUATORS
 from azure.ai.evaluation._common.utils import (
     parse_quality_evaluator_reason_score,
-    reformat_agent_response,
 )
 from azure.ai.evaluation._evaluators._common._validators import (
     ValidatorInterface,
@@ -56,6 +55,55 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
     )
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_json_response_if_applicable(response):
+    """Parse ``response`` as JSON when it is a JSON-encoded string of chat messages.
+
+    If ``response`` is a string that successfully parses as JSON into a list, the parsed
+    list is returned so it can be handled by the existing message-list preprocessing path.
+    Any other input (a plain string, an already-parsed list, or a string that fails to
+    parse as JSON) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: The parsed list of messages, or the original response if it is not a
+        JSON-encoded list.
+    :rtype: Any
+    """
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+        if isinstance(parsed, list):
+            return parsed
+    return response
+
+
+def _extract_final_text_response(response):
+    """Flatten a preprocessed list of chat messages into plain assistant text.
+
+    Only the ``text`` content of ``assistant`` role messages is collected; tool
+    calls, tool results, and any other message types are dropped so the evaluator
+    only ever scores the final plain-text agent response. Non-list inputs (e.g. an
+    already plain-string response) are returned unchanged.
+
+    :param response: A preprocessed list of chat-message dicts, or a plain string.
+    :type response: Any
+    :return: The joined plain text of all assistant messages, or the original
+        ``response`` if it is not a list.
+    :rtype: Any
+    """
+    if not isinstance(response, list):
+        return response
+    text_lines = []
+    for msg in response:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            for content in msg.get("content", []) or []:
+                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                    text_lines.append(content["text"])
+    return "\n".join(text_lines)
 
 
 class FluencyEvaluator(PromptyEvaluatorBase[Union[str, float]]):
@@ -414,6 +462,8 @@ class FluencyEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         :return: The evaluation result.
         :rtype: Dict
         """
+        eval_input["response"] = _parse_json_response_if_applicable(eval_input.get("response"))
+
         if _is_intermediate_response(eval_input.get("response")):
             return self._return_not_applicable_result(
                 "Intermediate response. Please provide the agent's final response for evaluation.",
@@ -422,7 +472,7 @@ class FluencyEvaluator(PromptyEvaluatorBase[Union[str, float]]):
         if isinstance(eval_input.get("response"), list):
             eval_input["response"] = _preprocess_messages(eval_input["response"])
 
-        eval_input["response"] = reformat_agent_response(eval_input.get("response"), logger)
+        eval_input["response"] = _extract_final_text_response(eval_input.get("response"))
 
         result = await self._the_super_do_eval(eval_input)
 

--- a/assets/evaluators/builtin/fluency/spec.yaml
+++ b/assets/evaluators/builtin/fluency/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.fluency"
-version: 10
+version: 11
 displayName: "Fluency-Evaluator"
 description: "Evaluates how natural and grammatically correct the response sounds. Higher scores indicate smoother and clearer language. It’s best used for generative business writing such as summarizing meeting notes, creating marketing materials, and drafting email."
 evaluatorType: "builtin"
@@ -24,7 +24,11 @@ dataMappingSchema:
   type: "object"
   properties:
     response:
-      type: "string"
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
   required: ["response"]
 outputSchema:
   fluency:

--- a/assets/evaluators/builtin/gleu_score/evaluator/_gleu.py
+++ b/assets/evaluators/builtin/gleu_score/evaluator/_gleu.py
@@ -39,7 +39,7 @@ def _extract_final_text_response(messages):
     for msg in messages:
         if isinstance(msg, dict) and msg.get("role") == "assistant":
             for content in msg.get("content", []) or []:
-                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                if isinstance(content, dict) and "text" in content:
                     text_lines.append(content["text"])
     return "\n".join(text_lines)
 

--- a/assets/evaluators/builtin/gleu_score/evaluator/_gleu.py
+++ b/assets/evaluators/builtin/gleu_score/evaluator/_gleu.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import json
 import logging
 from typing import Dict
 from nltk.translate.gleu_score import sentence_gleu
@@ -12,7 +13,66 @@ from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
+try:  # azure-ai-evaluation >= 1.18.1
+    from azure.ai.evaluation._common.utils import _preprocess_messages
+except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._evaluators._common._base_prompty_eval import _preprocess_messages
+
 logger = logging.getLogger(__name__)
+
+
+def _extract_final_text_response(messages):
+    """Extract only the plain text of assistant messages, dropping tool calls/results.
+
+    Iterates the preprocessed messages and collects the ``text`` content of every
+    ``assistant`` role message, ignoring any ``tool_call``/``tool_result`` content blocks
+    and any non-assistant messages (e.g. ``tool`` role messages). This ensures only the
+    final plain-text agent response is used for evaluation, never intermediate tool call
+    or tool result content.
+
+    :param messages: The preprocessed list of chat-message dicts.
+    :type messages: list
+    :return: The joined plain text of all assistant messages, or an empty string if none.
+    :rtype: str
+    """
+    text_lines = []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            for content in msg.get("content", []) or []:
+                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                    text_lines.append(content["text"])
+    return "\n".join(text_lines)
+
+
+def _parse_response_for_evaluation(response):
+    """Flatten ``response`` into a plain string, parsing a JSON-encoded list of messages if needed.
+
+    If ``response`` is a string, attempt to ``json.loads`` it. When it (or an already-parsed
+    ``response``) is a list of chat-message dicts, only the plain text of assistant messages
+    is extracted (tool calls, tool results, and other message types are dropped). Any other
+    input (a plain string that is not JSON, or a string/list that fails to parse or yields no
+    assistant text) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: A plain string ready for deterministic scoring.
+    :rtype: str
+    """
+    parsed = response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+    if isinstance(parsed, list):
+        try:
+            messages = _preprocess_messages(parsed)
+            text = _extract_final_text_response(messages)
+            if text:
+                return text
+        except Exception:
+            logger.debug("Could not extract plain text from response messages; falling back to original response")
+    return response
 
 
 class GleuScoreEvaluator(EvaluatorBase):
@@ -83,7 +143,7 @@ class GleuScoreEvaluator(EvaluatorBase):
         :rtype: Dict
         """
         ground_truth = eval_input["ground_truth"]
-        response = eval_input["response"]
+        response = _parse_response_for_evaluation(eval_input["response"])
         reference_tokens = nltk_tokenize(ground_truth)
         hypothesis_tokens = nltk_tokenize(response)
 

--- a/assets/evaluators/builtin/gleu_score/spec.yaml
+++ b/assets/evaluators/builtin/gleu_score/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.gleu_score"
-version: 2
+version: 3
 displayName: "Gleu-Score-Evaluator"
 description: "Compares generated text to reference text for overlap and phrasing consistency. Higher scores suggest closer similarity. It’s best used for natural language processing (NLP) tasks. This balanced evaluation, designed for sentence-level assessment, makes it ideal for detailed analysis of translation quality, text summarization, and text generation."
 evaluatorType: "builtin"
@@ -23,7 +23,11 @@ dataMappingSchema:
     ground_truth:
       type: "string"
     response:
-      type: "string"
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
   required: ["ground_truth", "response"]
 outputSchema:
   gleu:

--- a/assets/evaluators/builtin/ifeval/evaluator/_ifeval.py
+++ b/assets/evaluators/builtin/ifeval/evaluator/_ifeval.py
@@ -21,7 +21,66 @@ from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 
 from ._instructions import get_checker
 
+try:  # azure-ai-evaluation >= 1.18.1
+    from azure.ai.evaluation._common.utils import _preprocess_messages
+except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._evaluators._common._base_prompty_eval import _preprocess_messages
+
 logger = logging.getLogger(__name__)
+
+
+def _extract_final_text_response(messages):
+    """Extract only the plain text of assistant messages, dropping tool calls/results.
+
+    Iterates the preprocessed messages and collects the ``text`` content of every
+    ``assistant`` role message, ignoring any ``tool_call``/``tool_result`` content blocks
+    and any non-assistant messages (e.g. ``tool`` role messages). This ensures only the
+    final plain-text agent response is used for evaluation, never intermediate tool call
+    or tool result content.
+
+    :param messages: The preprocessed list of chat-message dicts.
+    :type messages: list
+    :return: The joined plain text of all assistant messages, or an empty string if none.
+    :rtype: str
+    """
+    text_lines = []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            for content in msg.get("content", []) or []:
+                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                    text_lines.append(content["text"])
+    return "\n".join(text_lines)
+
+
+def _parse_response_for_evaluation(response):
+    """Flatten ``response`` into a plain string, parsing a JSON-encoded list of messages if needed.
+
+    If ``response`` is a string, attempt to ``json.loads`` it. When it (or an already-parsed
+    ``response``) is a list of chat-message dicts, only the plain text of assistant messages
+    is extracted (tool calls, tool results, and other message types are dropped). Any other
+    input (a plain string that is not JSON, or a string/list that fails to parse or yields no
+    assistant text) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: A plain string ready for deterministic scoring.
+    :rtype: str
+    """
+    parsed = response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+    if isinstance(parsed, list):
+        try:
+            messages = _preprocess_messages(parsed)
+            text = _extract_final_text_response(messages)
+            if text:
+                return text
+        except Exception:
+            logger.debug("Could not extract plain text from response messages; falling back to original response")
+    return response
 
 
 class IFEvalEvaluator(EvaluatorBase):
@@ -111,7 +170,7 @@ class IFEvalEvaluator(EvaluatorBase):
         :return: The evaluation result with strict and loose scores.
         :rtype: Dict
         """
-        response = eval_input.get("response", "")
+        response = _parse_response_for_evaluation(eval_input.get("response", ""))
         instruction_id_list = self._parse_json_field(
             eval_input.get("instruction_id_list"), "instruction_id_list"
         )

--- a/assets/evaluators/builtin/ifeval/evaluator/_ifeval.py
+++ b/assets/evaluators/builtin/ifeval/evaluator/_ifeval.py
@@ -47,7 +47,7 @@ def _extract_final_text_response(messages):
     for msg in messages:
         if isinstance(msg, dict) and msg.get("role") == "assistant":
             for content in msg.get("content", []) or []:
-                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                if isinstance(content, dict) and "text" in content:
                     text_lines.append(content["text"])
     return "\n".join(text_lines)
 

--- a/assets/evaluators/builtin/ifeval/spec.yaml
+++ b/assets/evaluators/builtin/ifeval/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.ifeval"
-version: 3
+version: 4
 displayName: "IFEval-Evaluator"
 description: "Evaluates model responses for the Instruction-Following Eval (IFEval) benchmark. Checks whether model outputs comply with verifiable instructions such as word count constraints, format requirements, keyword usage, and language specifications. Returns both strict (exact compliance) and loose (minor tolerance) accuracy scores."
 evaluatorType: "builtin"
@@ -17,8 +17,12 @@ dataMappingSchema:
   type: "object"
   properties:
     response:
-      type: "string"
-      description: "The raw model output text to evaluate."
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
+      description: "The raw model output text to evaluate. Accepts a plain string or a JSON-encoded list of chat messages."
     instruction_id_list:
       type: "string"
       description: "JSON array of instruction IDs to verify, e.g. '[\"punctuation:no_comma\", \"length_constraints:number_words\"]'"

--- a/assets/evaluators/builtin/meteor_score/evaluator/_meteor.py
+++ b/assets/evaluators/builtin/meteor_score/evaluator/_meteor.py
@@ -39,7 +39,7 @@ def _extract_final_text_response(messages):
     for msg in messages:
         if isinstance(msg, dict) and msg.get("role") == "assistant":
             for content in msg.get("content", []) or []:
-                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                if isinstance(content, dict) and "text" in content:
                     text_lines.append(content["text"])
     return "\n".join(text_lines)
 

--- a/assets/evaluators/builtin/meteor_score/evaluator/_meteor.py
+++ b/assets/evaluators/builtin/meteor_score/evaluator/_meteor.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import json
 import logging
 from typing import Dict
 
@@ -12,7 +13,66 @@ from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
+try:  # azure-ai-evaluation >= 1.18.1
+    from azure.ai.evaluation._common.utils import _preprocess_messages
+except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._evaluators._common._base_prompty_eval import _preprocess_messages
+
 logger = logging.getLogger(__name__)
+
+
+def _extract_final_text_response(messages):
+    """Extract only the plain text of assistant messages, dropping tool calls/results.
+
+    Iterates the preprocessed messages and collects the ``text`` content of every
+    ``assistant`` role message, ignoring any ``tool_call``/``tool_result`` content blocks
+    and any non-assistant messages (e.g. ``tool`` role messages). This ensures only the
+    final plain-text agent response is used for evaluation, never intermediate tool call
+    or tool result content.
+
+    :param messages: The preprocessed list of chat-message dicts.
+    :type messages: list
+    :return: The joined plain text of all assistant messages, or an empty string if none.
+    :rtype: str
+    """
+    text_lines = []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            for content in msg.get("content", []) or []:
+                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                    text_lines.append(content["text"])
+    return "\n".join(text_lines)
+
+
+def _parse_response_for_evaluation(response):
+    """Flatten ``response`` into a plain string, parsing a JSON-encoded list of messages if needed.
+
+    If ``response`` is a string, attempt to ``json.loads`` it. When it (or an already-parsed
+    ``response``) is a list of chat-message dicts, only the plain text of assistant messages
+    is extracted (tool calls, tool results, and other message types are dropped). Any other
+    input (a plain string that is not JSON, or a string/list that fails to parse or yields no
+    assistant text) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: A plain string ready for deterministic scoring.
+    :rtype: str
+    """
+    parsed = response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+    if isinstance(parsed, list):
+        try:
+            messages = _preprocess_messages(parsed)
+            text = _extract_final_text_response(messages)
+            if text:
+                return text
+        except Exception:
+            logger.debug("Could not extract plain text from response messages; falling back to original response")
+    return response
 
 
 class MeteorScoreEvaluator(EvaluatorBase):
@@ -103,7 +163,7 @@ class MeteorScoreEvaluator(EvaluatorBase):
         :rtype: Dict
         """
         ground_truth = eval_input["ground_truth"]
-        response = eval_input["response"]
+        response = _parse_response_for_evaluation(eval_input["response"])
         reference_tokens = nltk_tokenize(ground_truth)
         hypothesis_tokens = nltk_tokenize(response)
         score = meteor_score(

--- a/assets/evaluators/builtin/meteor_score/spec.yaml
+++ b/assets/evaluators/builtin/meteor_score/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.meteor_score"
-version: 2
+version: 3
 displayName: "Meteor-Score-Evaluator"
 description: "Evaluates similarity between generated and reference text using flexible matching. Higher scores indicate better linguistic overlap. It’s best used for natural language processing (NLP) tasks. It addresses limitations of other metrics like BLEU by considering synonyms, stemming, and paraphrasing."
 evaluatorType: "builtin"
@@ -23,7 +23,11 @@ dataMappingSchema:
     ground_truth:
       type: "string"
     response:
-      type: "string"
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
   required: ["ground_truth", "response"]
 outputSchema:
   meteor:

--- a/assets/evaluators/builtin/regex_match/evaluator/_regex_match.py
+++ b/assets/evaluators/builtin/regex_match/evaluator/_regex_match.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import json
 import logging
 import re
 from typing import Dict, List, Optional, Union
@@ -10,10 +11,69 @@ from azure.ai.evaluation._evaluators._common import EvaluatorBase
 from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 
+try:  # azure-ai-evaluation >= 1.18.1
+    from azure.ai.evaluation._common.utils import _preprocess_messages
+except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._evaluators._common._base_prompty_eval import _preprocess_messages
+
 logger = logging.getLogger(__name__)
 
 # Regex to detect {{ground_truth}} reference in patterns
 GROUND_TRUTH_PATTERN = re.compile(r"\{\{ground_truth\}\}")
+
+
+def _extract_final_text_response(messages):
+    """Extract only the plain text of assistant messages, dropping tool calls/results.
+
+    Iterates the preprocessed messages and collects the ``text`` content of every
+    ``assistant`` role message, ignoring any ``tool_call``/``tool_result`` content blocks
+    and any non-assistant messages (e.g. ``tool`` role messages). This ensures only the
+    final plain-text agent response is used for evaluation, never intermediate tool call
+    or tool result content.
+
+    :param messages: The preprocessed list of chat-message dicts.
+    :type messages: list
+    :return: The joined plain text of all assistant messages, or an empty string if none.
+    :rtype: str
+    """
+    text_lines = []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            for content in msg.get("content", []) or []:
+                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                    text_lines.append(content["text"])
+    return "\n".join(text_lines)
+
+
+def _parse_response_for_evaluation(response):
+    """Flatten ``response`` into a plain string, parsing a JSON-encoded list of messages if needed.
+
+    If ``response`` is a string, attempt to ``json.loads`` it. When it (or an already-parsed
+    ``response``) is a list of chat-message dicts, only the plain text of assistant messages
+    is extracted (tool calls, tool results, and other message types are dropped). Any other
+    input (a plain string that is not JSON, or a string/list that fails to parse or yields no
+    assistant text) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: A plain string ready for deterministic scoring.
+    :rtype: str
+    """
+    parsed = response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+    if isinstance(parsed, list):
+        try:
+            messages = _preprocess_messages(parsed)
+            text = _extract_final_text_response(messages)
+            if text:
+                return text
+        except Exception:
+            logger.debug("Could not extract plain text from response messages; falling back to original response")
+    return response
 
 
 # Use the SDK's ErrorTarget member when the installed version defines it; otherwise fall back to EVALUATE.
@@ -269,7 +329,7 @@ class RegexMatchEvaluator(EvaluatorBase):
         :return: The evaluation result with score and match information.
         :rtype: Dict
         """
-        response = eval_input.get("response", "")
+        response = _parse_response_for_evaluation(eval_input.get("response", ""))
 
         # Get compiled patterns (resolves column references if needed)
         compiled_patterns = self._get_compiled_patterns(eval_input)

--- a/assets/evaluators/builtin/regex_match/evaluator/_regex_match.py
+++ b/assets/evaluators/builtin/regex_match/evaluator/_regex_match.py
@@ -40,7 +40,7 @@ def _extract_final_text_response(messages):
     for msg in messages:
         if isinstance(msg, dict) and msg.get("role") == "assistant":
             for content in msg.get("content", []) or []:
-                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                if isinstance(content, dict) and "text" in content:
                     text_lines.append(content["text"])
     return "\n".join(text_lines)
 

--- a/assets/evaluators/builtin/regex_match/spec.yaml
+++ b/assets/evaluators/builtin/regex_match/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.regex_match"
-version: 4
+version: 5
 displayName: "Regex-Match-Evaluator"
 description: "Evaluates whether a model response matches one or more regex patterns. Patterns can include {{ground_truth}} which is resolved per-row from the ground_truth parameter. Returns True if any pattern matches, False otherwise. Designed for benchmarking tasks where correctness is determined by pattern matching."
 evaluatorType: "builtin"
@@ -22,8 +22,12 @@ dataMappingSchema:
   type: "object"
   properties:
     response:
-      type: "string"
-      description: "The raw model output text to evaluate."
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
+      description: "The raw model output text to evaluate. Accepts a plain string or a JSON-encoded list of chat messages."
     ground_truth:
       type: "string"
       description: "The expected answer value used to resolve {{ground_truth}} in patterns."

--- a/assets/evaluators/builtin/response_completeness/evaluator/_response_completeness.py
+++ b/assets/evaluators/builtin/response_completeness/evaluator/_response_completeness.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import os
+import json
 import logging
 import math
 from typing import Dict, List, Union, Optional
@@ -45,6 +46,30 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
     )
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_json_response_if_applicable(response):
+    """Parse ``response`` as JSON when it is a JSON-encoded string of chat messages.
+
+    If ``response`` is a string that successfully parses as JSON into a list, the parsed
+    list is returned so it can be handled by the existing message-list preprocessing path.
+    Any other input (a plain string, an already-parsed list, or a string that fails to
+    parse as JSON) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: The parsed list of messages, or the original response if it is not a
+        JSON-encoded list.
+    :rtype: Any
+    """
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+        if isinstance(parsed, list):
+            return parsed
+    return response
 
 
 @experimental
@@ -251,6 +276,8 @@ class ResponseCompletenessEvaluator(PromptyEvaluatorBase[Union[str, float]]):
                 category=ErrorCategory.MISSING_FIELD,
                 target=ErrorTarget.COMPLETENESS_EVALUATOR,
             )
+
+        eval_input["response"] = _parse_json_response_if_applicable(eval_input.get("response"))
 
         if _is_intermediate_response(eval_input.get("response")):
             return self._return_not_applicable_result(

--- a/assets/evaluators/builtin/response_completeness/spec.yaml
+++ b/assets/evaluators/builtin/response_completeness/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.response_completeness"
-version: 10
+version: 11
 displayName: "Response-Completeness-Evaluator-(Preview)"
 description: "Assesses whether the response covers all key aspects of the question. Higher scores indicate more thorough and complete answers. This evaluator is useful when evaluating chatbots, virtual assistants, and QA systems where full and informative responses are critical."
 evaluatorType: "builtin"
@@ -25,7 +25,11 @@ dataMappingSchema:
     ground_truth:
       type: "string"
     response:
-      type: "string"
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
   required: ["ground_truth", "response"]
 outputSchema:
   response_completeness:

--- a/assets/evaluators/builtin/rouge_score/evaluator/_rouge.py
+++ b/assets/evaluators/builtin/rouge_score/evaluator/_rouge.py
@@ -40,7 +40,7 @@ def _extract_final_text_response(messages):
     for msg in messages:
         if isinstance(msg, dict) and msg.get("role") == "assistant":
             for content in msg.get("content", []) or []:
-                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                if isinstance(content, dict) and "text" in content:
                     text_lines.append(content["text"])
     return "\n".join(text_lines)
 

--- a/assets/evaluators/builtin/rouge_score/evaluator/_rouge.py
+++ b/assets/evaluators/builtin/rouge_score/evaluator/_rouge.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import json
 import logging
 from enum import Enum
 
@@ -13,7 +14,66 @@ from azure.ai.evaluation._constants import EVALUATION_PASS_FAIL_MAPPING
 from azure.ai.evaluation._exceptions import EvaluationException, ErrorBlame, ErrorCategory, ErrorTarget
 import math
 
+try:  # azure-ai-evaluation >= 1.18.1
+    from azure.ai.evaluation._common.utils import _preprocess_messages
+except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 1.17.x is dropped)  # pragma: no cover
+    from azure.ai.evaluation._evaluators._common._base_prompty_eval import _preprocess_messages
+
 logger = logging.getLogger(__name__)
+
+
+def _extract_final_text_response(messages):
+    """Extract only the plain text of assistant messages, dropping tool calls/results.
+
+    Iterates the preprocessed messages and collects the ``text`` content of every
+    ``assistant`` role message, ignoring any ``tool_call``/``tool_result`` content blocks
+    and any non-assistant messages (e.g. ``tool`` role messages). This ensures only the
+    final plain-text agent response is used for evaluation, never intermediate tool call
+    or tool result content.
+
+    :param messages: The preprocessed list of chat-message dicts.
+    :type messages: list
+    :return: The joined plain text of all assistant messages, or an empty string if none.
+    :rtype: str
+    """
+    text_lines = []
+    for msg in messages:
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            for content in msg.get("content", []) or []:
+                if isinstance(content, dict) and "text" in content and content.get("type", "text") == "text":
+                    text_lines.append(content["text"])
+    return "\n".join(text_lines)
+
+
+def _parse_response_for_evaluation(response):
+    """Flatten ``response`` into a plain string, parsing a JSON-encoded list of messages if needed.
+
+    If ``response`` is a string, attempt to ``json.loads`` it. When it (or an already-parsed
+    ``response``) is a list of chat-message dicts, only the plain text of assistant messages
+    is extracted (tool calls, tool results, and other message types are dropped). Any other
+    input (a plain string that is not JSON, or a string/list that fails to parse or yields no
+    assistant text) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: A plain string ready for deterministic scoring.
+    :rtype: str
+    """
+    parsed = response
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+    if isinstance(parsed, list):
+        try:
+            messages = _preprocess_messages(parsed)
+            text = _extract_final_text_response(messages)
+            if text:
+                return text
+        except Exception:
+            logger.debug("Could not extract plain text from response messages; falling back to original response")
+    return response
 
 
 class RougeType(str, Enum):
@@ -199,7 +259,7 @@ class RougeScoreEvaluator(EvaluatorBase):
         :rtype: Dict
         """
         ground_truth = eval_input["ground_truth"]
-        response = eval_input["response"]
+        response = _parse_response_for_evaluation(eval_input["response"])
         scorer = rouge_scorer.RougeScorer(rouge_types=[self._rouge_type])
         metrics = scorer.score(ground_truth, response)[self._rouge_type]
         binary_results = {

--- a/assets/evaluators/builtin/rouge_score/spec.yaml
+++ b/assets/evaluators/builtin/rouge_score/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.rouge_score"
-version: 3
+version: 4
 displayName: "Rouge-Score-Evaluator"
 description: "Compares the overlap of words or phrases between model output and reference text. Higher scores indicate closer alignment. Reccomended use cases include text summarization and document comparison, especially when focusing on recall and the ability to capture relevant information from the reference text."
 evaluatorType: "builtin"
@@ -36,7 +36,11 @@ dataMappingSchema:
     ground_truth:
       type: "string"
     response:
-      type: "string"
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
   required: ["ground_truth", "response"]
 outputSchema:
   rouge:

--- a/assets/evaluators/builtin/similarity/evaluator/_similarity.py
+++ b/assets/evaluators/builtin/similarity/evaluator/_similarity.py
@@ -50,6 +50,30 @@ except ImportError:  # azure-ai-evaluation 1.17.x (backward compat; remove when 
 logger = logging.getLogger(__name__)
 
 
+def _parse_json_response_if_applicable(response):
+    """Parse ``response``/``query`` as JSON when it is a JSON-encoded string of chat messages.
+
+    If ``response`` is a string that successfully parses as JSON into a list, the parsed
+    list is returned so it can be handled by the existing message-list preprocessing path.
+    Any other input (a plain string, an already-parsed list, or a string that fails to
+    parse as JSON) is returned unchanged.
+
+    :param response: The raw response value from the eval input.
+    :type response: Any
+    :return: The parsed list of messages, or the original response if it is not a
+        JSON-encoded list.
+    :rtype: Any
+    """
+    if isinstance(response, str):
+        try:
+            parsed = json.loads(response)
+        except (ValueError, TypeError):
+            return response
+        if isinstance(parsed, list):
+            return parsed
+    return response
+
+
 class SimilarityEvaluator(PromptyEvaluatorBase):
     """
     Evaluates similarity score for a given query, response, and ground truth.
@@ -267,6 +291,7 @@ class SimilarityEvaluator(PromptyEvaluatorBase):
                 target=ErrorTarget.CONVERSATION,
             )
         # Check for intermediate response
+        eval_input["response"] = _parse_json_response_if_applicable(eval_input.get("response"))
         if _is_intermediate_response(eval_input.get("response")):
             return self._return_not_applicable_result(
                 "Intermediate response. Please provide the agent's final response for evaluation.",

--- a/assets/evaluators/builtin/similarity/spec.yaml
+++ b/assets/evaluators/builtin/similarity/spec.yaml
@@ -1,6 +1,6 @@
 type: "evaluator"
 name: "builtin.similarity"
-version: 7
+version: 8
 displayName: "Similarity-Evaluator"
 description: "Measures how closely two pieces of text resemble each other in meaning. Higher scores indicate greater semantic similarity. It’s best used for NLP tasks with a user query. Use it when you want an objective evaluation of an AI model's performance, particularly in text generation tasks where you have access to ground truth responses."
 evaluatorType: "builtin"
@@ -25,7 +25,11 @@ dataMappingSchema:
     query:
       type: "string"
     response:
-      type: "string"
+      anyOf:
+        - type: "string"
+        - type: "array"
+          items:
+            type: "object"
     ground_truth:
       type: "string"
   required: ["query", "response", "ground_truth"]

--- a/assets/evaluators/tests/test_evaluators_behavior/test_bbeh_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_bbeh_evaluator_behavior.py
@@ -440,3 +440,14 @@ class TestBBEHEvaluatorBehavior(BaseCodeEvaluatorRunner):
         # If the tool call/result text ("no") leaked in, this would fail; it must pass.
         self.assert_pass(result_data)
 
+    def test_json_response_extraction_failure_falls_back_to_original(self):
+        """If message extraction raises, the original (unparsed) response is used instead of crashing."""
+        import json
+        from unittest.mock import patch
+        from ...builtin.bbeh.evaluator import _bbeh
+
+        messages = [{"role": "assistant", "content": [{"type": "text", "text": self.SIMPLE_RESPONSE}]}]
+        with patch.object(_bbeh, "_preprocess_messages", side_effect=RuntimeError("boom")):
+            result = _bbeh._parse_response_for_evaluation(json.dumps(messages))
+        # Falls back to the original (still JSON-encoded) response string, unchanged.
+        assert result == json.dumps(messages)

--- a/assets/evaluators/tests/test_evaluators_behavior/test_bbeh_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_bbeh_evaluator_behavior.py
@@ -370,3 +370,73 @@ class TestBBEHEvaluatorBehavior(BaseCodeEvaluatorRunner):
         )
         result_data = self._extract_and_print_result(results, "trailing_question_mark")
         self.assert_pass(result_data)
+
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON) is used as-is."""
+        results = self._run_evaluation(
+            response=self.SIMPLE_RESPONSE,
+            ground_truth=self.SIMPLE_ANSWER,
+        )
+        result_data = self._extract_and_print_result(results, "plain_string_response")
+        self.assert_pass(result_data)
+
+    def test_json_encoded_message_list_response(self):
+        """A JSON-encoded list of chat messages is parsed and flattened to plain text."""
+        import json
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Is this correct?"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "lookup",
+                        "arguments": {"q": "yes"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": [{"type": "tool_result", "tool_result": "n/a"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": self.SIMPLE_RESPONSE}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.SIMPLE_ANSWER,
+        )
+        result_data = self._extract_and_print_result(results, "json_encoded_message_list_response")
+        self.assert_pass(result_data)
+
+    def test_json_response_excludes_tool_call_and_result_content(self):
+        """Tool call/result content must never leak into the flattened response text."""
+        import json
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "search_docs",
+                        "arguments": {"query": "The answer is: no"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": [{"type": "tool_result", "tool_result": "The answer is: no"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": self.SIMPLE_RESPONSE}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.SIMPLE_ANSWER,
+        )
+        result_data = self._extract_and_print_result(results, "json_response_excludes_tool_content")
+        # If the tool call/result text ("no") leaked in, this would fail; it must pass.
+        self.assert_pass(result_data)
+

--- a/assets/evaluators/tests/test_evaluators_behavior/test_bleu_score_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_bleu_score_evaluator_behavior.py
@@ -596,3 +596,80 @@ class TestBleuScoreEvaluatorBehavior(BaseCodeEvaluatorRunner, SingleScoreCodeEva
             threshold=threshold,
         )
         assert results["bleu_threshold"] == threshold
+
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON) is used as-is."""
+        results = self._run_evaluation(
+            response=self.IDENTICAL_TEXT,
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "plain_string_response")
+        self.assert_pass(result_data)
+        self.assert_score_in_range(result_data, min_score=0.9)
+
+    def test_json_encoded_message_list_response(self):
+        """A JSON-encoded list of chat messages is parsed and flattened to plain text."""
+        import json
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "What is the fox doing?"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "lookup",
+                        "arguments": {"q": "fox"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": [{"type": "tool_result", "tool_result": "n/a"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "json_encoded_message_list_response")
+        self.assert_pass(result_data)
+        # Only the final assistant text should be scored, yielding a near-perfect match.
+        self.assert_score_in_range(result_data, min_score=0.9)
+
+    def test_json_response_excludes_tool_call_and_result_content(self):
+        """Tool call/result content must never leak into the flattened response text."""
+        import json
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "search_docs",
+                        "arguments": {"query": "unrelated gibberish xyz"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": [{"type": "tool_result", "tool_result": "completely unrelated wording"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "json_response_excludes_tool_content")
+        # If tool call/result text leaked in, the BLEU score would be dragged down
+        # significantly by the unrelated tool content; it should still score high.
+        self.assert_score_in_range(result_data, min_score=0.9)
+

--- a/assets/evaluators/tests/test_evaluators_behavior/test_bleu_score_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_bleu_score_evaluator_behavior.py
@@ -672,4 +672,3 @@ class TestBleuScoreEvaluatorBehavior(BaseCodeEvaluatorRunner, SingleScoreCodeEva
         # If tool call/result text leaked in, the BLEU score would be dragged down
         # significantly by the unrelated tool content; it should still score high.
         self.assert_score_in_range(result_data, min_score=0.9)
-

--- a/assets/evaluators/tests/test_evaluators_behavior/test_f1_score_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_f1_score_evaluator_behavior.py
@@ -677,6 +677,79 @@ class TestF1ScoreEvaluatorBehavior(BaseCodeEvaluatorRunner, SingleScoreCodeEvalC
         )
         assert results["f1_score_threshold"] == threshold
 
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON) is used as-is."""
+        results = self._run_evaluation(
+            response=self.IDENTICAL_TEXT,
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "plain_string_response")
+        self.assert_pass(result_data)
+        self.assert_score_in_range(result_data, min_score=0.9)
+
+    def test_json_encoded_message_list_response(self):
+        """A JSON-encoded list of chat messages is parsed and flattened to plain text."""
+        import json
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "What is the fox doing?"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "lookup",
+                        "arguments": {"q": "fox"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": [{"type": "tool_result", "tool_result": "n/a"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "json_encoded_message_list_response")
+        self.assert_pass(result_data)
+        self.assert_score_in_range(result_data, min_score=0.9)
+
+    def test_json_response_excludes_tool_call_and_result_content(self):
+        """Tool call/result content must never leak into the flattened response text."""
+        import json
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "search_docs",
+                        "arguments": {"query": "unrelated gibberish xyz"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": [{"type": "tool_result", "tool_result": "completely unrelated wording"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "json_response_excludes_tool_content")
+        self.assert_score_in_range(result_data, min_score=0.9)
+
     # ==================== F1 SCORE RANGE TESTS ====================
 
     def test_f1_score_range_various_inputs(self):

--- a/assets/evaluators/tests/test_evaluators_behavior/test_fluency_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_fluency_evaluator_behavior.py
@@ -27,8 +27,8 @@ class TestFluencyEvaluatorBehavior(BaseEvaluatorBehaviorTest, BaseToolEvaluation
     """
 
     # region Expected flow inputs for each test
-    # Fluency calls reformat_agent_response() which extracts text-only content
-    # from assistant messages, so expected inputs are the reformatted strings.
+    # Fluency calls _extract_final_text_response() which extracts text-only content
+    # from assistant messages, so expected inputs are the flattened text strings.
     test_function_tool_local_calls_expected_flow_inputs = {
         "response": data.LOCAL_CALLS_IR_EXPECTED_FLOW_RESPONSE,
     }
@@ -94,6 +94,53 @@ class TestFluencyEvaluatorBehavior(BaseEvaluatorBehaviorTest, BaseToolEvaluation
 
     # Test Configs
     requires_query = False
+
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON) should keep working as before."""
+        results = self._run_evaluation(response="It is sunny today.")
+        result_data = self._extract_and_print_result(results, "Plain String Response")
+        self.assert_pass_or_fail(result_data)
+
+    def test_json_encoded_message_list_response_flattens_to_final_text(self):
+        """A JSON-encoded list of chat messages is parsed and only the final assistant text reaches the flow.
+
+        Fluency flattens the preprocessed conversation to plain assistant text before calling the
+        flow, so tool calls/results must never leak into what the flow receives.
+        """
+        import json
+
+        final_answer = "The current weather in Seattle is sunny with a high of 72 degrees."
+        json_response = json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call_1",
+                            "name": "fetch_weather",
+                            "arguments": {"location": "Seattle"},
+                        }
+                    ],
+                },
+                {
+                    "tool_call_id": "call_1",
+                    "role": "tool",
+                    "content": [{"type": "tool_result", "tool_result": {"weather": "rainy, 40 degrees"}}],
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": final_answer}],
+                },
+            ]
+        )
+        _, captured = self._run_and_capture_flow_input(response=json_response)
+        flow_input_json = json.dumps(captured, default=str)
+        assert final_answer in flow_input_json, "final assistant text did not reach the flow"
+        assert "rainy, 40 degrees" not in flow_input_json, "tool result content leaked into the flow"
+        assert "fetch_weather" not in flow_input_json, "tool call content leaked into the flow"
 
 
 # region None score handling tests

--- a/assets/evaluators/tests/test_evaluators_behavior/test_gleu_score_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_gleu_score_evaluator_behavior.py
@@ -570,6 +570,79 @@ class TestGleuScoreEvaluatorBehavior(BaseCodeEvaluatorRunner, SingleScoreCodeEva
         )
         assert results["gleu_threshold"] == threshold
 
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON) is used as-is."""
+        results = self._run_evaluation(
+            response=self.IDENTICAL_TEXT,
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "plain_string_response")
+        self.assert_pass(result_data)
+        self.assert_score_in_range(result_data, min_score=0.9)
+
+    def test_json_encoded_message_list_response(self):
+        """A JSON-encoded list of chat messages is parsed and flattened to plain text."""
+        import json
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "What is the fox doing?"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "lookup",
+                        "arguments": {"q": "fox"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": [{"type": "tool_result", "tool_result": "n/a"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "json_encoded_message_list_response")
+        self.assert_pass(result_data)
+        self.assert_score_in_range(result_data, min_score=0.9)
+
+    def test_json_response_excludes_tool_call_and_result_content(self):
+        """Tool call/result content must never leak into the flattened response text."""
+        import json
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "search_docs",
+                        "arguments": {"query": "unrelated gibberish xyz"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": [{"type": "tool_result", "tool_result": "completely unrelated wording"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "json_response_excludes_tool_content")
+        self.assert_score_in_range(result_data, min_score=0.9)
+
     # ==================== GLEU SCORE RANGE TESTS ====================
 
     def test_gleu_score_range_various_inputs(self):

--- a/assets/evaluators/tests/test_evaluators_behavior/test_ifeval_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_ifeval_evaluator_behavior.py
@@ -288,6 +288,78 @@ class TestIFEvalEvaluatorBehavior(BaseCodeEvaluatorRunner):
         result_data = self._extract_and_print_result(results, "empty_instruction_list")
         self.assert_fail(result_data)
 
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON message list) is used as-is."""
+        results = self._run_evaluation(
+            response=self.NO_COMMA_RESPONSE,
+            instruction_id_list='["punctuation:no_comma"]',
+            instruction_kwargs='[{}]',
+        )
+        result_data = self._extract_and_print_result(results, "plain_string_response")
+        self.assert_pass(result_data)
+
+    def test_json_encoded_message_list_response(self):
+        """A JSON-encoded list of chat messages is parsed and flattened to plain text."""
+        import json
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Reply without commas."}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "lookup",
+                        "arguments": {"q": "comma, rule"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": [{"type": "tool_result", "tool_result": "n/a"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": self.NO_COMMA_RESPONSE}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            instruction_id_list='["punctuation:no_comma"]',
+            instruction_kwargs='[{}]',
+        )
+        result_data = self._extract_and_print_result(results, "json_encoded_message_list_response")
+        self.assert_pass(result_data)
+
+    def test_json_response_excludes_tool_call_and_result_content(self):
+        """Tool call/result content (which contains a comma) must not leak into the response."""
+        import json
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "search_docs",
+                        "arguments": {"query": "a, b, c"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": [{"type": "tool_result", "tool_result": "found, results, here"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": self.NO_COMMA_RESPONSE}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            instruction_id_list='["punctuation:no_comma"]',
+            instruction_kwargs='[{}]',
+        )
+        result_data = self._extract_and_print_result(results, "json_response_excludes_tool_content")
+        # If the tool call/result commas leaked into the scored text, this would fail.
+        self.assert_pass(result_data)
+
 
 @pytest.mark.unittest
 class TestIFEvalInstructionCheckers:

--- a/assets/evaluators/tests/test_evaluators_behavior/test_meteor_score_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_meteor_score_evaluator_behavior.py
@@ -688,6 +688,79 @@ class TestMeteorScoreEvaluatorBehavior(BaseCodeEvaluatorRunner, SingleScoreCodeE
         )
         assert results["meteor_threshold"] == threshold
 
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON) is used as-is."""
+        results = self._run_evaluation(
+            response=self.IDENTICAL_TEXT,
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "plain_string_response")
+        self.assert_pass(result_data)
+        self.assert_score_in_range(result_data, min_score=0.9)
+
+    def test_json_encoded_message_list_response(self):
+        """A JSON-encoded list of chat messages is parsed and flattened to plain text."""
+        import json
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "What is the fox doing?"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "lookup",
+                        "arguments": {"q": "fox"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": [{"type": "tool_result", "tool_result": "n/a"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "json_encoded_message_list_response")
+        self.assert_pass(result_data)
+        self.assert_score_in_range(result_data, min_score=0.9)
+
+    def test_json_response_excludes_tool_call_and_result_content(self):
+        """Tool call/result content must never leak into the flattened response text."""
+        import json
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "search_docs",
+                        "arguments": {"query": "unrelated gibberish xyz"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": [{"type": "tool_result", "tool_result": "completely unrelated wording"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            threshold=0.5,
+        )
+        result_data = self._extract_and_print_result(results, "json_response_excludes_tool_content")
+        self.assert_score_in_range(result_data, min_score=0.9)
+
     # ==================== METEOR SCORE RANGE TESTS ====================
 
     def test_meteor_score_range_various_inputs(self):

--- a/assets/evaluators/tests/test_evaluators_behavior/test_regex_match_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_regex_match_evaluator_behavior.py
@@ -190,6 +190,80 @@ class TestRegexMatchEvaluatorBehavior(BaseCodeEvaluatorRunner):
         result_data = self._extract_and_print_result(results, "whitespace_response")
         self.assert_fail(result_data)
 
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON) is used as-is."""
+        evaluator = RegexMatchEvaluator(patterns=self.SIMPLE_PATTERN)
+        results = self._run_evaluation_with_evaluator(
+            evaluator,
+            response=self.MATCHING_RESPONSE,
+        )
+        result_data = self._extract_and_print_result(results, "plain_string_response")
+        self.assert_pass(result_data)
+
+    def test_json_encoded_message_list_response(self):
+        """A JSON-encoded list of chat messages is parsed and flattened to plain text."""
+        import json
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "What's the answer?"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "lookup",
+                        "arguments": {"q": "answer"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": [{"type": "tool_result", "tool_result": "n/a"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": self.MATCHING_RESPONSE}]},
+        ]
+        evaluator = RegexMatchEvaluator(patterns=self.SIMPLE_PATTERN)
+        results = self._run_evaluation_with_evaluator(
+            evaluator,
+            response=json.dumps(messages),
+        )
+        result_data = self._extract_and_print_result(results, "json_encoded_message_list_response")
+        self.assert_pass(result_data)
+
+    def test_json_response_excludes_tool_call_and_result_content(self):
+        """Tool call/result content must never leak into the flattened response text."""
+        import json
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "search_docs",
+                        "arguments": {"query": "ANSWER: A"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": [{"type": "tool_result", "tool_result": "ANSWER: A"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": self.MATCHING_RESPONSE}]},
+        ]
+        evaluator = RegexMatchEvaluator(patterns=self.SIMPLE_PATTERN)
+        results = self._run_evaluation_with_evaluator(
+            evaluator,
+            response=json.dumps(messages),
+        )
+        result_data = self._extract_and_print_result(results, "json_response_excludes_tool_content")
+        # If the tool content "ANSWER: A" leaked in, the pattern would still find
+        # "ANSWER: B" in the final text and pass; verify it passes cleanly on the
+        # final assistant text alone.
+        self.assert_pass(result_data)
+
     # ==================== HELPER METHOD ====================
 
     def _run_evaluation_with_evaluator(self, evaluator, **kwargs):

--- a/assets/evaluators/tests/test_evaluators_behavior/test_regex_match_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_regex_match_evaluator_behavior.py
@@ -264,6 +264,18 @@ class TestRegexMatchEvaluatorBehavior(BaseCodeEvaluatorRunner):
         # final assistant text alone.
         self.assert_pass(result_data)
 
+    def test_json_response_extraction_failure_falls_back_to_original(self):
+        """If message extraction raises, the original (unparsed) response is used instead of crashing."""
+        import json
+        from unittest.mock import patch
+        from ...builtin.regex_match.evaluator import _regex_match
+
+        messages = [{"role": "assistant", "content": [{"type": "text", "text": self.MATCHING_RESPONSE}]}]
+        with patch.object(_regex_match, "_preprocess_messages", side_effect=RuntimeError("boom")):
+            result = _regex_match._parse_response_for_evaluation(json.dumps(messages))
+        # Falls back to the original (still JSON-encoded) response string, unchanged.
+        assert result == json.dumps(messages)
+
     # ==================== HELPER METHOD ====================
 
     def _run_evaluation_with_evaluator(self, evaluator, **kwargs):

--- a/assets/evaluators/tests/test_evaluators_behavior/test_response_completeness_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_response_completeness_evaluator_behavior.py
@@ -564,6 +564,58 @@ class TestResponseCompletenessEvaluatorBehavior(BasePromptyEvaluatorRunner):
         result_data = self._extract_and_print_result(results, "ground-truth-as-list")
         self.assert_pass_or_fail(result_data)
 
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self) -> None:
+        """A plain string response (not JSON) should keep working as before."""
+        results = self._run_evaluation(
+            response="Python is a programming language created by Guido van Rossum.",
+            ground_truth="Python is a programming language created by Guido van Rossum.",
+        )
+        result_data = self._extract_and_print_result(results, "plain-string-response")
+        self.assert_pass(result_data)
+
+    def test_json_encoded_message_list_response_reaches_flow(self) -> None:
+        """A JSON-encoded list of chat messages is parsed and the final assistant text reaches the flow.
+
+        Response Completeness passes the preprocessed conversation (not a flattened string) to
+        its prompty flow, same as it already does for a plain List[dict] response - this mirrors
+        that pre-existing behavior, just parsing the JSON-encoded string into the list first.
+        """
+        import json
+
+        final_answer = "Python is a programming language created by Guido van Rossum."
+        json_response = json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call_1",
+                            "name": "lookup",
+                            "arguments": {"q": "python creator"},
+                        }
+                    ],
+                },
+                {
+                    "tool_call_id": "call_1",
+                    "role": "tool",
+                    "content": [{"type": "tool_result", "tool_result": {"info": "not the real answer"}}],
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": final_answer}],
+                },
+            ]
+        )
+        _, captured = self._run_and_capture_flow_input(
+            response=json_response,
+            ground_truth=final_answer,
+        )
+        flow_input_json = json.dumps(captured, default=str)
+        assert final_answer in flow_input_json, "final assistant text did not reach the flow"
+
 
 # region Not-applicable handling tests (util-fix regression)
 

--- a/assets/evaluators/tests/test_evaluators_behavior/test_rouge_score_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_rouge_score_evaluator_behavior.py
@@ -781,6 +781,80 @@ class TestRougeScoreEvaluatorBehavior(BaseCodeEvaluatorRunner):
 
         assert result_similar["f1_score"] > result_different["f1_score"]
 
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON) is used as-is."""
+        results = self._run_evaluation(
+            response=self.IDENTICAL_TEXT,
+            ground_truth=self.IDENTICAL_TEXT,
+            rouge_type=RougeType.ROUGE_1,
+        )
+        result_data = self._extract_and_print_result(results, "plain_string_response")
+        self.assert_all_pass(result_data)
+        assert result_data["f1_score"] == 1.0
+
+    def test_json_encoded_message_list_response(self):
+        """A JSON-encoded list of chat messages is parsed and flattened to plain text."""
+        import json
+
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "What is the fox doing?"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "lookup",
+                        "arguments": {"q": "fox"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": [{"type": "tool_result", "tool_result": "n/a"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            rouge_type=RougeType.ROUGE_1,
+        )
+        result_data = self._extract_and_print_result(results, "json_encoded_message_list_response")
+        self.assert_all_pass(result_data)
+        assert result_data["f1_score"] == 1.0
+
+    def test_json_response_excludes_tool_call_and_result_content(self):
+        """Tool call/result content must never leak into the flattened response text."""
+        import json
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_call",
+                        "tool_call_id": "c1",
+                        "name": "search_docs",
+                        "arguments": {"query": "unrelated gibberish xyz"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c1",
+                "content": [{"type": "tool_result", "tool_result": "completely unrelated wording"}],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": self.IDENTICAL_TEXT}]},
+        ]
+        results = self._run_evaluation(
+            response=json.dumps(messages),
+            ground_truth=self.IDENTICAL_TEXT,
+            rouge_type=RougeType.ROUGE_1,
+        )
+        result_data = self._extract_and_print_result(results, "json_response_excludes_tool_content")
+        # If tool content leaked in, precision/recall/F1 would drop well below 1.0.
+        assert result_data["f1_score"] == 1.0
+
     # ==================== INTERNAL BRANCH COVERAGE TESTS ====================
     # ROUGE returns three sub-scores with a dict threshold, so it cannot reuse the
     # single-score coverage mixin. These white-box tests exercise the branches that

--- a/assets/evaluators/tests/test_evaluators_behavior/test_similarity_evaluator_behavior.py
+++ b/assets/evaluators/tests/test_evaluators_behavior/test_similarity_evaluator_behavior.py
@@ -298,6 +298,59 @@ class TestSimilarityEvaluatorBehavior(BasePromptyEvaluatorRunner):
         result_data = self._extract_and_print_result(results, "Dict Ground Truth Type")
         self.assert_pass(result_data)
 
+    # ==================== JSON RESPONSE SUPPORT TESTS ====================
+
+    def test_plain_string_response_still_works(self):
+        """A plain string response (not JSON) should keep working as before."""
+        results = self._run_evaluation(
+            query=self.VALID_QUERY,
+            response=self.PERFECT_RESPONSE,
+            ground_truth=self.PERFECT_GROUND_TRUTH,
+        )
+        result_data = self._extract_and_print_result(results, "Plain String Response")
+        self.assert_pass(result_data)
+
+    def test_json_encoded_message_list_response_reaches_flow(self):
+        """A JSON-encoded list of chat messages is parsed and the final assistant text reaches the flow.
+
+        Similarity passes the preprocessed conversation (not a flattened string) to its prompty
+        flow, same as it already does for a plain List[dict] response - this mirrors that
+        pre-existing behavior, just parsing the JSON-encoded string into the list first.
+        """
+        import json
+
+        json_response = json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call_1",
+                            "name": "lookup",
+                            "arguments": {"q": "ribosomes"},
+                        }
+                    ],
+                },
+                {
+                    "tool_call_id": "call_1",
+                    "role": "tool",
+                    "content": [{"type": "tool_result", "tool_result": {"info": "not the real answer"}}],
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": self.PERFECT_RESPONSE}],
+                },
+            ]
+        )
+        _, captured = self._run_and_capture_flow_input(
+            query=self.VALID_QUERY,
+            response=json_response,
+            ground_truth=self.PERFECT_GROUND_TRUTH,
+        )
+        flow_input_json = json.dumps(captured, default=str)
+        assert self.PERFECT_RESPONSE in flow_input_json, "final assistant text did not reach the flow"
+
     # ==================== OUTPUT STRUCTURE TESTS ====================
 
     def test_output_contains_required_keys(self):


### PR DESCRIPTION
11 evaluators updated with JSON-response support:

**LLM evals (3):**
- fluency
- similarity
- response_completeness

**Deterministic evals (8):**
- bbeh
- bleu_score
- gleu_score
- meteor_score
- rouge_score
- f1_score
- regex_match
- ifeval

Response can now be a plain string or a JSON-encoded list of chat messages. Only the final plain-text assistant response is extracted for scoring; tool calls and tool results are never included. spec.yaml response schemas updated to anyOf: string | array, and versions bumped. Unit tests added covering plain-string and JSON message-list inputs, including verification that tool call/result content does not leak into the scored response.