### PR TITLE
Remove memcpy node from Qwen3.5 CUDA Foundry Local models

### DIFF
--- a/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/asset.yaml
@@ -1,4 +1,5 @@
 extra_config: model.yaml
+version: 4
 spec: spec.yaml
 type: model
 categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-0.8b/onnx/cuda/v3
+  container_path: foundrylocal/models/qwen3.5-0.8b/onnx/cuda/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
@@ -48,4 +48,4 @@ variantInfo:
     executionProvider: CUDAExecutionProvider
     fileSizeBytes: 1555281448
     vRamFootprintBytes: 1555281448
-  version: 4
+version: 4

--- a/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-0.8b-cuda-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   previewType: hideUI
   alias: qwen3.5-0.8b
   publisher: Microsoft
-  directoryPath: v3
+  directoryPath: v4
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 1555287614
-    vRamFootprintBytes: 1555287614
-version: 3
+    fileSizeBytes: 1555281448
+    vRamFootprintBytes: 1555281448
+  version: 4

--- a/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/asset.yaml
@@ -1,4 +1,5 @@
 extra_config: model.yaml
+version: 4
 spec: spec.yaml
 type: model
 categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-2b/onnx/cuda/v3
+  container_path: foundrylocal/models/qwen3.5-2b/onnx/cuda/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   previewType: hideUI
   alias: qwen3.5-2b
   publisher: Microsoft
-  directoryPath: v3
+  directoryPath: v4
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 3071018029
-    vRamFootprintBytes: 3071018029
-version: 3
+    fileSizeBytes: 3071007627
+    vRamFootprintBytes: 3071007627
+  version: 4

--- a/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-2b-cuda-gpu/spec.yaml
@@ -48,4 +48,4 @@ variantInfo:
     executionProvider: CUDAExecutionProvider
     fileSizeBytes: 3071007627
     vRamFootprintBytes: 3071007627
-  version: 4
+version: 4

--- a/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/asset.yaml
@@ -1,4 +1,5 @@
 extra_config: model.yaml
+version: 4
 spec: spec.yaml
 type: model
 categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-4b/onnx/cuda/v3
+  container_path: foundrylocal/models/qwen3.5-4b/onnx/cuda/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
@@ -48,4 +48,4 @@ variantInfo:
     executionProvider: CUDAExecutionProvider
     fileSizeBytes: 4384866247
     vRamFootprintBytes: 4384866247
-  version: 4
+version: 4

--- a/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-4b-cuda-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   previewType: hideUI
   alias: qwen3.5-4b
   publisher: Microsoft
-  directoryPath: v3
+  directoryPath: v4
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 4384876649
-    vRamFootprintBytes: 4384876649
-version: 3
+    fileSizeBytes: 4384866247
+    vRamFootprintBytes: 4384866247
+  version: 4

--- a/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/asset.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/asset.yaml
@@ -1,4 +1,5 @@
 extra_config: model.yaml
+version: 4
 spec: spec.yaml
 type: model
 categories: ["Local"]

--- a/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/model.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/model.yaml
@@ -1,6 +1,6 @@
 path:
   container_name: models
-  container_path: foundrylocal/models/qwen3.5-9b/onnx/cuda/v3
+  container_path: foundrylocal/models/qwen3.5-9b/onnx/cuda/v4
   storage_name: foundrylocalassetdata
   type: azureblob
 publish:

--- a/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
@@ -10,7 +10,7 @@ system_metadata:
   previewType: hideUI
   alias: qwen3.5-9b
   publisher: Microsoft
-  directoryPath: v3
+  directoryPath: v4
   foundryLocal: ''
   deploymentOptions: ['Foundry Local on Devices']
   inputModalities:
@@ -46,6 +46,6 @@ variantInfo:
     - RTN
     device: gpu
     executionProvider: CUDAExecutionProvider
-    fileSizeBytes: 7491584028
-    vRamFootprintBytes: 7491584028
-version: 3
+    fileSizeBytes: 7491572567
+    vRamFootprintBytes: 7491572567
+  version: 4

--- a/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
+++ b/assets/models/foundrylocal/qwen3.5-9b-cuda-gpu/spec.yaml
@@ -48,4 +48,4 @@ variantInfo:
     executionProvider: CUDAExecutionProvider
     fileSizeBytes: 7491572567
     vRamFootprintBytes: 7491572567
-  version: 4
+version: 4


### PR DESCRIPTION
The current v3 version of Qwen3.5 CUDA models in Foundry Local has MemcpyToHost and MemcpyFromHost nodes. This PR is to remove such nodes and resolve the issue(https://github.com/microsoft/foundry-local/issues/1075). 