### PR TITLE
acft-medimageparse-3d-finetune: fix fine-tuned checkpoint filename for deployment + azure-ai-ml 1.33.0

### DIFF
--- a/assets/training/finetune_acft_image/components/finetune/medimage_parse_3d/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_parse_3d/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 
 name: medimageparse_3d_finetune
-version: 0.0.1
+version: 0.0.2
 
 
 type: command

--- a/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
+++ b/assets/training/finetune_acft_image/environments/acft_image_medimageparse_3d_finetune/context/requirements.txt
@@ -9,7 +9,7 @@ hydra-core==1.3.2
 marshmallow==3.26.2
 
 # Azure ML SDK
-azure-ai-ml==1.26.5
+azure-ai-ml==1.33.0
 azure-identity==1.16.1
 azureml-mlflow==1.62.0.post2
 azureml-dataprep==5.4.1
@@ -20,10 +20,6 @@ mlflow-skinny==3.9.0
 # DL training stack
 timm==0.9.16
 opencv-python-headless==4.11.0.86
-# deepspeed: not used by MIP-3D training path. Active Lightning strategy in
-# olympus_biomed_parse_3d/configs/trainer/biomedparse_trainer.yaml is
-# "ddp_find_unused_parameters_true"; deepspeed strategy + optimizer configs are
-# all commented out. Dropping saves ~200MB and avoids JIT-compile risk.
 transformers>=5.0.0,<6.0.0
 open-clip-torch==2.26.1
 sentencepiece==0.2.1
@@ -46,8 +42,6 @@ mup==1.0.0
 arrow==1.3.0
 dotmap==1.3.30
 appdirs==1.4.4
-# ffmpeg python wrapper dropped: no video codepaths in MIP3D (NIFTI/DICOM only)
-# and the OS ffmpeg pkg accounts for 11/12 scan findings.
 filelock>=3.20.1
 
 # Build tooling pins (CVE / compatibility)

--- a/assets/training/finetune_acft_image/src/medimage_parse_3d_finetune/medimageparse_3d_finetune.py
+++ b/assets/training/finetune_acft_image/src/medimage_parse_3d_finetune/medimageparse_3d_finetune.py
@@ -270,11 +270,14 @@ def execute_training(args):
                 / "checkpoints"
                 / "last.ckpt"
             )
+            # Must match the filename pickled into the base model's python_model.pkl
+            # (MedImageParseMLflowWrapper.vision_model_name): copy_catalog() reuses that
+            # wrapper verbatim, so a different name here makes the deployment fail to load.
             output_path = (
                 Path(args.mlflow_model_folder)
                 / "artifacts"
                 / "checkpoints"
-                / "boltzformer_focal_all.safetensors"
+                / "biomedparse_3D_AllData_MultiView_edge.safetensors"
             )
 
             logger.info("Starting conversion to HuggingFace format...")


### PR DESCRIPTION
Two changes to the MedImageParse3D finetune asset. Revives #5076 (auto-closed for inactivity) and adds the deployment fix found while validating the finetune -> deploy path.

## Fine-tuned checkpoint filename (component `0.0.1` -> `0.0.2`)

The finetune entrypoint wrote the converted weights to
`artifacts/checkpoints/boltzformer_focal_all.safetensors` - the filename used by the **2D**
MedImageParse wrapper this entrypoint was cloned from. The **3D** base model expects a different
name: `python_model.pkl` loads the vision weights by
`vision_model_name = "biomedparse_3D_AllData_MultiView_edge.safetensors"` (and `copy_catalog()`
reuses that wrapper verbatim), and the 3D checkpoint loader config points at the same path. The
expected file was therefore absent from the fine-tuned model, so it loaded fine in training but
failed at online-deployment container start. The entrypoint now writes the expected filename;
component bumped `0.0.1` -> `0.0.2` so the corrected code republishes.

### Validation
- Base model catalog confirmed: `python_model.pkl` -> `vision_model_name = biomedparse_3D_AllData_MultiView_edge.safetensors`; 3D checkpoint loader (`biomedparse_checkpoint_loader.yaml`) loads from the same path
- Reproduced on a full finetune run (real AMOS abdomen CT, 3 volumes -> 122 slices, `hls-4xA100`, job `upbeat_gyro_qzltblnj9d`): the registered model contained only `boltzformer_focal_all.safetensors`, with `biomedparse_3D_AllData_MultiView_edge.safetensors` missing
- With the fix the entrypoint emits the expected filename, so the registered model matches the wrapper and loads without a post-hoc rename

### Diff
```diff
-                / "boltzformer_focal_all.safetensors"
+                / "biomedparse_3D_AllData_MultiView_edge.safetensors"
```

## azure-ai-ml 1.33.0 (revival of #5076)

Follow-up to #5069 (marshmallow CVE-2025-68480 fix), which pinned `azure-ai-ml` to the minimum
version compatible with `marshmallow>=3.24` (1.26.5). Bumping to the latest stable so we don't
sit on a stale SDK unnecessarily. `azure-ai-ml 1.33.0` requires `marshmallow>=3.5,<4.0`, so the
existing `marshmallow==3.26.2` pin remains compatible.

### Validation
- `pip` resolution clean (no broken requirements)
- Local build pushed to staging ACR; `vcm image vulnerabilities show` -> **0 findings**
- AML finetune smoke run on `hls-NDA100-ncus-oor-gpu` against the rebuilt image entered training successfully (`frank_tangelo_7vs8tx0h1x`)
