### PR TITLE
acft-medimageparse-3d-finetune: write fine-tuned checkpoint under the deployable filename

### DIFF
--- a/assets/training/finetune_acft_image/components/finetune/medimage_parse_3d/spec.yaml
+++ b/assets/training/finetune_acft_image/components/finetune/medimage_parse_3d/spec.yaml
@@ -1,7 +1,7 @@
 $schema: https://azuremlschemas.azureedge.net/latest/commandComponent.schema.json
 
 name: medimageparse_3d_finetune
-version: 0.0.1
+version: 0.0.2
 
 
 type: command

--- a/assets/training/finetune_acft_image/src/medimage_parse_3d_finetune/medimageparse_3d_finetune.py
+++ b/assets/training/finetune_acft_image/src/medimage_parse_3d_finetune/medimageparse_3d_finetune.py
@@ -270,11 +270,14 @@ def execute_training(args):
                 / "checkpoints"
                 / "last.ckpt"
             )
+            # Must match the filename pickled into the base model's python_model.pkl
+            # (MedImageParseMLflowWrapper.vision_model_name): copy_catalog() reuses that
+            # wrapper verbatim, so a different name here makes the deployment fail to load.
             output_path = (
                 Path(args.mlflow_model_folder)
                 / "artifacts"
                 / "checkpoints"
-                / "boltzformer_focal_all.safetensors"
+                / "biomedparse_3D_AllData_MultiView_edge.safetensors"
             )
 
             logger.info("Starting conversion to HuggingFace format...")


### PR DESCRIPTION
The MedImageParse3D finetune entrypoint wrote the converted weights to
`artifacts/checkpoints/boltzformer_focal_all.safetensors` - the filename used by the **2D**
MedImageParse wrapper this entrypoint was cloned from. The **3D** base model expects a different
name: `python_model.pkl` loads the vision weights by
`vision_model_name = "biomedparse_3D_AllData_MultiView_edge.safetensors"` (and `copy_catalog()`
reuses that wrapper verbatim), and the 3D checkpoint loader config points at the same path. The
expected file was therefore absent from the fine-tuned model, so it loaded fine during training
but failed at online-deployment container start. The entrypoint now writes the expected filename;
component bumped `0.0.1` -> `0.0.2` so the corrected code republishes.

### Validation
- Base model catalog confirmed: `python_model.pkl` -> `vision_model_name = biomedparse_3D_AllData_MultiView_edge.safetensors`; 3D checkpoint loader (`biomedparse_checkpoint_loader.yaml`) loads from the same path
- Reproduced on a full finetune run (real AMOS abdomen CT, 3 volumes -> 122 slices, `hls-4xA100`, job `upbeat_gyro_qzltblnj9d`): the registered model contained only `boltzformer_focal_all.safetensors`, with `biomedparse_3D_AllData_MultiView_edge.safetensors` missing
- With the fix the entrypoint emits the expected filename, so the registered model matches the wrapper and loads without a post-hoc rename

### Diff
```diff
-                / "boltzformer_focal_all.safetensors"
+                / "biomedparse_3D_AllData_MultiView_edge.safetensors"
```
